### PR TITLE
commands,pkg/test: support single namespace mode for local test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ script:
 - operator-sdk test local .
 # test operator-sdk test flags
 - operator-sdk test local . --global-manifest deploy/crd.yaml --namespaced-manifest deploy/namespace-init.yaml --go-test-flags "-parallel 1" --kubeconfig $HOME/.kube/config
+# test operator-sdk test local single namespace mode
+- kubectl create namespace test-memcached
+- operator-sdk test local . --namespace=test-memcached
+- kubectl delete namespace test-memcached
 # go back to project root
 - cd ../..
 - go vet ./...

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -175,6 +175,7 @@ Runs the tests locally
 * `--kubeconfig` string - location of kubeconfig for kubernetes cluster (default "~/.kube/config")
 * `--global-manifest` string - path to manifest for global resources (default "deploy/crd.yaml)
 * `--namespaced-manifest` string - path to manifest for per-test, namespaced resources (default: combines deploy/sa.yaml, deploy/rbac.yaml, and deploy/operator.yaml)
+*  `--namespace` string - if non-empty, single namespace to run tests in (e.g. "operator-test") (default: "")
 * `--go-test-flags` string - extra arguments to pass to `go test` (e.g. -f "-v -parallel=2")
 * `-h, --help` - help for local
 

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -207,6 +207,13 @@ as an argument. You can use `--help` to view the other configuration options and
 $ operator-sdk test local ./test/e2e --go-test-flags "-v -parallel=2"
 ```
 
+If you wish to run all the tests in 1 namespace (which also forces `-parallel=1`), you can use the `--namespace` flag:
+
+```shell
+$ kubectl create namespace operator-test
+$ operator-sdk test local ./test/e2e --namespace operator-test
+```
+
 For more documentation on the `operator-sdk test local` command, see the [SDK CLI Reference][sdk-cli-ref] doc.
 
 For advanced use cases, it is possible to run the tests via `go test` directly. As long as all flags defined
@@ -258,6 +265,7 @@ Test Successfully Completed
 ```
 
 The `test cluster` command will deploy a test pod in the given namespace that will run the e2e tests packaged in the image.
+The tests run sequentially in the namespace (`-parallel=1`), the same as running `operator-sdk test local --namespace <namespace>`.
 The command will wait until the tests succeed (pod phase=`Succeeded`) or fail (pod phase=`Failed`).
 If the tests fail, the command will output the test pod logs which should be the standard go test error logs.
 

--- a/hack/ci/setup-openshift.sh
+++ b/hack/ci/setup-openshift.sh
@@ -10,3 +10,6 @@ tar xvzOf oc.tar.gz openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit/oc
 oc cluster up
 # Become cluster admin
 oc login -u system:admin
+
+# kubectl is needed for the single namespace local test
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.1/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/

--- a/pkg/test/framework.go
+++ b/pkg/test/framework.go
@@ -71,6 +71,7 @@ func setup(kubeconfigPath, namespacedManPath *string, singleNamespace *bool) err
 			os.Setenv("KUBERNETES_SERVICE_PORT", "443")
 		}
 		kubeconfig, err = rest.InClusterConfig()
+		*singleNamespace = true
 	} else {
 		kubeconfig, err = clientcmd.BuildConfigFromFlags("", *kubeconfigPath)
 	}

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -19,7 +19,6 @@ import (
 	goctx "context"
 	"fmt"
 	"io/ioutil"
-	"os"
 
 	yaml "gopkg.in/yaml.v2"
 	core "k8s.io/api/core/v1"
@@ -31,11 +30,8 @@ func (ctx *TestCtx) GetNamespace() (string, error) {
 	if ctx.Namespace != "" {
 		return ctx.Namespace, nil
 	}
-	if *Global.SingleNamespace {
-		ctx.Namespace = os.Getenv(TestNamespaceEnv)
-		if len(ctx.Namespace) == 0 {
-			return "", fmt.Errorf("namespace set in %s cannot be empty", TestNamespaceEnv)
-		}
+	if Global.SingleNamespace {
+		ctx.Namespace = Global.Namespace
 		return ctx.Namespace, nil
 	}
 	// create namespace

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -34,7 +34,7 @@ func (ctx *TestCtx) GetNamespace() (string, error) {
 	if *Global.SingleNamespace {
 		ctx.Namespace = os.Getenv(TestNamespaceEnv)
 		if len(ctx.Namespace) == 0 {
-			return "", fmt.Errorf("namepspace set in %s cannot be empty", TestNamespaceEnv)
+			return "", fmt.Errorf("namespace set in %s cannot be empty", TestNamespaceEnv)
 		}
 		return ctx.Namespace, nil
 	}

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -33,6 +33,9 @@ func (ctx *TestCtx) GetNamespace() (string, error) {
 	}
 	if *Global.SingleNamespace {
 		ctx.Namespace = os.Getenv(TestNamespaceEnv)
+		if len(ctx.Namespace) == 0 {
+			return "", fmt.Errorf("namepspace set in %s cannot be empty", TestNamespaceEnv)
+		}
 		return ctx.Namespace, nil
 	}
 	// create namespace

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -31,7 +31,7 @@ func (ctx *TestCtx) GetNamespace() (string, error) {
 	if ctx.Namespace != "" {
 		return ctx.Namespace, nil
 	}
-	if Global.InCluster {
+	if *Global.SingleNamespace {
 		ctx.Namespace = os.Getenv(TestNamespaceEnv)
 		return ctx.Namespace, nil
 	}


### PR DESCRIPTION
This commit brings support for running the tests in a single
namespace when using `test local`, which was previously only used
by `test cluster` (where it was a requirement to properly function)

/cc @hasbro17 @fanminshi 