### PR TITLE
pkg/{sdk, k8sclient}: Implement Retry when getResourceClient

### DIFF
--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -47,6 +47,11 @@ func init() {
 	clientPool = dynamic.NewClientPool(kubeConfig, restMapper, dynamic.LegacyAPIPathResolverFunc)
 }
 
+// ResetRestMapper Reset RestMapperCache
+func ResetRestMapper() {
+	restMapper.Reset()
+}
+
 // GetResourceClient returns the dynamic client and pluralName for the resource specified by the apiVersion and kind
 func GetResourceClient(apiVersion, kind, namespace string) (dynamic.ResourceInterface, string, error) {
 	gv, err := schema.ParseGroupVersion(apiVersion)


### PR DESCRIPTION
This PR aim to solve #272 

It implements retry when get `resourceClient`  and reset `RestMapper` cache to get newly create resources.