### PR TITLE
*: fold build and codegen scripts generation into renderTmp()

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -24,12 +24,14 @@ const (
 	stubDir    = pkgDir + "/stub"
 
 	// files
-	main     = "main.go"
-	handler  = "handler.go"
-	doc      = "doc.go"
-	register = "register.go"
-	types    = "types.go"
-	build    = "build.sh"
+	main            = "main.go"
+	handler         = "handler.go"
+	doc             = "doc.go"
+	register        = "register.go"
+	types           = "types.go"
+	build           = "build.sh"
+	boilerplate     = "boilerplate.go.txt"
+	updateGenerated = "update-generated.sh"
 )
 
 type Generator struct {
@@ -128,11 +130,11 @@ func (g *Generator) renderTmp() error {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Join(g.projectName, codegenDir), defaultDirFileMode); err != nil {
+	cDir := filepath.Join(g.projectName, codegenDir)
+	if err := os.MkdirAll(cDir, defaultDirFileMode); err != nil {
 		return err
 	}
-	// TODO render files.
-	return nil
+	return renderCodegenFiles(cDir, g.repoPath, apiDirName(g.apiVersion), version(g.apiVersion), g.projectName)
 }
 
 func renderBuildFiles(buildDir, repoPath, projectName string) error {
@@ -141,6 +143,22 @@ func renderBuildFiles(buildDir, repoPath, projectName string) error {
 		return err
 	}
 	return ioutil.WriteFile(filepath.Join(buildDir, build), buf.Bytes(), defaultExecFileMode)
+}
+
+func renderCodegenFiles(codegenDir, repoPath, apiDirName, version, projectName string) error {
+	buf := &bytes.Buffer{}
+	if err := renderBoilerplateFile(buf, projectName); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(filepath.Join(codegenDir, boilerplate), buf.Bytes(), defaultFileMode); err != nil {
+		return err
+	}
+
+	buf = &bytes.Buffer{}
+	if err := renderUpdateGeneratedFile(buf, repoPath, apiDirName, version); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filepath.Join(codegenDir, updateGenerated), buf.Bytes(), defaultExecFileMode)
 }
 
 func (g *Generator) renderPkg() error {


### PR DESCRIPTION
this pr allows `operator-sdk new` to generate `tmp/build/build.sh` and `tmp/codegen/boilerplate.go.txt` and `tmp/codegen/update-generated.sh`
