### PR TITLE
test/e2e: general cleanup and renaming of variables

### DIFF
--- a/test/e2e/e2eutil/check_util.go
+++ b/test/e2e/e2eutil/check_util.go
@@ -11,7 +11,7 @@ import (
 
 var retryInterval = time.Second * 5
 
-func DeploymentReplicaCheck(t *testing.T, kubeclient *kubernetes.Clientset, namespace, name string, replicas, retries int) error {
+func DeploymentReplicaCheck(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, replicas, retries int) error {
 	err := Retry(retryInterval, retries, func() (done bool, err error) {
 		deployment, err := kubeclient.AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{IncludeUninitialized: true})
 		if err != nil {

--- a/test/e2e/e2eutil/create_util.go
+++ b/test/e2e/e2eutil/create_util.go
@@ -21,9 +21,9 @@ import (
 func GetCRClient(t *testing.T, config *rest.Config, yamlCR []byte) *rest.RESTClient {
 	// get new RESTClient for custom resources
 	crConfig := config
-	m := make(map[interface{}]interface{})
-	err := yaml.Unmarshal(yamlCR, &m)
-	groupVersion := strings.Split(m["apiVersion"].(string), "/")
+	yamlMap := make(map[interface{}]interface{})
+	err := yaml.Unmarshal(yamlCR, &yamlMap)
+	groupVersion := strings.Split(yamlMap["apiVersion"].(string), "/")
 	crGV := schema.GroupVersion{Group: groupVersion[0], Version: groupVersion[1]}
 	crConfig.GroupVersion = &crGV
 	crConfig.APIPath = "/apis"
@@ -67,10 +67,10 @@ func createCRDFromYAML(t *testing.T, yamlFile []byte, extensionsClient *extensio
 	return nil
 }
 
-func CreateFromYAML(t *testing.T, yamlFile []byte, kubeclient *kubernetes.Clientset, kubeconfig *rest.Config, namespace string) error {
-	m := make(map[interface{}]interface{})
-	err := yaml.Unmarshal(yamlFile, &m)
-	kind := m["kind"].(string)
+func CreateFromYAML(t *testing.T, yamlFile []byte, kubeclient kubernetes.Interface, kubeconfig *rest.Config, namespace string) error {
+	yamlMap := make(map[interface{}]interface{})
+	err := yaml.Unmarshal(yamlFile, &yamlMap)
+	kind := yamlMap["kind"].(string)
 	switch kind {
 	case "Role":
 	case "RoleBinding":


### PR DESCRIPTION
This renames many variables in the e2e test to make the naming more
consistent and thus make the code more readable. It also makes a
small change to writing the new cr.yaml file to make it simpler and
changes the delete options for the cr's deletion to make them the
same as the rest of the deletion process.

This is one of the parts of PR #355 that is being split off for easier review.