### PR TITLE
test/e2e: test `up local` command in e2e test

### DIFF
--- a/test/e2e/framework/context.go
+++ b/test/e2e/framework/context.go
@@ -1,0 +1,59 @@
+package framework
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type TestCtx struct {
+	ID         string
+	cleanUpFns []finalizerFn
+}
+
+type finalizerFn func() error
+
+func (f *Framework) NewTestCtx(t *testing.T) TestCtx {
+	// TestCtx is used among others for namespace names where '/' is forbidden
+	prefix := strings.TrimPrefix(
+		strings.Replace(
+			strings.ToLower(t.Name()),
+			"/",
+			"-",
+			-1,
+		),
+		"test",
+	)
+
+	id := prefix + "-" + strconv.FormatInt(time.Now().Unix(), 10)
+	return TestCtx{
+		ID: id,
+	}
+}
+
+// GetObjID returns an ascending ID based on the length of cleanUpFns. It is
+// based on the premise that every new object also appends a new finalizerFn on
+// cleanUpFns. This can e.g. be used to create multiple namespaces in the same
+// test context.
+func (ctx *TestCtx) GetObjID() string {
+	return ctx.ID + "-" + strconv.Itoa(len(ctx.cleanUpFns))
+}
+
+func (ctx *TestCtx) Cleanup(t *testing.T) {
+	var eg errgroup.Group
+
+	for i := len(ctx.cleanUpFns) - 1; i >= 0; i-- {
+		eg.Go(ctx.cleanUpFns[i])
+	}
+
+	if err := eg.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (ctx *TestCtx) AddFinalizerFn(fn finalizerFn) {
+	ctx.cleanUpFns = append(ctx.cleanUpFns, fn)
+}

--- a/test/e2e/framework/resource_creator.go
+++ b/test/e2e/framework/resource_creator.go
@@ -1,0 +1,21 @@
+package framework
+
+import (
+	"testing"
+
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (ctx *TestCtx) CreateNamespace(f *Framework, t *testing.T) (string, error) {
+	// create namespace
+	namespace := ctx.GetObjID()
+	namespaceObj := &core.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+	_, err := f.KubeClient.CoreV1().Namespaces().Create(namespaceObj)
+	if err != nil {
+		return "", err
+	}
+	t.Log("Created namespace")
+	ctx.AddFinalizerFn(func() error { return f.KubeClient.CoreV1().Namespaces().Delete(namespace, metav1.NewDeleteOptions(0)) })
+	return namespace, nil
+}


### PR DESCRIPTION
Previous versions of this test only tested the operator running
in the cluster, not when running local by using the `up local`
subcommand. This commit makes both methods be tested in parallel. To
determine unique namespaces and keep track of cleanup functions,
the context.go file from the prometheus operator was added to
the sdk e2e test framework in the commit as well.

This commit contains a decent amount of rearranging, so it looks quite large.