### PR TITLE
informer: save deleted object and pass delete event to handler

### DIFF
--- a/example/memcached-operator/handler.go.tmpl
+++ b/example/memcached-operator/handler.go.tmpl
@@ -29,6 +29,12 @@ func (h *Handler) Handle(ctx types.Context, event types.Event) error {
 	case *v1alpha1.Memcached:
 		memcached := o
 
+		// Ignore the delete event since the garbage collector will clean up all secondary resources for the CR
+		// All secondary resources must have the CR set as their OwnerReference for this to be the case
+		if event.Deleted {
+			return nil
+		}
+
 		// Create the deployment if it doesn't exist
 		dep := deploymentForMemcached(memcached)
 		err := action.Create(dep)


### PR DESCRIPTION
ref: #173 

This fixes the expected behavior for the SDK Event type by correctly recording a delete event as indicated by the Event definition.
https://github.com/coreos/operator-sdk/blob/master/pkg/sdk/types/types.go#L27-L33
```Go
// Event is triggered when some change has happened on the watched resources.
// If created or updated, Object would be the current state and Deleted=false.
// If deleted, Object would be the last known state and Deleted=true.
type Event struct {
	Object  Object
	Deleted bool
}
```

/cc @fanminshi 

