### PR TITLE
Change handling of YAML resources in test framework

### DIFF
--- a/commands/operator-sdk/cmd/test.go
+++ b/commands/operator-sdk/cmd/test.go
@@ -57,7 +57,8 @@ func NewTestCmd() *cobra.Command {
 func testFunc(cmd *cobra.Command, args []string) {
 	// if no namespaced manifest path is given, combine deploy/rbac.yaml and deploy/operator.yaml
 	if namespacedManifestPath == "" {
-		namespacedManifestPath = "deploy/test-init-tmp.yaml"
+		os.Mkdir("deploy/test", os.FileMode(int(0775)))
+		namespacedManifestPath = "deploy/test/namespace-manifests.yaml"
 		rbac, err := ioutil.ReadFile("deploy/rbac.yaml")
 		if err != nil {
 			log.Fatalf("could not find rbac manifest: %v", err)
@@ -72,6 +73,12 @@ func testFunc(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatalf("could not create temporary namespaced manifest file: %v", err)
 		}
+		defer func() {
+			err := os.Remove(namespacedManifestPath)
+			if err != nil {
+				log.Fatalf("could not delete temporary namespace manifest file")
+			}
+		}()
 	}
 	testArgs := []string{"test", testLocation + "/..."}
 	testArgs = append(testArgs, "-"+test.KubeConfigFlag, kubeconfig)

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -162,10 +162,9 @@ Create app-operator/.gitignore
 
 * `-t, --test-location` **(required)** string - location of e2e test files
 * `-k, --kubeconfig` string - location of kubeconfig for kubernetes cluster
-* `-c, --crd` string - location of CRD manifest yaml file
-* `-r, --rbac` string - location of RBAC manifest yaml file
-* `-o, --operator` string - location of Operator manifest yaml file
-* `-g, --go-test-flags` string - extra arguments to pass to `go test` (e.g. -g "-v -parallel=2")
+* `-g, --global-init` string - location of global resource manifest yaml file
+* `-n, --namespaced-init` string - location of namespaced resource manifest yaml file
+* `-f, --go-test-flags` string - extra arguments to pass to `go test` (e.g. -f "-v -parallel=2")
 * `-h, --help` - help for test
 
 ### Use

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -195,7 +195,7 @@ functions will automatically be run since they were deferred when the TestCtx wa
 ## Running the Tests
 
 To make running the tests simpler, the `operator-sdk` CLI tool has a `test` subcommand that configures some
-default test settings, such as locations of the manifest files for the CRD, RBAC, and Operator, and allows the user to configure these runtime options. To use it, run the
+default test settings, such as locations of the manifest files for your global resource manifest file (by default `deploy/crd.yaml`) and your namespaced manifest file (by defualt `deploy/rbac.yaml` concatenated with `deploy/operator.yaml`), and allows the user to configure these runtime options. To use it, run the
 `operator-sdk test` command in your project root and pass the location of the tests using the
 `--test-location` flag. You can use `--help` to view the other configuration options and use
 `--go-test-flags` to pass in arguments to `go test`. Here is an example command:
@@ -211,7 +211,12 @@ in [MainEntry][main-entry-link] are declared, the tests will run correctly. Runn
 will result in undefined behavior. This is an example `go test` equivalent to the `operator-sdk test` example above:
 
 ```shell
-$ go test ./test/e2e/... -root=$(pwd) -kubeconfig=$HOME/.kube/config -crd deploy/crd.yaml -op deploy/operator.yaml -rbac deploy/rbac.yaml -v -parallel=2
+# Combine rbac and operator manifest into namespaced manifest
+$ cp deploy/rbac.yaml deploy/namespace-init.yaml
+$ echo -e "\n---\n" >> deploy/namespace-init.yaml
+$ cat deploy/operator.yaml >> deploy/namespace-init.yaml
+# Run tests
+$ go test ./test/e2e/... -root=$(pwd) -kubeconfig=$HOME/.kube/config -globalMan deploy/crd.yaml -namespacedMan deploy/namespace-init.yaml -v -parallel=2
 ```
 
 ## Manual Cleanup

--- a/pkg/test/framework.go
+++ b/pkg/test/framework.go
@@ -43,19 +43,17 @@ var (
 )
 
 type Framework struct {
-	KubeConfig       *rest.Config
-	KubeClient       kubernetes.Interface
-	ExtensionsClient *extensions.Clientset
-	Scheme           *runtime.Scheme
-	RestMapper       *discovery.DeferredDiscoveryRESTMapper
-	DynamicClient    dynclient.Client
-	DynamicDecoder   runtime.Decoder
-	CrdManPath       *string
-	OpManPath        *string
-	RbacManPath      *string
+	KubeConfig        *rest.Config
+	KubeClient        kubernetes.Interface
+	ExtensionsClient  *extensions.Clientset
+	Scheme            *runtime.Scheme
+	RestMapper        *discovery.DeferredDiscoveryRESTMapper
+	DynamicClient     dynclient.Client
+	DynamicDecoder    runtime.Decoder
+	NamespacedManPath *string
 }
 
-func setup(kubeconfigPath, crdManPath, opManPath, rbacManPath *string) error {
+func setup(kubeconfigPath, namespacedManPath *string) error {
 	kubeconfig, err := clientcmd.BuildConfigFromFlags("", *kubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to build the kubeconfig: %v", err)
@@ -77,15 +75,13 @@ func setup(kubeconfigPath, crdManPath, opManPath, rbacManPath *string) error {
 	}
 	dynDec := serializer.NewCodecFactory(scheme).UniversalDeserializer()
 	Global = &Framework{
-		KubeConfig:       kubeconfig,
-		KubeClient:       kubeclient,
-		ExtensionsClient: extensionsClient,
-		Scheme:           scheme,
-		DynamicClient:    dynClient,
-		DynamicDecoder:   dynDec,
-		CrdManPath:       crdManPath,
-		OpManPath:        opManPath,
-		RbacManPath:      rbacManPath,
+		KubeConfig:        kubeconfig,
+		KubeClient:        kubeclient,
+		ExtensionsClient:  extensionsClient,
+		Scheme:            scheme,
+		DynamicClient:     dynClient,
+		DynamicDecoder:    dynDec,
+		NamespacedManPath: namespacedManPath,
 	}
 	return nil
 }

--- a/pkg/test/main_entry.go
+++ b/pkg/test/main_entry.go
@@ -57,7 +57,7 @@ func MainEntry(m *testing.M) {
 	if err != nil {
 		log.Fatalf("failed to read global resource manifest: %v", err)
 	}
-	err = ctx.CreateFromYAML(globalYAML)
+	err = ctx.createFromYAML(globalYAML, true)
 	if err != nil {
 		log.Fatalf("failed to create resource(s) in global resource manifest: %v", err)
 	}

--- a/pkg/test/main_entry.go
+++ b/pkg/test/main_entry.go
@@ -23,26 +23,24 @@ import (
 )
 
 const (
-	ProjRootFlag    = "root"
-	KubeConfigFlag  = "kubeconfig"
-	CrdManPathFlag  = "crd"
-	OpManPathFlag   = "op"
-	RbacManPathFlag = "rbac"
+	ProjRootFlag          = "root"
+	KubeConfigFlag        = "kubeconfig"
+	NamespacedManPathFlag = "namespacedMan"
+	GlobalManPathFlag     = "globalMan"
 )
 
 func MainEntry(m *testing.M) {
-	projRoot := flag.String("root", "", "path to project root")
-	kubeconfigPath := flag.String("kubeconfig", "", "path to kubeconfig")
-	crdManPath := flag.String("crd", "", "path to crd manifest")
-	opManPath := flag.String("op", "", "path to operator manifest")
-	rbacManPath := flag.String("rbac", "", "path to rbac manifest")
+	projRoot := flag.String(ProjRootFlag, "", "path to project root")
+	kubeconfigPath := flag.String(KubeConfigFlag, "", "path to kubeconfig")
+	globalManPath := flag.String(GlobalManPathFlag, "", "path to operator manifest")
+	namespacedManPath := flag.String(NamespacedManPathFlag, "", "path to rbac manifest")
 	flag.Parse()
 	// go test always runs from the test directory; change to project root
 	err := os.Chdir(*projRoot)
 	if err != nil {
 		log.Fatalf("failed to change directory to project root: %v", err)
 	}
-	if err := setup(kubeconfigPath, crdManPath, opManPath, rbacManPath); err != nil {
+	if err := setup(kubeconfigPath, namespacedManPath); err != nil {
 		log.Fatalf("failed to set up framework: %v", err)
 	}
 	// setup context to use when setting up crd
@@ -55,12 +53,12 @@ func MainEntry(m *testing.M) {
 		os.Exit(exitCode)
 	}()
 	// create crd
-	crdYAML, err := ioutil.ReadFile(*Global.CrdManPath)
+	globalYAML, err := ioutil.ReadFile(*globalManPath)
 	if err != nil {
-		log.Fatalf("failed to read crd file: %v", err)
+		log.Fatalf("failed to read global resource manifest: %v", err)
 	}
-	err = ctx.CreateFromYAML(crdYAML)
+	err = ctx.CreateFromYAML(globalYAML)
 	if err != nil {
-		log.Fatalf("failed to create crd resource: %v", err)
+		log.Fatalf("failed to create resource(s) in global resource manifest: %v", err)
 	}
 }

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -55,7 +55,7 @@ func setNamespaceYAML(yamlFile []byte, namespace string) ([]byte, error) {
 	return yaml.Marshal(yamlMap)
 }
 
-func (ctx *TestCtx) CreateFromYAML(yamlFile []byte) error {
+func (ctx *TestCtx) createFromYAML(yamlFile []byte, skipIfExists bool) error {
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
 		return err
@@ -73,6 +73,9 @@ func (ctx *TestCtx) CreateFromYAML(yamlFile []byte) error {
 		}
 
 		err = Global.DynamicClient.Create(goctx.TODO(), obj)
+		if skipIfExists && apierrors.IsAlreadyExists(err) {
+			continue
+		}
 		if err != nil {
 			return err
 		}
@@ -87,5 +90,5 @@ func (ctx *TestCtx) InitializeClusterResources() error {
 	if err != nil {
 		return fmt.Errorf("failed to read namespaced manifest: %v", err)
 	}
-	return ctx.CreateFromYAML(namespacedYAML)
+	return ctx.createFromYAML(namespacedYAML, false)
 }

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -82,19 +82,10 @@ func (ctx *TestCtx) CreateFromYAML(yamlFile []byte) error {
 }
 
 func (ctx *TestCtx) InitializeClusterResources() error {
-	// create rbac
-	rbacYAML, err := ioutil.ReadFile(*Global.RbacManPath)
+	// create namespaced resources
+	namespacedYAML, err := ioutil.ReadFile(*Global.NamespacedManPath)
 	if err != nil {
-		return fmt.Errorf("failed to read rbac manifest: %v", err)
+		return fmt.Errorf("failed to read namespaced manifest: %v", err)
 	}
-	err = ctx.CreateFromYAML(rbacYAML)
-	if err != nil {
-		return err
-	}
-	// create operator deployment
-	operatorYAML, err := ioutil.ReadFile(*Global.OpManPath)
-	if err != nil {
-		return fmt.Errorf("failed to read operator manifest: %v", err)
-	}
-	return ctx.CreateFromYAML(operatorYAML)
+	return ctx.CreateFromYAML(namespacedYAML)
 }


### PR DESCRIPTION
To increase the flexibility of the framework and better describe
how we're using user provided YAML files, this commit removes the
specific crd, rbac, and operator yamls and replaces them with
a global init yaml (for things like CRDs) and a namespaced
init yaml (for things like rbac and operators).