### PR TITLE
Create olmCatalogDir if doesn't exists in deploy/

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -518,6 +518,9 @@ func apiDirName(apiVersion string) string {
 
 // Writes file to a given path and data buffer, as well as prints out a message confirming creation of a file
 func writeFileAndPrint(filePath string, data []byte, fileMode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(filePath), defaultDirFileMode); err != nil {
+		return err
+	}
 	if err := ioutil.WriteFile(filePath, data, fileMode); err != nil {
 		return err
 	}

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -16,6 +16,8 @@ package generator
 
 import (
 	"bytes"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -543,5 +545,22 @@ func TestGenBuild(t *testing.T) {
 		dmp := diffmatchpatch.New()
 		diffs := dmp.DiffMain(dockerFileExp, buf.String(), false)
 		t.Errorf("\nTest failed. Below is the diff of the expected vs actual results.\nRed text is missing and green text is extra.\n\n" + dmp.DiffPrettyText(diffs))
+	}
+}
+
+func TestWriteFileAndPrint(t *testing.T) {
+	deployDir, err := ioutil.TempDir("", "test-write-file-and-print")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(deployDir)
+
+	olmCatalogPackagePath := filepath.Join(deployDir, olmCatalogDir, catalogPackageYaml)
+	if err = writeFileAndPrint(olmCatalogPackagePath, []byte("sometext"), defaultFileMode); err != nil {
+		t.Fatalf("\nTest failed. Failed to write file and print: %v", err)
+	}
+	if _, err := os.Stat(olmCatalogPackagePath); os.IsNotExist(err) {
+		t.Errorf("\nTest failed. Failed to create %s", olmCatalogPackagePath)
 	}
 }


### PR DESCRIPTION
If olm-catalog/ is removed from deploy/ dir, olm-catalog generation
fails. This change creates deploy/olm-catalog/ dir if it doesn't exist
and avoids failure.

Fixes #495 