### PR TITLE
pkg/test/framework.go: protect AddToFrameworkScheme with mutex

### DIFF
--- a/pkg/test/framework.go
+++ b/pkg/test/framework.go
@@ -35,8 +35,12 @@ import (
 	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var mutex = sync.Mutex{}
-var Global *Framework
+var (
+	// mutex for AddToFrameworkScheme
+	mutex = sync.Mutex{}
+	// Global framework struct
+	Global *Framework
+)
 
 type Framework struct {
 	KubeConfig       *rest.Config
@@ -104,7 +108,7 @@ type addToSchemeFunc func(*runtime.Scheme) error
 // become ready, this function throws an error
 func AddToFrameworkScheme(addToScheme addToSchemeFunc, obj runtime.Object) error {
 	mutex.Lock()
-	defer func() { mutex.Unlock() }()
+	defer mutex.Unlock()
 	err := addToScheme(Global.Scheme)
 	if err != nil {
 		return err

--- a/pkg/test/framework.go
+++ b/pkg/test/framework.go
@@ -35,8 +35,7 @@ import (
 	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var mutex sync.Mutex
-
+var mutex = sync.Mutex{}
 var Global *Framework
 
 type Framework struct {
@@ -73,7 +72,6 @@ func setup(kubeconfigPath, crdManPath, opManPath, rbacManPath *string) error {
 		return fmt.Errorf("failed to build the dynamic client: %v", err)
 	}
 	dynDec := serializer.NewCodecFactory(scheme).UniversalDeserializer()
-	mutex = sync.Mutex{}
 	Global = &Framework{
 		KubeConfig:       kubeconfig,
 		KubeClient:       kubeclient,


### PR DESCRIPTION
If more than 1 test concurrently ran AddToFrameworkScheme,
there would be concurrent map read/write errors. By using a mutex,
we can ensure that there is not more than 1 function modifying the
scheme at the same time.