### PR TITLE
*: implement List and add necessary pieces

### DIFF
--- a/pkg/sdk/query/op.go
+++ b/pkg/sdk/query/op.go
@@ -56,6 +56,12 @@ type ListOp struct {
 	metaListOptions *metav1.ListOptions
 }
 
+func NewListOp() *ListOp {
+	op := &ListOp{}
+	op.setDefaults()
+	return op
+}
+
 // ListOption configures ListOp.
 type ListOption func(*ListOp)
 

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -101,6 +101,21 @@ func UnstructuredIntoRuntimeObject(u *unstructured.Unstructured, into runtime.Ob
 	return nil
 }
 
+// RuntimeObjectIntoRuntimeObject unmarshalls an runtime.Object into a given runtime object
+func RuntimeObjectIntoRuntimeObject(from runtime.Object, into runtime.Object) error {
+	b, err := json.Marshal(from)
+	if err != nil {
+		return err
+	}
+	gvk := from.GetObjectKind().GroupVersionKind()
+	decoder := decoder(gvk.GroupVersion())
+	_, _, err = decoder.Decode(b, &gvk, into)
+	if err != nil {
+		return fmt.Errorf("failed to decode json data with gvk(%v): %v", gvk.String(), err)
+	}
+	return nil
+}
+
 // GetNameAndNamespace extracts the name and namespace from the given runtime.Object
 // and returns a error if any of those is missing.
 func GetNameAndNamespace(object runtime.Object) (string, string, error) {


### PR DESCRIPTION
add `NewListOp()` factory function to create a listOp
add `RuntimeObjectIntoRuntimeObject()` which takes in `runtime.Object` and unmarshal its content into another `runtime.Object` of the same type.
Implement `List` that allows user to to query a list of objects.