### PR TITLE
pkg/generator: reorder dockerfile to reduce layer changes

### DIFF
--- a/pkg/generator/build_tmpls.go
+++ b/pkg/generator/build_tmpls.go
@@ -49,8 +49,8 @@ docker build -t "${IMAGE}" -f tmp/build/Dockerfile .
 
 const dockerFileTmpl = `FROM alpine:3.6
 
-ADD tmp/_output/bin/{{.ProjectName}} /usr/local/bin/{{.ProjectName}}
-
 RUN adduser -D {{.ProjectName}}
 USER {{.ProjectName}}
+
+ADD tmp/_output/bin/{{.ProjectName}} /usr/local/bin/{{.ProjectName}}
 `

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -262,10 +262,10 @@ GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ${BIN_DIR}/${PROJECT_NAME} $BU
 
 const dockerFileExp = `FROM alpine:3.6
 
-ADD tmp/_output/bin/app-operator /usr/local/bin/app-operator
-
 RUN adduser -D app-operator
 USER app-operator
+
+ADD tmp/_output/bin/app-operator /usr/local/bin/app-operator
 `
 
 func TestGenBuild(t *testing.T) {


### PR DESCRIPTION
Every time you rebuild the generated operator you are likely to get a new
binary. By doing the user operations after the binary ADD we have to redo
the user layers every time. If we do the user operations before the ADD
rebuilds only have a single new layer and re-use the original 3 layers