### PR TITLE
Return newly created informer after calling sdk.Watch()

### DIFF
--- a/pkg/sdk/api.go
+++ b/pkg/sdk/api.go
@@ -40,7 +40,7 @@ var (
 // Consult the API reference for the Group, Version and Kind of a resource: https://kubernetes.io/docs/reference/
 // namespace is the Namespace to watch for the resource
 // TODO: support opts for specifying label selector
-func Watch(apiVersion, kind, namespace string, resyncPeriod int) {
+func Watch(apiVersion, kind, namespace string, resyncPeriod int) Informer {
 	resourceClient, resourcePluralName, err := k8sclient.GetResourceClient(apiVersion, kind, namespace)
 	// TODO: Better error handling, e.g retry
 	if err != nil {
@@ -49,6 +49,7 @@ func Watch(apiVersion, kind, namespace string, resyncPeriod int) {
 	}
 	informer := sdkInformer.New(resourcePluralName, namespace, resourceClient, resyncPeriod)
 	informers = append(informers, informer)
+	return informer
 }
 
 // Handle registers the handler for all events.


### PR DESCRIPTION
sdk: Return the reference of the created shared informer of `sdk.Watch()` to be able to use the informers to access the watched resources via them.