### PR TITLE
new: add -v to dep ensure and output to terminal

### DIFF
--- a/commands/operator-sdk/cmd/new.go
+++ b/commands/operator-sdk/cmd/new.go
@@ -140,11 +140,13 @@ func verifyFlags() {
 
 func pullDep() {
 	fmt.Fprintln(os.Stdout, "Run dep ensure ...")
-	dc := exec.Command(dep, ensureCmd)
+	dc := exec.Command(dep, ensureCmd, "-v")
 	dc.Dir = filepath.Join(mustGetwd(), projectName)
-	o, err := dc.CombinedOutput()
+	dc.Stdout = os.Stdout
+	dc.Stderr = os.Stderr
+	err := dc.Run()
 	if err != nil {
-		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to ensure dependencies: (%v)", string(o)))
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to ensure dependencies: %v", err))
 	}
 	fmt.Fprintln(os.Stdout, "Run dep ensure done")
 }


### PR DESCRIPTION
Fix for https://github.com/coreos/operator-sdk/issues/164

This should also help showing when dep is stuck on something like a password prompt.

cc @hasbro17 @fanminshi 