### PR TITLE
pkg/generator: add return nil in stub.Handler() tmpl

### DIFF
--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -46,6 +46,7 @@ type Handler struct {
 
 func (h *Handler) Handle(ctx types.Context, event types.Event) []types.Action {
 	// Fill me
+	return nil
 }
 `
 

--- a/pkg/generator/handler_tmpl.go
+++ b/pkg/generator/handler_tmpl.go
@@ -13,5 +13,6 @@ type Handler struct {
 
 func (h *Handler) Handle(ctx types.Context, event types.Event) []types.Action {
 	// Fill me
+	return nil
 }
 `


### PR DESCRIPTION
fix the build error:
```
building app-operator...
# github.com/coreos/app-operator/pkg/stub
pkg/stub/handler.go:13:1: missing return at end of function
```

add `return nil` in `stub.Handle()` 