### PR TITLE
*: test the case where only the application TLS asset exists

### DIFF
--- a/pkg/tlsutil/error.go
+++ b/pkg/tlsutil/error.go
@@ -1,0 +1,22 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlsutil
+
+import "errors"
+
+var (
+	ErrCANotFound = errors.New("ca secret and configMap are not found")
+	// TODO: add other tls util errors.
+)

--- a/pkg/tlsutil/tls.go
+++ b/pkg/tlsutil/tls.go
@@ -167,7 +167,7 @@ func (scg *SDKCertGenerator) GenerateCert(cr runtime.Object, service *v1.Service
 	if hasAppSecret && hasCASecretAndConfigMap {
 		return appSecret, caConfigMap, caSecret, nil
 	} else if hasAppSecret && !hasCASecretAndConfigMap {
-		// TODO
+		return nil, nil, nil, errors.New("ca secret and configMap are not found")
 	} else if !hasAppSecret && hasCASecretAndConfigMap {
 		// TODO
 	} else {

--- a/pkg/tlsutil/tls.go
+++ b/pkg/tlsutil/tls.go
@@ -196,11 +196,11 @@ func ToCASecretAndConfigMapName(kind, name string) string {
 
 func getAppSecretInCluster(kubeClient kubernetes.Interface, name, namespace string) (*v1.Secret, error) {
 	se, err := kubeClient.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
+	if err != nil && !apiErrors.IsNotFound(err) {
+		return nil, err
+	}
 	if apiErrors.IsNotFound(err) {
 		return nil, nil
-	}
-	if err != nil {
-		return nil, err
 	}
 	return se, nil
 }
@@ -210,20 +210,20 @@ func getAppSecretInCluster(kubeClient kubernetes.Interface, name, namespace stri
 func getCASecretAndConfigMapInCluster(kubeClient kubernetes.Interface, name, namespace string) (*v1.Secret, *v1.ConfigMap, error) {
 	hasConfigMap := true
 	cm, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
+	if err != nil && !apiErrors.IsNotFound(err) {
+		return nil, nil, err
+	}
 	if apiErrors.IsNotFound(err) {
 		hasConfigMap = false
-	}
-	if err != nil {
-		return nil, nil, err
 	}
 
 	hasSecret := true
 	se, err := kubeClient.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
+	if err != nil && !apiErrors.IsNotFound(err) {
+		return nil, nil, err
+	}
 	if apiErrors.IsNotFound(err) {
 		hasSecret = false
-	}
-	if err != nil {
-		return nil, nil, err
 	}
 
 	if hasConfigMap != hasSecret {

--- a/pkg/tlsutil/tls.go
+++ b/pkg/tlsutil/tls.go
@@ -167,7 +167,7 @@ func (scg *SDKCertGenerator) GenerateCert(cr runtime.Object, service *v1.Service
 	if hasAppSecret && hasCASecretAndConfigMap {
 		return appSecret, caConfigMap, caSecret, nil
 	} else if hasAppSecret && !hasCASecretAndConfigMap {
-		return nil, nil, nil, errors.New("ca secret and configMap are not found")
+		return nil, nil, nil, ErrCANotFound
 	} else if !hasAppSecret && hasCASecretAndConfigMap {
 		// TODO
 	} else {

--- a/test/e2e/tls_util_test.go
+++ b/test/e2e/tls_util_test.go
@@ -138,8 +138,7 @@ func TestOnlyAppSecretExist(t *testing.T) {
 	if err == nil {
 		t.Fatal("expect error, but got none")
 	}
-	expErrMsg := "ca secret and configMap are not found"
-	if err.Error() != expErrMsg {
-		t.Fatalf("expect %v, but got %v", expErrMsg, err.Error())
+	if err != tlsutil.ErrCANotFound {
+		t.Fatalf("expect %v, but got %v", tlsutil.ErrCANotFound.Error(), err.Error())
 	}
 }


### PR DESCRIPTION
Test TLS Util for the case where only the application TLS asset exists in cluster and its corresponding CA doesn't. In this situation, the CertGenerator can't proceed because it can't generate a new CA as the new CA can't be used to verify the existing application TLS asset. Therefore, CertGenerator returns an error to the caller.

cc/ @hasbro17 