### PR TITLE
*: update README and fix templates and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,32 +56,48 @@ $ make install
 Create and deploy an app-operator using the SDK CLI:
 
 ```sh
-# Create an app-operator project that defines the App CR.
+# Create a new app-operator project
 $ cd $GOPATH/src/github.com/example-inc/
-$ operator-sdk new app-operator --api-version=app.example.com/v1alpha1 --kind=App
+$ operator-sdk new app-operator
 $ cd app-operator
+
+# Add a new API for the custom resource AppService
+$ operator-sdk add api --api-version=app.example.com/v1alpha1 --kind=AppService
+
+# Add a new controller that watches for AppService
+$ operator-sdk add controller --api-version=app.example.com/v1alpha1 --kind=AppService
 
 # Build and push the app-operator image to a public registry such as quay.io
 $ operator-sdk build quay.io/example/app-operator
 $ docker push quay.io/example/app-operator
 
+# Update the operator manifest to use the built image name
+$ sed -i 's|REPLACE_IMAGE|quay.io/example/app-operator|g' deploy/operator.yaml
+
+# Setup RBAC
+$ kubectl create -f deploy/role.yaml
+$ kubectl create -f deploy/role_binding.yaml
+# TODO: kubectl create -f deploy/service_account.yaml
+# Setup the CRD
+$ kubectl create -f deploy/crds/app_v1alpha1_appservice_crd.yaml
 # Deploy the app-operator
-$ kubectl create -f deploy/rbac.yaml
-$ kubectl create -f deploy/crd.yaml
 $ kubectl create -f deploy/operator.yaml
 
-# By default, creating a custom resource (App) triggers the app-operator to deploy a busybox pod
-$ kubectl create -f deploy/cr.yaml
+# Create an AppService CR
+# The default controller will watch for AppService objects and create a pod for each CR
+$ kubectl create -f deploy/crds/app_v1alpha1_appservice_cr.yaml
 
-# Verify that the busybox pod is created
-$ kubectl get pod -l app=busy-box
-NAME            READY     STATUS    RESTARTS   AGE
-busy-box   1/1       Running   0          50s
+# Verify that a pod is created
+$ kubectl get pod -l app=example-appservice
+NAME                     READY     STATUS    RESTARTS   AGE
+example-appservice-pod   1/1       Running   0          1m
 
 # Cleanup
-$ kubectl delete -f deploy/cr.yaml
+$ kubectl delete -f deploy/app_v1alpha1_appservice_cr.yaml
 $ kubectl delete -f deploy/operator.yaml
-$ kubectl delete -f deploy/rbac.yaml
+$ kubectl delete -f deploy/role.yaml
+$ kubectl delete -f deploy/role_binding.yaml
+$ kubectl delete -f deploy/app_v1alpha1_appservice_crd.yaml
 ```
 
 ## User Guide

--- a/commands/operator-sdk/cmd/add/api.go
+++ b/commands/operator-sdk/cmd/add/api.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 
 	"github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/cmdutil"
+	"github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/generate"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold"
 
 	"github.com/ghodss/yaml"
@@ -170,6 +171,9 @@ func apiRun(cmd *cobra.Command, args []string) {
 	if err := updateRoleForResource(r, fullProjectPath); err != nil {
 		log.Fatalf("failed to update the RBAC manifest for the resource (%v, %v): %v", r.APIVersion, r.Kind, err)
 	}
+
+	// Run k8s codegen for deepcopy
+	generate.K8sCodegen()
 }
 
 func updateRoleForResource(r *scaffold.Resource, fullProjectPath string) error {

--- a/commands/operator-sdk/cmd/build.go
+++ b/commands/operator-sdk/cmd/build.go
@@ -16,12 +16,9 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
-
-	"github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/cmdutil"
-	cmdError "github.com/operator-framework/operator-sdk/commands/operator-sdk/error"
-	"github.com/operator-framework/operator-sdk/pkg/generator"
 
 	"github.com/spf13/cobra"
 )
@@ -47,34 +44,26 @@ For example:
 }
 
 const (
-	build       = "./tmp/build/build.sh"
-	dockerBuild = "./tmp/build/docker_build.sh"
-	configYaml  = "./config/config.yaml"
+	build = "./build/build.sh"
 )
 
 func buildFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
-		cmdError.ExitWithError(cmdError.ExitBadArgs, fmt.Errorf("build command needs 1 argument."))
+		log.Fatalf("build command needs 1 argument.")
 	}
 
 	bcmd := exec.Command(build)
 	o, err := bcmd.CombinedOutput()
 	if err != nil {
-		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to build: (%v)", string(o)))
+		log.Fatalf("failed to build: %v (%v)", string(o), err)
 	}
 	fmt.Fprintln(os.Stdout, string(o))
 
 	image := args[0]
-	dbcmd := exec.Command(dockerBuild)
-	dbcmd.Env = append(os.Environ(), fmt.Sprintf("IMAGE=%v", image))
+	dbcmd := exec.Command("docker", "build", ".", "-f", "build/Dockerfile", "-t", image)
 	o, err = dbcmd.CombinedOutput()
 	if err != nil {
-		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to output build image %v: (%v)", image, string(o)))
+		log.Fatalf("failed to output build image %v: %v (%v)", image, string(o), err)
 	}
 	fmt.Fprintln(os.Stdout, string(o))
-
-	c := cmdutil.GetConfig()
-	if err = generator.RenderOperatorYaml(c, image); err != nil {
-		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to generate deploy/operator.yaml: (%v)", err))
-	}
 }

--- a/commands/operator-sdk/cmd/new.go
+++ b/commands/operator-sdk/cmd/new.go
@@ -163,7 +163,7 @@ func doScaffold() {
 	}
 
 	// create build dir
-	buildDir := filepath.Join(fullProjectPath, "pkg", "build")
+	buildDir := filepath.Join(fullProjectPath, "build")
 	if err := os.MkdirAll(buildDir, defaultDirFileMode); err != nil {
 		log.Fatalf("failed to create %v: %v", buildDir, err)
 	}

--- a/pkg/scaffold/cmd.go
+++ b/pkg/scaffold/cmd.go
@@ -55,7 +55,6 @@ import (
 
 	k8sutil "github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
-	"github.com/sirupsen/logrus"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -63,9 +62,9 @@ import (
 )
 
 func printVersion() {
-	logrus.Infof("Go Version: %s", runtime.Version())
-	logrus.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
-	logrus.Infof("operator-sdk Version: %v", sdkVersion.Version)
+	log.Printf("Go Version: %s", runtime.Version())
+	log.Printf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
+	log.Printf("operator-sdk Version: %v", sdkVersion.Version)
 }
 
 func main() {
@@ -74,10 +73,10 @@ func main() {
 
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
-		log.Fatal("Failed to get watch namespace: %v", err)
+		log.Fatalf("Failed to get watch namespace: %v", err)
 	}
 
-	// Expose metrics port after SDK uses controller-runtime's dynamic client
+	// TODO: Expose metrics port after SDK uses controller-runtime's dynamic client
 	// sdk.ExposeMetricsPort()
 
 	// Get a config to talk to the apiserver
@@ -87,14 +86,12 @@ func main() {
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components
-	// TODO: Need to support namespacing the manager upstream to avoid cluster wide permissions
-	// https://github.com/kubernetes-sigs/controller-runtime/issues/124
 	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	log.Printf("Registering Components.")
+	log.Print("Registering Components.")
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
@@ -106,7 +103,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	log.Printf("Starting the Cmd.")
+	log.Print("Starting the Cmd.")
 
 	// Start the Cmd
 	log.Fatal(mgr.Start(signals.SetupSignalHandler()))

--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -64,10 +64,10 @@ required = [
 [prune]
   go-tests = true
   non-go = true
-  unused-packages = true
   
   [[prune.project]]
     name = "k8s.io/code-generator"
     non-go = false
     unused-packages = false
+
 `

--- a/pkg/scaffold/operator.go
+++ b/pkg/scaffold/operator.go
@@ -60,7 +60,8 @@ spec:
     spec:
       containers:
         - name: {{.ProjectName}}
-          image: REPLACE_IMAGE // replace this with the built image.
+          # Replace this with the built image name
+          image: REPLACE_IMAGE
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
Updated the README example for the controller-runtime.

Update the `build` command to work with the new project layout. Fixed some template typos and the `new` cmd to get the full example working correctly.

We also can't prune unused pkgs because when we generate new files with `add api` and `add controller` they introduce dependencies on pkgs that were previously pruned. 
Meaning we would have to run dep ensure after both commands separately if we pruned.

/cc @fanminshi 