### PR TITLE
test/e2e: change current dir to root in TestMemcached

### DIFF
--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -48,6 +48,13 @@ func TestMemcached(t *testing.T) {
 	if !ok {
 		t.Fatalf("$GOPATH not set")
 	}
+	cd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		os.Chdir(cd)
+	}()
 	os.Chdir(path.Join(gopath, "/src/github.com/example-inc"))
 	t.Log("Creating new operator project")
 	cmdOut, err := exec.Command("operator-sdk",


### PR DESCRIPTION
TestCustomCA needs the current directory to be rooted at projectPath to resolve `e2e/testdata ` correctly. Since TestMemcached changes the current directory to `/src/github.com/example-inc`, it causes TestCustomCA to unable to find `e2e/testdata `. 

This pr changes TestMemcached current directory to the default one once test is done.

cc/ @AlexNPavel 