### PR TITLE
docs: add test command documentation

### DIFF
--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -156,6 +156,33 @@ Create app-operator/.gitignore
 ...
 ```
 
+## test
+
+### Flags
+
+* `-t, --test-location` **(required)** string - location of test
+* `-k, --kubeconfig` string - location of kubeconfig for kubernetes cluster
+* `-c, --crd` string - location of CRD manifest yaml file
+* `-r, --rbac` string - location of RBAC manifest yaml file
+* `-o, --operator` string - location of Operator manifest yaml file
+* `-g, --go-test-flags` string - extra arguments to pass to `go test` (e.g. -g "-v -parallel=2")
+* `-h, --help` - help for test
+
+### Use
+
+The operator-sdk test command runs go tests built using the Operator SDK's test framework.
+
+### Example:
+
+#### Test
+
+```bash
+operator-sdk test --test-location ./test/e2e/
+
+# Output:
+ok  	github.com/operator-framework/operator-sdk-samples/memcached-operator/test/e2e	20.410s
+```
+
 ## up
 
 ### Available Commands

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -160,7 +160,7 @@ Create app-operator/.gitignore
 
 ### Flags
 
-* `-t, --test-location` **(required)** string - location of test
+* `-t, --test-location` **(required)** string - location of e2e test files
 * `-k, --kubeconfig` string - location of kubeconfig for kubernetes cluster
 * `-c, --crd` string - location of CRD manifest yaml file
 * `-r, --rbac` string - location of RBAC manifest yaml file

--- a/doc/testing/travis-build.md
+++ b/doc/testing/travis-build.md
@@ -3,15 +3,18 @@
 Travis is set to run once every 24hrs against the master branch. The results of the builds can be found [here](https://travis-ci.org/operator-framework/operator-sdk/builds).
 
 ## Tool Versions
-* Kubernetes: 1.9.0
+* Kubernetes: 1.10.0
 * Minikube: 0.25.2
 * Go: 1.10.1
 
 ## Test Workflow
-1. Run unit tests
-2. Ensure proper formatting
-3. Install the sdk
-4. Create memcached operator from [user-guide.md](https://github.com/operator-framework/operator-sdk/blob/master/doc/user-guide.md#build-and-run-the-operator)
-5. Fill out handler.go and types.go
-6. Generate and build the operator for k8s
-7. Run the deployment
+1. Build the operator-sdk binary
+2. Run unit tests
+3. Run end-to-end tests
+  - Memcached: Creates the example memcached-operator project using the operator-sdk
+    - Cluster: Runs the example memcached-operator in the cluster and spins up 3 memcached containers in a deployment and verifies that all 3 are available.
+    It then scales the deployment to 4 containers and verifies that there are 4 available containers in the deployment
+    - Local: Same as cluster test, but runs the operator using `up local` instead of in a deployment in the cluster.
+4. Ensure proper formatting
+5. Ensure all go files contain a license header
+6. Ensure all error messages have consistent capitalization


### PR DESCRIPTION
This adds some documentation for the new e2e tests as well as for the `operator-sdk test` command