### PR TITLE
pkg/generator/templates.go: add new deps to Gopkg template

### DIFF
--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -263,6 +263,11 @@ required = [
   revision = "73d903622b7391f3312dcbac6483fed484e185f8"
 
 [[override]]
+  name = "k8s.io/apiextensions-apiserver"
+  # revision for tag "kubernetes-1.10.1"
+  revision = "4347b330d0ff094db860f2f75fa725b4f4b53618"
+
+[[override]]
   name = "k8s.io/apimachinery"
   # revision for tag "kubernetes-1.10.1"
   revision = "302974c03f7e50f16561ba237db776ab93594ef6"
@@ -271,6 +276,10 @@ required = [
   name = "k8s.io/client-go"
   # revision for tag "kubernetes-1.10.1"
   revision = "989be4278f353e42f26c416c53757d16fcff77db"
+
+[[override]]
+  name = "sigs.k8s.io/controller-runtime"
+  revision = "60bb251ad86f9b313653618aad0c2c53f41a6625"
 
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"


### PR DESCRIPTION
If a user wishes to use the testing framework, they need the
apiextensions and controller-runtime libraries as dependencies.