### PR TITLE
pkg/generator: Work in my namespace, not default

### DIFF
--- a/pkg/generator/deploy_tmpl.go
+++ b/pkg/generator/deploy_tmpl.go
@@ -49,6 +49,11 @@ spec:
           command:
           - {{.ProjectName}}
           imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
 `
 
 const rbacYamlTmpl = `kind: Role

--- a/pkg/generator/gen_deploy_test.go
+++ b/pkg/generator/gen_deploy_test.go
@@ -40,6 +40,11 @@ spec:
           command:
           - app-operator
           imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
 `
 
 const rbacYamlExp = `kind: Role

--- a/pkg/generator/gen_main.go
+++ b/pkg/generator/gen_main.go
@@ -23,6 +23,7 @@ import (
 const (
 	// sdkImport is the operator-sdk import path.
 	sdkImport     = "github.com/operator-framework/operator-sdk/pkg/sdk"
+	k8sutilImport = "github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 	versionImport = "github.com/operator-framework/operator-sdk/version"
 )
 
@@ -32,6 +33,7 @@ type Main struct {
 	// imports
 	OperatorSDKImport string
 	StubImport        string
+	K8sutilImport     string
 	SDKVersionImport  string
 
 	APIVersion string
@@ -49,6 +51,7 @@ func renderMainFile(w io.Writer, repo, apiVersion, kind string) error {
 	m := Main{
 		OperatorSDKImport: sdkImport,
 		StubImport:        filepath.Join(repo, stubDir),
+		K8sutilImport:     k8sutilImport,
 		SDKVersionImport:  versionImport,
 		APIVersion:        apiVersion,
 		Kind:              kind,

--- a/pkg/generator/handler_tmpl.go
+++ b/pkg/generator/handler_tmpl.go
@@ -61,8 +61,8 @@ func newbusyBoxPod(cr *{{.Version}}.{{.Kind}}) *v1.Pod {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "busy-box",
-			Namespace:    "default",
+			Name:      "busy-box",
+			Namespace: cr.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(cr, schema.GroupVersionKind{
 					Group:   {{.Version}}.SchemeGroupVersion.Group,

--- a/pkg/generator/main_tmpl.go
+++ b/pkg/generator/main_tmpl.go
@@ -23,6 +23,7 @@ import (
 
 	stub "{{.StubImport}}"
 	sdk "{{.OperatorSDKImport}}"
+	k8sutil "{{.K8sutilImport}}"
 	sdkVersion "{{.SDKVersionImport}}"
 
 	"github.com/sirupsen/logrus"
@@ -36,7 +37,16 @@ func printVersion() {
 
 func main() {
 	printVersion()
-	sdk.Watch("{{.APIVersion}}", "{{.Kind}}", "default", 5)
+
+	resource := "{{.APIVersion}}"
+	kind := "{{.Kind}}"
+	namespace, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		logrus.Fatalf("Failed to get watch namespace: %v", err)
+	}
+	resyncPeriod := 5
+	logrus.Infof("Watching %s, %s, %s, %d", resource, kind, namespace, resyncPeriod)
+	sdk.Watch(resource, kind, namespace, resyncPeriod)
 	sdk.Handle(stub.NewHandler())
 	sdk.Run(context.TODO())
 }

--- a/pkg/util/k8sutil/constants.go
+++ b/pkg/util/k8sutil/constants.go
@@ -4,4 +4,8 @@ const (
 	// KubeConfigEnvVar defines the env variable KUBERNETES_CONFIG which
 	// contains the kubeconfig file path.
 	KubeConfigEnvVar = "KUBERNETES_CONFIG"
+
+	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
+	// which is the namespace that the pod is currently running in.
+	WatchNamespaceEnvVar = "WATCH_NAMESPACE"
 )

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -17,6 +17,7 @@ package k8sutil
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -133,4 +134,16 @@ func GetNameAndNamespace(object runtime.Object) (string, string, error) {
 
 func ObjectInfo(kind, name, namespace string) string {
 	return kind + ": " + namespace + "/" + name
+}
+
+// GetWatchNamespace returns the namespace the operator should be watching for changes
+func GetWatchNamespace() (string, error) {
+	ns, found := os.LookupEnv(WatchNamespaceEnvVar)
+	if !found {
+		return "", fmt.Errorf("%s must be set", WatchNamespaceEnvVar)
+	}
+	if len(ns) == 0 {
+		return "", fmt.Errorf("%s must not be empty", WatchNamespaceEnvVar)
+	}
+	return ns, nil
 }


### PR DESCRIPTION
This will make it, by default, watch for CRs in the same namespace as the
operator and it will create the busybox pods in that namespace as well.

Resolves #187