### PR TITLE
doc/test-framework: add test framework documentation

### DIFF
--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -1,6 +1,6 @@
 # Using the Operator SDK's Test Framework to Write E2E Tests
 
-End-to-end tests are an essential tool to ensure that an operator works
+End-to-end tests are essential to ensure that an operator works
 as intended in real-world scenarios. The Operator SDK includes a testing
 framework to make writing tests simpler and quicker by removing boilerplate
 code and providing common test utilities. The Operator SDK includes the

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -64,7 +64,7 @@ import (
 #### 2. Register types with framework scheme
 The next step is to register your operator's scheme with the framework's dynamic client.
 To do this, you need to create a list struct for your custom resource and pass the list
-object and the object's addToScheme function to the framework's AddToFrameworkScheme
+object and the object's addToScheme function to the framework's [AddToFrameworkScheme][scheme-link]
 function. For our example memcached-operator, it looks like this:
 ```
 memcachedList := &cachev1alpha1.MemcachedList{
@@ -79,14 +79,10 @@ if err != nil {
 }
 ```
 
-The reason that the list struct is necessary for this function is because the dynamic client's RESTMapper
-needs to have the custom resource's mappings to work. These mappings are created by the kubernetes
-cluster. Since the CRD is created as the last step of the framework setup process, it is likely that the
-resource will not be ready by the time the first test starts. By providing the custom resource's list
-struct, the AddToFrameworkScheme function can verify that the dynamic client has the REST mappings for
-your custom resource. If the mappings are not yet available, the framework simply waits and attempts again
-1 second later. If the mappings are still not available after 5 seconds, the framework assumes something
-went wrong and returns an error.
+We pass in the CR List object `memcachedList` as an argument to `AddToFrameworkScheme()` because
+the framework needs to ensure that the dynamic client has the REST mappings to query the API
+server for the CR type. The framework will keep polling the API server for the mappings and
+timeout after 5 seconds, returning an error if the mappings were not discovered in that time.
 
 #### 3. Setup the test context and resources
 The next step is to create a TestCtx for the current test and defer its cleanup function:
@@ -213,3 +209,4 @@ $ kubectl delete -f deploy/crd.yaml
 [testctx-link]:https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/context.go
 [e2eutil-link]:https://github.com/operator-framework/operator-sdk/tree/master/pkg/test/e2eutil
 [memcached-test-link]:https://github.com/operator-framework/operator-sdk-samples/blob/master/memcached-operator/test/e2e/memcached_test.go
+[scheme-link]:https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/framework.go#L109

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -3,10 +3,9 @@
 End-to-end tests are an essential tool to ensure that an operator works
 as intended in real-world scenarios. The Operator SDK includes a testing
 framework to make writing tests simpler and quicker by removing boilerplate
-code and providing useful tools testing, such as a dynamic client that can
-handle any registered kubernetes resource, including an operator's custom
-resources. The Operator SDK includes the test framework as a library under
-`pkg/test` and the e2e tests are written as standard go tests.
+code and providing common test utilities. The Operator SDK includes the
+test framework as a library under `pkg/test` and the e2e tests are written
+as standard go tests.
 
 ## Components
 

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -11,13 +11,13 @@ resources. The Operator SDK includes the test framework as a library under
 The test framework includes a few components. The most important to talk
 about are Framework and TestCtx.
 
-### [Framework][framework-link]
-Framework contains all global variables, such as the kubeconfig, kubeclient,
+### Framework
+[Framework][framework-link] contains all global variables, such as the kubeconfig, kubeclient,
 scheme, and dynamic client (provided via the controller-runtime project).
 It is initialized by MainEntry and can be used anywhere in the tests.
 
-### [TestCtx][testctx-link]
-TestCtx is a local context that stores important information for each test, such
+### TestCtx
+[TestCtx][testctx-link] is a local context that stores important information for each test, such
 as the namespace for that test and the finalizer (cleanup) functions. By handling
 namespace and resource initialization through TestCtx, we can make sure that all
 resources are properly handled and removed after the test finishes.

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -11,12 +11,12 @@ resources. The Operator SDK includes the test framework as a library under
 The test framework includes a few components. The most important to talk
 about are Framework and TestCtx.
 
-### Framework
+### [Framework][framework-link]
 Framework contains all global variables, such as the kubeconfig, kubeclient,
 scheme, and dynamic client (provided via the controller-runtime project).
 It is initialized by MainEntry and can be used anywhere in the tests.
 
-### TestCtx
+### [TestCtx][testctx-link]
 TestCtx is a local context that stores important information for each test, such
 as the namespace for that test and the finalizer (cleanup) functions. By handling
 namespace and resource initialization through TestCtx, we can make sure that all
@@ -46,6 +46,8 @@ func TestMain(m *testing.M) {
 ```
 
 ### Individual Tests
+In this section, we will be designing a test based on the [memcached_test.go][memcached-test-link] file 
+from the [memcached-operator][memcached-sample] sample.
 #### 1. Import the framework
 Once MainEntry sets up the framework, it runs the remainder of the tests. First, make
 sure to import `testing`, the operator-sdk test framework (`pkg/test`) as well as your operator's libraries:
@@ -103,7 +105,7 @@ if err != nil {
 ```
 
 If you want to make sure the operator's deployment is fully ready before moving onto the next part of the
-test, the `WaitForDeployment` function from e2eutil (in the sdk under `pkg/test/e2eutil`) can be used:
+test, the `WaitForDeployment` function from [e2eutil][e2eutil-link] (in the sdk under `pkg/test/e2eutil`) can be used:
 ```
 // get namespace
 namespace, err := ctx.GetNamespace()
@@ -207,3 +209,7 @@ $ kubectl delete -f deploy/crd.yaml
 ```
 
 [memcached-sample]:https://github.com/operator-framework/operator-sdk-samples/tree/master/memcached-operator
+[framework-link]:https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/framework.go#L45
+[testctx-link]:https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/context.go
+[e2eutil-link]:https://github.com/operator-framework/operator-sdk/tree/master/pkg/test/e2eutil
+[memcached-test-link]:https://github.com/operator-framework/operator-sdk-samples/blob/master/memcached-operator/test/e2e/memcached_test.go

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -23,7 +23,7 @@ namespace and resource initialization through TestCtx, we can make sure that all
 resources are properly handled and removed after the test finishes.
 
 ## Walkthrough: Writing Tests
-In this section, we will be walking through writing the end-to-end tests of the sample
+In this section, we will be walking through writing the e2e tests of the sample
 [memcached-operator][memcached-sample].
 
 ### Main Test
@@ -46,18 +46,20 @@ func TestMain(m *testing.M) {
 ```
 
 ### Individual Tests
+#### 1. Import the framework
 Once MainEntry sets up the framework, it runs the remainder of the tests. First, make
 sure to import `testing`, the operator-sdk test framework (`pkg/test`) as well as your operator's libraries:
 ```
 import (
     "testing"
 
-    cachev1alpha1 "github.com/operator-framework/operator-sdk/test/test-framework/pkg/apis/cache/v1alpha1"
+    cachev1alpha1 "github.com/operator-framework/operator-sdk-samples/memcached-operator/pkg/apis/cache/v1alpha1"
 
     framework "github.com/operator-framework/operator-sdk/pkg/test"
 )
 ```
 
+#### 2. Register types with framework scheme
 The next step is to register your operator's scheme with the framework's dynamic client.
 To do this, you need to create a list struct for your custom resource and pass the list
 object and the object's addToScheme function to the framework's AddToFrameworkScheme
@@ -84,6 +86,7 @@ your custom resource. If the mappings are not yet available, the framework simpl
 1 second later. If the mappings are still not available after 5 seconds, the framework assumes something
 went wrong and returns an error.
 
+#### 3. Setup the test context and resources
 The next step is to create a TestCtx for the current test and defer its cleanup function:
 ```
 ctx := framework.NewTestCtx(t)
@@ -100,8 +103,7 @@ if err != nil {
 ```
 
 If you want to make sure the operator's deployment is fully ready before moving onto the next part of the
-test, the `WaitForDeployment` function from e2eutil can be used. First, import `"github.com/operator-framework/operator-sdk/pkg/util/e2eutil"`
-	and retrieve the required arguments to pass to the `WaitForDeployment` function. Then, call the function:
+test, the `WaitForDeployment` function from e2eutil (in the sdk under `pkg/test/e2eutil`) can be used:
 ```
 // get namespace
 namespace, err := ctx.GetNamespace()
@@ -117,6 +119,7 @@ if err != nil {
 }
 ```
 
+#### 4. Write the test specific code
 Now that the operator is ready, we can create a custom resource. Since the controller-runtime's dynamic client uses
 go contexts, make sure to import the go context library. In this example, we imported it as `goctx`:
 ```

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -1,0 +1,206 @@
+# Using the Operator SDK's Test Framework to Write E2E Tests
+End-to-end tests are an essential tool to ensure that an operator works
+as intended in real-world scenarios. The Operator SDK includes a testing
+framework to make writing tests simpler and quicker by removing boilerplate
+code and providing useful tools testing, such as a dynamic client that can
+handle any registered kubernetes resource, including an operator's custom
+resources. The Operator SDK includes the test framework as a library under
+`pkg/test` and the e2e tests are written as standard go tests.
+
+## Components
+The test framework includes a few components. The most important to talk
+about are Framework and TestCtx.
+
+### Framework
+Framework contains all global variables, such as the kubeconfig, kubeclient,
+scheme, and dynamic client (provided via the controller-runtime project).
+It is initialized by MainEntry and can be used anywhere in the tests.
+
+### TestCtx
+TestCtx is a local context that stores important information for each test, such
+as the namespace for that test and the finalizer (cleanup) functions. By handling
+namespace and resource initialization through TestCtx, we can make sure that all
+resources are properly handled and removed after the test finishes.
+
+## Walkthrough: Writing Tests
+In this section, we will be walking through writing the end-to-end tests of the sample
+[memcached-operator][memcached-sample].
+
+### Main Test
+The first step to writing a test is to create the `main_test.go` file. The `main_test.go`
+file simply calls the test framework's main entry that sets up the framework and then
+starts the tests. It should be pretty much identical for all operators. This is what it
+looks like for the memcached-operator:
+```
+package e2e
+
+import (
+    "testing"
+
+    f "github.com/operator-framework/operator-sdk/pkg/test"
+)
+
+func TestMain(m *testing.M) {
+    f.MainEntry(m)
+}
+```
+
+### Individual Tests
+Once MainEntry sets up the framework, it runs the remainder of the tests. First, make
+sure to import `testing`, the operator-sdk test framework (`pkg/test`) as well as your operator's libraries:
+```
+import (
+    "testing"
+
+    cachev1alpha1 "github.com/operator-framework/operator-sdk/test/test-framework/pkg/apis/cache/v1alpha1"
+
+    framework "github.com/operator-framework/operator-sdk/pkg/test"
+)
+```
+
+The next step is to register your operator's scheme with the framework's dynamic client.
+To do this, you need to create a list struct for your custom resource and pass the list
+object and the object's addToScheme function to the framework's AddToFrameworkScheme
+function. For our example memcached-operator, it looks like this:
+```
+memcachedList := &cachev1alpha1.MemcachedList{
+    TypeMeta: metav1.TypeMeta{
+        Kind:       "Memcached",
+        APIVersion: "cache.example.com/v1alpha1",
+    },
+}
+err := framework.AddToFrameworkScheme(cachev1alpha1.AddToScheme, memcachedList)
+if err != nil {
+    t.Fatalf("failed to add custom resource scheme to framework: %v", err)
+}
+```
+
+The reason that the list struct is necessary for this function is because the dynamic client's RESTMapper
+needs to have the custom resource's mappings to work. These mappings are created by the kubernetes
+cluster. Since the CRD is created as the last step of the framework setup process, it is likely that the
+resource will not be ready by the time the first test starts. By providing the custom resource's list
+struct, the AddToFrameworkScheme function can verify that the dynamic client has the REST mappings for
+your custom resource. If the mappings are not yet available, the framework simply waits and attempts again
+1 second later. If the mappings are still not available after 5 seconds, the framework assumes something
+went wrong and returns an error.
+
+The next step is to create a TestCtx for the current test and defer its cleanup function:
+```
+ctx := framework.NewTestCtx(t)
+defer ctx.Cleanup(t)
+```
+
+Now that there is a TestCtx, the test's kubernetes resources (specifically the RBAC and Operator deployment)
+can be initialized:
+```
+err := ctx.InitializeClusterResources()
+if err != nil {
+    t.Fatalf("failed to initialize cluster resources: %v", err)
+}
+```
+
+If you want to make sure the operator's deployment is fully ready before moving onto the next part of the
+test, the `WaitForDeployment` function from e2eutil can be used. First, import `"github.com/operator-framework/operator-sdk/pkg/util/e2eutil"`
+	and retrieve the required arguments to pass to the `WaitForDeployment` function. Then, call the function:
+```
+// get namespace
+namespace, err := ctx.GetNamespace()
+if err != nil {
+    t.Fatal(err)
+}
+// get global framework variables
+f := framework.Global
+// wait for memcached-operator to be ready
+err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "memcached-operator", 1, time.Second*5, time.Second*30)
+if err != nil {
+    t.Fatal(err)
+}
+```
+
+Now that the operator is ready, we can create a custom resource. Since the controller-runtime's dynamic client uses
+go contexts, make sure to import the go context library. In this example, we imported it as `goctx`:
+```
+// create memcached custom resource
+exampleMemcached := &cachev1alpha1.Memcached{
+    TypeMeta: metav1.TypeMeta{
+        Kind:       "Memcached",
+        APIVersion: "cache.example.com/v1alpha1",
+    },
+    ObjectMeta: metav1.ObjectMeta{
+        Name:      "example-memcached",
+        Namespace: namespace,
+    },
+    Spec: cachev1alpha1.MemcachedSpec{
+        Size: 3,
+    },
+}
+err = f.DynamicClient.Create(goctx.TODO(), exampleMemcached)
+if err != nil {
+    return err
+}
+```
+
+Now we can check if the operator successfully worked. In the case of the memcached operator, it should have
+created a deployment called "example-memcached" with 3 replicas:
+```
+// wait for example-memcached to reach 3 replicas
+err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-memcached", 3, time.Second*5, time.Second*30)
+if err != nil {
+    return err
+}
+```
+ 
+We can also test that the deployment scales correctly when the CR is updated:
+```
+err = f.DynamicClient.Get(goctx.TODO(), types.NamespacedName{Name: "example-memcached", Namespace: namespace}, exampleMemcached)
+if err != nil {
+    return err
+}
+exampleMemcached.Spec.Size = 4
+err = f.DynamicClient.Update(goctx.TODO(), exampleMemcached)
+if err != nil {
+    return err
+}
+
+// wait for example-memcached to reach 4 replicas
+err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-memcached", 4, time.Second*5, time.Second*30)
+if err != nil {
+    return err
+}
+```
+
+Now that the test is complete, we are done with the function. Once the end of the function is reached, the TestCtx's cleanup
+functions will automatically be run since they were deferred when the TestCtx was created.
+
+## Manual Cleanup
+While the test framework provides utilities that allow the test to automatically be cleaned up when done,
+it is possible that an error in the test code could cause a panic, which would stop the test
+without running the deferred cleanup. To clean up manually, you should check what namespaces currently exist
+in your cluster. You can do this with `kubectl`:
+```
+$ kubectl get namespaces
+
+Example Output:
+NAME                                            STATUS    AGE
+default                                         Active    2h
+kube-public                                     Active    2h
+kube-system                                     Active    2h
+main-1534287036                                 Active    23s
+memcached-memcached-group-cluster-1534287037    Active    22s
+memcached-memcached-group-cluster2-1534287037   Active    22s
+```
+
+The names of the namespaces will be either start with `main` or with the name of the tests and the suffix will
+be a Unix timestamp (number of seconds since January 1, 1970 00:00 UTC). Kubectl can be used to delete these
+namespaces and the resources in those namespaces:
+```
+$ kubectl delete namespace main-153428703
+```
+
+The tests also create a CRD. The CRD can be removed quite easily. The simplest way is to use `kubectl` and
+the file that was used to create the crd (by default `deploy/crd.yaml`):
+```
+$ kubectl delete -f deploy/crd.yaml
+```
+
+[memcached-sample]:https://github.com/operator-framework/operator-sdk-samples/tree/master/memcached-operator

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -74,9 +74,8 @@ import (
 #### 2. Register types with framework scheme
 
 The next step is to register your operator's scheme with the framework's dynamic client.
-To do this, you need to create a list struct for your custom resource and pass the list
-object and the object's addToScheme function to the framework's [AddToFrameworkScheme][scheme-link]
-function. For our example memcached-operator, it looks like this:
+To do this, pass the CRD's `AddToScheme` function and its List type object to the framework's
+[AddToFrameworkScheme][scheme-link] function. For our example memcached-operator, it looks like this:
 
 ```go
 memcachedList := &cachev1alpha1.MemcachedList{
@@ -105,8 +104,8 @@ ctx := framework.NewTestCtx(t)
 defer ctx.Cleanup(t)
 ```
 
-Now that there is a TestCtx, the test's kubernetes resources (specifically the RBAC and Operator deployment)
-can be initialized:
+Now that there is a TestCtx, the test's kubernetes resources (specifically the test namespace,
+RBAC, and Operator deployment) can be initialized:
 
 ```go
 err := ctx.InitializeClusterResources()
@@ -190,8 +189,12 @@ if err != nil {
 }
 ```
 
-Now that the test is complete, we are done with the function. Once the end of the function is reached, the TestCtx's cleanup
+Once the end of the function is reached, the TestCtx's cleanup
 functions will automatically be run since they were deferred when the TestCtx was created.
+
+## Running the Tests
+
+TODO
 
 ## Manual Cleanup
 
@@ -221,8 +224,7 @@ namespaces and the resources in those namespaces:
 $ kubectl delete namespace main-153428703
 ```
 
-The tests also create a CRD. The CRD can be removed quite easily. The simplest way is to use `kubectl` and
-the file that was used to create the crd (by default `deploy/crd.yaml`):
+Since the CRD is not namespaced, it must be deleted separately. Clean up the CRD created by the tests using the CRD manifest `deploy/crd.yaml`:
 
 ```shell
 $ kubectl delete -f deploy/crd.yaml


### PR DESCRIPTION
This PR provides documentation on the SDK's test framework
and a waltkthrough on how to create a simple e2e test for the
example memcached-operator.