### PR TITLE
commands/opreator-sdk: command to autogenerate shell completions

### DIFF
--- a/commands/operator-sdk/cmd/completion.go
+++ b/commands/operator-sdk/cmd/completion.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Operator-SDK Authors
+// Copyright © 2018 The Operator-SDK Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,21 +17,15 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/operator-framework/operator-sdk/version"
+	"github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/completion"
 )
 
-func NewRootCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "operator-sdk",
-		Short:   "A sdk for building operator with ease",
-		Version: version.Version,
+func NewCompletionCmd() *cobra.Command {
+	completionCmd := &cobra.Command{
+		Use:   "completion",
+		Short: "Generators for shell completions",
 	}
-
-	cmd.AddCommand(NewNewCmd())
-	cmd.AddCommand(NewBuildCmd())
-	cmd.AddCommand(NewGenerateCmd())
-	cmd.AddCommand(NewUpCmd())
-	cmd.AddCommand(NewCompletionCmd())
-
-	return cmd
+	completionCmd.AddCommand(completion.NewZshCmd())
+	completionCmd.AddCommand(completion.NewBashCmd())
+	return completionCmd
 }

--- a/commands/operator-sdk/cmd/completion/bash.go
+++ b/commands/operator-sdk/cmd/completion/bash.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Operator-SDK Authors
+// Copyright © 2018 The Operator-SDK Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,26 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package completion
 
 import (
-	"github.com/spf13/cobra"
+	"os"
 
-	"github.com/operator-framework/operator-sdk/version"
+	"github.com/spf13/cobra"
 )
 
-func NewRootCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "operator-sdk",
-		Short:   "A sdk for building operator with ease",
-		Version: version.Version,
+func NewBashCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "bash",
+		Short: "Generate bash completions",
+		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
+			return cmd.Root().GenBashCompletion(os.Stdout)
+		},
 	}
-
-	cmd.AddCommand(NewNewCmd())
-	cmd.AddCommand(NewBuildCmd())
-	cmd.AddCommand(NewGenerateCmd())
-	cmd.AddCommand(NewUpCmd())
-	cmd.AddCommand(NewCompletionCmd())
-
-	return cmd
 }

--- a/commands/operator-sdk/cmd/completion/zsh.go
+++ b/commands/operator-sdk/cmd/completion/zsh.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Operator-SDK Authors
+// Copyright © 2018 The Operator-SDK Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,26 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package completion
 
 import (
-	"github.com/spf13/cobra"
+	"os"
 
-	"github.com/operator-framework/operator-sdk/version"
+	"github.com/spf13/cobra"
 )
 
-func NewRootCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "operator-sdk",
-		Short:   "A sdk for building operator with ease",
-		Version: version.Version,
+func NewZshCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "zsh",
+		Short: "Generate zsh completions",
+		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
+			return cmd.Root().GenZshCompletion(os.Stdout)
+		},
 	}
-
-	cmd.AddCommand(NewNewCmd())
-	cmd.AddCommand(NewBuildCmd())
-	cmd.AddCommand(NewGenerateCmd())
-	cmd.AddCommand(NewUpCmd())
-	cmd.AddCommand(NewCompletionCmd())
-
-	return cmd
 }


### PR DESCRIPTION
Bash completions can be set up in your shell by running:
```bash
. <(operator-sdk completion bash)
```

`operator-sdk completion zsh` will generate zsh completions too!