### PR TITLE
pkg/generator: add auto-gen for tmp/build.sh

### DIFF
--- a/pkg/generator/build_tmpl.go
+++ b/pkg/generator/build_tmpl.go
@@ -1,0 +1,21 @@
+package generator
+
+const buildTmpl = `#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if ! which go > /dev/null; then
+	echo "golang needs to be installed"
+	exit 1
+fi
+
+BIN_DIR="$(pwd)/tmp/_output/bin"
+mkdir -p ${BIN_DIR}
+PROJECT_NAME="{{.ProjectName}}"
+REPO_PATH="{{.RepoPath}}"
+BUILD_PATH="${REPO_PATH}/cmd/${PROJECT_NAME}"
+echo "building "${PROJECT_NAME}"..."
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ${BIN_DIR}/${PROJECT_NAME} $BUILD_PATH
+`

--- a/pkg/generator/gen_build.go
+++ b/pkg/generator/gen_build.go
@@ -1,0 +1,29 @@
+package generator
+
+import (
+	"io"
+	"text/template"
+)
+
+// Build contains all the customized data needed to generate tmp/build.sh
+// for a new operator when pairing with buildTmpl template.
+type Build struct {
+	RepoPath    string
+	ProjectName string
+}
+
+// renderBuildFile generates the tmp/build.sh file given a repo path ("github.com/coreos/app-operator")
+// and projectName ("app-operator").
+func renderBuildFile(w io.Writer, repo, projectName string) error {
+	t := template.New("tmp/build.sh")
+	t, err := t.Parse(buildTmpl)
+	if err != nil {
+		return err
+	}
+
+	m := Build{
+		RepoPath:    repo,
+		ProjectName: projectName,
+	}
+	return t.Execute(w, m)
+}


### PR DESCRIPTION
This generates a build script that compiles this operator project into a binary. 
Also, we need to think about how to integrate this build script with operator-sdk build command and along with other potential scripts to make   `operator-sdk build $IMAGE` work.