### PR TITLE
Makefile: remove make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,6 @@ all: format test install
 install:
 	go install github.com/operator-framework/operator-sdk/commands/operator-sdk
 
-test:
-	./hack/test
-
 format:
 	go fmt $(pkgs)
 

--- a/hack/test
+++ b/hack/test
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-go test ./...


### PR DESCRIPTION
The make test is old and not valid anymore. We will add instructions
for running the tests locally in a future PR.