### PR TITLE
commands/.../up/local.go: handle sigint and sigterm

### DIFF
--- a/commands/operator-sdk/cmd/up/local.go
+++ b/commands/operator-sdk/cmd/up/local.go
@@ -86,7 +86,7 @@ func upLocal(projectName string) {
 		<-c
 		err := dc.Process.Kill()
 		if err != nil {
-			os.Exit(1)
+			cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to terminate the operator: %v", err))
 		}
 		os.Exit(0)
 	}()


### PR DESCRIPTION
This commit fixes issue #366 and kills the `go run` command spawned
by `up local` when a `SIGINT` or `SIGTERM` signal is sent.