### PR TITLE
generator: remove commercial license from generated code

### DIFF
--- a/pkg/generator/codegen_tmpls.go
+++ b/pkg/generator/codegen_tmpls.go
@@ -14,11 +14,7 @@
 
 package generator
 
-const boilerplateTmpl = `/*
-Copyright YEAR The {{.ProjectName}} Authors
-
-Commercial software license.
-*/
+const boilerplateTmpl = `
 `
 
 const updateGeneratedTmpl = `#!/usr/bin/env bash

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -234,11 +234,7 @@ func TestGenBuild(t *testing.T) {
 	}
 }
 
-const boilerplateExp = `/*
-Copyright YEAR The play Authors
-
-Commercial software license.
-*/
+const boilerplateExp = `
 `
 
 const updateGeneratedExp = `#!/usr/bin/env bash


### PR DESCRIPTION
The command `operator-sdk generate k8s` should not put the commercial license header for generated code.

/cc @fanminshi 