### PR TITLE
util: add UnstructuredIntoRuntimeObject() in k8sutil.go

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -82,3 +82,19 @@ func UnstructuredFromRuntimeObject(ro runtime.Object) *unstructured.Unstructured
 	}
 	return &u
 }
+
+// UnstructuredIntoRuntimeObject unmarshalls an unstructured into a given runtime object
+func UnstructuredIntoRuntimeObject(u *unstructured.Unstructured, into runtime.Object) error {
+	gvk := u.GroupVersionKind()
+	decoder := decoder(gvk.GroupVersion())
+
+	b, err := u.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	_, _, err = decoder.Decode(b, &gvk, into)
+	if err != nil {
+		return fmt.Errorf("failed to decode json data with gvk(%v): %v", gvk.String(), err)
+	}
+	return nil
+}


### PR DESCRIPTION
The Get, Create, Update, and Patch methods of the kubernetes dynamic client `ResourceInterface` returns `unstructured.Unstructured` object. The Query APIs (Get) and Action APIs(Create) needs to unmarshalls this `unstructured.Unstructured` object into a pass-in argument `into sdkTypes.Object` so that user can access the content of the retrieved object.

`UnstructuredIntoRuntimeObject()` performs the above unmarshmaling.

cc/ @hasbro17 