### PR TITLE
 commands/operator-sdk: Add better error message when dep is not installed or not in path

### DIFF
--- a/commands/operator-sdk/cmd/new.go
+++ b/commands/operator-sdk/cmd/new.go
@@ -161,11 +161,10 @@ func execCmd(stdout *os.File, cmd string, args ...string) {
 }
 
 func pullDep() {
-	depPath, err := exec.LookPath(dep)
+	_, err := exec.LookPath(dep)
 	if err != nil {
-		cmdError.ExitWithError(cmdError.ExitError, err)
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("Looking for dep in $PATH: %v", err))
 	}
-	fmt.Printf("dep is available at %s\n", depPath)
 	fmt.Fprintln(os.Stdout, "Run dep ensure ...")
 	execCmd(os.Stdout, dep, ensureCmd, "-v")
 	fmt.Fprintln(os.Stdout, "Run dep ensure done")

--- a/commands/operator-sdk/cmd/new.go
+++ b/commands/operator-sdk/cmd/new.go
@@ -161,6 +161,11 @@ func execCmd(stdout *os.File, cmd string, args ...string) {
 }
 
 func pullDep() {
+	depPath, err := exec.LookPath(dep)
+	if err != nil {
+		cmdError.ExitWithError(cmdError.ExitError, err)
+	}
+	fmt.Printf("dep is available at %s\n", depPath)
 	fmt.Fprintln(os.Stdout, "Run dep ensure ...")
 	execCmd(os.Stdout, dep, ensureCmd, "-v")
 	fmt.Fprintln(os.Stdout, "Run dep ensure done")


### PR DESCRIPTION
Addresses Issue #163 