### PR TITLE
commands/operator-sdk: Add CLI support for Ansible Operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ script:
 - operator-sdk test local .
 # test operator-sdk test flags
 - operator-sdk test local . --global-manifest deploy/crd.yaml --namespaced-manifest deploy/namespace-init.yaml --go-test-flags "-parallel 1" --kubeconfig $HOME/.kube/config
+# test operator-sdk test local single namespace mode
+- kubectl create namespace test-memcached
+- operator-sdk test local . --namespace=test-memcached
+- kubectl delete namespace test-memcached
 # go back to project root
 - cd ../..
 - go vet ./...

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,6 +26,22 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:65587005c6fa4293c0b8a2e457e689df7fda48cc5e1f5449ea2c1e7784551558"
+  name = "github.com/go-logr/logr"
+  packages = ["."]
+  pruneopts = ""
+  revision = "9fb12b3b21c5415d16ac18dc5cd42c1cfdd40c4e"
+
+[[projects]]
+  branch = "master"
+  digest = "1:ce43ad4015e7cdad3f0e8f2c8339439dd4470859a828d2a6988b0f713699e94a"
+  name = "github.com/go-logr/zapr"
+  packages = ["."]
+  pruneopts = ""
+  revision = "7536572e8d55209135cd5e7ccf7fce43dca217ab"
+
+[[projects]]
   digest = "1:6e73003ecd35f4487a5e88270d3ca0a81bc80dc88053ac7e4dcfec5fba30d918"
   name = "github.com/gogo/protobuf"
   packages = [
@@ -43,6 +59,14 @@
   packages = ["."]
   pruneopts = ""
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+
+[[projects]]
+  branch = "master"
+  digest = "1:9854532d7b2fee9414d4fcd8d8bccd6b1c1e1663d8ec0337af63a19aaf4a778e"
+  name = "github.com/golang/groupcache"
+  packages = ["lru"]
+  pruneopts = ""
+  revision = "6f2cf27854a4a29e3811b0371547be335d411b8b"
 
 [[projects]]
   digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
@@ -73,6 +97,14 @@
   packages = ["."]
   pruneopts = ""
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
+
+[[projects]]
+  digest = "1:5247b135b5492aa232a731acdcb52b08f32b874cb398f21ab460396eadbe866b"
+  name = "github.com/google/uuid"
+  packages = ["."]
+  pruneopts = ""
+  revision = "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:16b2837c8b3cf045fa2cdc82af0cf78b19582701394484ae76b2c3bc3c99ad73"
@@ -133,6 +165,14 @@
   version = "v1.1.5"
 
 [[projects]]
+  branch = "master"
+  digest = "1:58050e2bc9621cc6b68c1da3e4a0d1c40ad1f89062b9855c26521fd42a97a106"
+  name = "github.com/mattbaird/jsonpatch"
+  packages = ["."]
+  pruneopts = ""
+  revision = "81af80346b1a01caae0cbc27fd3c1ba5b11e189f"
+
+[[projects]]
   digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
@@ -163,6 +203,14 @@
   packages = ["flowrate"]
   pruneopts = ""
   revision = "cca7078d478f8520f85629ad7c68962d31ed7682"
+
+[[projects]]
+  digest = "1:a5484d4fa43127138ae6e7b2299a6a52ae006c7f803d98d717f60abf3e97192e"
+  name = "github.com/pborman/uuid"
+  packages = ["."]
+  pruneopts = ""
+  revision = "adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1"
+  version = "v1.2"
 
 [[projects]]
   branch = "master"
@@ -213,7 +261,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e04aaa0e8f8da0ed3d6c0700bd77eda52a47f38510063209d72d62f0ef807d5e"
+  digest = "1:5a57ea878c9a40657ebe7916eca6bea7c76808f5acb68fd42ea5e204dd35f6f7"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
@@ -222,7 +270,7 @@
     "xfs",
   ]
   pruneopts = ""
-  revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
+  revision = "418d78d0b9a7b7de3a6bbc8a23def624cc977bb2"
 
 [[projects]]
   digest = "1:3962f553b77bf6c03fc07cd687a22dd3b00fe11aa14d31194f5505f5bb65cdc8"
@@ -257,6 +305,37 @@
   version = "v1.0.2"
 
 [[projects]]
+  digest = "1:74f86c458e82e1c4efbab95233e0cf51b7cc02dc03193be9f62cd81224e10401"
+  name = "go.uber.org/atomic"
+  packages = ["."]
+  pruneopts = ""
+  revision = "1ea20fb1cbb1cc08cbd0d913a96dead89aa18289"
+  version = "v1.3.2"
+
+[[projects]]
+  digest = "1:22c7effcb4da0eacb2bb1940ee173fac010e9ef3c691f5de4b524d538bd980f5"
+  name = "go.uber.org/multierr"
+  packages = ["."]
+  pruneopts = ""
+  revision = "3c4937480c32f4c13a875a1829af76c98ca3d40a"
+  version = "v1.1.0"
+
+[[projects]]
+  digest = "1:246f378f80fba6fcf0f191c486b6613265abd2bc0f2fa55a36b928c67352021e"
+  name = "go.uber.org/zap"
+  packages = [
+    ".",
+    "buffer",
+    "internal/bufferpool",
+    "internal/color",
+    "internal/exit",
+    "zapcore",
+  ]
+  pruneopts = ""
+  revision = "ff33455a0e382e8a81d14dd7c922020b6b5e7982"
+  version = "v1.9.1"
+
+[[projects]]
   branch = "master"
   digest = "1:61a86f0be8b466d6e3fbdabb155aaa4006137cb5e3fd3b949329d103fa0ceb0f"
   name = "golang.org/x/crypto"
@@ -266,7 +345,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:fbdbb6cf8db3278412c9425ad78b26bb8eb788181f26a3ffb3e4f216b314f86a"
+  digest = "1:6846191f608c0dd6109f37ca46b784f9630191ff13f86ae974135c05a4c92971"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -278,18 +357,18 @@
     "idna",
   ]
   pruneopts = ""
-  revision = "26e67e76b6c3f6ce91f7c52def5af501b4e0f3a2"
+  revision = "f04abc6bdfa7a0171a8a0c9fd2ada9391044d056"
 
 [[projects]]
   branch = "master"
-  digest = "1:ed900376500543ca05f2a2383e1f541b4606f19cd22f34acb81b17a0b90c7f3e"
+  digest = "1:18ebd6e65d5223778b5fc92bbf2afffb54c6ac3889bbc362df692b965f932fae"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = ""
-  revision = "d0be0721c37eeb5299f245a996a483160fc36940"
+  revision = "b09afc3d579e346c4a7e4705953acaf6f9e551bd"
 
 [[projects]]
   digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
@@ -342,6 +421,7 @@
   digest = "1:2fe7efa9ea3052443378383d27c15ba088d03babe69a89815ce7fe9ec1d9aeb4"
   name = "k8s.io/api"
   packages = [
+    "admission/v1beta1",
     "admissionregistration/v1alpha1",
     "admissionregistration/v1beta1",
     "apps/v1",
@@ -423,16 +503,20 @@
     "pkg/util/httpstream",
     "pkg/util/intstr",
     "pkg/util/json",
+    "pkg/util/mergepatch",
     "pkg/util/net",
     "pkg/util/proxy",
     "pkg/util/runtime",
     "pkg/util/sets",
+    "pkg/util/strategicpatch",
+    "pkg/util/uuid",
     "pkg/util/validation",
     "pkg/util/validation/field",
     "pkg/util/wait",
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
+    "third_party/forked/golang/json",
     "third_party/forked/golang/netutil",
     "third_party/forked/golang/reflect",
   ]
@@ -492,8 +576,11 @@
     "tools/clientcmd/api",
     "tools/clientcmd/api/latest",
     "tools/clientcmd/api/v1",
+    "tools/leaderelection",
+    "tools/leaderelection/resourcelock",
     "tools/metrics",
     "tools/pager",
+    "tools/record",
     "tools/reference",
     "transport",
     "util/buffer",
@@ -510,11 +597,39 @@
   version = "kubernetes-1.11.2"
 
 [[projects]]
+  branch = "master"
+  digest = "1:951bc2047eea6d316a17850244274554f26fd59189360e45f4056b424dadf2c1"
+  name = "k8s.io/kube-openapi"
+  packages = ["pkg/util/proto"]
+  pruneopts = ""
+  revision = "e3762e86a74c878ffed47484592986685639c2cd"
+
+[[projects]]
   digest = "1:207e862b55f9399362c667ce30f1ac8b2180d282bc7bb5749fc81122944aa2b5"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
+    "pkg/cache",
+    "pkg/cache/internal",
     "pkg/client",
     "pkg/client/apiutil",
+    "pkg/controller",
+    "pkg/event",
+    "pkg/handler",
+    "pkg/internal/controller",
+    "pkg/internal/recorder",
+    "pkg/leaderelection",
+    "pkg/manager",
+    "pkg/patch",
+    "pkg/predicate",
+    "pkg/reconcile",
+    "pkg/recorder",
+    "pkg/runtime/inject",
+    "pkg/runtime/log",
+    "pkg/source",
+    "pkg/source/internal",
+    "pkg/webhook/admission",
+    "pkg/webhook/admission/types",
+    "pkg/webhook/types",
   ]
   pruneopts = ""
   revision = "79f06014d49b565e2d980fcd9519b33874ddb8d6"
@@ -558,6 +673,12 @@
     "k8s.io/client-go/transport",
     "k8s.io/client-go/util/workqueue",
     "sigs.k8s.io/controller-runtime/pkg/client",
+    "sigs.k8s.io/controller-runtime/pkg/controller",
+    "sigs.k8s.io/controller-runtime/pkg/event",
+    "sigs.k8s.io/controller-runtime/pkg/handler",
+    "sigs.k8s.io/controller-runtime/pkg/manager",
+    "sigs.k8s.io/controller-runtime/pkg/reconcile",
+    "sigs.k8s.io/controller-runtime/pkg/source",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/commands/operator-sdk/cmd/build.go
+++ b/commands/operator-sdk/cmd/build.go
@@ -147,6 +147,8 @@ func buildFunc(cmd *cobra.Command, args []string) {
 	// Don't need to buld go code if Ansible Operator
 	if buildCmd() {
 		bcmd := exec.Command(build)
+		bcmd.Env = append(os.Environ(), fmt.Sprintf("TEST_LOCATION=%v", testLocationBuild))
+		bcmd.Env = append(bcmd.Env, fmt.Sprintf("ENABLE_TESTS=%v", enableTests))
 		o, err := bcmd.CombinedOutput()
 		if err != nil {
 			cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to build: (%v)", string(o)))

--- a/commands/operator-sdk/cmd/build.go
+++ b/commands/operator-sdk/cmd/build.go
@@ -145,7 +145,7 @@ func buildFunc(cmd *cobra.Command, args []string) {
 	}
 
 	// Don't need to buld go code if Ansible Operator
-	if buildCmd() {
+	if mainExists() {
 		bcmd := exec.Command(build)
 		bcmd.Env = append(os.Environ(), fmt.Sprintf("TEST_LOCATION=%v", testLocationBuild))
 		bcmd.Env = append(bcmd.Env, fmt.Sprintf("ENABLE_TESTS=%v", enableTests))
@@ -184,7 +184,7 @@ func buildFunc(cmd *cobra.Command, args []string) {
 	}
 }
 
-func buildCmd() bool {
+func mainExists() bool {
 	dir, err := os.Getwd()
 	if err != nil {
 		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to get current working dir: %v", err))

--- a/commands/operator-sdk/cmd/generate.go
+++ b/commands/operator-sdk/cmd/generate.go
@@ -29,5 +29,6 @@ func NewGenerateCmd() *cobra.Command {
 	}
 	cmd.AddCommand(generate.NewGenerateK8SCmd())
 	cmd.AddCommand(generate.NewGenerateOlmCatalogCmd())
+	cmd.AddCommand(generate.NewGenerateCrdCmd())
 	return cmd
 }

--- a/commands/operator-sdk/cmd/generate/crd.go
+++ b/commands/operator-sdk/cmd/generate/crd.go
@@ -43,8 +43,8 @@ func NewGenerateCrdCmd() *cobra.Command {
 		Short: "Generates a custom resource definition (CRD) and the custom resource (CR) files",
 		Long: `The operator-sdk generate command will create a custom resource definition (CRD) and the custom resource (CR) files for the specified api-version and kind.
 
-Generated CRD filename: <project-name>/deploy/<kind>_crd.yaml
-Generated CR  filename: <project-name>/deploy/<kind>_cr.yaml
+Generated CRD filename: <project-name>/deploy/<group>_<version>_<kind>_crd.yaml
+Generated CR  filename: <project-name>/deploy/<group>_<version>_<kind>_cr.yaml
 
 	<project-name>/deploy path must already exist
 	--api-version and --kind are required flags to generate the new operator application.
@@ -67,7 +67,7 @@ func crdFunc(cmd *cobra.Command, args []string) {
 
 	fmt.Fprintln(os.Stdout, "Generating custom resource definition (CRD) file")
 
-	// generate CRD file
+	// generate CR/CRD file
 	wd, err := os.Getwd()
 	if err != nil {
 		cmdError.ExitWithError(cmdError.ExitError, err)
@@ -95,18 +95,9 @@ func verifyCrdFlags() {
 
 // verifyCrdDeployPath checks if the path <project-name>/deploy sub-directory is exists, and that is rooted under $GOPATH
 func verifyCrdDeployPath() {
-	// check if $GOPATH env exists
-	gp := os.Getenv(goDir)
-	if len(gp) == 0 {
-		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("$GOPATH env not set"))
-	}
 	wd, err := os.Getwd()
 	if err != nil {
 		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to determine the full path of the current directory: %v", err))
-	}
-	// check if this project's repository path is rooted under $GOPATH
-	if !strings.HasPrefix(wd, gp) {
-		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("project's repository path (%v) is not rooted under GOPATH (%v)", wd, gp))
 	}
 	// check if the deploy sub-directory exist
 	_, err = os.Stat(filepath.Join(wd, deployCrdDir))

--- a/commands/operator-sdk/cmd/generate/crd.go
+++ b/commands/operator-sdk/cmd/generate/crd.go
@@ -68,7 +68,10 @@ func crdFunc(cmd *cobra.Command, args []string) {
 	fmt.Fprintln(os.Stdout, "Generating custom resource definition (CRD) file")
 
 	// generate CRD file
-	wd, _ := os.Getwd()
+	wd, err := os.Getwd()
+	if err != nil {
+		cmdError.ExitWithError(cmdError.ExitError, err)
+	}
 	if err := generator.RenderDeployCrdFiles(filepath.Join(wd, deployCrdDir), apiVersion, kind); err != nil {
 		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to generate CRD and CR files: (%v)", err))
 	}

--- a/commands/operator-sdk/cmd/generate/crd.go
+++ b/commands/operator-sdk/cmd/generate/crd.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	cmdError "github.com/operator-framework/operator-sdk/commands/operator-sdk/error"
 	"github.com/operator-framework/operator-sdk/pkg/generator"
@@ -29,11 +31,22 @@ var (
 	kind       string
 )
 
+const (
+	goDir        = "GOPATH"
+	deployCrdDir = "deploy"
+)
+
 func NewGenerateCrdCmd() *cobra.Command {
 	crdCmd := &cobra.Command{
 		Use:   "crd",
-		Short: "Generates a custom resource definition",
-		Long: `generates a custom resource definition (CRD) file for the .
+		Short: "Generates a custom resource definition (CRD) and the custom resource (CR) files",
+		Long: `The operator-sdk generate command will create a custom resource definition (CRD) and the custom resource (CR) files for the specified api-version and kind.
+
+Generated CRD filename: <project-name>/deploy/<kind>_crd.yaml
+Generated CR  filename: <project-name>/deploy/<kind>_cr.yaml
+
+	<project-name>/deploy path must already exist
+	--api-version and --kind are required flags to generate the new operator application.
 `,
 		Run: crdFunc,
 	}
@@ -49,12 +62,14 @@ func crdFunc(cmd *cobra.Command, args []string) {
 		cmdError.ExitWithError(cmdError.ExitBadArgs, errors.New("crd command doesn't accept any arguments."))
 	}
 	verifyCrdFlags()
+	verifyCrdDeployPath()
 
 	fmt.Fprintln(os.Stdout, "Generating custom resource definition (CRD) file")
 
-	// Generate CRD file
-	if err := generator.RenderDeployCrdFile(apiVersion, kind); err != nil {
-		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to generate CRD file: (%v)", err))
+	// generate CRD file
+	wd, _ := os.Getwd()
+	if err := generator.RenderDeployCrdFiles(filepath.Join(wd, deployCrdDir), apiVersion, kind); err != nil {
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to generate CRD and CR files: (%v)", err))
 	}
 }
 
@@ -64,5 +79,34 @@ func verifyCrdFlags() {
 	}
 	if len(kind) == 0 {
 		cmdError.ExitWithError(cmdError.ExitBadArgs, errors.New("--kind must not have empty value"))
+	}
+	kindFirstLetter := string(kind[0])
+	if kindFirstLetter != strings.ToUpper(kindFirstLetter) {
+		cmdError.ExitWithError(cmdError.ExitBadArgs, errors.New("--kind must start with an uppercase letter"))
+	}
+	if strings.Count(apiVersion, "/") != 1 {
+		cmdError.ExitWithError(cmdError.ExitBadArgs, fmt.Errorf("api-version has wrong format (%v); format must be $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)", apiVersion))
+	}
+}
+
+// verifyCrdDeployPath checks if the path <project-name>/deploy sub-directory is exists, and that is rooted under $GOPATH
+func verifyCrdDeployPath() {
+	// check if $GOPATH env exists
+	gp := os.Getenv(goDir)
+	if len(gp) == 0 {
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("$GOPATH env not set"))
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to determine the full path of the current directory: %v", err))
+	}
+	// check if this project's repository path is rooted under $GOPATH
+	if !strings.HasPrefix(wd, gp) {
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("project's repository path (%v) is not rooted under GOPATH (%v)", wd, gp))
+	}
+	// check if the deploy sub-directory exist
+	_, err = os.Stat(filepath.Join(wd, deployCrdDir))
+	if err != nil {
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("the path (./%v) does not exist. run this command in your project directory", deployCrdDir))
 	}
 }

--- a/commands/operator-sdk/cmd/generate/crd.go
+++ b/commands/operator-sdk/cmd/generate/crd.go
@@ -1,0 +1,68 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	cmdError "github.com/operator-framework/operator-sdk/commands/operator-sdk/error"
+	"github.com/operator-framework/operator-sdk/pkg/generator"
+	"github.com/spf13/cobra"
+)
+
+var (
+	apiVersion string
+	kind       string
+)
+
+func NewGenerateCrdCmd() *cobra.Command {
+	crdCmd := &cobra.Command{
+		Use:   "crd",
+		Short: "Generates a custom resource definition",
+		Long: `generates a custom resource definition (CRD) file for the .
+`,
+		Run: crdFunc,
+	}
+	crdCmd.Flags().StringVar(&apiVersion, "api-version", "", "Kubernetes apiVersion and has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)")
+	crdCmd.MarkFlagRequired("api-version")
+	crdCmd.Flags().StringVar(&kind, "kind", "", "Kubernetes CustomResourceDefintion kind. (e.g AppService)")
+	crdCmd.MarkFlagRequired("kind")
+	return crdCmd
+}
+
+func crdFunc(cmd *cobra.Command, args []string) {
+	if len(args) != 0 {
+		cmdError.ExitWithError(cmdError.ExitBadArgs, errors.New("crd command doesn't accept any arguments."))
+	}
+	verifyCrdFlags()
+
+	fmt.Fprintln(os.Stdout, "Generating custom resource definition (CRD) file")
+
+	// Generate CRD file
+	if err := generator.RenderDeployCrdFile(apiVersion, kind); err != nil {
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to generate CRD file: (%v)", err))
+	}
+}
+
+func verifyCrdFlags() {
+	if len(apiVersion) == 0 {
+		cmdError.ExitWithError(cmdError.ExitBadArgs, errors.New("--api-version must not have empty value"))
+	}
+	if len(kind) == 0 {
+		cmdError.ExitWithError(cmdError.ExitBadArgs, errors.New("--kind must not have empty value"))
+	}
+}

--- a/commands/operator-sdk/cmd/generate/crd.go
+++ b/commands/operator-sdk/cmd/generate/crd.go
@@ -23,6 +23,7 @@ import (
 
 	cmdError "github.com/operator-framework/operator-sdk/commands/operator-sdk/error"
 	"github.com/operator-framework/operator-sdk/pkg/generator"
+
 	"github.com/spf13/cobra"
 )
 

--- a/commands/operator-sdk/cmd/new.go
+++ b/commands/operator-sdk/cmd/new.go
@@ -55,7 +55,7 @@ generates a skeletal app-operator application in $GOPATH/src/github.com/example.
 	newCmd.MarkFlagRequired("kind")
 	newCmd.Flags().StringVar(&operatorType, "type", "go", "Type of operator to initialize (e.g \"ansible\")")
 	newCmd.Flags().BoolVar(&skipGit, "skip-git-init", false, "Do not init the directory as a git repository")
-	newCmd.Flags().BoolVar(&generatePlaybook, "generate-playbook", false, "Generate a playbook skeleton in watches.yaml. (Only used for --type ansible)")
+	newCmd.Flags().BoolVar(&generatePlaybook, "generate-playbook", false, "Generate a playbook skeleton. (Only used for --type ansible)")
 
 	return newCmd
 }
@@ -146,6 +146,9 @@ func verifyFlags() {
 	}
 	if operatorType != goOperatorType && operatorType != ansibleOperatorType {
 		cmdError.ExitWithError(cmdError.ExitBadArgs, errors.New("--type can only be `go` or `ansible`"))
+	}
+	if operatorType != ansibleOperatorType && generatePlaybook {
+		cmdError.ExitWithError(cmdError.ExitBadArgs, errors.New("--generate-playbook can only be used with --type `ansible`"))
 	}
 	kindFirstLetter := string(kind[0])
 	if kindFirstLetter != strings.ToUpper(kindFirstLetter) {

--- a/commands/operator-sdk/cmd/new.go
+++ b/commands/operator-sdk/cmd/new.go
@@ -53,23 +53,29 @@ generates a skeletal app-operator application in $GOPATH/src/github.com/example.
 	newCmd.MarkFlagRequired("api-version")
 	newCmd.Flags().StringVar(&kind, "kind", "", "Kubernetes CustomResourceDefintion kind. (e.g AppService)")
 	newCmd.MarkFlagRequired("kind")
+	newCmd.Flags().StringVar(&operatorType, "type", "go", "Type of operator to initialize (e.g \"ansible\")")
 	newCmd.Flags().BoolVar(&skipGit, "skip-git-init", false, "Do not init the directory as a git repository")
+	newCmd.Flags().BoolVar(&generatePlaybook, "generate-playbook", false, "Generate a playbook skeleton in watches.yaml. (Only used for --type ansible)")
 
 	return newCmd
 }
 
 var (
-	apiVersion  string
-	kind        string
-	projectName string
-	skipGit     bool
+	apiVersion       string
+	kind             string
+	operatorType     string
+	projectName      string
+	skipGit          bool
+	generatePlaybook bool
 )
 
 const (
-	gopath    = "GOPATH"
-	src       = "src"
-	dep       = "dep"
-	ensureCmd = "ensure"
+	gopath              = "GOPATH"
+	src                 = "src"
+	dep                 = "dep"
+	ensureCmd           = "ensure"
+	goOperatorType      = "go"
+	ansibleOperatorType = "ansible"
 )
 
 func newFunc(cmd *cobra.Command, args []string) {
@@ -79,13 +85,15 @@ func newFunc(cmd *cobra.Command, args []string) {
 	parse(args)
 	mustBeNewProject()
 	verifyFlags()
-	g := generator.NewGenerator(apiVersion, kind, projectName, repoPath())
+	g := generator.NewGenerator(apiVersion, kind, operatorType, projectName, repoPath(), generatePlaybook)
 	err := g.Render()
 	if err != nil {
 		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to create project %v: %v", projectName, err))
 	}
-	pullDep()
-	generate.K8sCodegen(projectName)
+	if operatorType == goOperatorType {
+		pullDep()
+		generate.K8sCodegen(projectName)
+	}
 	initGit()
 }
 
@@ -135,6 +143,9 @@ func verifyFlags() {
 	}
 	if len(kind) == 0 {
 		cmdError.ExitWithError(cmdError.ExitBadArgs, errors.New("--kind must not have empty value"))
+	}
+	if operatorType != goOperatorType && operatorType != ansibleOperatorType {
+		cmdError.ExitWithError(cmdError.ExitBadArgs, errors.New("--type can only be `go` or `ansible`"))
 	}
 	kindFirstLetter := string(kind[0])
 	if kindFirstLetter != strings.ToUpper(kindFirstLetter) {

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -175,6 +175,7 @@ Runs the tests locally
 * `--kubeconfig` string - location of kubeconfig for kubernetes cluster (default "~/.kube/config")
 * `--global-manifest` string - path to manifest for global resources (default "deploy/crd.yaml)
 * `--namespaced-manifest` string - path to manifest for per-test, namespaced resources (default: combines deploy/sa.yaml, deploy/rbac.yaml, and deploy/operator.yaml)
+*  `--namespace` string - if non-empty, single namespace to run tests in (e.g. "operator-test") (default: "")
 * `--go-test-flags` string - extra arguments to pass to `go test` (e.g. -f "-v -parallel=2")
 * `-h, --help` - help for local
 

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -207,6 +207,13 @@ as an argument. You can use `--help` to view the other configuration options and
 $ operator-sdk test local ./test/e2e --go-test-flags "-v -parallel=2"
 ```
 
+If you wish to run all the tests in 1 namespace (which also forces `-parallel=1`), you can use the `--namespace` flag:
+
+```shell
+$ kubectl create namespace operator-test
+$ operator-sdk test local ./test/e2e --namespace operator-test
+```
+
 For more documentation on the `operator-sdk test local` command, see the [SDK CLI Reference][sdk-cli-ref] doc.
 
 For advanced use cases, it is possible to run the tests via `go test` directly. As long as all flags defined
@@ -258,6 +265,7 @@ Test Successfully Completed
 ```
 
 The `test cluster` command will deploy a test pod in the given namespace that will run the e2e tests packaged in the image.
+The tests run sequentially in the namespace (`-parallel=1`), the same as running `operator-sdk test local --namespace <namespace>`.
 The command will wait until the tests succeed (pod phase=`Succeeded`) or fail (pod phase=`Failed`).
 If the tests fail, the command will output the test pod logs which should be the standard go test error logs.
 

--- a/hack/ci/setup-openshift.sh
+++ b/hack/ci/setup-openshift.sh
@@ -10,3 +10,6 @@ tar xvzOf oc.tar.gz openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit/oc
 oc cluster up
 # Become cluster admin
 oc login -u system:admin
+
+# kubectl is needed for the single namespace local test
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/

--- a/pkg/ansible/controller/controller.go
+++ b/pkg/ansible/controller/controller.go
@@ -1,0 +1,91 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/operator-framework/operator-sdk/pkg/ansible/events"
+	"github.com/operator-framework/operator-sdk/pkg/ansible/runner"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	crthandler "sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// Options - options for your controller
+type Options struct {
+	EventHandlers []events.EventHandler
+	LoggingLevel  events.LogLevel
+	Runner        runner.Runner
+	Namespace     string
+	GVK           schema.GroupVersionKind
+	// StopChannel is used to deal with the bug:
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/103
+	StopChannel <-chan struct{}
+}
+
+// Add - Creates a new ansible operator controller and adds it to the manager
+func Add(mgr manager.Manager, options Options) {
+	logrus.Infof("Watching %s/%v, %s, %s", options.GVK.Group, options.GVK.Version, options.GVK.Kind, options.Namespace)
+	if options.EventHandlers == nil {
+		options.EventHandlers = []events.EventHandler{}
+	}
+	eventHandlers := append(options.EventHandlers, events.NewLoggingEventHandler(options.LoggingLevel))
+
+	aor := &AnsibleOperatorReconciler{
+		Client:        mgr.GetClient(),
+		GVK:           options.GVK,
+		Runner:        options.Runner,
+		EventHandlers: eventHandlers,
+	}
+
+	// Register the GVK with the schema
+	mgr.GetScheme().AddKnownTypeWithName(options.GVK, &unstructured.Unstructured{})
+	metav1.AddToGroupVersion(mgr.GetScheme(), schema.GroupVersion{
+		Group:   options.GVK.Group,
+		Version: options.GVK.Version,
+	})
+
+	//Create new controller runtime controller and set the controller to watch GVK.
+	c, err := controller.New(fmt.Sprintf("%v-controller", strings.ToLower(options.GVK.Kind)), mgr, controller.Options{
+		Reconciler: aor,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(options.GVK)
+	if err := c.Watch(&source.Kind{Type: u}, &crthandler.EnqueueRequestForObject{}); err != nil {
+		log.Fatal(err)
+	}
+
+	r := NewReconcileLoop(time.Minute*1, options.GVK, mgr.GetClient())
+	r.Stop = options.StopChannel
+	cs := &source.Channel{Source: r.Source}
+	cs.InjectStopChannel(options.StopChannel)
+	if err := c.Watch(cs, &crthandler.EnqueueRequestForObject{}); err != nil {
+		log.Fatal(err)
+	}
+	r.Start()
+}

--- a/pkg/ansible/controller/reconcile.go
+++ b/pkg/ansible/controller/reconcile.go
@@ -1,0 +1,173 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+
+	"github.com/operator-framework/operator-sdk/pkg/ansible/events"
+	"github.com/operator-framework/operator-sdk/pkg/ansible/proxy/kubeconfig"
+	"github.com/operator-framework/operator-sdk/pkg/ansible/runner"
+	"github.com/operator-framework/operator-sdk/pkg/ansible/runner/eventapi"
+
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// AnsibleOperatorReconciler - object to reconcile runner requests
+type AnsibleOperatorReconciler struct {
+	GVK           schema.GroupVersionKind
+	Runner        runner.Runner
+	Client        client.Client
+	EventHandlers []events.EventHandler
+}
+
+// Reconcile - handle the event.
+func (r *AnsibleOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(r.GVK)
+	err := r.Client.Get(context.TODO(), request.NamespacedName, u)
+	if apierrors.IsNotFound(err) {
+		return reconcile.Result{}, nil
+	}
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	deleted := u.GetDeletionTimestamp() != nil
+	finalizer, finalizerExists := r.Runner.GetFinalizer()
+	pendingFinalizers := u.GetFinalizers()
+	// If the resource is being deleted we don't want to add the finalizer again
+	if finalizerExists && !deleted && !contains(pendingFinalizers, finalizer) {
+		logrus.Debugf("Adding finalizer %s to resource", finalizer)
+		finalizers := append(pendingFinalizers, finalizer)
+		u.SetFinalizers(finalizers)
+		err := r.Client.Update(context.TODO(), u)
+		return reconcile.Result{}, err
+	}
+	if !contains(pendingFinalizers, finalizer) && deleted {
+		logrus.Info("Resource is terminated, skipping reconcilation")
+		return reconcile.Result{}, nil
+	}
+
+	s := u.Object["spec"]
+	_, ok := s.(map[string]interface{})
+	if !ok {
+		logrus.Warnf("spec was not found")
+		u.Object["spec"] = map[string]interface{}{}
+		r.Client.Update(context.TODO(), u)
+		return reconcile.Result{Requeue: true}, nil
+	}
+	ownerRef := metav1.OwnerReference{
+		APIVersion: u.GetAPIVersion(),
+		Kind:       u.GetKind(),
+		Name:       u.GetName(),
+		UID:        u.GetUID(),
+	}
+
+	kc, err := kubeconfig.Create(ownerRef, "http://localhost:8888", u.GetNamespace())
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	defer os.Remove(kc.Name())
+	eventChan, err := r.Runner.Run(u, kc.Name())
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// iterate events from ansible, looking for the final one
+	statusEvent := eventapi.StatusJobEvent{}
+	for event := range eventChan {
+		for _, eHandler := range r.EventHandlers {
+			go eHandler.Handle(u, event)
+		}
+		if event.Event == "playbook_on_stats" {
+			// convert to StatusJobEvent; would love a better way to do this
+			data, err := json.Marshal(event)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+			err = json.Unmarshal(data, &statusEvent)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+	}
+	if statusEvent.Event == "" {
+		err := errors.New("did not receive playbook_on_stats event")
+		logrus.Error(err.Error())
+		return reconcile.Result{}, err
+	}
+
+	// We only want to update the CustomResource once, so we'll track changes and do it at the end
+	var needsUpdate bool
+	runSuccessful := true
+	for _, count := range statusEvent.EventData.Failures {
+		if count > 0 {
+			runSuccessful = false
+			break
+		}
+	}
+	// The finalizer has run successfully, time to remove it
+	if deleted && finalizerExists && runSuccessful {
+		finalizers := []string{}
+		for _, pendingFinalizer := range pendingFinalizers {
+			if pendingFinalizer != finalizer {
+				finalizers = append(finalizers, pendingFinalizer)
+			}
+		}
+		u.SetFinalizers(finalizers)
+		needsUpdate = true
+	}
+
+	statusMap, ok := u.Object["status"].(map[string]interface{})
+	if !ok {
+		u.Object["status"] = ResourceStatus{
+			Status: NewStatusFromStatusJobEvent(statusEvent),
+		}
+		logrus.Infof("adding status for the first time")
+		needsUpdate = true
+	} else {
+		// Need to conver the map[string]interface into a resource status.
+		if update, status := UpdateResourceStatus(statusMap, statusEvent); update {
+			u.Object["status"] = status
+			needsUpdate = true
+		}
+	}
+	if needsUpdate {
+		err = r.Client.Update(context.TODO(), u)
+	}
+	if !runSuccessful {
+		return reconcile.Result{Requeue: true}, err
+	}
+	return reconcile.Result{}, err
+}
+
+func contains(l []string, s string) bool {
+	for _, elem := range l {
+		if elem == s {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/ansible/controller/source.go
+++ b/pkg/ansible/controller/source.go
@@ -1,0 +1,78 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+// ReconcileLoop - new loop
+type ReconcileLoop struct {
+	Source   chan event.GenericEvent
+	Stop     <-chan struct{}
+	GVK      schema.GroupVersionKind
+	Interval time.Duration
+	Client   client.Client
+}
+
+// NewReconcileLoop - loop for a GVK.
+// The reconcilation loop is needed because the resync period
+// for the informer is not suitable for this use case.
+func NewReconcileLoop(interval time.Duration, gvk schema.GroupVersionKind, c client.Client) ReconcileLoop {
+	s := make(chan event.GenericEvent, 1025)
+	return ReconcileLoop{
+		Source:   s,
+		GVK:      gvk,
+		Interval: interval,
+		Client:   c,
+	}
+}
+
+// Start - start the reconcile loop
+func (r *ReconcileLoop) Start() {
+	go func() {
+		ticker := time.NewTicker(r.Interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				// List all object for the GVK
+				ul := &unstructured.UnstructuredList{}
+				ul.SetGroupVersionKind(r.GVK)
+				err := r.Client.List(context.Background(), nil, ul)
+				if err != nil {
+					logrus.Warningf("unable to list resources for GV: %v during reconcilation", r.GVK)
+					continue
+				}
+				for _, u := range ul.Items {
+					e := event.GenericEvent{
+						Meta:   &u,
+						Object: &u,
+					}
+					r.Source <- e
+				}
+			case <-r.Stop:
+				return
+			}
+		}
+	}()
+}

--- a/pkg/ansible/controller/types.go
+++ b/pkg/ansible/controller/types.go
@@ -1,0 +1,125 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"github.com/operator-framework/operator-sdk/pkg/ansible/runner/eventapi"
+)
+
+const (
+	host = "localhost"
+)
+
+type Status struct {
+	Ok               int                `json:"ok"`
+	Changed          int                `json:"changed"`
+	Skipped          int                `json:"skipped"`
+	Failures         int                `json:"failures"`
+	TimeOfCompletion eventapi.EventTime `json:"completion"`
+}
+
+func NewStatusFromStatusJobEvent(je eventapi.StatusJobEvent) Status {
+	// ok events.
+	o := 0
+	changed := 0
+	skipped := 0
+	failures := 0
+	if v, ok := je.EventData.Changed[host]; ok {
+		changed = v
+	}
+	if v, ok := je.EventData.Ok[host]; ok {
+		o = v
+	}
+	if v, ok := je.EventData.Skipped[host]; ok {
+		skipped = v
+	}
+	if v, ok := je.EventData.Failures[host]; ok {
+		failures = v
+	}
+	return Status{
+		Ok:               o,
+		Changed:          changed,
+		Skipped:          skipped,
+		Failures:         failures,
+		TimeOfCompletion: je.Created,
+	}
+}
+
+func IsStatusEqual(s1, s2 Status) bool {
+	return (s1.Ok == s2.Ok && s1.Changed == s2.Changed && s1.Skipped == s2.Skipped && s1.Failures == s2.Failures)
+}
+
+func NewStatusFromMap(sm map[string]interface{}) Status {
+	//Create Old top level status
+	// ok events.
+	o := 0
+	changed := 0
+	skipped := 0
+	failures := 0
+	e := eventapi.EventTime{}
+	if v, ok := sm["changed"]; ok {
+		changed = int(v.(int64))
+	}
+	if v, ok := sm["ok"]; ok {
+		o = int(v.(int64))
+	}
+	if v, ok := sm["skipped"]; ok {
+		skipped = int(v.(int64))
+	}
+	if v, ok := sm["failures"]; ok {
+		failures = int(v.(int64))
+	}
+	if v, ok := sm["completion"]; ok {
+		s := v.(string)
+		e.UnmarshalJSON([]byte(s))
+	}
+	return Status{
+		Ok:               o,
+		Changed:          changed,
+		Skipped:          skipped,
+		Failures:         failures,
+		TimeOfCompletion: e,
+	}
+}
+
+type ResourceStatus struct {
+	Status         `json:",inline"`
+	FailureMessage string   `json:"reason,omitempty"`
+	History        []Status `json:"history,omitempty"`
+}
+
+func UpdateResourceStatus(sm map[string]interface{}, je eventapi.StatusJobEvent) (bool, ResourceStatus) {
+	newStatus := NewStatusFromStatusJobEvent(je)
+	oldStatus := NewStatusFromMap(sm)
+	// Don't update the status if new status and old status are equal.
+	if IsStatusEqual(newStatus, oldStatus) {
+		return false, ResourceStatus{}
+	}
+
+	history := []Status{}
+	h, ok := sm["history"]
+	if ok {
+		hi := h.([]interface{})
+		for _, m := range hi {
+			ma := m.(map[string]interface{})
+			history = append(history, NewStatusFromMap(ma))
+		}
+	}
+	history = append(history, oldStatus)
+	return true, ResourceStatus{
+		Status:  newStatus,
+		History: history,
+	}
+}

--- a/pkg/ansible/events/log_events.go
+++ b/pkg/ansible/events/log_events.go
@@ -1,0 +1,73 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"github.com/operator-framework/operator-sdk/pkg/ansible/runner/eventapi"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// LogLevel - Levelt for the logging to take place.
+type LogLevel int
+
+const (
+	// Tasks - only log the high level tasks.
+	Tasks LogLevel = iota
+
+	// Everything - log every event.
+	Everything
+
+	// Nothing -  this will log nothing.
+	Nothing
+)
+
+// EventHandler - knows how to handle job events.
+type EventHandler interface {
+	Handle(*unstructured.Unstructured, eventapi.JobEvent)
+}
+
+type loggingEventHandler struct {
+	LogLevel LogLevel
+}
+
+func (l loggingEventHandler) Handle(u *unstructured.Unstructured, e eventapi.JobEvent) {
+	log := logrus.WithFields(logrus.Fields{
+		"component":  "logging_event_handler",
+		"name":       u.GetName(),
+		"namespace":  u.GetNamespace(),
+		"gvk":        u.GroupVersionKind().String(),
+		"event_type": e.Event,
+	})
+	t, ok := e.EventData["task"]
+	if ok {
+		log = log.WithField("task", t)
+	}
+	switch l.LogLevel {
+	case Everything:
+		log.Infof("event: %#v", e.EventData)
+	case Tasks:
+		if ok {
+			log.Infof("event: %#v", e.EventData)
+		}
+	}
+}
+
+// NewLoggingEventHandler - Creates a Logging Event Handler to log events.
+func NewLoggingEventHandler(l LogLevel) EventHandler {
+	return loggingEventHandler{
+		LogLevel: l,
+	}
+}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -194,8 +194,9 @@ func (g *Generator) renderAnsibleOperator() error {
 func (g *Generator) renderRole() error {
 	fmt.Printf("Rendering Ansible Galaxy role [%v/%v/%v]...\n", g.projectName, rolesDir, g.kind)
 	agcmd := exec.Command(filepath.Join(g.projectName, galaxyInitCmd))
-	_, err := agcmd.CombinedOutput()
+	output, err := agcmd.CombinedOutput()
 	if err != nil {
+		fmt.Printf("Rendering Ansible Galaxy role failed: [%v], Output: %s", err.Error(), string(output))
 		return err
 	}
 	// Clean up tmp/init

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -16,7 +16,6 @@ package generator
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -168,7 +167,7 @@ func (g *Generator) Render() error {
 			return err
 		}
 	default:
-		return errors.New(fmt.Sprintf("unexpected operator type [%v]", g.operatorType))
+		return fmt.Errorf("unexpected operator type [%v]", g.operatorType)
 	}
 	return nil
 }
@@ -349,7 +348,7 @@ func RenderDeployCrdFile(apiVersion, kind string) error {
 		GroupName:    groupName(apiVersion),
 		Version:      version(apiVersion),
 	}
-	crdFilePath := filepath.Join(deployDir, strings.ToLower(kind) + "_crd.yaml")
+	crdFilePath := filepath.Join(deployDir, strings.ToLower(kind)+"_crd.yaml")
 	return renderWriteFile(crdFilePath, crdFilePath, crdYamlTmpl, crdTd)
 }
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -392,11 +392,14 @@ func renderDeployFiles(deployDir, projectName, apiVersion, kind, operatorType st
 		return err
 	}
 
-	saTd := tmplData{
-		ProjectName: projectName,
-	}
-	if err := renderWriteFile(filepath.Join(deployDir, saYaml), saTmplName, saYamlTmpl, saTd); err != nil {
-		return err
+	// Service account file is only needed for Go operator
+	if operatorType == goOperatorType {
+		saTd := tmplData{
+			ProjectName: projectName,
+		}
+		if err := renderWriteFile(filepath.Join(deployDir, saYaml), saTmplName, saYamlTmpl, saTd); err != nil {
+			return err
+		}
 	}
 
 	opTd := tmplData{

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -346,7 +346,8 @@ func RenderDeployCrdFiles(deployPath, apiVersion, kind string) error {
 		APIVersion: apiVersion,
 		Kind:       kind,
 	}
-	crFilePath := filepath.Join(deployPath, strings.ToLower(kind)+"_cr.yaml")
+	crFilePath := filepath.Join(deployPath,
+		groupName(apiVersion)+"_"+version(apiVersion)+"_"+strings.ToLower(kind)+"_cr.yaml")
 	if err := renderWriteFile(crFilePath, crFilePath, crYamlTmpl, crTd); err != nil {
 		return err
 	}
@@ -358,7 +359,8 @@ func RenderDeployCrdFiles(deployPath, apiVersion, kind string) error {
 		GroupName:    groupName(apiVersion),
 		Version:      version(apiVersion),
 	}
-	crdFilePath := filepath.Join(deployPath, strings.ToLower(kind)+"_crd.yaml")
+	crdFilePath := filepath.Join(deployPath,
+		groupName(apiVersion)+"_"+version(apiVersion)+"_"+strings.ToLower(kind)+"_crd.yaml")
 	return renderWriteFile(crdFilePath, crdFilePath, crdYamlTmpl, crdTd)
 }
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -340,7 +340,16 @@ func renderRBAC(deployDir, projectName, groupName string) error {
 	return renderWriteFile(filepath.Join(deployDir, rbacYaml), rbacTmplName, rbacYamlTmpl, td)
 }
 
-func RenderDeployCrdFile(apiVersion, kind string) error {
+func RenderDeployCrdFiles(deployPath, apiVersion, kind string) error {
+	crTd := tmplData{
+		APIVersion: apiVersion,
+		Kind:       kind,
+	}
+	crFilePath := filepath.Join(deployPath, strings.ToLower(kind)+"_cr.yaml")
+	if err := renderWriteFile(crFilePath, crFilePath, crYamlTmpl, crTd); err != nil {
+		return err
+	}
+
 	crdTd := tmplData{
 		Kind:         kind,
 		KindSingular: strings.ToLower(kind),
@@ -348,7 +357,7 @@ func RenderDeployCrdFile(apiVersion, kind string) error {
 		GroupName:    groupName(apiVersion),
 		Version:      version(apiVersion),
 	}
-	crdFilePath := filepath.Join(deployDir, strings.ToLower(kind)+"_crd.yaml")
+	crdFilePath := filepath.Join(deployPath, strings.ToLower(kind)+"_crd.yaml")
 	return renderWriteFile(crdFilePath, crdFilePath, crdYamlTmpl, crdTd)
 }
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -341,6 +341,18 @@ func renderRBAC(deployDir, projectName, groupName string) error {
 	return renderWriteFile(filepath.Join(deployDir, rbacYaml), rbacTmplName, rbacYamlTmpl, td)
 }
 
+func RenderDeployCrdFile(apiVersion, kind string) error {
+	crdTd := tmplData{
+		Kind:         kind,
+		KindSingular: strings.ToLower(kind),
+		KindPlural:   toPlural(strings.ToLower(kind)),
+		GroupName:    groupName(apiVersion),
+		Version:      version(apiVersion),
+	}
+	crdFilePath := filepath.Join(deployDir, strings.ToLower(kind) + "_crd.yaml")
+	return renderWriteFile(crdFilePath, crdFilePath, crdYamlTmpl, crdTd)
+}
+
 func renderDeployFiles(deployDir, projectName, apiVersion, kind, operatorType string) error {
 	rbacTd := tmplData{
 		ProjectName: projectName,

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -232,7 +232,6 @@ spec:
       labels:
         name: app-operator
     spec:
-      serviceAccountName: app-operator
       containers:
         - name: app-operator
           image: quay.io/example-inc/app-operator:0.0.1

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -232,6 +232,7 @@ spec:
       labels:
         name: app-operator
     spec:
+      serviceAccountName: app-operator
       containers:
         - name: app-operator
           image: quay.io/example-inc/app-operator:0.0.1

--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -630,7 +630,6 @@ fi
 
 echo "Initializing role skeleton..."
 ansible-galaxy init --init-path={{.Name}}/roles/ {{.Kind}}
->>>>>>> Add --type flag to new command
 `
 
 // apiDocTmpl is the template for apis/../doc.go

--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -456,7 +456,8 @@ spec:
       labels:
         name: {{.ProjectName}}
     spec:
-      serviceAccountName: {{.ProjectName}}
+{{- if .IsGoOperator }}
+      serviceAccountName: {{.ProjectName}}{{ end }}
       containers:
         - name: {{.ProjectName}}
           image: {{.Image}}

--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -463,9 +463,9 @@ spec:
           ports:
           - containerPort: {{.MetricsPort}}
             name: {{.MetricsPortName}}
-          command:
+{{ if .IsGoOperator }}          command:
           - {{.ProjectName}}
-          imagePullPolicy: Always
+{{ end }}          imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -596,6 +596,41 @@ ADD tmp/_output/bin/memcached-operator-test /usr/local/bin/memcached-operator-te
 ARG NAMESPACEDMAN
 ADD $NAMESPACEDMAN /namespaced.yaml
 ADD tmp/build/go-test.sh /go-test.sh
+`
+
+// Ansible Operator files
+const dockerFileAnsibleTmpl = `FROM quay.io/water-hole/ansible-operator
+
+COPY roles/ ${HOME}/roles/
+{{- if .GeneratePlaybook }}
+COPY playbook.yaml ${HOME}/playbook.yaml{{ end }}
+COPY watches.yaml ${HOME}/watches.yaml
+`
+
+const watchesTmpl = `---
+- version: {{.Version}}
+  group: {{.GroupName}}
+  kind: {{.Kind}}
+{{ if .GeneratePlaybook }}  playbook: /opt/ansible/playbook.yaml{{ else }}  role: {{.Kind}}{{ end }}
+`
+
+const playbookTmpl = `- hosts: localhost
+  gather_facts: no
+  tasks:
+  - import_role:
+      name: "{{.Kind}}"
+`
+
+const galaxyInitTmpl = `#!/usr/bin/env bash
+
+if ! which ansible-galaxy > /dev/null; then
+	echo "ansible needs to be installed"
+	exit 1
+fi
+
+echo "Initializing role skeleton..."
+ansible-galaxy init --init-path={{.Name}}/roles/ {{.Kind}}
+>>>>>>> Add --type flag to new command
 `
 
 // apiDocTmpl is the template for apis/../doc.go

--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -611,7 +611,7 @@ const watchesTmpl = `---
 - version: {{.Version}}
   group: {{.GroupName}}
   kind: {{.Kind}}
-{{ if .GeneratePlaybook }}  playbook: /opt/ansible/playbook.yaml{{ else }}  role: {{.Kind}}{{ end }}
+{{ if .GeneratePlaybook }}  playbook: /opt/ansible/playbook.yaml{{ else }}  role: /opt/ansible/roles/{{.Kind}}{{ end }}
 `
 
 const playbookTmpl = `- hosts: localhost

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -19,7 +19,6 @@ import (
 	goctx "context"
 	"fmt"
 	"io/ioutil"
-	"os"
 
 	yaml "gopkg.in/yaml.v2"
 	core "k8s.io/api/core/v1"
@@ -31,8 +30,8 @@ func (ctx *TestCtx) GetNamespace() (string, error) {
 	if ctx.Namespace != "" {
 		return ctx.Namespace, nil
 	}
-	if Global.InCluster {
-		ctx.Namespace = os.Getenv(TestNamespaceEnv)
+	if Global.SingleNamespace {
+		ctx.Namespace = Global.Namespace
 		return ctx.Namespace, nil
 	}
 	// create namespace

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -147,6 +147,12 @@ func TestMemcached(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dep ensure failed: %v\nCommand Output:\n%v", err, string(cmdOut))
 	}
+	// link local sdk to vendor if not in travis
+	if prSlug == "" {
+		os.RemoveAll("vendor/github.com/operator-framework/operator-sdk/pkg")
+		os.Symlink(path.Join(gopath, "/src/github.com/operator-framework/operator-sdk/pkg"),
+			"vendor/github.com/operator-framework/operator-sdk/pkg")
+	}
 
 	// create crd
 	crdYAML, err := ioutil.ReadFile("deploy/crd.yaml")


### PR DESCRIPTION
- [x] `operator-sdk new --type ansible`
- [x] `operator-sdk build` support. Autodetect type of operator by looking for `watches.yaml`
- [x] `operator-sdk generate` support.
- ~~[ ] `operator-sdk up local` support.~~ Going to break this out to a separate PR
