### PR TITLE
k8sclient.client: refactored to create singleton pattern, remove init

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,12 +14,6 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/beorn7/perks"
-  packages = ["quantile"]
-  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
-
-[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
@@ -172,10 +166,21 @@
   revision = "32fa128f234d041f196a9f3e0fea5ac9772c08e1"
 
 [[projects]]
-  name = "github.com/matttproud/golang_protobuf_extensions"
-  packages = ["pbutil"]
-  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
-  version = "v1.0.1"
+  branch = "master"
+  name = "github.com/operator-framework/operator-sdk"
+  packages = [
+    "commands/operator-sdk/cmd",
+    "commands/operator-sdk/cmd/cmdutil",
+    "commands/operator-sdk/cmd/completion",
+    "commands/operator-sdk/cmd/generate",
+    "commands/operator-sdk/cmd/up",
+    "commands/operator-sdk/error",
+    "pkg/generator",
+    "pkg/k8sclient",
+    "pkg/util/k8sutil",
+    "version"
+  ]
+  revision = "ec322ba6585fe5b21abafc57e7ca16abe8b924d2"
 
 [[projects]]
   branch = "master"
@@ -188,42 +193,6 @@
   packages = ["."]
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
-
-[[projects]]
-  name = "github.com/prometheus/client_golang"
-  packages = [
-    "prometheus",
-    "prometheus/promhttp"
-  ]
-  revision = "c5b7fccd204277076155f10851dad72b76a49317"
-  version = "v0.8.0"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/prometheus/client_model"
-  packages = ["go"]
-  revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/prometheus/common"
-  packages = [
-    "expfmt",
-    "internal/bitbucket.org/ww/goautoneg",
-    "model"
-  ]
-  revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/prometheus/procfs"
-  packages = [
-    ".",
-    "internal/util",
-    "nfs",
-    "xfs"
-  ]
-  revision = "7d6f385de8bea29190f15ba9931442a0eaef9af7"
 
 [[projects]]
   name = "github.com/sergi/go-diff"
@@ -458,6 +427,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e39a3b50eecf50ee2f3c6ce8a36306abeea762a41fab1117f0c5e2a038b72fb4"
+  inputs-digest = "3c35ad715f8ab84af1963d1e25268707e5548ce00bea2dde7fe556fc3a7ce333"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,6 +14,12 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
@@ -166,21 +172,10 @@
   revision = "32fa128f234d041f196a9f3e0fea5ac9772c08e1"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/operator-framework/operator-sdk"
-  packages = [
-    "commands/operator-sdk/cmd",
-    "commands/operator-sdk/cmd/cmdutil",
-    "commands/operator-sdk/cmd/completion",
-    "commands/operator-sdk/cmd/generate",
-    "commands/operator-sdk/cmd/up",
-    "commands/operator-sdk/error",
-    "pkg/generator",
-    "pkg/k8sclient",
-    "pkg/util/k8sutil",
-    "version"
-  ]
-  revision = "ec322ba6585fe5b21abafc57e7ca16abe8b924d2"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
 
 [[projects]]
   branch = "master"
@@ -193,6 +188,42 @@
   packages = ["."]
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
+
+[[projects]]
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/promhttp"
+  ]
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
+  revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs"
+  ]
+  revision = "7d6f385de8bea29190f15ba9931442a0eaef9af7"
 
 [[projects]]
   name = "github.com/sergi/go-diff"
@@ -427,6 +458,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3c35ad715f8ab84af1963d1e25268707e5548ce00bea2dde7fe556fc3a7ce333"
+  inputs-digest = "e39a3b50eecf50ee2f3c6ce8a36306abeea762a41fab1117f0c5e2a038b72fb4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -71,6 +71,12 @@ func GetResourceClient(apiVersion, kind, namespace string) (dynamic.ResourceInte
 	return singletonFactory.GetResourceClient(apiVersion, kind, namespace)
 }
 
+// GetKubeClient returns the kubernetes client used to create the dynamic client
+func GetKubeClient() kubernetes.Interface {
+	once.Do(newSingletonFactory)
+	return singletonFactory.kubeClient
+}
+
 // GetResourceClient returns the dynamic client and pluralName for the resource specified by the apiVersion and kind
 func (c *resourceClientFactory) GetResourceClient(apiVersion, kind, namespace string) (dynamic.ResourceInterface, string, error) {
 	gv, err := schema.ParseGroupVersion(apiVersion)
@@ -94,11 +100,6 @@ func (c *resourceClientFactory) GetResourceClient(apiVersion, kind, namespace st
 	pluralName := resource.Name
 	resourceClient := client.Resource(resource, namespace)
 	return resourceClient, pluralName, nil
-}
-
-// GetKubeClient returns the kubernetes client used to create the dynamic client
-func (c *resourceClientFactory) GetKubeClient() kubernetes.Interface {
-	return c.kubeClient
 }
 
 // apiResource consults the REST mapper to translate an <apiVersion, kind, namespace> tuple to a metav1.APIResource struct.


### PR DESCRIPTION
ref: #292 

k8sclient.client: refactored to create singleton pattern, remove `init`

At this time it is possible to abstract away the api for unit testing, the `init` 
method blocks the ability to do the unit tests because it tries to connect to 
the cluster. This refactor though not fully the direction you guys are going, is a temporary fix to allow unit testing of downstream code in operators using the sdk. In addition, this does not break the existing API and allows for no other code to change.

