### PR TITLE
Missing step to create the example directory

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -36,6 +36,7 @@ This installs the CLI binary `operator-sdk` at `$GOPATH/bin`.
 Use the CLI to create a new memcached-operator project:
 
 ```sh
+$ mkdir -p $GOPATH/src/github.com/example-inc/
 $ cd $GOPATH/src/github.com/example-inc/
 $ operator-sdk new memcached-operator --api-version=cache.example.com/v1alpha1 --kind=Memcached
 $ cd memcached-operator


### PR DESCRIPTION
The instructions to create the `example-inc` project are missing a step to create the directory first.