### PR TITLE
pkg/generator: only generate deepcopy

### DIFF
--- a/pkg/generator/codegen_tmpls.go
+++ b/pkg/generator/codegen_tmpls.go
@@ -31,7 +31,7 @@ docker run --rm \
   -w "$DOCKER_REPO_ROOT" \
   "$IMAGE" \
   "/go/src/k8s.io/code-generator/generate-groups.sh"  \
-  "all" \
+  "deepcopy" \
   "{{.RepoPath}}/pkg/generated" \
   "{{.RepoPath}}/pkg/apis" \
   "{{.APIDirName}}:{{.Version}}" \

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -251,7 +251,7 @@ docker run --rm \
   -w "$DOCKER_REPO_ROOT" \
   "$IMAGE" \
   "/go/src/k8s.io/code-generator/generate-groups.sh"  \
-  "all" \
+  "deepcopy" \
   "github.com/coreos/play/pkg/generated" \
   "github.com/coreos/play/pkg/apis" \
   "play:v1alpha1" \


### PR DESCRIPTION
change the auto-gen script to only generate the deepcopy files for a operator project. 