### PR TITLE
*: use master branch for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ First, checkout and install the operator-sdk CLI:
 
 ```sh
 $ cd $GOPATH/src/github.com/operator-framework/operator-sdk
-$ git checkout tags/v0.0.5
+$ git checkout master
 $ dep ensure
 $ go install github.com/operator-framework/operator-sdk/commands/operator-sdk
 ```
@@ -53,6 +53,7 @@ $ docker push quay.io/example/app-operator
 
 # Deploy the app-operator
 $ kubectl create -f deploy/rbac.yaml
+$ kubectl create -f deploy/crd.yaml
 $ kubectl create -f deploy/operator.yaml
 
 # By default, creating a custom resource (App) triggers the app-operator to deploy a busybox pod

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -20,7 +20,7 @@ Checkout the desired release tag and install the SDK CLI tool:
 
 ```sh
 $ cd $GOPATH/src/github.com/operator-framework/operator-sdk
-$ git checkout tags/v0.0.5
+$ git checkout master
 $ dep ensure
 $ go install github.com/operator-framework/operator-sdk/commands/operator-sdk
 ```
@@ -102,6 +102,7 @@ Deploy the memcached-operator:
 
 ```sh
 $ kubectl create -f deploy/rbac.yaml
+$ kubectl create -f deploy/crd.yaml
 $ kubectl create -f deploy/operator.yaml
 ```
 


### PR DESCRIPTION
The README and user-guide will now expect the SDK to be installed from the master branch for all commands to work as expected.