### PR TITLE
Adds ability to use kubeconfig context

### DIFF
--- a/commands/operator-sdk/cmd/up/local.go
+++ b/commands/operator-sdk/cmd/up/local.go
@@ -26,7 +26,8 @@ kubernetes cluster using a kubeconfig file.
 		Run: upLocalFunc,
 	}
 
-	upLocalCmd.Flags().StringVar(&kubeConfig, "kubeconfig", "", "The file path to kubernetes configuration file; defaults to $HOME/.kube/config")
+	upLocalCmd.Flags().StringVar(&kubeConfig, "kubeconfig", "", "The file path to Kubernetes configuration file; defaults to $HOME/.kube/config")
+	upLocalCmd.Flags().StringVar(&kubeContext, "context", "", "The kubeconfig context to use")
 	upLocalCmd.Flags().StringVar(&operatorFlags, "operator-flags", "", "The flags that the operator needs. Example: \"--flag1 value1 --flag2=value2\"")
 	upLocalCmd.Flags().StringVar(&namespace, "namespace", "default", "The namespace where the operator watches for changes.")
 
@@ -35,6 +36,7 @@ kubernetes cluster using a kubeconfig file.
 
 var (
 	kubeConfig    string
+	kubeContext   string
 	operatorFlags string
 	namespace     string
 )
@@ -80,7 +82,10 @@ func upLocal(projectName string) {
 	dc := exec.Command(gocmd, args...)
 	dc.Stdout = os.Stdout
 	dc.Stderr = os.Stderr
-	dc.Env = append(os.Environ(), fmt.Sprintf("%v=%v", k8sutil.KubeConfigEnvVar, kubeConfig), fmt.Sprintf("%v=%v", k8sutil.WatchNamespaceEnvVar, namespace))
+	dc.Env = append(os.Environ(),
+		fmt.Sprintf("%v=%v", k8sutil.KubeConfigEnvVar, kubeConfig),
+		fmt.Sprintf("%v=%v", k8sutil.KubeContextEnvVar, kubeContext),
+		fmt.Sprintf("%v=%v", k8sutil.WatchNamespaceEnvVar, namespace))
 	err := dc.Run()
 	if err != nil {
 		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to run operator locally: %v", err))

--- a/pkg/util/k8sutil/constants.go
+++ b/pkg/util/k8sutil/constants.go
@@ -5,6 +5,10 @@ const (
 	// contains the kubeconfig file path.
 	KubeConfigEnvVar = "KUBERNETES_CONFIG"
 
+	// KubeContextEnvVar defines the env variable KUBERNETES_CONTEXT which
+	// contains the kubeconfig context.
+	KubeContextEnvVar = "KUBERNETES_CONTEXT"
+
 	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
 	// which is the namespace that the pod is currently running in.
 	WatchNamespaceEnvVar = "WATCH_NAMESPACE"


### PR DESCRIPTION
Add support for multi-cluster use cases like `kubectl` does.

- adds `--context` parameter to `operator-sdk` command
- adds `KUBERNETES_CONTEXT` env var
- adds `buildConfigWithContext` to `client.go`
- fixes some error handling

With this you can do e.g.:

    operator-sdk up local --kubeconfig=$HOME/.kube/config --context=eu-west-1c-nonprod

---
I've tried to contribute the `buildConfigWithContext` upstream but it was rejected:
https://github.com/kubernetes/kubernetes/pull/66329
https://github.com/kubernetes/client-go/issues/192