### PR TITLE
commands/operator-sdk: change defintion of operator-sdk new

### DIFF
--- a/commands/operator-sdk/cmd/new.go
+++ b/commands/operator-sdk/cmd/new.go
@@ -8,20 +8,20 @@ import (
 
 // newCmd represents the new command
 var newCmd = &cobra.Command{
-	Use:   "new [options] <project-name>",
+	Use:   "new <project-name> [required-flags]",
 	Short: "Creates a new operator application",
 	Long: `The operator-sdk new command creates a new operator application and 
 	generates a default directory layout based on the input <project-name>. 
 
-	If none of options are specified, the operator-sdk defaults 
-	the Kubernetes api group to play.example.com/v1 
-	and the Kubernetes resource kind to PlayService.
+	<project-name> is the project name of the new operator. (e.g app-operator)
+
+	--api-group and --kind are required flags to generate the new operator application.
 
 	For example,
-	$ mkdir $GOPATH/src/github.com/example.com/play
-	$ cd $GOPATH/src/github.com/example.com/play
-	$ operator-sdk new play
-	generates a skeletal play application in $GOPATH/src/github.com/example.com/play.
+	$ mkdir $GOPATH/src/github.com/example.com/
+	$ cd $GOPATH/src/github.com/example.com/
+	$ operator-sdk new app-operator --api-group=app.example.com --kind=AppService
+	generates a skeletal app-operator application in $GOPATH/src/github.com/example.com/app-operator.
 `,
 	Run: newFunc,
 }
@@ -33,13 +33,15 @@ var (
 
 func init() {
 	RootCmd.AddCommand(newCmd)
-	newCmd.Flags().StringVar(&apiGroup, "api-group", "play.example.com/v1", "Kubernetes API Group. e.g play.example.com/v1")
-	newCmd.Flags().StringVar(&kind, "kind", "PlayService", "Kubernetes Resource Kind. e.g PlayService")
+	newCmd.Flags().StringVar(&apiGroup, "api-group", "", "Kubernetes API Group and has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)")
+	newCmd.MarkFlagRequired("api-group")
+	newCmd.Flags().StringVar(&kind, "kind", "", "Kubernetes CustomResourceDefintion kind. (e.g AppService)")
+	newCmd.MarkFlagRequired("kind")
 }
 
 func newFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		ExitWithError(ExitBadArgs, fmt.Errorf("new command needs 1 arguments."))
+		ExitWithError(ExitBadArgs, fmt.Errorf("new command needs 1 argument."))
 	}
 	parse(args)
 	// TODO: add generation logic.


### PR DESCRIPTION
new now requires flags --api-group and --api-kind because providing defaults to those value are not useful; hence un-useful defaults shouldn't be defaults.