### PR TITLE
pkg/generator: fix path to boilerplate.go.txt in coden

### DIFF
--- a/pkg/generator/codegen_tmpls.go
+++ b/pkg/generator/codegen_tmpls.go
@@ -25,7 +25,7 @@ docker run --rm \
   "{{.RepoPath}}/pkg/generated" \
   "{{.RepoPath}}/pkg/apis" \
   "{{.APIDirName}}:{{.Version}}" \
-  --go-header-file "./hack/codegen/boilerplate.go.txt" \
+  --go-header-file "./tmp/codegen/boilerplate.go.txt" \
   $@
 .
 `

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -229,7 +229,7 @@ docker run --rm \
   "github.com/coreos/play/pkg/generated" \
   "github.com/coreos/play/pkg/apis" \
   "play:v1alpha1" \
-  --go-header-file "./hack/codegen/boilerplate.go.txt" \
+  --go-header-file "./tmp/codegen/boilerplate.go.txt" \
   $@
 .
 `


### PR DESCRIPTION
the update-generated.sh must use `./tmp/codegen/boilerplate.go.txt` instead of `./hack/codegen/boilerplate.go.txt` to do code-generation for custom resource.