### PR TITLE
*: add resyncPeriod arg to Watch

### DIFF
--- a/doc/milestone/user_guide.md
+++ b/doc/milestone/user_guide.md
@@ -51,7 +51,7 @@ By default, the memcached-operator watches `Memcached` resource events as shown 
 
 ```Go
 func main() {
-  sdk.Watch("cache.example.com/v1alpha1", "Memcached", "default")
+  sdk.Watch("cache.example.com/v1alpha1", "Memcached", "default", 5)
   sdk.Handle(stub.NewHandler())
   sdk.Run(context.TODO())
 }

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -50,7 +50,7 @@ func printVersion() {
 
 func main() {
 	printVersion()
-	sdk.Watch("app.example.com/v1alpha1", "App", "default")
+	sdk.Watch("app.example.com/v1alpha1", "App", "default", 5)
 	sdk.Handle(stub.NewHandler())
 	sdk.Run(context.TODO())
 }

--- a/pkg/generator/main_tmpl.go
+++ b/pkg/generator/main_tmpl.go
@@ -36,7 +36,7 @@ func printVersion() {
 
 func main() {
 	printVersion()
-	sdk.Watch("{{.APIVersion}}", "{{.Kind}}", "default")
+	sdk.Watch("{{.APIVersion}}", "{{.Kind}}", "default", 5)
 	sdk.Handle(stub.NewHandler())
 	sdk.Run(context.TODO())
 }

--- a/pkg/sdk/api.go
+++ b/pkg/sdk/api.go
@@ -35,17 +35,19 @@ var (
 //   - Pods have Group "Core" and Version "v1" giving the APIVersion "v1"
 //   - The custom resource Memcached might have Group "cache.example.com" and Version "v1alpha1" giving the APIVersion "cache.example.com/v1alpha1"
 // kind is the Kind of the resource, e.g "Pod" for pods
+// resyncPeriod is the time period in seconds for how often an event with the latest resource version will be sent to the handler, even if there is no change.
+//   - 0 means no periodic events will be sent
 // Consult the API reference for the Group, Version and Kind of a resource: https://kubernetes.io/docs/reference/
 // namespace is the Namespace to watch for the resource
 // TODO: support opts for specifying label selector
-func Watch(apiVersion, kind, namespace string) {
+func Watch(apiVersion, kind, namespace string, resyncPeriod int) {
 	resourceClient, resourcePluralName, err := k8sclient.GetResourceClient(apiVersion, kind, namespace)
 	// TODO: Better error handling, e.g retry
 	if err != nil {
 		logrus.Errorf("failed to get resource client for (apiVersion:%s, kind:%s, ns:%s): %v", apiVersion, kind, namespace, err)
 		panic(err)
 	}
-	informer := sdkInformer.New(resourcePluralName, namespace, resourceClient)
+	informer := sdkInformer.New(resourcePluralName, namespace, resourceClient, resyncPeriod)
 	informers = append(informers, informer)
 }
 

--- a/pkg/sdk/informer/informer.go
+++ b/pkg/sdk/informer/informer.go
@@ -41,15 +41,16 @@ type informer struct {
 	context             context.Context
 }
 
-func New(resourcePluralName, namespace string, resourceClient dynamic.ResourceInterface) Informer {
+func New(resourcePluralName, namespace string, resourceClient dynamic.ResourceInterface, resyncPeriod int) Informer {
 	i := &informer{
 		resourcePluralName: resourcePluralName,
 		queue:              workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), resourcePluralName),
 		namespace:          namespace,
 	}
 
+	resyncDuration := time.Duration(resyncPeriod) * time.Second
 	i.sharedIndexInformer = cache.NewSharedIndexInformer(
-		newListWatcherFromResourceClient(resourceClient), &unstructured.Unstructured{}, 0, cache.Indexers{},
+		newListWatcherFromResourceClient(resourceClient), &unstructured.Unstructured{}, resyncDuration, cache.Indexers{},
 	)
 	i.sharedIndexInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    i.handleAddResourceEvent,


### PR DESCRIPTION
ref: #141

Added a resyncPeriod argument to Watch() to allow configuring the resync period for the informer.
This should be an explicit argument and not an option since the default value of 0 or no periodic resyncs can be ambiguous if not set by the user explicitly.
 
As mentioned in the issue, the periodic resync is needed even by a simple operator that needs to periodically refresh the CR status, and is not expected to start a separate go-routine per CR to do that.