### PR TITLE
pkg/sdk: Add /debug and /metrics http endpoints

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,6 +14,12 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
@@ -166,6 +172,12 @@
   revision = "32fa128f234d041f196a9f3e0fea5ac9772c08e1"
 
 [[projects]]
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
@@ -176,6 +188,42 @@
   packages = ["."]
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
+
+[[projects]]
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/promhttp"
+  ]
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
+  revision = "d811d2e9bf898806ecfb6ef6296774b13ffc314c"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs"
+  ]
+  revision = "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
@@ -404,6 +452,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d5cc928bcf8f796babddedb13b1516b8d6fbc2f48d68546b712af753671673e2"
+  inputs-digest = "258254390be71f18d8a475c6af36aa0c76507f2560287356c5b5d3b793437762"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/generator/deploy_tmpl.go
+++ b/pkg/generator/deploy_tmpl.go
@@ -54,6 +54,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          ports:
+            - containerPort: 8080
+              name: metrics
 `
 
 const rbacYamlTmpl = `kind: Role

--- a/pkg/generator/gen_deploy_test.go
+++ b/pkg/generator/gen_deploy_test.go
@@ -45,6 +45,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          ports:
+            - containerPort: 8080
+              name: metrics
 `
 
 const rbacYamlExp = `kind: Role

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -41,6 +41,7 @@ func printVersion() {
 
 func main() {
 	printVersion()
+	sdk.RegisterMetrics()
 
 	resource := "app.example.com/v1alpha1"
 	kind := "AppService"

--- a/pkg/generator/main_tmpl.go
+++ b/pkg/generator/main_tmpl.go
@@ -37,6 +37,7 @@ func printVersion() {
 
 func main() {
 	printVersion()
+	sdk.RegisterMetrics()
 
 	resource := "{{.APIVersion}}"
 	kind := "{{.Kind}}"

--- a/pkg/sdk/metrics/metrics.go
+++ b/pkg/sdk/metrics/metrics.go
@@ -1,0 +1,12 @@
+package metrics
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func Register() error {
+	http.Handle("/metrics", promhttp.Handler())
+	return nil
+}

--- a/pkg/sdk/pprof/pprof.go
+++ b/pkg/sdk/pprof/pprof.go
@@ -1,0 +1,5 @@
+package pprof
+
+import (
+	_ "net/http/pprof"
+)


### PR DESCRIPTION
listen on :8080 and expose default prometheus metrics on /metrics and
pprof information on /debug/pprof