### PR TITLE
generator: restrict default RBAC rules

### DIFF
--- a/pkg/generator/deploy_tmpl.go
+++ b/pkg/generator/deploy_tmpl.go
@@ -56,9 +56,30 @@ metadata:
   name: {{.ProjectName}}
 rules:
 - apiGroups:
-  - "*"
+  - {{.GroupName}}
   resources:
   - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
   verbs:
   - "*"
 

--- a/pkg/generator/gen_deploy.go
+++ b/pkg/generator/gen_deploy.go
@@ -66,17 +66,21 @@ func renderOperatorYaml(w io.Writer, kind, apiVersion, projectName, image string
 // when pairing with rbacYamlTmpl template.
 type RBACYaml struct {
 	ProjectName string
+	GroupName   string
 }
 
 // renderRBACYaml generates deploy/rbac.yaml.
-func renderRBACYaml(w io.Writer, projectName string) error {
+func renderRBACYaml(w io.Writer, projectName, groupName string) error {
 	t := template.New(rbacTmplName)
 	t, err := t.Parse(rbacYamlTmpl)
 	if err != nil {
 		return fmt.Errorf("failed to parse rbac yaml template: %v", err)
 	}
 
-	r := RBACYaml{ProjectName: projectName}
+	r := RBACYaml{
+		ProjectName: projectName,
+		GroupName:   groupName,
+	}
 	return t.Execute(w, r)
 }
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -163,9 +163,9 @@ func (g *Generator) renderDeploy() error {
 	return renderDeployFiles(dp, g.projectName, g.apiVersion, g.kind)
 }
 
-func renderRBAC(deployDir, projectName string) error {
+func renderRBAC(deployDir, projectName, groupName string) error {
 	buf := &bytes.Buffer{}
-	if err := renderRBACYaml(buf, projectName); err != nil {
+	if err := renderRBACYaml(buf, projectName, groupName); err != nil {
 		return err
 	}
 	return writeFileAndPrint(filepath.Join(deployDir, rbacYaml), buf.Bytes(), defaultFileMode)
@@ -173,7 +173,7 @@ func renderRBAC(deployDir, projectName string) error {
 
 func renderDeployFiles(deployDir, projectName, apiVersion, kind string) error {
 	buf := &bytes.Buffer{}
-	if err := renderRBACYaml(buf, projectName); err != nil {
+	if err := renderRBACYaml(buf, projectName, groupName(apiVersion)); err != nil {
 		return err
 	}
 	if err := writeFileAndPrint(filepath.Join(deployDir, rbacYaml), buf.Bytes(), defaultFileMode); err != nil {


### PR DESCRIPTION
ref: #165 
Restrict the default RBAC admin access rules.
Ideally the default rules should grant no privileges since the SDK does not know what resources an operator needs to access. Instead it would be expected that the user should update the RBAC manifest as needed by their operator.

However that means by default none of the operators(including our examples) would work out of the box.
So the current rules are an arbitrary middle ground to at least avoid giving admin access by default.

/cc @fanminshi 
