### PR TITLE
sdk: change FuncType back to string

### DIFF
--- a/pkg/sdk/action/action.go
+++ b/pkg/sdk/action/action.go
@@ -14,8 +14,8 @@ import (
 
 const (
 	// Supported function types
-	KubeApplyFunc sdkTypes.FuncType = iota
-	KubeDeleteFunc
+	KubeApplyFunc  sdkTypes.FuncType = "kube-apply"
+	KubeDeleteFunc sdkTypes.FuncType = "kube-delete"
 )
 
 var (

--- a/pkg/sdk/types/types.go
+++ b/pkg/sdk/types/types.go
@@ -26,7 +26,7 @@ type Context struct {
 }
 
 // FuncType defines the type of the function of an Action.
-type FuncType int
+type FuncType string
 
 // KubeFunc is the function signature for supported kubernetes functions
 type KubeFunc func(Object) error


### PR DESCRIPTION
The API spec doc originally outlined `types.FuncType` as a string so reverting it back to that. 
The string generally makes it easier for the user to get more context about the function type. 
But if we want to change it back to int we can discuss first on the design doc.

/cc @hongchaodeng 