### PR TITLE
Allow running of E2E tests locally

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -15,7 +15,7 @@ var Global *Framework
 type Framework struct {
 	KubeConfig   *rest.Config
 	KubeClient   kubernetes.Interface
-	ExternalRepo *string
+	ImageName *string
 }
 
 func setup() error {
@@ -25,7 +25,7 @@ func setup() error {
 		defaultKubeConfig = homedir + "/.kube/config"
 	}
 	config := flag.String("kubeconfig", defaultKubeConfig, "kubeconfig path, defaults to $HOME/.kube/config")
-	extRepo := flag.String("external_repo", "", "external repo to push to, defaults to none (builds image to local docker repo)")
+	imageName := flag.String("image", "", "operator image name <repository>:<tag> used to push the image, defaults to none (builds image to local docker repo)")
 	flag.Parse()
 	if *config == "" {
 		log.Fatalf("Cannot find kubeconfig, exiting\n")
@@ -41,7 +41,7 @@ func setup() error {
 	Global = &Framework{
 		KubeConfig:   kubeconfig,
 		KubeClient:   kubeclient,
-		ExternalRepo: extRepo,
+		ImageName: imageName,
 	}
 	return nil
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -13,9 +13,9 @@ import (
 var Global *Framework
 
 type Framework struct {
-	KubeConfig   *rest.Config
-	KubeClient   kubernetes.Interface
-	ImageName *string
+	KubeConfig *rest.Config
+	KubeClient kubernetes.Interface
+	ImageName  *string
 }
 
 func setup() error {
@@ -39,9 +39,9 @@ func setup() error {
 		return err
 	}
 	Global = &Framework{
-		KubeConfig:   kubeconfig,
-		KubeClient:   kubeclient,
-		ImageName: imageName,
+		KubeConfig: kubeconfig,
+		KubeClient: kubeclient,
+		ImageName:  imageName,
 	}
 	return nil
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -13,8 +13,9 @@ import (
 var Global *Framework
 
 type Framework struct {
-	KubeConfig *rest.Config
-	KubeClient kubernetes.Interface
+	KubeConfig   *rest.Config
+	KubeClient   kubernetes.Interface
+	ExternalRepo *string
 }
 
 func setup() error {
@@ -24,6 +25,7 @@ func setup() error {
 		defaultKubeConfig = homedir + "/.kube/config"
 	}
 	config := flag.String("kubeconfig", defaultKubeConfig, "kubeconfig path, defaults to $HOME/.kube/config")
+	extRepo := flag.String("external_repo", "", "external repo to push to, defaults to none (builds image to local docker repo)")
 	flag.Parse()
 	if *config == "" {
 		log.Fatalf("Cannot find kubeconfig, exiting\n")
@@ -37,8 +39,9 @@ func setup() error {
 		return err
 	}
 	Global = &Framework{
-		KubeConfig: kubeconfig,
-		KubeClient: kubeclient,
+		KubeConfig:   kubeconfig,
+		KubeClient:   kubeclient,
+		ExternalRepo: extRepo,
 	}
 	return nil
 }

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -108,9 +108,7 @@ func TestMemcached(t *testing.T) {
 		}
 	} else {
 		t.Log("Pushing docker image to repo")
-		cmdOut, err = exec.Command("docker",
-			"push",
-			*f.ImageName).CombinedOutput()
+		cmdOut, err = exec.Command("docker", "push", *f.ImageName).CombinedOutput()
 		if err != nil {
 			t.Fatalf("Error: %v\nCommand Output: %s\n", err, string(cmdOut))
 		}

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -45,7 +45,8 @@ func TestMemcached(t *testing.T) {
 
 	os.Chdir("memcached-operator")
 	os.RemoveAll("vendor/github.com/operator-framework/operator-sdk/pkg")
-	os.Symlink(path.Join(os.Getenv("TRAVIS_BUILD_DIR"), "/pkg"), "vendor/github.com/operator-framework/operator-sdk/pkg")
+	os.Symlink(path.Join(gopath, "/src/github.com/operator-framework/operator-sdk/pkg"),
+		"vendor/github.com/operator-framework/operator-sdk/pkg")
 	handlerFile, err := os.Create("pkg/stub/handler.go")
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -85,9 +85,8 @@ func TestMemcached(t *testing.T) {
 
 	// get global framework variables
 	f := framework.Global
-
 	t.Log("Building operator docker image")
-	if *f.ExternalRepo == "" {
+	if *f.ImageName == "" {
 		cmdOut, err = exec.Command("operator-sdk",
 			"build",
 			"quay.io/example/memcached-operator:v0.0.1").CombinedOutput()
@@ -106,14 +105,14 @@ func TestMemcached(t *testing.T) {
 	} else {
 		cmdOut, err = exec.Command("operator-sdk",
 			"build",
-			*f.ExternalRepo+":v0.0.1").CombinedOutput()
+			*f.ImageName).CombinedOutput()
 		if err != nil {
 			t.Fatalf("Error: %v\nCommand Output: %s\n", err, string(cmdOut))
 		}
 		t.Log("Pushing docker image to repo")
 		cmdOut, err = exec.Command("docker",
 			"push",
-			*f.ExternalRepo+":v0.0.1").CombinedOutput()
+			*f.ImageName).CombinedOutput()
 		if err != nil {
 			t.Fatalf("Error: %v\nCommand Output: %s\n", err, string(cmdOut))
 		}
@@ -167,6 +166,9 @@ func TestMemcached(t *testing.T) {
 
 	// create operator
 	operatorYAML, err := ioutil.ReadFile("deploy/operator.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = e2eutil.CreateFromYAML(t, operatorYAML, f.KubeClient, f.KubeConfig, namespace)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
These commits add the ability to run E2E tests on a local machine using an external repository for the image and using the GOPATH instead of TRAVIS_BUILD_DIR for the pkg symlink.

This is the last part of PR #355 that was split up for easier review.