### PR TITLE
pkg/sdk: don't exit on failure to create metrics service

### DIFF
--- a/pkg/sdk/metrics.go
+++ b/pkg/sdk/metrics.go
@@ -17,11 +17,12 @@ func ExposeMetricsPort() {
 
 	service, err := k8sutil.InitOperatorService()
 	if err != nil {
-		logrus.Fatalf("Failed to init operator service: %v", err)
+		logrus.Errorf("Failed to initialize service object for operator metrics: %v", err)
+		return
 	}
 	err = Create(service)
 	if err != nil && !errors.IsAlreadyExists(err) {
-		logrus.Infof("Failed to create operator service: %v", err)
+		logrus.Errorf("Failed to create service for operator metrics: %v", err)
 		return
 	}
 	logrus.Infof("Metrics service %s created", service.Name)


### PR DESCRIPTION
ref: #356 

/cc @fanminshi 

Setting up the operator metrics service was supposed to be best effort and not fail. With this `operator-sdk up local` should be fixed:
```sh
$ operator-sdk up local --namespace=haseeb
INFO[0000] Go Version: go1.10.2
INFO[0000] Go OS/Arch: darwin/amd64
INFO[0000] operator-sdk Version: 0.0.5+git
ERRO[0000] Failed to initialize service object for operator metrics: OPERATOR_NAME must be set
INFO[0000] Watching app.example.com/v1alpha1, App, haseeb, 5
```