### PR TITLE
pkg/tlsutil: add support for custom CA

### DIFF
--- a/pkg/tlsutil/error.go
+++ b/pkg/tlsutil/error.go
@@ -17,6 +17,8 @@ package tlsutil
 import "errors"
 
 var (
-	ErrCANotFound = errors.New("ca secret and configMap are not found")
+	ErrCANotFound        = errors.New("ca secret and configMap are not found")
+	ErrCAKeyAndCACertReq = errors.New("ca key and ca cert need to be provided when requesting a custom CA.")
+	ErrInternal          = errors.New("internal error while generating TLS assets.")
 	// TODO: add other tls util errors.
 )


### PR DESCRIPTION
this PR adds support for users to provide a custom CA Key and Cert to generate other TLS assets. A unit test has also been added to test the functionality.