### PR TITLE
test/e2e/memcached_test.go: defer teardown

### DIFF
--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"testing"
 
 	"github.com/operator-framework/operator-sdk/test/e2e/e2eutil"
@@ -30,7 +31,7 @@ func TestMemcached(t *testing.T) {
 	if !ok {
 		t.Fatalf("GOPATH not set")
 	}
-	os.Chdir(gopath + "/src/github.com/example-inc")
+	os.Chdir(path.Join(gopath, "/src/github.com/example-inc"))
 	t.Log("Creating new operator project")
 	cmdOut, err := exec.Command("operator-sdk",
 		"new",
@@ -40,11 +41,11 @@ func TestMemcached(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error: %v\nCommand Output: %s\n", err, string(cmdOut))
 	}
-	defer os.RemoveAll(gopath + "/src/github.com/example-inc/memcached-operator")
+	defer os.RemoveAll(path.Join(gopath, "/src/github.com/example-inc/memcached-operator"))
 
 	os.Chdir("memcached-operator")
 	os.RemoveAll("vendor/github.com/operator-framework/operator-sdk/pkg")
-	os.Symlink(os.Getenv("TRAVIS_BUILD_DIR")+"/pkg", "vendor/github.com/operator-framework/operator-sdk/pkg")
+	os.Symlink(path.Join(os.Getenv("TRAVIS_BUILD_DIR"), "/pkg"), "vendor/github.com/operator-framework/operator-sdk/pkg")
 	handlerFile, err := os.Create("pkg/stub/handler.go")
 	if err != nil {
 		t.Fatal(err)
@@ -135,7 +136,7 @@ func TestMemcached(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() {
-		extensionclient, err := extensions.NewForConfig(kubeconfig)
+		extensionclient, err := extensions.NewForConfig(f.KubeConfig)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -180,7 +181,7 @@ func TestMemcached(t *testing.T) {
 	}
 
 	// update memcached CR size to 4
-	memcachedClient := e2eutil.GetCRClient(t, kubeconfig, crYAML)
+	memcachedClient := e2eutil.GetCRClient(t, f.KubeConfig, crYAML)
 	err = memcachedClient.Patch(types.JSONPatchType).
 		Namespace(namespace).
 		Resource("memcacheds").

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -112,8 +112,7 @@ func TestMemcached(t *testing.T) {
 	defer func() {
 		err = f.KubeClient.CoreV1().Namespaces().Delete(namespace, metav1.NewDeleteOptions(0))
 		if err != nil {
-			t.Log("Failed to delete memcached namespace")
-			t.Fatal(err)
+			t.Fatalf("Failed to delete memcached namespace(%s): %v", namespace, err)
 		}
 	}()
 	t.Log("Created namespace")
@@ -142,8 +141,7 @@ func TestMemcached(t *testing.T) {
 		}
 		err = extensionclient.ApiextensionsV1beta1().CustomResourceDefinitions().Delete("memcacheds.cache.example.com", metav1.NewDeleteOptions(0))
 		if err != nil {
-			t.Log("Failed to delete memcached CRD")
-			t.Fatal(err)
+			t.Fatalf("Failed to delete memcached CRD: %v", err)
 		}
 	}()
 	t.Log("Created crd")

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -26,7 +26,11 @@ const (
 )
 
 func TestMemcached(t *testing.T) {
-	os.Chdir(os.Getenv("GOPATH") + "/src/github.com/example-inc")
+	gopath, ok := os.LookupEnv("GOPATH")
+	if !ok {
+		t.Fatalf("GOPATH not set")
+	}
+	os.Chdir(gopath + "/src/github.com/example-inc")
 	t.Log("Creating new operator project")
 	cmdOut, err := exec.Command("operator-sdk",
 		"new",
@@ -36,7 +40,7 @@ func TestMemcached(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error: %v\nCommand Output: %s\n", err, string(cmdOut))
 	}
-	defer os.RemoveAll(os.Getenv("GOPATH") + "/src/github.com/example-inc/memcached-operator")
+	defer os.RemoveAll(gopath + "/src/github.com/example-inc/memcached-operator")
 
 	os.Chdir("memcached-operator")
 	os.RemoveAll("vendor/github.com/operator-framework/operator-sdk/pkg")

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -100,6 +100,7 @@ func TestMemcached(t *testing.T) {
 
 	// get global framework variables
 	f := framework.Global
+	// TODO: make namespace unique to avoid namespace collision
 	namespace := "memcached"
 	// create namespace
 	namespaceObj := &core.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}


### PR DESCRIPTION
Currently, if the test fails, the teardown does not occur, which
may cause problems for future tests or local tests. It is also
cleaner to defer the teardown after creation of a resource instead
of lumping all the teardown together at the end of the function.

This is one of the parts of PR #355 that is being split off for easier review.