### PR TITLE
pkg/generator: Change test failure output format + TestGenTypes use const

### DIFF
--- a/pkg/generator/gen_api_register_test.go
+++ b/pkg/generator/gen_api_register_test.go
@@ -63,6 +63,6 @@ func TestGenRegister(t *testing.T) {
 		return
 	}
 	if registerExp != buf.String() {
-		t.Errorf("want %v, got %v", registerExp, buf.String())
+		t.Errorf(errorMessage, registerExp, buf.String())
 	}
 }

--- a/pkg/generator/gen_api_types_test.go
+++ b/pkg/generator/gen_api_types_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 )
 
-const typesExp = `package v1alpha1
+const typesExp = `package app.example.com/v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,36 +27,36 @@ import (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-type PlayServiceList struct {
+type AppServiceList struct {
 	metav1.TypeMeta ` + "`" + `json:",inline"` + "`\n" +
 	`	metav1.ListMeta ` + "`" + `json:"metadata"` + "`\n" +
-	`	Items           []PlayService ` + "`" + `json:"items"` + "`" + `
+	`	Items           []AppService ` + "`" + `json:"items"` + "`" + `
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-type PlayService struct {
+type AppService struct {
 	metav1.TypeMeta   ` + "`" + `json:",inline"` + "`\n" +
 	`	metav1.ObjectMeta ` + "`" + `json:"metadata"` + "`\n" +
-	`	Spec              PlayServiceSpec   ` + "`" + `json:"spec"` + "`\n" +
-	`	Status            PlayServiceStatus ` + "`" + `json:"status,omitempty"` + "`" + `
+	`	Spec              AppServiceSpec   ` + "`" + `json:"spec"` + "`\n" +
+	`	Status            AppServiceStatus ` + "`" + `json:"status,omitempty"` + "`" + `
 }
 
-type PlayServiceSpec struct {
+type AppServiceSpec struct {
 	// Fill me
 }
-type PlayServiceStatus struct {
+type AppServiceStatus struct {
 	// Fill me
 }
 `
 
 func TestGenTypes(t *testing.T) {
 	buf := &bytes.Buffer{}
-	if err := renderAPITypesFile(buf, "PlayService", "v1alpha1"); err != nil {
+	if err := renderAPITypesFile(buf, appKind, appAPIVersion); err != nil {
 		t.Error(err)
 		return
 	}
 	if typesExp != buf.String() {
-		t.Errorf("want %v, got %v", typesExp, buf.String())
+		t.Errorf(errorMessage, typesExp, buf.String())
 	}
 }

--- a/pkg/generator/gen_build_test.go
+++ b/pkg/generator/gen_build_test.go
@@ -54,7 +54,7 @@ func TestGenBuild(t *testing.T) {
 		return
 	}
 	if buildExp != buf.String() {
-		t.Errorf("want %v, got %v", buildExp, buf.String())
+		t.Errorf(errorMessage, buildExp, buf.String())
 	}
 
 	buf = &bytes.Buffer{}
@@ -63,7 +63,7 @@ func TestGenBuild(t *testing.T) {
 		return
 	}
 	if dockerBuildTmpl != buf.String() {
-		t.Errorf("want %v, got %v", dockerBuildTmpl, buf.String())
+		t.Errorf(errorMessage, dockerBuildTmpl, buf.String())
 	}
 
 	buf = &bytes.Buffer{}
@@ -72,6 +72,6 @@ func TestGenBuild(t *testing.T) {
 		return
 	}
 	if dockerFileExp != buf.String() {
-		t.Errorf("want %v, got %v", dockerFileExp, buf.String())
+		t.Errorf(errorMessage, dockerFileExp, buf.String())
 	}
 }

--- a/pkg/generator/gen_codegen_test.go
+++ b/pkg/generator/gen_codegen_test.go
@@ -51,7 +51,7 @@ func TestCodeGen(t *testing.T) {
 		return
 	}
 	if boilerplateExp != buf.String() {
-		t.Errorf("want %v, got %v", boilerplateExp, buf.String())
+		t.Errorf(errorMessage, boilerplateExp, buf.String())
 	}
 
 	buf = &bytes.Buffer{}
@@ -60,6 +60,6 @@ func TestCodeGen(t *testing.T) {
 		return
 	}
 	if updateGeneratedExp != buf.String() {
-		t.Errorf("want %v, got %v", updateGeneratedExp, buf.String())
+		t.Errorf(errorMessage, updateGeneratedExp, buf.String())
 	}
 }

--- a/pkg/generator/gen_config_test.go
+++ b/pkg/generator/gen_config_test.go
@@ -30,6 +30,6 @@ func TestGenConfig(t *testing.T) {
 		t.Error(err)
 	}
 	if configExp != buf.String() {
-		t.Errorf("want %v, got %v", configExp, buf.String())
+		t.Errorf(errorMessage, configExp, buf.String())
 	}
 }

--- a/pkg/generator/gen_deploy_test.go
+++ b/pkg/generator/gen_deploy_test.go
@@ -101,7 +101,7 @@ func TestGenDeploy(t *testing.T) {
 		t.Error(err)
 	}
 	if crdYamlExp != buf.String() {
-		t.Errorf("want %v, got %v", crdYamlExp, buf.String())
+		t.Errorf(errorMessage, crdYamlExp, buf.String())
 	}
 
 	buf = &bytes.Buffer{}
@@ -109,7 +109,7 @@ func TestGenDeploy(t *testing.T) {
 		t.Error(err)
 	}
 	if operatorYamlExp != buf.String() {
-		t.Errorf("want %v, got %v", operatorYamlExp, buf.String())
+		t.Errorf(errorMessage, operatorYamlExp, buf.String())
 	}
 
 	buf = &bytes.Buffer{}
@@ -117,6 +117,6 @@ func TestGenDeploy(t *testing.T) {
 		t.Error(err)
 	}
 	if rbacYamlExp != buf.String() {
-		t.Errorf("want %v, got %v", rbacYamlExp, buf.String())
+		t.Errorf(errorMessage, rbacYamlExp, buf.String())
 	}
 }

--- a/pkg/generator/gen_deps_test.go
+++ b/pkg/generator/gen_deps_test.go
@@ -27,7 +27,7 @@ func TestGenGopkg(t *testing.T) {
 	}
 
 	if gopkgTomlTmpl != buf.String() {
-		t.Errorf("want %v, got %v", gopkgTomlTmpl, buf.String())
+		t.Errorf(errorMessage, gopkgTomlTmpl, buf.String())
 	}
 
 	buf = &bytes.Buffer{}
@@ -36,6 +36,6 @@ func TestGenGopkg(t *testing.T) {
 		return
 	}
 	if gopkgLockTmpl != buf.String() {
-		t.Errorf("want %v, got %v", gopkgLockTmpl, buf.String())
+		t.Errorf(errorMessage, gopkgLockTmpl, buf.String())
 	}
 }

--- a/pkg/generator/gen_handler_test.go
+++ b/pkg/generator/gen_handler_test.go
@@ -96,6 +96,6 @@ func TestGenHandler(t *testing.T) {
 		return
 	}
 	if handlerExp != buf.String() {
-		t.Errorf("want %v, got %v", handlerExp, buf.String())
+		t.Errorf(errorMessage, handlerExp, buf.String())
 	}
 }

--- a/pkg/generator/gen_main_test.go
+++ b/pkg/generator/gen_main_test.go
@@ -64,6 +64,6 @@ func TestGenMain(t *testing.T) {
 	}
 
 	if mainExp != buf.String() {
-		t.Errorf("want %v\ngot %v", mainExp, buf.String())
+		t.Errorf(errorMessage, mainExp, buf.String())
 	}
 }

--- a/pkg/generator/test_constants.go
+++ b/pkg/generator/test_constants.go
@@ -10,4 +10,5 @@ const (
 	appVersion     = "v1alpha1"
 	appGroupName   = "app.example.com"
 	appProjectName = "app-operator"
+	errorMessage   = "Want:\n%vGot:\n%v"
 )


### PR DESCRIPTION
Refer to #252 

This PR change test failure output format for more lisibility. Newline have been add in output

New output now like:
```shell
$ make test
./hack/test
?   	github.com/operator-framework/operator-sdk/commands/operator-sdk	[no test files]
?   	github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd	[no test files]
?   	github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/cmdutil	[no test files]
?   	github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/completion	[no test files]
?   	github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/generate	[no test files]
?   	github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/up	[no test files]
?   	github.com/operator-framework/operator-sdk/commands/operator-sdk/error	[no test files]
--- FAIL: TestGenConfig (0.00s)
	gen_config_test.go:34: Want:
		 apiVersion: app.example.com/v1alpha1
		kind: AppService
		projectName: app-operator
		//
		Got:
		 apiVersion: app.example.com/v1alpha1
		kind: AppService
		projectName: app-operator
FAIL
FAIL	github.com/operator-framework/operator-sdk/pkg/generator	0.009s
?   	github.com/operator-framework/operator-sdk/pkg/k8sclient	[no test files]
?   	github.com/operator-framework/operator-sdk/pkg/sdk	[no test files]
?   	github.com/operator-framework/operator-sdk/pkg/util/k8sutil	[no test files]
?   	github.com/operator-framework/operator-sdk/version	[no test files]
make: *** [test] Error 1
```

instead of:
```shell
$ make test
./hack/test
?   	github.com/operator-framework/operator-sdk/commands/operator-sdk	[no test files]
?   	github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd	[no test files]
?   	github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/cmdutil	[no test files]
?   	github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/completion	[no test files]
?   	github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/generate	[no test files]
?   	github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/up	[no test files]
?   	github.com/operator-framework/operator-sdk/commands/operator-sdk/error	[no test files]
--- FAIL: TestGenConfig (0.00s)
	gen_config_test.go:34: want apiVersion: app.example.com/v1alpha1
		kind: AppService
		projectName: app-operator
		//
		, got apiVersion: app.example.com/v1alpha1
		kind: AppService
		projectName: app-operator
FAIL
FAIL	github.com/operator-framework/operator-sdk/pkg/generator	0.011s
?   	github.com/operator-framework/operator-sdk/pkg/k8sclient	[no test files]
?   	github.com/operator-framework/operator-sdk/pkg/sdk	[no test files]
?   	github.com/operator-framework/operator-sdk/pkg/util/k8sutil	[no test files]
?   	github.com/operator-framework/operator-sdk/version	[no test files]
make: *** [test] Error 1
```