### PR TITLE
bom: remove unlicense for operator-sdk

### DIFF
--- a/bill-of-materials.json
+++ b/bill-of-materials.json
@@ -23,10 +23,6 @@
 			{
 				"type": "Apache License 2.0",
 				"confidence": 1
-			},
-			{
-				"type": "The Unlicense",
-				"confidence": 0.31413612565445026
 			}
 		]
 	},


### PR DESCRIPTION
the `"type": "The Unlicense"` was generated because of there was a `license.rb` in the root folder. Once I removed it, the `Unlicense` type went away. Note that `license.rb` was there because I used it to generate copyright-header and forgot to remove it when I ran the `license-bill-of-materials` for operator-sdk.