### PR TITLE
ci: add travis yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+go_import_path: github.com/operator-framework/operator-sdk
+
+go:
+- 1.10.1
+
+before_install:
+- go get -u github.com/golang/dep/cmd/dep
+- dep ensure
+
+install: 
+- go get -t -d ./...
+
+script:
+- go test ./...


### PR DESCRIPTION
This pr adds the initial travis manifest that allows a new PR to trigger `go test ./...`.
The manifest file should be changed to run tests and build inside an container.

cc/ @hasbro17 @spahl @Verolop 