### PR TITLE
Update csv template's apiVersion and kind

### DIFF
--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -42,8 +42,8 @@ spec:
   version: {{.Version}}
 `
 
-const catalogCSVTmpl = `apiVersion: app.coreos.com/v1alpha1
-kind: ClusterServiceVersion-v1
+const catalogCSVTmpl = `apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
 metadata:
   name: {{.CSVName}}
   namespace: placeholder


### PR DESCRIPTION
The latest OLM has csv kind as `ClusterServiceVersion` under the group
`operators.coreos.com`.

Refer: https://github.com/operator-framework/getting-started/issues/21