### PR TITLE
operator-sdk/cmd: add up command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -126,6 +126,18 @@
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/howeyc/gopass"
+  packages = ["."]
+  revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
+
+[[projects]]
+  name = "github.com/imdario/mergo"
+  packages = ["."]
+  revision = "9d5f1277e9a8ed20c3684bda8fde67c05628518c"
+  version = "v0.3.4"
+
+[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
@@ -363,8 +375,12 @@
     "pkg/version",
     "rest",
     "rest/watch",
+    "tools/auth",
     "tools/cache",
+    "tools/clientcmd",
     "tools/clientcmd/api",
+    "tools/clientcmd/api/latest",
+    "tools/clientcmd/api/v1",
     "tools/metrics",
     "tools/pager",
     "tools/reference",
@@ -372,6 +388,7 @@
     "util/buffer",
     "util/cert",
     "util/flowcontrol",
+    "util/homedir",
     "util/integer",
     "util/workqueue"
   ]
@@ -387,6 +404,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "071affe4f34c92407f2f6145d0d0d61d4e730789fe4f2d3dcf8b23271fb48ee9"
+  inputs-digest = "c79bcf7324a24288d72ab4f475131f384721c685be4b8d555696d34efac6ed40"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/commands/operator-sdk/cmd/build.go
+++ b/commands/operator-sdk/cmd/build.go
@@ -16,15 +16,14 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
+	"github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/cmdutil"
 	cmdError "github.com/operator-framework/operator-sdk/commands/operator-sdk/error"
 	"github.com/operator-framework/operator-sdk/pkg/generator"
 
 	"github.com/spf13/cobra"
-	yaml "gopkg.in/yaml.v2"
 )
 
 func NewBuildCmd() *cobra.Command {
@@ -74,14 +73,7 @@ func buildFunc(cmd *cobra.Command, args []string) {
 	}
 	fmt.Fprintln(os.Stdout, string(o))
 
-	c := &generator.Config{}
-	fp, err := ioutil.ReadFile(configYaml)
-	if err != nil {
-		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to read config file %v: (%v)", configYaml, err))
-	}
-	if err = yaml.Unmarshal(fp, c); err != nil {
-		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to unmarshal config file %v: (%v)", configYaml, err))
-	}
+	c := cmdutil.GetConfig()
 	if err = generator.RenderOperatorYaml(c, image); err != nil {
 		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to generate deploy/operator.yaml: (%v)", err))
 	}

--- a/commands/operator-sdk/cmd/cmdutil/util.go
+++ b/commands/operator-sdk/cmd/cmdutil/util.go
@@ -1,0 +1,37 @@
+package cmdutil
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	cmdError "github.com/operator-framework/operator-sdk/commands/operator-sdk/error"
+	"github.com/operator-framework/operator-sdk/pkg/generator"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+const configYaml = "./config/config.yaml"
+
+// MustInProjectRoot checks if the current dir is the project root.
+func MustInProjectRoot() {
+	// if the current directory has the "./config/config.yaml" file, then it is safe to say
+	// we are at the project root.
+	_, err := os.Stat(configYaml)
+	if err != nil && os.IsNotExist(err) {
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("must in project root dir: %v", err))
+	}
+}
+
+// GetConfig gets the values from ./config/config.yaml and parses them into a Config struct.
+func GetConfig() *generator.Config {
+	c := &generator.Config{}
+	fp, err := ioutil.ReadFile(configYaml)
+	if err != nil {
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to read config file %v: (%v)", configYaml, err))
+	}
+	if err = yaml.Unmarshal(fp, c); err != nil {
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to unmarshal config file %v: (%v)", configYaml, err))
+	}
+	return c
+}

--- a/commands/operator-sdk/cmd/root.go
+++ b/commands/operator-sdk/cmd/root.go
@@ -25,6 +25,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(NewNewCmd())
 	cmd.AddCommand(NewBuildCmd())
 	cmd.AddCommand(NewGenerateCmd())
+	cmd.AddCommand(NewUpCmd())
 
 	return cmd
 }

--- a/commands/operator-sdk/cmd/up.go
+++ b/commands/operator-sdk/cmd/up.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/up"
+
+	"github.com/spf13/cobra"
+)
+
+func NewUpCmd() *cobra.Command {
+	upCmd := &cobra.Command{
+		Use:   "up",
+		Short: "Launches the operator",
+		Long: `The up command has subcommands that can launch the operator in various ways.
+`,
+	}
+
+	upCmd.AddCommand(up.NewLocalCmd())
+	return upCmd
+}

--- a/commands/operator-sdk/cmd/up/local.go
+++ b/commands/operator-sdk/cmd/up/local.go
@@ -1,0 +1,78 @@
+package up
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+
+	"github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/cmdutil"
+	cmdError "github.com/operator-framework/operator-sdk/commands/operator-sdk/error"
+	"github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
+
+	"github.com/spf13/cobra"
+)
+
+func NewLocalCmd() *cobra.Command {
+	upLocalCmd := &cobra.Command{
+		Use:   "local",
+		Short: "Launches the operator locally",
+		Long: `The operator-sdk up local command launches the operator on the local machine 
+by building the operator binary with the ability to access a 
+kubernetes cluster using a kubeconfig file.
+`,
+		Run: upLocalFunc,
+	}
+
+	upLocalCmd.Flags().StringVar(&kubeConfig, "kubeconfig", "", "The file path to kubernetes configuration file; defaults to $HOME/.kube/config")
+
+	return upLocalCmd
+}
+
+var (
+	kubeConfig string
+)
+
+const (
+	gocmd             = "go"
+	run               = "run"
+	cmd               = "cmd"
+	main              = "main.go"
+	defaultConfigPath = ".kube/config"
+)
+
+func upLocalFunc(cmd *cobra.Command, args []string) {
+	mustKubeConfig()
+	cmdutil.MustInProjectRoot()
+	c := cmdutil.GetConfig()
+	upLocal(c.ProjectName)
+}
+
+// mustKubeConfig checks if the kubeconfig file exists.
+func mustKubeConfig() {
+	// if kubeConfig is not specified, search for the default kubeconfig file under the $HOME/.kube/config.
+	if len(kubeConfig) == 0 {
+		usr, err := user.Current()
+		if err != nil {
+			cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to determine user's home dir: %v", err))
+		}
+		kubeConfig = filepath.Join(usr.HomeDir, defaultConfigPath)
+	}
+
+	_, err := os.Stat(kubeConfig)
+	if err != nil && os.IsNotExist(err) {
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to find the kubeconfig file (%v): %v", kubeConfig, err))
+	}
+}
+
+func upLocal(projectName string) {
+	dc := exec.Command(gocmd, run, filepath.Join(cmd, projectName, main))
+	dc.Stdout = os.Stdout
+	dc.Stderr = os.Stderr
+	dc.Env = append(os.Environ(), fmt.Sprintf("%v=%v", k8sutil.KubeConfigEnvVar, kubeConfig))
+	err := dc.Run()
+	if err != nil {
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to run operator locally: %v", err))
+	}
+}

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"os"
 
+	"github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -89,7 +90,7 @@ func apiResource(gvk schema.GroupVersionKind, restMapper *discovery.DeferredDisc
 func mustNewKubeClientAndConfig() (kubernetes.Interface, *rest.Config) {
 	var cfg *rest.Config
 	var err error
-	if os.Getenv("KUBERNETES_CONFIG") != "" {
+	if os.Getenv(KubeConfigEnvVar) != "" {
 		cfg, err = outOfClusterConfig()
 	} else {
 		cfg, err = inClusterConfig()
@@ -118,7 +119,7 @@ func inClusterConfig() (*rest.Config, error) {
 }
 
 func outOfClusterConfig() (*rest.Config, error) {
-	kubeconfig := os.Getenv("KUBERNETES_CONFIG")
+	kubeconfig := os.Getenv(k8sutil.KubeConfigEnvVar)
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	return config, err
 }

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -90,7 +91,7 @@ func apiResource(gvk schema.GroupVersionKind, restMapper *discovery.DeferredDisc
 func mustNewKubeClientAndConfig() (kubernetes.Interface, *rest.Config) {
 	var cfg *rest.Config
 	var err error
-	if os.Getenv(KubeConfigEnvVar) != "" {
+	if os.Getenv(k8sutil.KubeConfigEnvVar) != "" {
 		cfg, err = outOfClusterConfig()
 	} else {
 		cfg, err = inClusterConfig()

--- a/pkg/util/k8sutil/constants.go
+++ b/pkg/util/k8sutil/constants.go
@@ -1,0 +1,7 @@
+package k8sutil
+
+const (
+	// KubeConfigEnvVar defines the env variable KUBERNETES_CONFIG which
+	// contains the kubeconfig file path.
+	KubeConfigEnvVar = "KUBERNETES_CONFIG"
+)


### PR DESCRIPTION
This pr adds a new command call `up` and its subcommand `local`.

 When`operator-sdk up local` is called, the operator is run locally on developer's machine with the access to a kubernetes cluster via the `--kubeconfig` flag.

ref: https://github.com/operator-framework/operator-sdk/issues/142

cc/ @hasbro17 @spahl 