### PR TITLE
Windows support

### DIFF
--- a/commands/operator-sdk/cmd/build.go
+++ b/commands/operator-sdk/cmd/build.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 
 	cmdError "github.com/operator-framework/operator-sdk/commands/operator-sdk/error"
 
@@ -56,18 +57,24 @@ func buildFunc(cmd *cobra.Command, args []string) {
 	}
 
 	bcmd := exec.Command(build)
+	if runtime.GOOS == "windows" {
+		bcmd = exec.Command("bash", build)
+	}
 	o, err := bcmd.CombinedOutput()
 	if err != nil {
-		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to build: (%v)", string(o)))
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to build: (%v)", err))
 	}
 	fmt.Fprintln(os.Stdout, string(o))
 
 	image := args[0]
 	dbcmd := exec.Command(dockerBuild)
+	if runtime.GOOS == "windows" {
+		dbcmd = exec.Command("bash", dockerBuild)
+	}
 	dbcmd.Env = append(os.Environ(), fmt.Sprintf("IMAGE=%v", image))
 	o, err = dbcmd.CombinedOutput()
 	if err != nil {
-		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to output build image %v: (%v)", image, string(o)))
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to output build image %v: (%v)", image, err))
 	}
 	fmt.Fprintln(os.Stdout, string(o))
 }

--- a/commands/operator-sdk/cmd/generate/k8s.go
+++ b/commands/operator-sdk/cmd/generate/k8s.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 
 	cmdError "github.com/operator-framework/operator-sdk/commands/operator-sdk/error"
 
@@ -53,10 +54,13 @@ func k8sFunc(cmd *cobra.Command, args []string) {
 func K8sCodegen(projectDir string) {
 	fmt.Fprintln(os.Stdout, "Run code-generation for custom resources")
 	kcmd := exec.Command(k8sGenerated)
+	if runtime.GOOS == "windows" {
+		kcmd = exec.Command("bash", k8sGenerated)
+	}
 	kcmd.Dir = projectDir
 	o, err := kcmd.CombinedOutput()
 	if err != nil {
-		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to perform code-generation for CustomResources: (%v)", string(o)))
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to perform code-generation for CustomResources: (%s)", err))
 	}
 	fmt.Fprintln(os.Stdout, string(o))
 }

--- a/commands/operator-sdk/cmd/new.go
+++ b/commands/operator-sdk/cmd/new.go
@@ -126,7 +126,8 @@ func repoPath() string {
 	// compute the repo path by stripping "$GOPATH/src/" from the path of the current directory.
 	rp := filepath.Join(string(wd[len(filepath.Join(gp, src)):]), projectName)
 	// strip any "/" prefix from the repo path.
-	return strings.TrimPrefix(rp, string(filepath.Separator))
+	wpath := strings.TrimPrefix(rp, string(filepath.Separator))
+	return strings.Replace(wpath, "\\", "/", -1)
 }
 
 func verifyFlags() {

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -171,7 +172,7 @@ func (g *Generator) renderCmd() error {
 func renderCmdFiles(cmdProjectDir, repoPath, apiVersion, kind string) error {
 	td := tmplData{
 		OperatorSDKImport: sdkImport,
-		StubImport:        filepath.Join(repoPath, stubDir),
+		StubImport:        path.Join(repoPath, stubDir),
 		K8sutilImport:     k8sutilImport,
 		SDKVersionImport:  versionImport,
 		APIVersion:        apiVersion,


### PR DESCRIPTION
**Problem**:  Generate application skeleton for Windows platform and make docker build command works on Windows

**Changes**:
- replaced backward slashes with forward slashes while generating import statement via templates
- replace `exec.Command` to use `bash` to execute on windows

NOTE: This change is currently tested and works only using Git Bash for Windows, using minikube for windows. Git bash is required to understand Shell scripts used in this project to generate k8s and docker build scripts.