### PR TITLE
commands/operator-sdk/cmd: quiet initial git commit

### DIFF
--- a/commands/operator-sdk/cmd/new.go
+++ b/commands/operator-sdk/cmd/new.go
@@ -181,6 +181,6 @@ func initGit() {
 	fmt.Fprintln(os.Stdout, "Run git init ...")
 	execCmd(os.Stdout, "git", "init")
 	execCmd(os.Stdout, "git", "add", "--all")
-	execCmd(nil, "git", "commit", "-m", "INITIAL COMMIT")
+	execCmd(os.Stdout, "git", "commit", "-q", "-m", "INITIAL COMMIT")
 	fmt.Fprintln(os.Stdout, "Run git init done")
 }


### PR DESCRIPTION
`fatal: write failure on 'stdout': Bad file descriptor` error is encountered by some users because the call to `git commit` uses a nil output fd. This commit allows `git commit` to print to stdout but quietly, fixing the error.

Fixes #363