### PR TITLE
Rename alm to olm

### DIFF
--- a/commands/operator-sdk/cmd/generate.go
+++ b/commands/operator-sdk/cmd/generate.go
@@ -28,6 +28,6 @@ func NewGenerateCmd() *cobra.Command {
 `,
 	}
 	cmd.AddCommand(generate.NewGenerateK8SCmd())
-	cmd.AddCommand(generate.NewGenerateAlmCatalogCmd())
+	cmd.AddCommand(generate.NewGenerateOlmCatalogCmd())
 	return cmd
 }

--- a/commands/operator-sdk/cmd/generate/olm_catalog.go
+++ b/commands/operator-sdk/cmd/generate/olm_catalog.go
@@ -36,39 +36,39 @@ var (
 	version string
 )
 
-func NewGenerateAlmCatalogCmd() *cobra.Command {
-	almCatalogCmd := &cobra.Command{
-		Use:   "alm-catalog",
-		Short: "Generates ALM Catalog manifests",
-		Long: `alm-catalog generator generates the following ALM Catalog manifests needed to create a catalog entry in ALM:
-- Cluster Service Version: deploy/alm-catalog/csv.yaml
-- Package: deploy/alm-catalog/package.yaml
-- Custom Resource Definition: deploy/alm-catalog/crd.yaml
+func NewGenerateOlmCatalogCmd() *cobra.Command {
+	olmCatalogCmd := &cobra.Command{
+		Use:   "olm-catalog",
+		Short: "Generates OLM Catalog manifests",
+		Long: `olm-catalog generator generates the following OLM Catalog manifests needed to create a catalog entry in OLM:
+- Cluster Service Version: deploy/olm-catalog/csv.yaml
+- Package: deploy/olm-catalog/package.yaml
+- Custom Resource Definition: deploy/olm-catalog/crd.yaml
 
 The following flags are required:
 --image: The container image name to set in the CSV to deploy the operator
 --version: The version of the current CSV
 
 For example:
-	$ operator-sdk generate alm-catalog --image=quay.io/example/operator:v0.0.1 --version=0.0.1
+	$ operator-sdk generate olm-catalog --image=quay.io/example/operator:v0.0.1 --version=0.0.1
 `,
-		Run: almCatalogFunc,
+		Run: olmCatalogFunc,
 	}
-	almCatalogCmd.Flags().StringVar(&image, "image", "", "The container image name to set in the CSV to deploy the operator e.g: quay.io/example/operator:v0.0.1")
-	almCatalogCmd.MarkFlagRequired("image")
-	almCatalogCmd.Flags().StringVar(&version, "version", "", "The version of the current CSV e.g: 0.0.1")
-	almCatalogCmd.MarkFlagRequired("version")
+	olmCatalogCmd.Flags().StringVar(&image, "image", "", "The container image name to set in the CSV to deploy the operator e.g: quay.io/example/operator:v0.0.1")
+	olmCatalogCmd.MarkFlagRequired("image")
+	olmCatalogCmd.Flags().StringVar(&version, "version", "", "The version of the current CSV e.g: 0.0.1")
+	olmCatalogCmd.MarkFlagRequired("version")
 
-	return almCatalogCmd
+	return olmCatalogCmd
 }
 
-func almCatalogFunc(cmd *cobra.Command, args []string) {
+func olmCatalogFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 0 {
-		cmdError.ExitWithError(cmdError.ExitBadArgs, errors.New("alm-catalog command doesn't accept any arguments."))
+		cmdError.ExitWithError(cmdError.ExitBadArgs, errors.New("olm-catalog command doesn't accept any arguments."))
 	}
 	verifyFlags()
 
-	fmt.Fprintln(os.Stdout, "Generating ALM catalog manifests")
+	fmt.Fprintln(os.Stdout, "Generating OLM catalog manifests")
 
 	c := &generator.Config{}
 	fp, err := ioutil.ReadFile(configYaml)
@@ -79,9 +79,9 @@ func almCatalogFunc(cmd *cobra.Command, args []string) {
 		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to unmarshal config file %v: (%v)", configYaml, err))
 	}
 
-	// Generate ALM catalog manifests
-	if err = generator.RenderAlmCatalog(c, image, version); err != nil {
-		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to generate deploy/alm-catalog: (%v)", err))
+	// Generate OLM catalog manifests
+	if err = generator.RenderOlmCatalog(c, image, version); err != nil {
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to generate deploy/olm-catalog: (%v)", err))
 	}
 }
 

--- a/pkg/generator/gen_olm_catalog.go
+++ b/pkg/generator/gen_olm_catalog.go
@@ -27,14 +27,14 @@ const (
 	packageChannel = "alpha"
 )
 
-// CatalogPackageConfig contains the data needed to generate deploy/alm-catalog/package.yaml
+// CatalogPackageConfig contains the data needed to generate deploy/olm-catalog/package.yaml
 type CatalogPackageConfig struct {
 	PackageName string
 	ChannelName string
 	CurrentCSV  string
 }
 
-// renderCatalogPackage generates deploy/alm-catalog/package.yaml
+// renderCatalogPackage generates deploy/olm-catalog/package.yaml
 func renderCatalogPackage(w io.Writer, config *Config, catalogVersion string) error {
 	t := template.New(catalogPackageYaml)
 	t, err := t.Parse(catalogPackageTmpl)
@@ -51,7 +51,7 @@ func renderCatalogPackage(w io.Writer, config *Config, catalogVersion string) er
 	return t.Execute(w, cpConfig)
 }
 
-// CRDConfig contains the data needed to generate deploy/alm-catalog/crd.yaml
+// CRDConfig contains the data needed to generate deploy/olm-catalog/crd.yaml
 type CRDConfig struct {
 	Kind         string
 	KindSingular string
@@ -60,7 +60,7 @@ type CRDConfig struct {
 	Version      string
 }
 
-// renderCRD generates deploy/alm-catalog/crd.yaml
+// renderCRD generates deploy/olm-catalog/crd.yaml
 func renderCRD(w io.Writer, config *Config) error {
 	t := template.New(catalogCRDYaml)
 	t, err := t.Parse(crdTmpl)
@@ -79,7 +79,7 @@ func renderCRD(w io.Writer, config *Config) error {
 	return t.Execute(w, crdConfig)
 }
 
-// CSVConfig contains the data needed to generate deploy/alm-catalog/csv.yaml
+// CSVConfig contains the data needed to generate deploy/olm-catalog/csv.yaml
 type CSVConfig struct {
 	Kind           string
 	KindSingular   string
@@ -92,7 +92,7 @@ type CSVConfig struct {
 	CatalogVersion string
 }
 
-// renderCatalogCSV generates deploy/alm-catalog/csv.yaml
+// renderCatalogCSV generates deploy/olm-catalog/csv.yaml
 func renderCatalogCSV(w io.Writer, config *Config, image, catalogVersion string) error {
 	t := template.New(catalogCSVYaml)
 	t, err := t.Parse(catalogCSVTmpl)

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -30,7 +30,7 @@ const (
 	// dirs
 	cmdDir        = "cmd"
 	deployDir     = "deploy"
-	almCatalogDir = deployDir + "/alm-catalog"
+	olmCatalogDir = deployDir + "/olm-catalog"
 	configDir     = "config"
 	tmpDir        = "tmp"
 	buildDir      = tmpDir + "/build"
@@ -200,45 +200,45 @@ func RenderOperatorYaml(c *Config, image string) error {
 	return ioutil.WriteFile(operatorYaml, buf.Bytes(), defaultFileMode)
 }
 
-// RenderAlmCatalog generates catalog manifests "deploy/alm-catalog/*"
+// RenderOlmCatalog generates catalog manifests "deploy/olm-catalog/*"
 // The current working directory must be the project repository root
-func RenderAlmCatalog(c *Config, image, version string) error {
-	// mkdir deploy/alm-catalog
+func RenderOlmCatalog(c *Config, image, version string) error {
+	// mkdir deploy/olm-catalog
 	repoPath, err := os.Getwd()
 	if err != nil {
 		return err
 	}
-	almDir := filepath.Join(repoPath, almCatalogDir)
-	if err := os.MkdirAll(almDir, defaultDirFileMode); err != nil {
+	olmDir := filepath.Join(repoPath, olmCatalogDir)
+	if err := os.MkdirAll(olmDir, defaultDirFileMode); err != nil {
 		return err
 	}
 
-	// deploy/alm-catalog/package.yaml
+	// deploy/olm-catalog/package.yaml
 	buf := &bytes.Buffer{}
 	if err := renderCatalogPackage(buf, c, version); err != nil {
 		return err
 	}
-	path := filepath.Join(almDir, catalogPackageYaml)
+	path := filepath.Join(olmDir, catalogPackageYaml)
 	if err := ioutil.WriteFile(path, buf.Bytes(), defaultFileMode); err != nil {
 		return err
 	}
 
-	// deploy/alm-catalog/crd.yaml
+	// deploy/olm-catalog/crd.yaml
 	buf = &bytes.Buffer{}
 	if err := renderCRD(buf, c); err != nil {
 		return err
 	}
-	path = filepath.Join(almDir, catalogCRDYaml)
+	path = filepath.Join(olmDir, catalogCRDYaml)
 	if err := ioutil.WriteFile(path, buf.Bytes(), defaultFileMode); err != nil {
 		return err
 	}
 
-	// deploy/alm-catalog/csv.yaml
+	// deploy/olm-catalog/csv.yaml
 	buf = &bytes.Buffer{}
 	if err := renderCatalogCSV(buf, c, image, version); err != nil {
 		return err
 	}
-	path = filepath.Join(almDir, catalogCSVYaml)
+	path = filepath.Join(olmDir, catalogCSVYaml)
 	return ioutil.WriteFile(path, buf.Bytes(), defaultFileMode)
 }
 

--- a/pkg/generator/olm_catalog_tmpl.go
+++ b/pkg/generator/olm_catalog_tmpl.go
@@ -87,7 +87,7 @@ spec:
                 app: {{.ProjectName}}
             spec:
               containers:
-                - name: {{.ProjectName}}-alm-owned
+                - name: {{.ProjectName}}-olm-owned
                   image: {{.Image}}
                   command:
                   - {{.ProjectName}}
@@ -115,6 +115,6 @@ spec:
   version: {{.CatalogVersion}}
   displayName: {{.Kind}}
   labels:
-    alm-owner-enterprise-app: {{.ProjectName}}
-    alm-status-descriptors: {{.CSVName}}
+    olm-owner-enterprise-app: {{.ProjectName}}
+    olm-status-descriptors: {{.CSVName}}
 `


### PR DESCRIPTION
ALM is now OLM: https://github.com/operator-framework/operator-lifecycle-manager

This PR renames all references in the code.