### PR TITLE
add api: add new type, generate crd and example cr

### DIFF
--- a/pkg/scaffold/cr.go
+++ b/pkg/scaffold/cr.go
@@ -1,0 +1,53 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scaffold
+
+import (
+	"io"
+	"text/template"
+)
+
+type cr struct {
+	crInput *CrInput
+}
+
+// CrInput is the input needed to generate a deploy/crds/<group>_<version>_<kind>_cr.yaml file
+type CrInput struct {
+	// Resource defines the inputs for the new api
+	Resource *Resource
+}
+
+func NewCrCodegen(input *CrInput) Codegen {
+	return &cr{crInput: input}
+}
+
+func (c *cr) Render(w io.Writer) error {
+	t := template.New("<group>_<version>_<kind>_cr.yaml")
+	t, err := t.Parse(crTemplate)
+	if err != nil {
+		return err
+	}
+
+	return t.Execute(w, c.crInput)
+}
+
+const crTemplate = `apiVersion: {{ .Resource.APIVersion }}
+kind: {{ .Resource.Kind }}
+metadata:
+  name: example-{{ .Resource.LowerKind }}
+spec:
+  # Add fields here
+  size: 3
+`

--- a/pkg/scaffold/crd.go
+++ b/pkg/scaffold/crd.go
@@ -1,0 +1,60 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scaffold
+
+import (
+	"io"
+	"text/template"
+)
+
+type crd struct {
+	crdInput *CrdInput
+}
+
+// CrdInput is the input needed to generate a deploy/crds/<group>_<version>_<kind>_crd.yaml file
+type CrdInput struct {
+	// Resource defines the inputs for the new api
+	Resource *Resource
+}
+
+func NewCrdCodegen(input *CrdInput) Codegen {
+	return &crd{crdInput: input}
+}
+
+func (c *crd) Render(w io.Writer) error {
+	t := template.New("<group>_<version>_<kind>_crd.yaml")
+	t, err := t.Parse(crdTemplate)
+	if err != nil {
+		return err
+	}
+
+	return t.Execute(w, c.crdInput)
+}
+
+// TODO: Parse pkg/apis to generate CRD with open-api validation instead of using a static template
+const crdTemplate = `apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: {{ .Resource.Resource }}.{{ .Resource.FullGroup }}
+spec:
+  group: {{ .Resource.FullGroup }}
+  names:
+    kind: {{ .Resource.Kind }}
+    listKind: {{ .Resource.Kind }}List
+    plural: {{ .Resource.Resource }}
+    singular: {{ .Resource.LowerKind }}
+  scope: Namespaced
+  version: v1alpha1
+`

--- a/pkg/scaffold/resource.go
+++ b/pkg/scaffold/resource.go
@@ -47,6 +47,9 @@ type Resource struct {
 	// Resource is the API Resource i.e plural(lowercased(Kind)) e.g appservices
 	Resource string
 
+	// LowerKind is lowercased(Kind) e.g appservice
+	LowerKind string
+
 	// TODO: allow user to specify list of short names for Resource e.g app, myapp
 }
 
@@ -80,6 +83,8 @@ func (r *Resource) Validate() error {
 	if len(r.Kind) == 0 {
 		return errors.New("kind cannot be empty")
 	}
+
+	r.LowerKind = strings.ToLower(r.Kind)
 
 	// TODO: regex match kind to only be [aA-zZ]]
 	if strings.Title(r.Kind) != r.Kind {


### PR DESCRIPTION
[skip ci]
The `operator-sdk add api --kind --api-version` command can now add a new Kind for an existing api-version.

It also scaffolds the crd.yaml and cr.yaml for a new (apiversion,kind) under deploy/crds/.