### PR TITLE
pkg/generator: Add prune to Gopkg.toml template

### DIFF
--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -281,6 +281,16 @@ required = [
   name = "sigs.k8s.io/controller-runtime"
   revision = "60bb251ad86f9b313653618aad0c2c53f41a6625"
 
+[prune]
+  go-tests = true
+  non-go = true
+  unused-packages = true
+
+  [[prune.project]]
+    name = "k8s.io/code-generator"
+    non-go = false
+    unused-packages = false
+
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.


### PR DESCRIPTION
The code that gets vendored by dep by default is huge. We can
leverage the functionality given by dep viz. prune. This will remove
all the non-go code and unused packages.

It makes an exception to the k8s.io/code-generator repository. Since
we use the scripts from this repository to generate code.

Ref: https://golang.github.io/dep/docs/Gopkg.toml.html#prune