### PR TITLE
pkg/generator: remove "." in updateGenerated tmpl

### DIFF
--- a/pkg/generator/codegen_tmpls.go
+++ b/pkg/generator/codegen_tmpls.go
@@ -27,5 +27,4 @@ docker run --rm \
   "{{.APIDirName}}:{{.Version}}" \
   --go-header-file "./tmp/codegen/boilerplate.go.txt" \
   $@
-.
 `

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -231,7 +231,6 @@ docker run --rm \
   "play:v1alpha1" \
   --go-header-file "./tmp/codegen/boilerplate.go.txt" \
   $@
-.
 `
 
 func TestCodeGen(t *testing.T) {


### PR DESCRIPTION
This should fix the "line 21: .: filename argument required .: usage: . filename [arguments]" when running update-generated.sh

