### PR TITLE
commands/.../test.go: allow passing of flags to `go test`

### DIFF
--- a/commands/operator-sdk/cmd/test.go
+++ b/commands/operator-sdk/cmd/test.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"os"
+	"strings"
 
 	"github.com/operator-framework/operator-sdk/pkg/test"
 
@@ -28,13 +29,12 @@ var (
 	crdManifestPath  string
 	opManifestPath   string
 	rbacManifestPath string
-	verbose          bool
+	goTestFlags      string
 )
 
-// TODO: allow users to pass flags through to `go test`
 func NewTestCmd() *cobra.Command {
 	testCmd := &cobra.Command{
-		Use:   "test --test-location <path to tests directory> [flags]",
+		Use:   "test --test-location <path to tests directory> [flags] args [go test flags]",
 		Short: "Run End-To-End tests",
 		Run:   testFunc,
 	}
@@ -49,20 +49,18 @@ func NewTestCmd() *cobra.Command {
 	testCmd.Flags().StringVarP(&crdManifestPath, "crd", "c", "deploy/crd.yaml", "Path to CRD manifest")
 	testCmd.Flags().StringVarP(&opManifestPath, "operator", "o", "deploy/operator.yaml", "Path to operator manifest")
 	testCmd.Flags().StringVarP(&rbacManifestPath, "rbac", "r", "deploy/rbac.yaml", "Path to RBAC manifest")
-	testCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose go test")
+	testCmd.Flags().StringVarP(&goTestFlags, "go-test-flags", "g", "", "Additional flags to pass to go test")
 
 	return testCmd
 }
 
 func testFunc(cmd *cobra.Command, args []string) {
 	testArgs := []string{"test", testLocation + "/..."}
-	if verbose {
-		testArgs = append(testArgs, "-v")
-	}
 	testArgs = append(testArgs, "-"+test.KubeConfigFlag, kubeconfig)
 	testArgs = append(testArgs, "-"+test.CrdManPathFlag, crdManifestPath)
 	testArgs = append(testArgs, "-"+test.OpManPathFlag, opManifestPath)
 	testArgs = append(testArgs, "-"+test.RbacManPathFlag, rbacManifestPath)
 	testArgs = append(testArgs, "-"+test.ProjRootFlag, mustGetwd())
+	testArgs = append(testArgs, strings.Split(goTestFlags, " ")...)
 	execCmd(os.Stdout, "go", testArgs...)
 }

--- a/commands/operator-sdk/cmd/test.go
+++ b/commands/operator-sdk/cmd/test.go
@@ -34,7 +34,7 @@ var (
 
 func NewTestCmd() *cobra.Command {
 	testCmd := &cobra.Command{
-		Use:   "test --test-location <path to tests directory> [flags] args [go test flags]",
+		Use:   "test --test-location <path to tests directory> [flags]",
 		Short: "Run End-To-End tests",
 		Run:   testFunc,
 	}


### PR DESCRIPTION
This allows users of the `operator-sdk test` command to pass arguments to `go test`. For instance, `operator-sdk -t ./test/e2e/ args -v -parallel=2`.

Part of issue #387.