### PR TITLE
pkg/generator: use apiVersion apps/v1 in deploy_tmpl.go

### DIFF
--- a/pkg/generator/deploy_tmpl.go
+++ b/pkg/generator/deploy_tmpl.go
@@ -28,12 +28,15 @@ spec:
   scope: Namespaced
   version: {{.Version}}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{.ProjectName}}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: {{.ProjectName}}
   template:
     metadata:
       labels:

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -340,12 +340,15 @@ spec:
   scope: Namespaced
   version: v1alpha1
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-operator
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: app-operator
   template:
     metadata:
       labels:


### PR DESCRIPTION
fixes https://github.com/coreos/operator-sdk/issues/125

cc/ @hasbro17 