### PR TITLE
[Do Not Merge] test/e2e: clean ups and improvements

### DIFF
--- a/test/e2e/e2eutil/check_util.go
+++ b/test/e2e/e2eutil/check_util.go
@@ -11,7 +11,7 @@ import (
 
 var retryInterval = time.Second * 5
 
-func DeploymentReplicaCheck(t *testing.T, kubeclient *kubernetes.Clientset, namespace, name string, replicas, retries int) error {
+func DeploymentReplicaCheck(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, replicas, retries int) error {
 	err := Retry(retryInterval, retries, func() (done bool, err error) {
 		deployment, err := kubeclient.AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{IncludeUninitialized: true})
 		if err != nil {

--- a/test/e2e/e2eutil/create_util.go
+++ b/test/e2e/e2eutil/create_util.go
@@ -21,9 +21,9 @@ import (
 func GetCRClient(t *testing.T, config *rest.Config, yamlCR []byte) *rest.RESTClient {
 	// get new RESTClient for custom resources
 	crConfig := config
-	m := make(map[interface{}]interface{})
-	err := yaml.Unmarshal(yamlCR, &m)
-	groupVersion := strings.Split(m["apiVersion"].(string), "/")
+	yamlMap := make(map[interface{}]interface{})
+	err := yaml.Unmarshal(yamlCR, &yamlMap)
+	groupVersion := strings.Split(yamlMap["apiVersion"].(string), "/")
 	crGV := schema.GroupVersion{Group: groupVersion[0], Version: groupVersion[1]}
 	crConfig.GroupVersion = &crGV
 	crConfig.APIPath = "/apis"
@@ -67,10 +67,10 @@ func createCRDFromYAML(t *testing.T, yamlFile []byte, extensionsClient *extensio
 	return nil
 }
 
-func CreateFromYAML(t *testing.T, yamlFile []byte, kubeclient *kubernetes.Clientset, kubeconfig *rest.Config, namespace string) error {
-	m := make(map[interface{}]interface{})
-	err := yaml.Unmarshal(yamlFile, &m)
-	kind := m["kind"].(string)
+func CreateFromYAML(t *testing.T, yamlFile []byte, kubeclient kubernetes.Interface, kubeconfig *rest.Config, namespace string) error {
+	yamlMap := make(map[interface{}]interface{})
+	err := yaml.Unmarshal(yamlFile, &yamlMap)
+	kind := yamlMap["kind"].(string)
 	switch kind {
 	case "Role":
 	case "RoleBinding":

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -1,0 +1,39 @@
+package framework
+
+import (
+	"flag"
+	"os"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"k8s.io/client-go/rest"
+)
+
+var Global *Framework
+
+type Framework struct {
+	KubeConfig   *rest.Config
+	KubeClient   kubernetes.Interface
+	ExternalRepo string
+}
+
+func setup() error {
+	config := flag.String("kubeconfig", os.Getenv("HOME")+"/.kube/config", "kube config path, e.g. $HOME/.kube/config")
+	externalRepo := flag.String("external-repo", "", "Repo to push docker image to, e.g. quay.io/example-inc")
+	flag.Parse()
+	kubeconfig, err := clientcmd.BuildConfigFromFlags("", *config)
+	if err != nil {
+		return err
+	}
+	kubeclient, err := kubernetes.NewForConfig(kubeconfig)
+	if err != nil {
+		return err
+	}
+	Global = &Framework{
+		KubeConfig:   kubeconfig,
+		KubeClient:   kubeclient,
+		ExternalRepo: *externalRepo,
+	}
+	return nil
+}

--- a/test/e2e/framework/main_entry.go
+++ b/test/e2e/framework/main_entry.go
@@ -1,0 +1,18 @@
+package framework
+
+import (
+	"os"
+	"testing"
+
+	"github.com/prometheus/common/log"
+)
+
+func MainEntry(m *testing.M) {
+	if err := setup(); err != nil {
+		log.Errorf("Failed to set up framework: %v", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	os.Exit(code)
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,11 +1,11 @@
 package e2e
 
 import (
-	"os"
 	"testing"
+
+	f "github.com/operator-framework/operator-sdk/test/e2e/framework"
 )
 
 func TestMain(m *testing.M) {
-	// TODO: create a setup step for the framework here
-	os.Exit(m.Run())
+	f.MainEntry(m)
 }

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -7,16 +7,14 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"testing"
 
 	"github.com/operator-framework/operator-sdk/test/e2e/e2eutil"
+	framework "github.com/operator-framework/operator-sdk/test/e2e/framework"
 	core "k8s.io/api/core/v1"
 	extensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 func TestMemcached(t *testing.T) {
@@ -30,33 +28,35 @@ func TestMemcached(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error: %v\nCommand Output: %s\n", err, string(cmdOut))
 	}
+	defer os.RemoveAll(os.Getenv("GOPATH") + "/src/github.com/example-inc/memcached-operator")
+
 	os.Chdir("memcached-operator")
 	os.RemoveAll("vendor/github.com/operator-framework/operator-sdk/pkg")
-	os.Symlink(os.Getenv("TRAVIS_BUILD_DIR")+"/pkg", "vendor/github.com/operator-framework/operator-sdk/pkg")
-	handler, err := os.Create("pkg/stub/handler.go")
+	os.Symlink(os.Getenv("GOPATH")+"/src/github.com/operator-framework/operator-sdk/pkg", "vendor/github.com/operator-framework/operator-sdk/pkg")
+	handlerFile, err := os.Create("pkg/stub/handler.go")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer handler.Close()
-	resp, err := http.Get("https://raw.githubusercontent.com/operator-framework/operator-sdk/master/example/memcached-operator/handler.go.tmpl")
+	defer handlerFile.Close()
+	handlerTemplate, err := http.Get("https://raw.githubusercontent.com/operator-framework/operator-sdk/master/example/memcached-operator/handler.go.tmpl")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
-	_, err = io.Copy(handler, resp.Body)
+	defer handlerTemplate.Body.Close()
+	_, err = io.Copy(handlerFile, handlerTemplate.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	gotypes, err := ioutil.ReadFile("pkg/apis/cache/v1alpha1/types.go")
+	memcachedTypesFile, err := ioutil.ReadFile("pkg/apis/cache/v1alpha1/types.go")
 	if err != nil {
 		t.Fatal(err)
 	}
-	lines := bytes.Split(gotypes, []byte("\n"))
-	lines = lines[:len(lines)-7]
-	lines = append(lines, []byte("type MemcachedSpec struct {	Size int32 `json:\"size\"`}"))
-	lines = append(lines, []byte("type MemcachedStatus struct {Nodes []string `json:\"nodes\"`}\n"))
+	memcachedTypesFileLines := bytes.Split(memcachedTypesFile, []byte("\n"))
+	memcachedTypesFileLines = memcachedTypesFileLines[:len(memcachedTypesFileLines)-7]
+	memcachedTypesFileLines = append(memcachedTypesFileLines, []byte("type MemcachedSpec struct {	Size int32 `json:\"size\"`}"))
+	memcachedTypesFileLines = append(memcachedTypesFileLines, []byte("type MemcachedStatus struct {Nodes []string `json:\"nodes\"`}\n"))
 	os.Remove("pkg/apis/cache/v1alpha1/types.go")
-	err = ioutil.WriteFile("pkg/apis/cache/v1alpha1/types.go", bytes.Join(lines, []byte("\n")), os.FileMode(int(0664)))
+	err = ioutil.WriteFile("pkg/apis/cache/v1alpha1/types.go", bytes.Join(memcachedTypesFileLines, []byte("\n")), os.FileMode(int(0664)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,100 +69,156 @@ func TestMemcached(t *testing.T) {
 		t.Fatalf("Error: %v\nCommand Output: %s\n", err, string(cmdOut))
 	}
 
+	// get global framework variables
+	f := framework.Global
+
 	t.Log("Building operator docker image")
-	cmdOut, err = exec.Command("operator-sdk",
-		"build",
-		"quay.io/example/memcached-operator:v0.0.1").CombinedOutput()
-	if err != nil {
-		t.Fatalf("Error: %v\nCommand Output: %s\n", err, string(cmdOut))
-	}
+	if f.ExternalRepo == "" {
+		cmdOut, err = exec.Command("operator-sdk",
+			"build",
+			"quay.io/example/memcached-operator:v0.0.1").CombinedOutput()
+		if err != nil {
+			t.Fatalf("Error: %v\nCommand Output: %s\n", err, string(cmdOut))
+		}
+		operatorYAML, err := ioutil.ReadFile("deploy/operator.yaml")
+		if err != nil {
+			t.Fatal(err)
+		}
+		operatorYAML = bytes.Replace(operatorYAML, []byte("imagePullPolicy: Always"), []byte("imagePullPolicy: Never"), 1)
+		err = ioutil.WriteFile("deploy/operator.yaml", operatorYAML, os.FileMode(int(0664)))
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		cmdOut, err = exec.Command("operator-sdk",
+			"build",
+			f.ExternalRepo+":v0.0.1").CombinedOutput()
+		if err != nil {
+			t.Fatalf("Error: %v\nCommand Output: %s\n", err, string(cmdOut))
+		}
+		t.Log("Pushing docker image to repo")
+		cmdOut, err = exec.Command("docker",
+			"push",
+			f.ExternalRepo+":v0.0.1").CombinedOutput()
+		if err != nil {
+			t.Fatalf("Error: %v\nCommand Output: %s\n", err, string(cmdOut))
+		}
 
-	opYAML, err := ioutil.ReadFile("deploy/operator.yaml")
-	if err != nil {
-		t.Fatal(err)
-	}
-	opYAML = bytes.Replace(opYAML, []byte("imagePullPolicy: Always"), []byte("imagePullPolicy: Never"), 1)
-	err = ioutil.WriteFile("deploy/operator.yaml", opYAML, os.FileMode(int(0664)))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	namespace := "memcached"
-	kubeconfigPath := filepath.Join(
-		os.Getenv("HOME"), ".kube", "config",
-	)
-	kubeconfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	kubeclient, err := kubernetes.NewForConfig(kubeconfig)
-	if err != nil {
-		t.Fatal(err)
 	}
 
 	// create namespace
+	namespace := "memcached"
 	namespaceObj := &core.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-	_, err = kubeclient.CoreV1().Namespaces().Create(namespaceObj)
+	_, err = f.KubeClient.CoreV1().Namespaces().Create(namespaceObj)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		err = f.KubeClient.CoreV1().Namespaces().Delete(namespace, metav1.NewDeleteOptions(0))
+		if err != nil {
+			t.Log("Failed to delete memcached namespace")
+			t.Fatal(err)
+		}
+	}()
+	t.Log("Created namespace")
 
 	// create rbac
-	dat, err := ioutil.ReadFile("deploy/rbac.yaml")
-	splitDat := bytes.Split(dat, []byte("\n---\n"))
-	for _, thing := range splitDat {
-		err = e2eutil.CreateFromYAML(t, thing, kubeclient, kubeconfig, namespace)
+	rbacYAML, err := ioutil.ReadFile("deploy/rbac.yaml")
+	rbacYAMLSplit := bytes.Split(rbacYAML, []byte("\n---\n"))
+	for _, rbacSpec := range rbacYAMLSplit {
+		err = e2eutil.CreateFromYAML(t, rbacSpec, f.KubeClient, f.KubeConfig, namespace)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
+	defer func() {
+		err = f.KubeClient.RbacV1beta1().Roles(namespace).Delete("memcached-operator", metav1.NewDeleteOptions(0))
+		if err != nil {
+			t.Log("Failed to delete memcached-operator Role")
+			t.Fatal(err)
+		}
+		err = f.KubeClient.RbacV1beta1().RoleBindings(namespace).Delete("default-account-memcached-operator", metav1.NewDeleteOptions(0))
+		if err != nil {
+			t.Log("Failed to delete memcached-operator RoleBinding")
+			t.Fatal(err)
+		}
+	}()
 	t.Log("Created rbac")
 
 	// create crd
-	yamlCRD, err := ioutil.ReadFile("deploy/crd.yaml")
-	err = e2eutil.CreateFromYAML(t, yamlCRD, kubeclient, kubeconfig, namespace)
+	crdYAML, err := ioutil.ReadFile("deploy/crd.yaml")
+	err = e2eutil.CreateFromYAML(t, crdYAML, f.KubeClient, f.KubeConfig, namespace)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		extensionclient, err := extensions.NewForConfig(f.KubeConfig)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = extensionclient.ApiextensionsV1beta1().CustomResourceDefinitions().Delete("memcacheds.cache.example.com", metav1.NewDeleteOptions(0))
+		if err != nil {
+			t.Log("Failed to delete memcached CRD")
+			t.Fatal(err)
+		}
+	}()
 	t.Log("Created crd")
 
 	// create operator
-	dat, err = ioutil.ReadFile("deploy/operator.yaml")
-	err = e2eutil.CreateFromYAML(t, dat, kubeclient, kubeconfig, namespace)
+	operatorYAML, err := ioutil.ReadFile("deploy/operator.yaml")
+	err = e2eutil.CreateFromYAML(t, operatorYAML, f.KubeClient, f.KubeConfig, namespace)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		err = f.KubeClient.AppsV1().Deployments(namespace).
+			Delete("memcached-operator", metav1.NewDeleteOptions(0))
+		if err != nil {
+			t.Log("Failed to delete memcached-operator deployment")
+			t.Fatal(err)
+		}
+	}()
 	t.Log("Created operator")
 
-	err = e2eutil.DeploymentReplicaCheck(t, kubeclient, namespace, "memcached-operator", 1, 6)
+	// wait for memcached-operator to be ready
+	err = e2eutil.DeploymentReplicaCheck(t, f.KubeClient, namespace, "memcached-operator", 1, 6)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// create example-memcached yaml file
-	file, err := os.OpenFile("deploy/cr.yaml", os.O_WRONLY|os.O_CREATE, 0644)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer file.Close()
-
-	_, err = file.WriteString("apiVersion: \"cache.example.com/v1alpha1\"\nkind: \"Memcached\"\nmetadata:\n  name: \"example-memcached\"\nspec:\n  size: 3")
+	err = ioutil.WriteFile("deploy/cr.yaml",
+		[]byte("apiVersion: \"cache.example.com/v1alpha1\"\nkind: \"Memcached\"\nmetadata:\n  name: \"example-memcached\"\nspec:\n  size: 3"),
+		os.FileMode(int(0664)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	file.Close()
+	// create memcached custom resource
+	crYAML, err := ioutil.ReadFile("deploy/cr.yaml")
+	e2eutil.CreateFromYAML(t, crYAML, f.KubeClient, f.KubeConfig, namespace)
+	memcachedClient := e2eutil.GetCRClient(t, f.KubeConfig, crYAML)
+	defer func() {
+		err = memcachedClient.Delete().
+			Namespace(namespace).
+			Resource("memcacheds").
+			Name("example-memcached").
+			Body([]byte("{\"gracePeriodSeconds\":0}")).
+			Do().
+			Error()
+		if err != nil {
+			t.Log("Failed to delete example-memcached CR")
+			t.Fatal(err)
+		}
+	}()
 
-	yamlCR, err := ioutil.ReadFile("deploy/cr.yaml")
-	memcachedClient := e2eutil.GetCRClient(t, kubeconfig, yamlCR)
-	e2eutil.CreateFromYAML(t, yamlCR, kubeclient, kubeconfig, namespace)
-
-	err = e2eutil.DeploymentReplicaCheck(t, kubeclient, namespace, "example-memcached", 3, 6)
+	// wait for example-memcached to reach 3 replicas
+	err = e2eutil.DeploymentReplicaCheck(t, f.KubeClient, namespace, "example-memcached", 3, 6)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// update CR size to 4
+	// update memcached CR size to 4
 	err = memcachedClient.Patch(types.JSONPatchType).
 		Namespace(namespace).
 		Resource("memcacheds").
@@ -174,53 +230,9 @@ func TestMemcached(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = e2eutil.DeploymentReplicaCheck(t, kubeclient, namespace, "example-memcached", 4, 6)
+	// wait for example-memcached to reach 4 replicas
+	err = e2eutil.DeploymentReplicaCheck(t, f.KubeClient, namespace, "example-memcached", 4, 6)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// clean everything up
-	err = memcachedClient.Delete().
-		Namespace(namespace).
-		Resource("memcacheds").
-		Name("example-memcached").
-		Body([]byte("{\"propagationPolicy\":\"Foreground\"}")).
-		Do().
-		Error()
-	if err != nil {
-		t.Log("Failed to delete example-memcached CR")
-		t.Fatal(err)
-	}
-	err = kubeclient.AppsV1().Deployments(namespace).
-		Delete("memcached-operator", metav1.NewDeleteOptions(0))
-	if err != nil {
-		t.Log("Failed to delete memcached-operator deployment")
-		t.Fatal(err)
-	}
-	err = kubeclient.RbacV1beta1().Roles(namespace).Delete("memcached-operator", metav1.NewDeleteOptions(0))
-	if err != nil {
-		t.Log("Failed to delete memcached-operator Role")
-		t.Fatal(err)
-	}
-	err = kubeclient.RbacV1beta1().RoleBindings(namespace).Delete("default-account-memcached-operator", metav1.NewDeleteOptions(0))
-	if err != nil {
-		t.Log("Failed to delete memcached-operator RoleBinding")
-		t.Fatal(err)
-	}
-	extensionclient, err := extensions.NewForConfig(kubeconfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = extensionclient.ApiextensionsV1beta1().CustomResourceDefinitions().Delete("memcacheds.cache.example.com", metav1.NewDeleteOptions(0))
-	if err != nil {
-		t.Log("Failed to delete memcached CRD")
-		t.Fatal(err)
-	}
-	err = kubeclient.CoreV1().Namespaces().Delete(namespace, metav1.NewDeleteOptions(0))
-	if err != nil {
-		t.Log("Failed to delete memcached namespace")
-		t.Fatal(err)
-	}
-
-	os.RemoveAll(os.Getenv("GOPATH") + "/src/github.com/example-inc/memcached-operator")
 }


### PR DESCRIPTION
This commit cleans up the current e2e tests. Naming has been made more
consistent and logical, teardown functions have been deferred to
ensure that they run even on test failure, local testing is now
simpler with external repo pushing support, and a basic framework
has been created to allow easier management multiple tests in the
future.