### PR TITLE
Allow empty namespace to watch all namespaces.

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -142,8 +142,5 @@ func GetWatchNamespace() (string, error) {
 	if !found {
 		return "", fmt.Errorf("%s must be set", WatchNamespaceEnvVar)
 	}
-	if len(ns) == 0 {
-		return "", fmt.Errorf("%s must not be empty", WatchNamespaceEnvVar)
-	}
 	return ns, nil
 }


### PR DESCRIPTION
Perhaps the default should be changed in `operator-sdk up local`, but I didn't include in this PR.