### PR TITLE
pkg/generator: use cobra to parse golang flags

### DIFF
--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -23,6 +23,9 @@ const mainExp = `package main
 
 import (
 	"context"
+	goflag "flag"
+	"os"
+	"path/filepath"
 	"runtime"
 
 	stub "github.com/example-inc/app-operator/pkg/stub"
@@ -31,6 +34,7 @@ import (
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 func printVersion() {
@@ -39,7 +43,7 @@ func printVersion() {
 	logrus.Infof("operator-sdk Version: %v", sdkVersion.Version)
 }
 
-func main() {
+func execute(_ *cobra.Command, _ []string) error {
 	printVersion()
 
 	resource := "app.example.com/v1alpha1"
@@ -53,6 +57,16 @@ func main() {
 	sdk.Watch(resource, kind, namespace, resyncPeriod)
 	sdk.Handle(stub.NewHandler())
 	sdk.Run(context.TODO())
+	return nil
+}
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:  filepath.Base(os.Args[0]),
+		RunE: execute,
+	}
+	rootCmd.Flags().AddGoFlagSet(goflag.CommandLine)
+	rootCmd.Execute()
 }
 `
 

--- a/pkg/generator/main_tmpl.go
+++ b/pkg/generator/main_tmpl.go
@@ -19,6 +19,9 @@ const mainTmpl = `package main
 
 import (
 	"context"
+	goflag "flag"
+	"os"
+	"path/filepath"
 	"runtime"
 
 	stub "{{.StubImport}}"
@@ -27,6 +30,7 @@ import (
 	sdkVersion "{{.SDKVersionImport}}"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 func printVersion() {
@@ -35,7 +39,7 @@ func printVersion() {
 	logrus.Infof("operator-sdk Version: %v", sdkVersion.Version)
 }
 
-func main() {
+func execute(_ *cobra.Command, _ []string) error {
 	printVersion()
 
 	resource := "{{.APIVersion}}"
@@ -49,5 +53,15 @@ func main() {
 	sdk.Watch(resource, kind, namespace, resyncPeriod)
 	sdk.Handle(stub.NewHandler())
 	sdk.Run(context.TODO())
+	return nil
+}
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:  filepath.Base(os.Args[0]),
+		RunE: execute,
+	}
+	rootCmd.Flags().AddGoFlagSet(goflag.CommandLine)
+	rootCmd.Execute()
 }
 `


### PR DESCRIPTION
We were not parsing the stg golang flag library flags on startup. This makes
glog (used by a lot of dependencies) complain on every log message:

ERROR: logging before flag.Parse: E0515 13:06:46.682939       1 reflector.go:205] github.com/[snip]

This switches the operator main() to use cobra and to parse the flag std lib.
Which silences these errors:

E0515 14:03:11.678472       1 reflector.go:205] github.com [snip]