### PR TITLE
*: add controller command and templates

### DIFF
--- a/commands/operator-sdk/cmd/add.go
+++ b/commands/operator-sdk/cmd/add.go
@@ -28,5 +28,6 @@ func NewAddCmd() *cobra.Command {
 	}
 
 	upCmd.AddCommand(add.NewApiCmd())
+	upCmd.AddCommand(add.NewControllerCmd())
 	return upCmd
 }

--- a/commands/operator-sdk/cmd/add/api.go
+++ b/commands/operator-sdk/cmd/add/api.go
@@ -42,7 +42,7 @@ api definition for a new custom resource under pkg/apis. This command must be ru
 If the api already exists at pkg/apis/<group>/<version> then the command will not overwrite and return an error.
 
 Example:
-	$ operator-sdk add --api-version=app.example.com/v1alpha1 --kind=AppService
+	$ operator-sdk add api --api-version=app.example.com/v1alpha1 --kind=AppService
 	$ tree pkg/apis
 	pkg/apis/
 	├── addtoscheme_app_appservice.go
@@ -184,6 +184,7 @@ func mustGetwd() string {
 	return wd
 }
 
+// TODO: combine with writeFileAndPrint to return error if file already exists
 func mustNotExist(path string) {
 	_, err := os.Stat(path)
 	if err == nil {

--- a/commands/operator-sdk/cmd/add/controller.go
+++ b/commands/operator-sdk/cmd/add/controller.go
@@ -1,0 +1,103 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package add
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/cmdutil"
+	"github.com/operator-framework/operator-sdk/pkg/scaffold"
+
+	"github.com/spf13/cobra"
+)
+
+func NewControllerCmd() *cobra.Command {
+	apiCmd := &cobra.Command{
+		Use:   "controller",
+		Short: "Adds a new controller pkg",
+		Long: `operator-sdk add controller --kind=<kind> --api-version=<group/version> creates a new
+controller pkg under pkg/controller/<kind> that, by default, reconciles on a custom resource for the specified apiversion and kind.
+The controller will expect to use the custom resource type that should already be defined under pkg/apis/<group>/<version> 
+via the "operator-sdk add api --kind=<kind> --api-version=<group/version>" command.
+This command must be run from the project root directory.
+If the controller pkg for that Kind already exists at pkg/controller/<kind> then the command will not overwrite and return an error.
+
+Example:
+	$ operator-sdk add controller --api-version=app.example.com/v1alpha1 --kind=AppService
+	$ tree pkg/controller
+	pkg/controller/
+	├── add_appservice.go
+	├── appservice
+	│   └── appservice_controller.go
+	└── controller.go
+
+`,
+		Run: controllerRun,
+	}
+
+	apiCmd.Flags().StringVar(&apiVersion, "api-version", "", "Kubernetes APIVersion that has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)")
+	apiCmd.MarkFlagRequired("api-version")
+	apiCmd.Flags().StringVar(&kind, "kind", "", "Kubernetes resource Kind name. (e.g AppService)")
+	apiCmd.MarkFlagRequired("kind")
+
+	return apiCmd
+}
+
+func controllerRun(cmd *cobra.Command, args []string) {
+	projectPath := cmdutil.MustInProjectRoot()
+	fullProjectPath := mustGetwd()
+
+	// Create and validate new resource
+	r, err := scaffold.NewResource(apiVersion, kind)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Must be controller for a new kind: pkg/controller/<kind>/<kind>_controller.go shouldn't exist
+	kindControllerFileName := r.LowerKind + "_controller.go"
+	pkgControllerDir := filepath.Join(fullProjectPath, "pkg", "controller", r.LowerKind)
+	mustNotExist(filepath.Join(pkgControllerDir, kindControllerFileName))
+
+	// Scaffold pkg/controller/add_<kind>.go
+	filePath := filepath.Join(fullProjectPath, "pkg", "controller", "add_"+r.LowerKind+".go")
+	codeGen := scaffold.NewAddControllerCodegen(&scaffold.AddControllerInput{ProjectPath: projectPath, Resource: r})
+	buf := &bytes.Buffer{}
+	if err := codeGen.Render(buf); err != nil {
+		log.Fatalf("failed to render the template for (%v): %v", filePath, err)
+	}
+	if err := writeFileAndPrint(filePath, buf.Bytes(), cmdutil.DefaultFileMode); err != nil {
+		log.Fatalf("failed to create %v: %v", filePath, err)
+	}
+
+	// Scaffold pkg/controller/<kind> directory
+	if err := os.MkdirAll(pkgControllerDir, cmdutil.DefaultDirFileMode); err != nil {
+		log.Fatalf("failed to create %v: %v", pkgControllerDir, err)
+	}
+
+	// Scaffold pkg/controller/<kind>/<kind>_controller.go
+	filePath = filepath.Join(pkgControllerDir, kindControllerFileName)
+	codeGen = scaffold.NewControllerKindCodegen(&scaffold.ControllerKindInput{ProjectPath: projectPath, Resource: r})
+	buf = &bytes.Buffer{}
+	if err := codeGen.Render(buf); err != nil {
+		log.Fatalf("failed to render the template for (%v): %v", filePath, err)
+	}
+	if err := writeFileAndPrint(filePath, buf.Bytes(), cmdutil.DefaultFileMode); err != nil {
+		log.Fatalf("failed to create %v: %v", filePath, err)
+	}
+
+}

--- a/commands/operator-sdk/cmd/generate/k8s.go
+++ b/commands/operator-sdk/cmd/generate/k8s.go
@@ -63,13 +63,14 @@ func K8sCodegen() {
 	fmt.Fprintf(os.Stdout, "Running code-generation for custom resource group versions: [%s]\n", groupVersions)
 	// TODO: Replace generate-groups.sh by building the vendored generators(deepcopy, lister etc)
 	// and running them directly
+	// TODO: remove dependency on boilerplate.go.txt
 	genGroupsCmd := "vendor/k8s.io/code-generator/generate-groups.sh"
 	args := []string{
 		"deepcopy",
 		outputPkg,
 		apisPkg,
 		groupVersions,
-		"--go-header-file", "./tmp/codegen/boilerplate.go.txt",
+		"--go-header-file", "./scripts/codegen/boilerplate.go.txt",
 	}
 	out, err := exec.Command(genGroupsCmd, args...).CombinedOutput()
 	if err != nil {

--- a/commands/operator-sdk/cmd/new.go
+++ b/commands/operator-sdk/cmd/new.go
@@ -258,8 +258,8 @@ func doScaffold() {
 		log.Fatalf("failed to create %v: %v", codegenDir, err)
 	}
 
-	// generate scripts/codegen/Boilerplate.go.txt
-	boilerplatePath := filepath.Join(codegenDir, "Boilerplate.go.txt")
+	// generate scripts/codegen/boilerplate.go.txt
+	boilerplatePath := filepath.Join(codegenDir, "boilerplate.go.txt")
 	err = writeFileAndPrint(boilerplatePath, []byte{}, defaultFileMode)
 	if err != nil {
 		log.Fatalf("failed to create %v: %v", boilerplatePath, err)

--- a/pkg/scaffold/add_controller.go
+++ b/pkg/scaffold/add_controller.go
@@ -1,0 +1,58 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scaffold
+
+import (
+	"io"
+	"text/template"
+)
+
+type addController struct {
+	addControllerInput *AddControllerInput
+}
+
+// AddControllerInput is the input needed to generate a pkg/controller/add_<kind>.go file
+type AddControllerInput struct {
+	// ProjectPath is the project path rooted at GOPATH.
+	ProjectPath string
+	// Resource defines the inputs for the controller's primary resource
+	Resource *Resource
+}
+
+func NewAddControllerCodegen(input *AddControllerInput) Codegen {
+	return &addController{addControllerInput: input}
+}
+
+func (c *addController) Render(w io.Writer) error {
+	t := template.New("add_<kind>.go")
+	t, err := t.Parse(addControllerTemplate)
+	if err != nil {
+		return err
+	}
+
+	return t.Execute(w, c.addControllerInput)
+}
+
+const addControllerTemplate = `package controller
+
+import (
+	"{{ .ProjectPath }}/pkg/controller/{{ .Resource.LowerKind }}"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, {{ .Resource.LowerKind }}.Add)
+}
+`

--- a/pkg/scaffold/controller_kind.go
+++ b/pkg/scaffold/controller_kind.go
@@ -1,0 +1,199 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scaffold
+
+import (
+	"io"
+	"text/template"
+)
+
+type controllerKind struct {
+	controllerKindInput *ControllerKindInput
+}
+
+// ControllerKindInput is the input needed to generate a pkg/controller/<kind>/<kind>_controller.go file
+type ControllerKindInput struct {
+	// ProjectPath is the project path rooted at GOPATH.
+	ProjectPath string
+	// Resource defines the inputs for the controller's primary resource
+	Resource *Resource
+}
+
+func NewControllerKindCodegen(input *ControllerKindInput) Codegen {
+	return &controllerKind{controllerKindInput: input}
+}
+
+func (c *controllerKind) Render(w io.Writer) error {
+	t := template.New("<kind>_controller.go")
+	t, err := t.Parse(controllerKindTemplate)
+	if err != nil {
+		return err
+	}
+
+	return t.Execute(w, c.controllerKindInput)
+}
+
+const controllerKindTemplate = `package {{ .Resource.LowerKind }}
+
+import (
+	"context"
+	"log"
+
+	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ProjectPath }}/pkg/apis/{{ .Resource.Group}}/{{ .Resource.Version }}"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+/**
+* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
+* business logic.  Delete these comments after modifying this file.*
+ */
+
+// Add creates a new {{ .Resource.Kind }} Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &Reconcile{{ .Resource.Kind }}{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("{{ .Resource.LowerKind }}-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource {{ .Resource.Kind }}
+	err = c.Watch(&source.Kind{Type: &{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	// TODO(user): Modify this to be the types you create that are owned by the primary resource
+	// Watch for changes to secondary resource Pods and requeue the owner {{ .Resource.Kind }}
+	err = c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}{},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &Reconcile{{ .Resource.Kind }}{}
+
+// Reconcile{{ .Resource.Kind }} reconciles a {{ .Resource.Kind }} object
+type Reconcile{{ .Resource.Kind }} struct {
+	// TODO: Clarify the split client
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a {{ .Resource.Kind }} object and makes changes based on the state read
+// and what is in the {{ .Resource.Kind }}.Spec
+// TODO(user): Modify this Reconcile function to implement your Controller logic.  This example creates
+// a Pod as an example
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *Reconcile{{ .Resource.Kind }}) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	// Fetch the {{ .Resource.Kind }} instance
+	instance := &{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	// Define a new Pod object
+	pod := newPodForCR(instance)
+
+	// Set {{ .Resource.Kind }} instance as the owner and controller
+	if err := controllerutil.SetControllerReference(instance, pod, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Check if this Pod already exists
+	found := &corev1.Pod{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, found)
+	if err != nil && errors.IsNotFound(err) {
+		log.Printf("Creating a new Pod %s/%s\n", pod.Namespace, pod.Name)
+		err = r.client.Create(context.TODO(), pod)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// Pod created successfully - don't requeue
+		return reconcile.Result{}, nil
+	} else if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Pod already exists - don't requeue
+	return reconcile.Result{}, nil
+}
+
+// newPodForCR returns a busybox pod with the same name/namespace as the cr 
+func newPodForCR(cr *&{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}) *corev1.Pod {
+	labels := map[string]string{
+		"app": cr.Name,
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name + "-pod",
+			Namespace: cr.Namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "busybox",
+					Image:   "busybox",
+					Command: []string{"sleep", "3600"},
+				},
+			},
+		},
+	}
+}
+`


### PR DESCRIPTION
Added `operator-sdk add controller --kind=<Kind> --api-version=<APIversion>` command.

The default controller reconcile code is similar to our existing busy-box pod operator example. 
Later on we could add a flag to skip generating the example code.

Also made some typo fixes in the code-generator and `add api` cmd.

/cc @fanminshi 