### PR TITLE
pkg/k8sclient: expose the kubernetes client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - All the modules in [`pkg/sdk`](https://github.com/operator-framework/operator-sdk/tree/master/pkg/sdk) have been combined into a single package. `action`, `handler`, `informer` `types` and `query` pkgs have been consolidated into `pkg/sdk`. [#242](https://github.com/operator-framework/operator-sdk/pull/242)
+- The SDK exposes the Kubernetes clientset via `k8sclient.GetKubeClient()` #295
 
 ### Removed
 

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -36,11 +36,13 @@ import (
 var (
 	restMapper *discovery.DeferredDiscoveryRESTMapper
 	clientPool dynamic.ClientPool
+	kubeClient kubernetes.Interface
+	kubeConfig *rest.Config
 )
 
 // init initializes the restMapper and clientPool needed to create a resource client dynamically
 func init() {
-	kubeClient, kubeConfig := mustNewKubeClientAndConfig()
+	kubeClient, kubeConfig = mustNewKubeClientAndConfig()
 	cachedDiscoveryClient := cached.NewMemCacheClient(kubeClient.Discovery())
 	restMapper = discovery.NewDeferredDiscoveryRESTMapper(cachedDiscoveryClient, meta.InterfacesForUnstructured)
 	restMapper.Reset()
@@ -72,6 +74,11 @@ func GetResourceClient(apiVersion, kind, namespace string) (dynamic.ResourceInte
 	pluralName := resource.Name
 	resourceClient := client.Resource(resource, namespace)
 	return resourceClient, pluralName, nil
+}
+
+// GetKubeClient returns the kubernetes client used to create the dynamic client
+func GetKubeClient() kubernetes.Interface {
+	return kubeClient
 }
 
 // apiResource consults the REST mapper to translate an <apiVersion, kind, namespace> tuple to a metav1.APIResource struct.


### PR DESCRIPTION
Exposing the underlying kubernetes client will provide the flexibility of
allowing the user to perform more advanced actions that the SDK does not
provide out of the box. Often, more advanced actions are located in
subresources of the resource, like Pods().Evict and Pods().GetLogs. The SDK
does not provide access to these, and restricts the user to create, get,
update, delete and list.

Some examples:

```go
kubeClient := k8sclient.GetKubeClient()

// Evict pod
kubeClient.CoreV1().Pods("default").Evict(&v1beta1.Eviction{})

// Get pod logs
kubeClient.CoreV1().Pods("default").GetLogs("example", &v1.PodLogOptions{})
```

Resolves #190