### PR TITLE
test/e2e: add framework for e2e tests

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -23,7 +23,7 @@ func setup() error {
 	if ok {
 		defaultKubeConfig = homedir + "/.kube/config"
 	}
-	config := flag.String("kubeconfig", defaultKubeConfig, "kube config path, e.g. $HOME/.kube/config")
+	config := flag.String("kubeconfig", defaultKubeConfig, "kubeconfig path, defaults to $HOME/.kube/config")
 	flag.Parse()
 	if *config == "" {
 		log.Fatalf("Cannot find kubeconfig, exiting\n")

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -1,0 +1,45 @@
+package framework
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var Global *Framework
+
+type Framework struct {
+	KubeConfig *rest.Config
+	KubeClient kubernetes.Interface
+}
+
+func setup() error {
+	homedir, ok := os.LookupEnv("HOME")
+	var config *string
+	if !ok {
+		config = flag.String("kubeconfig", "", "kube config path, e.g. $HOME/.kube/config")
+	} else {
+		config = flag.String("kubeconfig", homedir+"/.kube/config", "kube config path, e.g. $HOME/.kube/config")
+	}
+	flag.Parse()
+	if *config == "" {
+		log.Fatalf("Cannot find kubeconfig, exiting\n")
+	}
+	kubeconfig, err := clientcmd.BuildConfigFromFlags("", *config)
+	if err != nil {
+		return err
+	}
+	kubeclient, err := kubernetes.NewForConfig(kubeconfig)
+	if err != nil {
+		return err
+	}
+	Global = &Framework{
+		KubeConfig: kubeconfig,
+		KubeClient: kubeclient,
+	}
+	return nil
+}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -18,13 +18,12 @@ type Framework struct {
 }
 
 func setup() error {
+	defaultKubeConfig := ""
 	homedir, ok := os.LookupEnv("HOME")
-	var config *string
-	if !ok {
-		config = flag.String("kubeconfig", "", "kube config path, e.g. $HOME/.kube/config")
-	} else {
-		config = flag.String("kubeconfig", homedir+"/.kube/config", "kube config path, e.g. $HOME/.kube/config")
+	if ok {
+		defaultKubeConfig = homedir + "/.kube/config"
 	}
+	config := flag.String("kubeconfig", defaultKubeConfig, "kube config path, e.g. $HOME/.kube/config")
 	flag.Parse()
 	if *config == "" {
 		log.Fatalf("Cannot find kubeconfig, exiting\n")

--- a/test/e2e/framework/main_entry.go
+++ b/test/e2e/framework/main_entry.go
@@ -1,0 +1,15 @@
+package framework
+
+import (
+	"log"
+	"os"
+	"testing"
+)
+
+func MainEntry(m *testing.M) {
+	if err := setup(); err != nil {
+		log.Fatalf("Failed to set up framework: %v", err)
+	}
+
+	os.Exit(m.Run())
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,11 +1,11 @@
 package e2e
 
 import (
-	"os"
 	"testing"
+
+	f "github.com/operator-framework/operator-sdk/test/e2e/framework"
 )
 
 func TestMain(m *testing.M) {
-	// TODO: create a setup step for the framework here
-	os.Exit(m.Run())
+	f.MainEntry(m)
 }

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -7,16 +7,15 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"testing"
 
 	"github.com/operator-framework/operator-sdk/test/e2e/e2eutil"
+	framework "github.com/operator-framework/operator-sdk/test/e2e/framework"
+
 	core "k8s.io/api/core/v1"
 	extensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -94,22 +93,12 @@ func TestMemcached(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// get global framework variables
+	f := framework.Global
 	namespace := "memcached"
-	kubeconfigPath := filepath.Join(
-		os.Getenv("HOME"), ".kube", "config",
-	)
-	kubeconfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	kubeclient, err := kubernetes.NewForConfig(kubeconfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// create namespace
 	namespaceObj := &core.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-	_, err = kubeclient.CoreV1().Namespaces().Create(namespaceObj)
+	_, err = f.KubeClient.CoreV1().Namespaces().Create(namespaceObj)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +108,7 @@ func TestMemcached(t *testing.T) {
 	rbacYAML, err := ioutil.ReadFile("deploy/rbac.yaml")
 	rbacYAMLSplit := bytes.Split(rbacYAML, []byte("\n---\n"))
 	for _, rbacSpec := range rbacYAMLSplit {
-		err = e2eutil.CreateFromYAML(t, rbacSpec, kubeclient, kubeconfig, namespace)
+		err = e2eutil.CreateFromYAML(t, rbacSpec, f.KubeClient, f.KubeConfig, namespace)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -128,7 +117,7 @@ func TestMemcached(t *testing.T) {
 
 	// create crd
 	crdYAML, err := ioutil.ReadFile("deploy/crd.yaml")
-	err = e2eutil.CreateFromYAML(t, crdYAML, kubeclient, kubeconfig, namespace)
+	err = e2eutil.CreateFromYAML(t, crdYAML, f.KubeClient, f.KubeConfig, namespace)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,14 +125,14 @@ func TestMemcached(t *testing.T) {
 
 	// create operator
 	operatorYAML, err = ioutil.ReadFile("deploy/operator.yaml")
-	err = e2eutil.CreateFromYAML(t, operatorYAML, kubeclient, kubeconfig, namespace)
+	err = e2eutil.CreateFromYAML(t, operatorYAML, f.KubeClient, f.KubeConfig, namespace)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log("Created operator")
 
 	// wait for memcached-operator to be ready
-	err = e2eutil.DeploymentReplicaCheck(t, kubeclient, namespace, "memcached-operator", 1, 6)
+	err = e2eutil.DeploymentReplicaCheck(t, f.KubeClient, namespace, "memcached-operator", 1, 6)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,11 +147,11 @@ func TestMemcached(t *testing.T) {
 
 	// create memcached custom resource
 	crYAML, err := ioutil.ReadFile("deploy/cr.yaml")
-	e2eutil.CreateFromYAML(t, crYAML, kubeclient, kubeconfig, namespace)
-	memcachedClient := e2eutil.GetCRClient(t, kubeconfig, crYAML)
+	e2eutil.CreateFromYAML(t, crYAML, f.KubeClient, f.KubeConfig, namespace)
+	memcachedClient := e2eutil.GetCRClient(t, f.KubeConfig, crYAML)
 
 	// wait for example-memcached to reach 3 replicas
-	err = e2eutil.DeploymentReplicaCheck(t, kubeclient, namespace, "example-memcached", 3, 6)
+	err = e2eutil.DeploymentReplicaCheck(t, f.KubeClient, namespace, "example-memcached", 3, 6)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,7 +169,7 @@ func TestMemcached(t *testing.T) {
 	}
 
 	// wait for example-memcached to reach 4 replicas
-	err = e2eutil.DeploymentReplicaCheck(t, kubeclient, namespace, "example-memcached", 4, 6)
+	err = e2eutil.DeploymentReplicaCheck(t, f.KubeClient, namespace, "example-memcached", 4, 6)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,23 +186,23 @@ func TestMemcached(t *testing.T) {
 		t.Log("Failed to delete example-memcached CR")
 		t.Fatal(err)
 	}
-	err = kubeclient.AppsV1().Deployments(namespace).
+	err = f.KubeClient.AppsV1().Deployments(namespace).
 		Delete("memcached-operator", metav1.NewDeleteOptions(0))
 	if err != nil {
 		t.Log("Failed to delete memcached-operator deployment")
 		t.Fatal(err)
 	}
-	err = kubeclient.RbacV1beta1().Roles(namespace).Delete("memcached-operator", metav1.NewDeleteOptions(0))
+	err = f.KubeClient.RbacV1beta1().Roles(namespace).Delete("memcached-operator", metav1.NewDeleteOptions(0))
 	if err != nil {
 		t.Log("Failed to delete memcached-operator Role")
 		t.Fatal(err)
 	}
-	err = kubeclient.RbacV1beta1().RoleBindings(namespace).Delete("default-account-memcached-operator", metav1.NewDeleteOptions(0))
+	err = f.KubeClient.RbacV1beta1().RoleBindings(namespace).Delete("default-account-memcached-operator", metav1.NewDeleteOptions(0))
 	if err != nil {
 		t.Log("Failed to delete memcached-operator RoleBinding")
 		t.Fatal(err)
 	}
-	extensionclient, err := extensions.NewForConfig(kubeconfig)
+	extensionclient, err := extensions.NewForConfig(f.KubeConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +211,7 @@ func TestMemcached(t *testing.T) {
 		t.Log("Failed to delete memcached CRD")
 		t.Fatal(err)
 	}
-	err = kubeclient.CoreV1().Namespaces().Delete(namespace, metav1.NewDeleteOptions(0))
+	err = f.KubeClient.CoreV1().Namespaces().Delete(namespace, metav1.NewDeleteOptions(0))
 	if err != nil {
 		t.Log("Failed to delete memcached namespace")
 		t.Fatal(err)


### PR DESCRIPTION
This will allow us to add more tests in the future without
duplicating code and will also allow us to parse command line options
more easily.

This is one of the parts of PR #355 that is being split off for easier review.