### PR TITLE
pkg/k8sclient: add cache reset on 1 minute interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- The cache of available clients is being reset every minute for discovery of newely added resources to a cluster. [#280](https://github.com/operator-framework/operator-sdk/pull/280)
+
 ### Deprecated
 
 ### Security


### PR DESCRIPTION
This sets up a go routine to reset the restMapper at a 1 minute
interval so that new resources can be found in the cluster.

fixes #272