### PR TITLE
pkg/sdk: implement sdk.Handle() API

### DIFF
--- a/pkg/sdk/api.go
+++ b/pkg/sdk/api.go
@@ -3,8 +3,8 @@ package sdk
 import (
 	"context"
 
+	sdkHandler "github.com/coreos/operator-sdk/pkg/sdk/handler"
 	sdkInformer "github.com/coreos/operator-sdk/pkg/sdk/informer"
-	sdkTypes "github.com/coreos/operator-sdk/pkg/sdk/types"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,13 +27,16 @@ func Watch(resourcePluralName, namespace string, obj runtime.Object, resourceCli
 	informers = append(informers, informer)
 }
 
-// TODO: func Handle(handler sdkTypes.Handler)
+// Handle registers the handler for all events.
+// In the future, we would have a mux-pattern to dispatch events to matched handlers.
+func Handle(handler sdkHandler.Handler) {
+	sdkHandler.RegisteredHandler = handler
+}
 
 // Run starts the process of Watching resources, handling Events, and processing Actions
 func Run(ctx context.Context) {
-	sdkCtx := sdkTypes.Context{Context: ctx}
 	for _, informer := range informers {
-		err := informer.Run(sdkCtx)
+		err := informer.Run(ctx)
 		if err != nil {
 			logrus.Errorf("failed to run informer: %v", err)
 			return

--- a/pkg/sdk/handler/handler.go
+++ b/pkg/sdk/handler/handler.go
@@ -1,0 +1,17 @@
+package handler
+
+import (
+	sdkTypes "github.com/coreos/operator-sdk/pkg/sdk/types"
+)
+
+// Handler reacts to events and outputs actions.
+// If any intended action failed, the event would be re-triggered.
+// For actions done before the failed action, there is no rollback.
+type Handler interface {
+	Handle(sdkTypes.Context, sdkTypes.Event) []sdkTypes.Action
+}
+
+var (
+	// RegisteredHandler is the user registered handler set by sdk.Handle()
+	RegisteredHandler Handler
+)

--- a/pkg/sdk/informer/sync.go
+++ b/pkg/sdk/informer/sync.go
@@ -1,6 +1,7 @@
 package informer
 
 import (
+	sdkHandler "github.com/coreos/operator-sdk/pkg/sdk/handler"
 	sdkTypes "github.com/coreos/operator-sdk/pkg/sdk/types"
 
 	"github.com/sirupsen/logrus"
@@ -53,7 +54,8 @@ func (i *informer) sync(key string) error {
 		Deleted: !exists,
 	}
 
-	// TODO: call registered handler for the event
+	sdkCtx := sdkTypes.Context{Context: i.context}
+	actions := sdkHandler.RegisteredHandler.Handle(sdkCtx, event)
 	// TODO: Add option to prevent multiple informers from invoking Handle() concurrently?
 
 	// TODO: process all actions for this event

--- a/pkg/sdk/types/types.go
+++ b/pkg/sdk/types/types.go
@@ -24,3 +24,12 @@ type Event struct {
 type Context struct {
 	Context context.Context
 }
+
+// FuncType defines the type of the function of an Action.
+type FuncType string
+
+// Action defines what Func(tion) to apply on the given Object.
+type Action struct {
+	Object Object
+	Func   FuncType
+}


### PR DESCRIPTION
Added the sdk.Handle() API and the related `Action` type definition.
The informer now invokes the handler.Handle() for an Event to get its Actions.