### PR TITLE
fully-qualifies example image, to support non-docker runtimes

### DIFF
--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -139,7 +139,7 @@ func newbusyBoxPod(cr *v1alpha1.AppService) *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:    "busybox",
-					Image:   "busybox",
+					Image:   "docker.io/busybox",
 					Command: []string{"sleep", "3600"},
 				},
 			},

--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -230,7 +230,7 @@ func newbusyBoxPod(cr *{{.Version}}.{{.Kind}}) *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:    "busybox",
-					Image:   "busybox",
+					Image:   "docker.io/busybox",
 					Command: []string{"sleep", "3600"},
 				},
 			},


### PR DESCRIPTION
Non-docker runtimes may not assume a particular registry. The CRI avoids such
assumptions, leaving it up to individual runtimes. CRI-O as one runtime example
does not assume docker.io.

This change can be tested with cri-o on minikube with a command similar to:

`minikube start --kubernetes-version=v1.11.3 --network-plugin=cni --container-runtime=cri-o`