### PR TITLE
*: use codec to decode json to runtime object

### DIFF
--- a/pkg/generator/api_tmpls.go
+++ b/pkg/generator/api_tmpls.go
@@ -10,6 +10,8 @@ package {{.Version}}
 const apiRegisterTmpl = `package {{.Version}}
 
 import (
+	sdkK8sutil "github.com/coreos/operator-sdk/pkg/util/k8sutil"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -26,6 +28,10 @@ var (
 	// SchemeGroupVersion is the group version used to register these objects.
 	SchemeGroupVersion = schema.GroupVersion{Group: groupName, Version: version}
 )
+
+func init() {
+	sdkK8sutil.AddToSDKScheme(AddToScheme)
+}
 
 // addKnownTypes adds the set of types defined in this package to the supplied scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -68,6 +68,8 @@ func TestGenHandler(t *testing.T) {
 const registerExp = `package v1alpha1
 
 import (
+	sdkK8sutil "github.com/coreos/operator-sdk/pkg/util/k8sutil"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -84,6 +86,10 @@ var (
 	// SchemeGroupVersion is the group version used to register these objects.
 	SchemeGroupVersion = schema.GroupVersion{Group: groupName, Version: version}
 )
+
+func init() {
+	sdkK8sutil.AddToSDKScheme(AddToScheme)
+}
 
 // addKnownTypes adds the set of types defined in this package to the supplied scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {

--- a/pkg/sdk/informer/informer.go
+++ b/pkg/sdk/informer/informer.go
@@ -70,6 +70,7 @@ func (i *informer) Run(ctx context.Context) {
 	for n := 0; n < numWorkers; n++ {
 		go wait.Until(i.runWorker, time.Second, ctx.Done())
 	}
+	<-ctx.Done()
 	logrus.Infof("stopping %s controller", i.resourcePluralName)
 }
 

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -2,19 +2,55 @@ package k8sutil
 
 import (
 	"encoding/json"
+	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	cgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
+
+var (
+	// scheme tracks the type registry for the sdk
+	// This scheme is used to decode json data into the correct Go type based on the object's GVK
+	// All types that the operator watches must be added to this scheme
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+)
+
+func init() {
+	// Add the standard kubernetes [GVK:Types] type registry
+	// e.g (v1,Pods):&v1.Pod{}
+	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	cgoscheme.AddToScheme(scheme)
+}
+
+func decoder(gv schema.GroupVersion) runtime.Decoder {
+	codec := codecs.UniversalDecoder(gv)
+	return codec
+}
+
+type addToSchemeFunc func(*runtime.Scheme) error
+
+// AddToSDKScheme allows CRDs to register their types with the sdk scheme
+func AddToSDKScheme(addToScheme addToSchemeFunc) {
+	addToScheme(scheme)
+}
 
 // RuntimeObjectFromUnstructured converts an unstructured to a runtime object
 func RuntimeObjectFromUnstructured(u *unstructured.Unstructured) runtime.Object {
-	b, err := json.Marshal(u.Object)
+	gvk := u.GroupVersionKind()
+	decoder := decoder(gvk.GroupVersion())
+
+	b, err := u.MarshalJSON()
 	if err != nil {
 		panic(err)
 	}
-	var ro runtime.Object
-	if err := json.Unmarshal(b, ro); err != nil {
+	ro, _, err := decoder.Decode(b, &gvk, nil)
+	if err != nil {
+		err = fmt.Errorf("failed to decode json data with gvk(%v): %v", gvk.String(), err)
 		panic(err)
 	}
 	return ro


### PR DESCRIPTION
Added a scheme and a codec to the SDK. The codec is used to decode json data into a `runtime.Object` with the correct underlying Go type, e.g `Pod{}` or `Memcached{}` .

For the codec to correctly decode all expected object types, the sdk scheme must have all the necessary types added to it.
- The standard k8s types like `v1.Pod{} ` are added using client-go's existing scheme.
- For CRDs generated in a project by the `operator-sdk new` an `init()` function is added to call `AddToSDKScheme()` which adds the CRD's scheme to the SDK's scheme.

Also included a fix for `informer.Run()` to be blocking.

**Note:**
This only allows the sdk to decode CR types added by the user in his project e.g `Memcached`.
Other CR types like `EtcdCluster` or `VaultService` that are already registered at the API server but were not generated by the SDK will not be decoded since their scheme is not registered with the SDK.

/cc @hongchaodeng @fanminshi 