### PR TITLE
.travis.yaml: enable test-framework tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,13 @@ script:
 - make install
 - go test ./pkg/...
 - go test ./test/e2e/...
+- cd test/test-framework
+# test framework with defaults
+- operator-sdk test -t .
+# test operator-sdk test flags
+- operator-sdk test -t . -g deploy/crd.yaml -n deploy/namespace-init.yaml -f "-parallel 1" -k $HOME/.kube/config
+# go back to project root
+- cd ../..
 - go vet ./...
 - ./hack/check_license.sh
 - ./hack/check_error_case.sh

--- a/test/test-framework/deploy/namespace-init.yaml
+++ b/test/test-framework/deploy/namespace-init.yaml
@@ -1,0 +1,79 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: memcached-operator
+rules:
+- apiGroups:
+  - cache.example.com
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - "*"
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: default-account-memcached-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: memcached-operator
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: memcached-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: memcached-operator
+  template:
+    metadata:
+      labels:
+        name: memcached-operator
+    spec:
+      containers:
+        - name: memcached-operator
+          image: quay.io/coreos/operator-sdk-dev:test-framework-operator
+          ports:
+          - containerPort: 60000
+            name: metrics
+          command:
+          - memcached-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPERATOR_NAME
+              value: "memcached-operator"


### PR DESCRIPTION
This enables testing of the test-framework using the tests that are in the sdk. It runs `operator-sdk test` both with flag defaults and directly specified flags.