### PR TITLE
pkg/sdk: update informer logging levels

### DIFF
--- a/pkg/sdk/informer-sync.go
+++ b/pkg/sdk/informer-sync.go
@@ -62,7 +62,7 @@ func (i *informer) sync(key string) error {
 		return err
 	}
 	if !exists {
-		logrus.Infof("Object (%s) is deleted", key)
+		logrus.Debugf("Object (%s) is deleted", key)
 		// Lookup the last saved state for the deleted object
 		_, ok := i.deletedObjects[key]
 		if !ok {
@@ -110,5 +110,5 @@ func (i *informer) handleErr(err error, key interface{}) {
 
 	i.queue.Forget(key)
 	// Report that, even after several retries, we could not successfully process this key
-	logrus.Infof("Dropping key (%v) out of the queue: %v", key, err)
+	logrus.Warnf("Dropping key (%v) out of the queue: %v", key, err)
 }

--- a/pkg/sdk/informer.go
+++ b/pkg/sdk/informer.go
@@ -76,7 +76,7 @@ func (i *informer) Run(ctx context.Context) {
 	i.context = ctx
 	defer i.queue.ShutDown()
 
-	logrus.Infof("starting %s controller", i.resourcePluralName)
+	logrus.Debugf("starting %s controller", i.resourcePluralName)
 	go i.sharedIndexInformer.Run(ctx.Done())
 
 	if !cache.WaitForCacheSync(ctx.Done(), i.sharedIndexInformer.HasSynced) {
@@ -88,7 +88,7 @@ func (i *informer) Run(ctx context.Context) {
 		go wait.Until(i.runWorker, time.Second, ctx.Done())
 	}
 	<-ctx.Done()
-	logrus.Infof("stopping %s controller", i.resourcePluralName)
+	logrus.Debugf("stopping %s controller", i.resourcePluralName)
 }
 
 func (i *informer) handleAddResourceEvent(obj interface{}) {


### PR DESCRIPTION
Logs generated by the informer were not in the appropriate logging level.
The user can then change the log level for the sdk with the following:

```
logrus.SetLevel(logrus.DebugLevel)
```

Resolves #307