### PR TITLE
pkg: remove custom Context type

### DIFF
--- a/example/memcached-operator/handler.go.tmpl
+++ b/example/memcached-operator/handler.go.tmpl
@@ -3,6 +3,7 @@ package stub
 import (
 	"fmt"
 	"reflect"
+	"context"
 
 	v1alpha1 "github.com/example-inc/memcached-operator/pkg/apis/cache/v1alpha1"
 
@@ -21,7 +22,7 @@ func NewHandler() sdk.Handler {
 type Handler struct {
 }
 
-func (h *Handler) Handle(ctx sdk.Context, event sdk.Event) error {
+func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 	switch o := event.Object.(type) {
 	case *v1alpha1.Memcached:
 		memcached := o

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -71,6 +71,8 @@ func TestGenMain(t *testing.T) {
 const handlerExp = `package stub
 
 import (
+	"context"
+
 	"github.com/example-inc/app-operator/pkg/apis/app/v1alpha1"
 
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
@@ -89,7 +91,7 @@ type Handler struct {
 	// Fill me
 }
 
-func (h *Handler) Handle(ctx sdk.Context, event sdk.Event) error {
+func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 	switch o := event.Object.(type) {
 	case *v1alpha1.AppService:
 		err := sdk.Create(newbusyBoxPod(o))

--- a/pkg/generator/handler_tmpl.go
+++ b/pkg/generator/handler_tmpl.go
@@ -18,6 +18,8 @@ package generator
 const handlerTmpl = `package stub
 
 import (
+	"context"
+
 	"{{.RepoPath}}/pkg/apis/{{.APIDirName}}/{{.Version}}"
 
 	"{{.OperatorSDKImport}}"
@@ -36,7 +38,7 @@ type Handler struct {
 	// Fill me
 }
 
-func (h *Handler) Handle(ctx sdk.Context, event sdk.Event) error {
+func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 	switch o := event.Object.(type) {
 	case *{{.Version}}.{{.Kind}}:
 		err := sdk.Create(newbusyBoxPod(o))

--- a/pkg/sdk/handler.go
+++ b/pkg/sdk/handler.go
@@ -14,11 +14,13 @@
 
 package sdk
 
+import "context"
+
 // Handler reacts to events and outputs actions.
 // If any intended action failed, the event would be re-triggered.
 // For actions done before the failed action, there is no rollback.
 type Handler interface {
-	Handle(Context, Event) error
+	Handle(context.Context, Event) error
 }
 
 var (

--- a/pkg/sdk/informer-sync.go
+++ b/pkg/sdk/informer-sync.go
@@ -80,9 +80,8 @@ func (i *informer) sync(key string) error {
 		Deleted: !exists,
 	}
 
-	sdkCtx := Context{Context: i.context}
 	// TODO: Add option to prevent multiple informers from invoking Handle() concurrently?
-	err = RegisteredHandler.Handle(sdkCtx, event)
+	err = RegisteredHandler.Handle(i.context, event)
 	if !exists && err == nil {
 		delete(i.deletedObjects, key)
 	}

--- a/pkg/sdk/types.go
+++ b/pkg/sdk/types.go
@@ -14,11 +14,7 @@
 
 package sdk
 
-import (
-	"context"
-
-	"k8s.io/apimachinery/pkg/runtime"
-)
+import "k8s.io/apimachinery/pkg/runtime"
 
 // Object is the Kubernetes runtime.Object interface expected
 // of all resources that the user can watch.
@@ -30,11 +26,4 @@ type Object runtime.Object
 type Event struct {
 	Object  Object
 	Deleted bool
-}
-
-// Context is the special context that is passed to the Handler.
-// It includes:
-// - Context: standard Go context that is used to pass cancellation signals and deadlines
-type Context struct {
-	Context context.Context
 }


### PR DESCRIPTION
Addressing #161 

This PR removes the custom Context type defined in `pkg/sdk/types.go`. Its better to use the default golang context type.