### PR TITLE
pkg/generator: vendor the code-generators, remove Gopkg.lock template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - All the modules in [`pkg/sdk`](https://github.com/operator-framework/operator-sdk/tree/master/pkg/sdk) have been combined into a single package. `action`, `handler`, `informer` `types` and `query` pkgs have been consolidated into `pkg/sdk`. [#242](https://github.com/operator-framework/operator-sdk/pull/242)
 - The SDK exposes the Kubernetes clientset via `k8sclient.GetKubeClient()` #295
+- The SDK now vendors the k8s code-generators for an operator instead of using the prebuilt image `gcr.io/coreos-k8s-scale-testing/codegen:1.9.3` [#319](https://github.com/operator-framework/operator-sdk/pull/242)
 
 ### Removed
 

--- a/pkg/generator/gen_deps.go
+++ b/pkg/generator/gen_deps.go
@@ -20,8 +20,3 @@ func renderGopkgTomlFile(w io.Writer) error {
 	_, err := w.Write([]byte(gopkgTomlTmpl))
 	return err
 }
-
-func renderGopkgLockFile(w io.Writer) error {
-	_, err := w.Write([]byte(gopkgLockTmpl))
-	return err
-}

--- a/pkg/generator/gen_deps_test.go
+++ b/pkg/generator/gen_deps_test.go
@@ -29,13 +29,4 @@ func TestGenGopkg(t *testing.T) {
 	if gopkgTomlTmpl != buf.String() {
 		t.Errorf(errorMessage, gopkgTomlTmpl, buf.String())
 	}
-
-	buf = &bytes.Buffer{}
-	if err := renderGopkgLockFile(buf); err != nil {
-		t.Error(err)
-		return
-	}
-	if gopkgLockTmpl != buf.String() {
-		t.Errorf(errorMessage, gopkgLockTmpl, buf.String())
-	}
 }

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -159,15 +159,7 @@ func (g *Generator) renderGoDep() error {
 	if err := renderGopkgTomlFile(buf); err != nil {
 		return err
 	}
-	if err := writeFileAndPrint(filepath.Join(g.projectName, gopkgtoml), buf.Bytes(), defaultFileMode); err != nil {
-		return err
-	}
-
-	buf = &bytes.Buffer{}
-	if err := renderGopkgLockFile(buf); err != nil {
-		return err
-	}
-	return writeFileAndPrint(filepath.Join(g.projectName, gopkglock), buf.Bytes(), defaultFileMode)
+	return writeFileAndPrint(filepath.Join(g.projectName, gopkgtoml), buf.Bytes(), defaultFileMode)
 }
 
 func (g *Generator) renderCmd() error {

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -19,6 +19,36 @@ import (
 	"testing"
 )
 
+const updateGeneratedExp = `#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+vendor/k8s.io/code-generator/generate-groups.sh \
+deepcopy \
+github.com/example-inc/app-operator/pkg/generated \
+github.com/example-inc/app-operator/pkg/apis \
+app:v1alpha1 \
+--go-header-file "./tmp/codegen/boilerplate.go.txt"
+`
+
+func TestCodeGen(t *testing.T) {
+	buf := &bytes.Buffer{}
+	td := tmplData{
+		RepoPath:   appRepoPath,
+		APIDirName: appApiDirName,
+		Version:    appVersion,
+	}
+	if err := renderFile(buf, "codegen/update-generated.sh", updateGeneratedTmpl, td); err != nil {
+		t.Error(err)
+		return
+	}
+	if updateGeneratedExp != buf.String() {
+		t.Errorf(errorMessage, updateGeneratedExp, buf.String())
+	}
+}
+
 const versionExp = `package version
 
 var (

--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -234,152 +234,40 @@ func newbusyBoxPod(cr *{{.Version}}.{{.Kind}}) *corev1.Pod {
 	}
 }
 `
-const gopkgLockTmpl = `[[projects]]
+
+const gopkgTomlTmpl = `
+# Force dep to vendor the code generators, which aren't imported just used at dev time.
+# Picking a subpackage with Go code won't be necessary once https://github.com/golang/dep/pull/1545 is merged.
+required = [
+  "k8s.io/code-generator/cmd/defaulter-gen",
+  "k8s.io/code-generator/cmd/deepcopy-gen",
+  "k8s.io/code-generator/cmd/conversion-gen",
+  "k8s.io/code-generator/cmd/client-gen",
+  "k8s.io/code-generator/cmd/lister-gen",
+  "k8s.io/code-generator/cmd/informer-gen",
+  "k8s.io/code-generator/cmd/openapi-gen",
+  "k8s.io/gengo/args",
+]
+
+[[override]]
+  name = "k8s.io/code-generator"
+  # revision for tag "kubernetes-1.9.3"
+  revision = "91d3f6a57905178524105a085085901bb73bd3dc"
+
+[[override]]
   name = "k8s.io/api"
-  packages = [
-    "admissionregistration/v1alpha1",
-    "admissionregistration/v1beta1",
-    "apps/v1",
-    "apps/v1beta1",
-    "apps/v1beta2",
-    "authentication/v1",
-    "authentication/v1beta1",
-    "authorization/v1",
-    "authorization/v1beta1",
-    "autoscaling/v1",
-    "autoscaling/v2beta1",
-    "batch/v1",
-    "batch/v1beta1",
-    "batch/v2alpha1",
-    "certificates/v1beta1",
-    "core/v1",
-    "events/v1beta1",
-    "extensions/v1beta1",
-    "networking/v1",
-    "policy/v1beta1",
-    "rbac/v1",
-    "rbac/v1alpha1",
-    "rbac/v1beta1",
-    "scheduling/v1alpha1",
-    "settings/v1alpha1",
-    "storage/v1",
-    "storage/v1alpha1",
-    "storage/v1beta1"
-  ]
+  # revision for tag "kubernetes-1.9.3"
   revision = "acf347b865f29325eb61f4cd2df11e86e073a5ee"
-  version = "kubernetes-1.9.3"
 
-[[projects]]
+[[override]]
   name = "k8s.io/apimachinery"
-  packages = [
-    "pkg/api/errors",
-    "pkg/api/meta",
-    "pkg/api/resource",
-    "pkg/apis/meta/internalversion",
-    "pkg/apis/meta/v1",
-    "pkg/apis/meta/v1/unstructured",
-    "pkg/apis/meta/v1alpha1",
-    "pkg/conversion",
-    "pkg/conversion/queryparams",
-    "pkg/fields",
-    "pkg/labels",
-    "pkg/runtime",
-    "pkg/runtime/schema",
-    "pkg/runtime/serializer",
-    "pkg/runtime/serializer/json",
-    "pkg/runtime/serializer/protobuf",
-    "pkg/runtime/serializer/recognizer",
-    "pkg/runtime/serializer/streaming",
-    "pkg/runtime/serializer/versioning",
-    "pkg/selection",
-    "pkg/types",
-    "pkg/util/cache",
-    "pkg/util/clock",
-    "pkg/util/diff",
-    "pkg/util/errors",
-    "pkg/util/framer",
-    "pkg/util/intstr",
-    "pkg/util/json",
-    "pkg/util/net",
-    "pkg/util/runtime",
-    "pkg/util/sets",
-    "pkg/util/validation",
-    "pkg/util/validation/field",
-    "pkg/util/wait",
-    "pkg/util/yaml",
-    "pkg/version",
-    "pkg/watch",
-    "third_party/forked/golang/reflect"
-  ]
+  # revision for tag "kubernetes-1.9.3"
   revision = "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
-  version = "kubernetes-1.9.3"
 
-[[projects]]
+[[override]]
   name = "k8s.io/client-go"
-  packages = [
-    "discovery",
-    "discovery/cached",
-    "dynamic",
-    "kubernetes",
-    "kubernetes/scheme",
-    "kubernetes/typed/admissionregistration/v1alpha1",
-    "kubernetes/typed/admissionregistration/v1beta1",
-    "kubernetes/typed/apps/v1",
-    "kubernetes/typed/apps/v1beta1",
-    "kubernetes/typed/apps/v1beta2",
-    "kubernetes/typed/authentication/v1",
-    "kubernetes/typed/authentication/v1beta1",
-    "kubernetes/typed/authorization/v1",
-    "kubernetes/typed/authorization/v1beta1",
-    "kubernetes/typed/autoscaling/v1",
-    "kubernetes/typed/autoscaling/v2beta1",
-    "kubernetes/typed/batch/v1",
-    "kubernetes/typed/batch/v1beta1",
-    "kubernetes/typed/batch/v2alpha1",
-    "kubernetes/typed/certificates/v1beta1",
-    "kubernetes/typed/core/v1",
-    "kubernetes/typed/events/v1beta1",
-    "kubernetes/typed/extensions/v1beta1",
-    "kubernetes/typed/networking/v1",
-    "kubernetes/typed/policy/v1beta1",
-    "kubernetes/typed/rbac/v1",
-    "kubernetes/typed/rbac/v1alpha1",
-    "kubernetes/typed/rbac/v1beta1",
-    "kubernetes/typed/scheduling/v1alpha1",
-    "kubernetes/typed/settings/v1alpha1",
-    "kubernetes/typed/storage/v1",
-    "kubernetes/typed/storage/v1alpha1",
-    "kubernetes/typed/storage/v1beta1",
-    "pkg/version",
-    "rest",
-    "rest/watch",
-    "tools/cache",
-    "tools/clientcmd/api",
-    "tools/metrics",
-    "tools/pager",
-    "tools/reference",
-    "transport",
-    "util/buffer",
-    "util/cert",
-    "util/flowcontrol",
-    "util/integer",
-    "util/workqueue"
-  ]
+  # revision for tag "kubernetes-1.9.3"
   revision = "9389c055a838d4f208b699b3c7c51b70f2368861"
-  version = "kubernetes-1.9.3"
-`
-
-const gopkgTomlTmpl = `[[override]]
-  name = "k8s.io/api"
-  version = "kubernetes-1.9.3"
-
-[[override]]
-  name = "k8s.io/apimachinery"
-  version = "kubernetes-1.9.3"
-
-[[override]]
-  name = "k8s.io/client-go"
-  version = "kubernetes-1.9.3"
 
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
@@ -601,20 +489,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-DOCKER_REPO_ROOT="/go/src/{{.RepoPath}}"
-IMAGE=${IMAGE:-"gcr.io/coreos-k8s-scale-testing/codegen:1.9.3"}
-
-docker run --rm \
-  -v "$PWD":"$DOCKER_REPO_ROOT":Z \
-  -w "$DOCKER_REPO_ROOT" \
-  "$IMAGE" \
-  "/go/src/k8s.io/code-generator/generate-groups.sh"  \
-  "deepcopy" \
-  "{{.RepoPath}}/pkg/generated" \
-  "{{.RepoPath}}/pkg/apis" \
-  "{{.APIDirName}}:{{.Version}}" \
-  --go-header-file "./tmp/codegen/boilerplate.go.txt" \
-  $@
+vendor/k8s.io/code-generator/generate-groups.sh \
+deepcopy \
+{{.RepoPath}}/pkg/generated \
+{{.RepoPath}}/pkg/apis \
+{{.APIDirName}}:{{.Version}} \
+--go-header-file "./tmp/codegen/boilerplate.go.txt"
 `
 const buildTmpl = `#!/usr/bin/env bash
 

--- a/pkg/generator/test_constants.go
+++ b/pkg/generator/test_constants.go
@@ -10,5 +10,5 @@ const (
 	appVersion     = "v1alpha1"
 	appGroupName   = "app.example.com"
 	appProjectName = "app-operator"
-	errorMessage   = "Want:\n%vGot:\n%v"
+	errorMessage   = "Want:\n%v\nGot:\n%v"
 )


### PR DESCRIPTION
Fixes #226 

The k8s code-generators are now vendored for every project so they can be used locally instead of relying on `gcr.io/coreos-k8s-scale-testing/codegen:1.9.3`.
`k8s.io/code-generator` and `k8s.io/gengo` are not imports of an operator project so they need the [required](https://golang.github.io/dep/docs/Gopkg.toml.html#required) rule.

Secondly the generator should not generate `Gopkg.lock` just to ensure that the k8s.io dependencies are pinned at the respective revisions for a particular tag. That can be done in the `Gopkg.toml` file by specifying `revision = "xyz"`. I've kept the `version` field as a comment to indicate the tag for each revision.

With that change `tmp/codegen/update-generated.sh` can simply call the vendored code-generator.

/cc @fanminshi 