### PR TITLE
*: fix formatting in api template

### DIFF
--- a/pkg/generator/api_tmpls.go
+++ b/pkg/generator/api_tmpls.go
@@ -50,7 +50,7 @@ import (
 type {{.Kind}}List struct {
 	metav1.TypeMeta ` + "`" + `json:",inline"` + "`\n" +
 	`	metav1.ListMeta ` + "`" + `json:"metadata"` + "`\n" +
-	`	Items           []{{.Kind}} ` + "`" + `json:"items"` + `
+	`	Items           []{{.Kind}} ` + "`" + `json:"items"` + "`" + `
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -59,7 +59,7 @@ type {{.Kind}} struct {
 	metav1.TypeMeta   ` + "`" + `json:",inline"` + "`\n" +
 	`	metav1.ObjectMeta ` + "`" + `json:"metadata"` + "`\n" +
 	`	Spec              {{.Kind}}Spec   ` + "`" + `json:"spec"` + "`\n" +
-	`	Status            {{.Kind}}Status ` + "`" + `json:"status,omitempty"` + `
+	`	Status            {{.Kind}}Status ` + "`" + `json:"status,omitempty"` + "`" + `
 }
 
 type {{.Kind}}Spec struct {

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -115,7 +115,7 @@ import (
 type PlayServiceList struct {
 	metav1.TypeMeta ` + "`" + `json:",inline"` + "`\n" +
 	`	metav1.ListMeta ` + "`" + `json:"metadata"` + "`\n" +
-	`	Items           []PlayService ` + "`" + `json:"items"` + `
+	`	Items           []PlayService ` + "`" + `json:"items"` + "`" + `
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -124,7 +124,7 @@ type PlayService struct {
 	metav1.TypeMeta   ` + "`" + `json:",inline"` + "`\n" +
 	`	metav1.ObjectMeta ` + "`" + `json:"metadata"` + "`\n" +
 	`	Spec              PlayServiceSpec   ` + "`" + `json:"spec"` + "`\n" +
-	`	Status            PlayServiceStatus ` + "`" + `json:"status,omitempty"` + `
+	`	Status            PlayServiceStatus ` + "`" + `json:"status,omitempty"` + "`" + `
 }
 
 type PlayServiceSpec struct {


### PR DESCRIPTION
The `pkg/apis/cache/v1alpha1/types.go` file is generated with an incorrect template. This PR adds the missing back ticks.
@fanminshi you can verify that the master branch template is incorrect.