### PR TITLE
generator: pull dependency at last step of `new`

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -70,7 +70,15 @@ func (g *Generator) Render() error {
 	if err := g.renderPkg(); err != nil {
 		return err
 	}
-	return g.renderTmp()
+	if err := g.renderTmp(); err != nil {
+		return err
+	}
+	return g.pullDep()
+}
+
+func (g *Generator) pullDep() error {
+	// TODO: After we have setup scalffolding, pull dependencies: render Gopkg.toml, then `dep ensure`
+	return nil
 }
 
 func (g *Generator) renderCmd() error {


### PR DESCRIPTION
To simplify the workflow, we would also pull down the dependencies in `new` generator.

But there are two options to set up dep:

1. Render `Gopkg.toml` beforehand, since we know all the dependencies and can better control versions.
   Then do `dep ensure`.
2. Do `dep init`. This would rely on the tool to pick the versions and introduce unpredictability. It might be simpler and more generic if we don't know some dependencies beforehand.
   Then do `dep ensure`.

