### PR TITLE
pkg/util/tlsutil: add tls primitives functions

### DIFF
--- a/pkg/tlsutil/primitives.go
+++ b/pkg/tlsutil/primitives.go
@@ -1,0 +1,114 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlsutil
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math"
+	"math/big"
+	"time"
+
+	"k8s.io/api/core/v1"
+)
+
+const (
+	rsaKeySize   = 2048
+	duration365d = time.Hour * 24 * 365
+)
+
+// newPrivateKey returns randomly generated RSA private key.
+func newPrivateKey() (*rsa.PrivateKey, error) {
+	return rsa.GenerateKey(rand.Reader, rsaKeySize)
+}
+
+// encodePrivateKeyPEM encodes the given private key pem and returns bytes (base64).
+func encodePrivateKeyPEM(key *rsa.PrivateKey) []byte {
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+}
+
+// encodeCertificatePEM encodes the given certificate pem and returns bytes (base64).
+func encodeCertificatePEM(cert *x509.Certificate) []byte {
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	})
+}
+
+// newSelfSignedCACertificate returns a self-signed CA certificate based on given configuration and private key.
+// The certificate has one-year lease.
+func newSelfSignedCACertificate(key *rsa.PrivateKey) (*x509.Certificate, error) {
+	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	tmpl := x509.Certificate{
+		SerialNumber:          serial,
+		NotBefore:             now.UTC(),
+		NotAfter:              now.Add(duration365d).UTC(),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA: true,
+	}
+	certDERBytes, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, key.Public(), key)
+	if err != nil {
+		return nil, err
+	}
+	return x509.ParseCertificate(certDERBytes)
+}
+
+// newSignedCertificate signs a certificate using the given private key, CA and returns a signed certificate.
+// The certificate could be used for both client and server auth.
+// The certificate has one-year lease.
+func newSignedCertificate(cfg *CertConfig, service *v1.Service, key *rsa.PrivateKey, caCert *x509.Certificate, caKey *rsa.PrivateKey) (*x509.Certificate, error) {
+	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
+	if err != nil {
+		return nil, err
+	}
+	eku := []x509.ExtKeyUsage{}
+	switch cfg.CertType {
+	case ClientCert:
+		eku = append(eku, x509.ExtKeyUsageClientAuth)
+	case ServingCert:
+		eku = append(eku, x509.ExtKeyUsageServerAuth)
+	case ClientAndServingCert:
+		eku = append(eku, x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth)
+	}
+	certTmpl := x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:   cfg.CommonName,
+			Organization: cfg.Organization,
+		},
+		DNSNames:     []string{fmt.Sprintf("%s.%s.svc.cluster.local", service.Name, service.Namespace)},
+		SerialNumber: serial,
+		NotBefore:    caCert.NotBefore,
+		NotAfter:     time.Now().Add(duration365d).UTC(),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  eku,
+	}
+	certDERBytes, err := x509.CreateCertificate(rand.Reader, &certTmpl, caCert, key.Public(), caKey)
+	if err != nil {
+		return nil, err
+	}
+	return x509.ParseCertificate(certDERBytes)
+}

--- a/pkg/tlsutil/tls.go
+++ b/pkg/tlsutil/tls.go
@@ -23,12 +23,12 @@ import (
 type CertType int
 
 const (
-	// ClientCert defines a client cert.
-	ClientCert CertType = iota
+	// ClientAndServingCert defines both client and serving cert.
+	ClientAndServingCert CertType = iota
 	// ServingCert defines a serving cert.
 	ServingCert
-	// ClientAndServingCert defines both client and serving cert.
-	ClientAndServingCert
+	// ClientCert defines a client cert.
+	ClientCert
 )
 
 // CertConfig configures how to generate the Cert.


### PR DESCRIPTION
add tls primitives that generate the private key, the ca cert, and the signed cert for the private key.