### PR TITLE
pkg/{sdk,sdk/metrics}: Adding default metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Added `operator-sdk up` command to help deploy an operator. Currently supports running an operator locally against an existing cluster e.g `operator-sdk up local --kubeconfig=<path-to-kubeconfig> --namespace=<operator-namespace>`. See `operator-sdk up -h` for help. [#219](https://github.com/operator-framework/operator-sdk/pull/219) [#274](https://github.com/operator-framework/operator-sdk/pull/274)
+- Added initial default metrics to be captured and exposed by Prometheus. [#323](https://github.com/operator-framework/operator-sdk/pull/323) exposes the metrics port and [#349](https://github.com/operator-framework/operator-sdk/pull/323) adds the initial default metrics.
 
 ### Changed
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -482,6 +482,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d3740f4348ec1b11ffbcb71d7323496f157bc3d15ee151a8ea43b52c04351c24"
+  inputs-digest = "b379b7abf6dbff42b70b2f8c5a1ae4839b8e4fb197bd3860fdbed63bc981bf85"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/sdk/api.go
+++ b/pkg/sdk/api.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sclient"
+	"github.com/operator-framework/operator-sdk/pkg/sdk/internal/metrics"
 
 	"github.com/sirupsen/logrus"
 )
@@ -25,6 +26,7 @@ import (
 var (
 	// informers is the set of all informers for the resources watched by the user
 	informers []Informer
+	collector *metrics.Collector
 )
 
 // Watch watches for changes on the given resource.
@@ -45,7 +47,11 @@ func Watch(apiVersion, kind, namespace string, resyncPeriod int) {
 		logrus.Errorf("failed to get resource client for (apiVersion:%s, kind:%s, ns:%s): %v", apiVersion, kind, namespace, err)
 		panic(err)
 	}
-	informer := NewInformer(resourcePluralName, namespace, resourceClient, resyncPeriod)
+	if collector == nil {
+		collector = metrics.New()
+		metrics.RegisterCollector(collector)
+	}
+	informer := NewInformer(resourcePluralName, namespace, resourceClient, resyncPeriod, collector)
 	informers = append(informers, informer)
 }
 

--- a/pkg/sdk/informer-sync.go
+++ b/pkg/sdk/informer-sync.go
@@ -15,6 +15,7 @@
 package sdk
 
 import (
+	"github.com/operator-framework/operator-sdk/pkg/sdk/internal/metrics"
 	"github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 
 	"github.com/sirupsen/logrus"
@@ -84,6 +85,12 @@ func (i *informer) sync(key string) error {
 	err = RegisteredHandler.Handle(i.context, event)
 	if !exists && err == nil {
 		delete(i.deletedObjects, key)
+	}
+	switch {
+	case err == nil:
+		i.collector.ReconcileResult.WithLabelValues(metrics.ReconcileResultSuccess).Inc()
+	case err != nil:
+		i.collector.ReconcileResult.WithLabelValues(metrics.ReconcileResultFailure).Inc()
 	}
 	return err
 }

--- a/pkg/sdk/internal/metrics/metrics.go
+++ b/pkg/sdk/internal/metrics/metrics.go
@@ -1,0 +1,88 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"sync"
+
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	eventTypesMetricName       = "operator_event_types_total"
+	reconcileResultsMetricName = "operator_reconcile_results_total"
+	// EventTypeLabel - metric label for event type
+	EventTypeLabel = "type"
+	// EventTypeAdd - addition event label
+	EventTypeAdd = "add"
+	// EventTypeDelete - deletion event label
+	EventTypeDelete = "delete"
+	// EventTypeUpdate - update event label
+	EventTypeUpdate = "update"
+	// ReconcileResultLabel - metric label for event result
+	ReconcileResultLabel = "result"
+	// ReconcileResultSuccess - successful event label
+	ReconcileResultSuccess = "success"
+	// ReconcileResultFailure - failed event label
+	ReconcileResultFailure = "failure"
+)
+
+var (
+	once sync.Once
+)
+
+// Collector - metric collector for all the metrics the sdk will watch
+type Collector struct {
+	EventType       *prom.CounterVec
+	ReconcileResult *prom.CounterVec
+}
+
+// New - create a new Collector
+func New() *Collector {
+	return &Collector{
+		EventType: prom.NewCounterVec(prom.CounterOpts{
+			Name: eventTypesMetricName,
+			Help: "events that the sdk has recieved, segmented by type(add or delete or update)",
+		}, []string{EventTypeLabel}),
+		ReconcileResult: prom.NewCounterVec(prom.CounterOpts{
+			Name: reconcileResultsMetricName,
+			Help: "reconcilation events that the sdk has processed segmented by result(success or failure)",
+		}, []string{ReconcileResultLabel}),
+	}
+}
+
+// RegisterCollector - add collector safely to prometheus
+func RegisterCollector(c *Collector) {
+	once.Do(func() {
+		err := prom.Register(c)
+		if err != nil {
+			logrus.Errorf("unable to register collector with prometheus: %v", err)
+		}
+	})
+}
+
+// Describe returns all the descriptions of the collector
+func (c *Collector) Describe(ch chan<- *prom.Desc) {
+	c.EventType.Describe(ch)
+	c.ReconcileResult.Describe(ch)
+
+}
+
+// Collect returns the current state of the metrics
+func (c *Collector) Collect(ch chan<- prom.Metric) {
+	c.EventType.Collect(ch)
+	c.ReconcileResult.Collect(ch)
+}


### PR DESCRIPTION
this sets up the sdk to expose metrics by registering metrics with
prometheus.

it also adds the metrics as a type to be used by clients to update the
metrics.