### PR TITLE
pkg/generator: fix generated handler signature

### DIFF
--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -44,7 +44,7 @@ type Handler struct {
 	// Fill me
 }
 
-func (h *Handler) Handle(ctx types.Context, event types.Event) {
+func (h *Handler) Handle(ctx types.Context, event types.Event) []types.Action {
 	// Fill me
 }
 `

--- a/pkg/generator/handler_tmpl.go
+++ b/pkg/generator/handler_tmpl.go
@@ -11,7 +11,7 @@ type Handler struct {
 	// Fill me
 }
 
-func (h *Handler) Handle(ctx types.Context, event types.Event) {
+func (h *Handler) Handle(ctx types.Context, event types.Event) []types.Action {
 	// Fill me
 }
 `


### PR DESCRIPTION
stub.Hander() must return  []types.Action to comply with sdkType.Handler interface.

from build error:
```
cmd/app-operator/main.go:13:28: cannot use stub.Handler literal (type *stub.Handler) as type handler.Handler in argument to sdk.Handle:
	*stub.Handler does not implement handler.Handler (wrong type for Handle method)
		have Handle(types.Context, types.Event)
		want Handle(types.Context, types.Event) []types.Action
```