### PR TITLE
add privileged flag for quick fix

### DIFF
--- a/pkg/generator/codegen_tmpls.go
+++ b/pkg/generator/codegen_tmpls.go
@@ -29,6 +29,7 @@ IMAGE=${IMAGE:-"gcr.io/coreos-k8s-scale-testing/codegen:1.9.3"}
 docker run --rm \
   -v "$PWD":"$DOCKER_REPO_ROOT" \
   -w "$DOCKER_REPO_ROOT" \
+  --privileged \
   "$IMAGE" \
   "/go/src/k8s.io/code-generator/generate-groups.sh"  \
   "deepcopy" \


### PR DESCRIPTION
ref: #213 
This makes code generation work for non-privileged golang env. 
Its a quick fix, and should be dealt either with changing generation image or any other way.