### PR TITLE
pkg/test: add new CreateWithFinalizer helper function

### DIFF
--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -115,11 +115,11 @@ if err != nil {
 }
 ```
 
-The `InitializeClusterResources` function uses the `CreateWithFinalizer` function to creates the resources provided
-in your namespaced manifest. `CreateWithFinalizer` use the controller-runtime's client to create resources and then
-creates a finalizer that is called by `ctx.Cleanup` which deletes the resource and then waits for the resource to be
+The `InitializeClusterResources` function uses the `CreateWithCleanup` function to creates the resources provided
+in your namespaced manifest. `CreateWithCleanup` use the controller-runtime's client to create resources and then
+creates a cleanup function that is called by `ctx.Cleanup` which deletes the resource and then waits for the resource to be
 fully deleted before returning. This is configurable with `CleanupOptions`. If the `CleanupOptions` argument is set
-to `nil`, the finalizer simply calls the delete function and returns without waiting.
+to `nil`, the cleanup function simply calls the delete function and returns without waiting.
 
 If you want to make sure the operator's deployment is fully ready before moving onto the next part of the
 test, the `WaitForDeployment` function from [e2eutil][e2eutil-link] (in the sdk under `pkg/test/e2eutil`) can be used:
@@ -142,8 +142,8 @@ if err != nil {
 #### 4. Write the test specific code
 
 Now that the operator is ready, we can create a custom resource. As mentioned when speaking about the
-`InitializeClusterResources` function, the test framework provides a `CreateWithFinalizer` function that
-creates the resource with the controller-runtime's dynamic client and then adds a finalizer function
+`InitializeClusterResources` function, the test framework provides a `CreateWithCleanup` function that
+creates the resource with the controller-runtime's dynamic client and then adds a cleanup function
 to the context. This function should be used to create all resources. Since the controller-runtime's
 dynamic client uses go contexts, make sure to import the go context library. In this example, we imported
 it as `goctx`:

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -120,7 +120,7 @@ func (ctx *TestCtx) CreateWithFinalizer(gCtx goctx.Context, obj runtime.Object, 
 			return err
 		}
 		if cleanupOptions != nil && !cleanupOptions.SkipPolling {
-			return wait.PollImmediate(time.Second*1, time.Second*5, func() (bool, error) {
+			return wait.PollImmediate(cleanupOptions.RetryInterval, cleanupOptions.Timeout, func() (bool, error) {
 				err = Global.DynamicClient.Get(gCtx, key, obj)
 				if err != nil {
 					if apierrors.IsNotFound(err) {

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -111,7 +111,7 @@ func (ctx *TestCtx) CreateWithFinalizer(gCtx goctx.Context, obj runtime.Object, 
 		return err
 	}
 	key, err := dynclient.ObjectKeyFromObject(objCopy)
-	ctx.t.Logf("resource type %+v with namespace/name \"%+v\" created\n", objCopy.GetObjectKind().GroupVersionKind().Kind, key)
+	ctx.t.Logf("resource type %+v with namespace/name (%+v) created\n", objCopy.GetObjectKind().GroupVersionKind().Kind, key)
 	ctx.AddFinalizerFn(func() error {
 		err = Global.DynamicClient.Delete(gCtx, objCopy)
 		if err != nil {
@@ -122,12 +122,12 @@ func (ctx *TestCtx) CreateWithFinalizer(gCtx goctx.Context, obj runtime.Object, 
 				err = Global.DynamicClient.Get(gCtx, key, objCopy)
 				if err != nil {
 					if apierrors.IsNotFound(err) {
-						ctx.t.Logf("resource type %+v with namespace/name \"%+v\" successfully deleted\n", objCopy.GetObjectKind().GroupVersionKind().Kind, key)
+						ctx.t.Logf("resource type %+v with namespace/name (%+v) successfully deleted\n", objCopy.GetObjectKind().GroupVersionKind().Kind, key)
 						return true, nil
 					}
-					return false, fmt.Errorf("error encountered during deletion of resource type %v with namespace/name \"%+v\": %v", objCopy.GetObjectKind().GroupVersionKind().Kind, key, err)
+					return false, fmt.Errorf("error encountered during deletion of resource type %v with namespace/name (%+v): %v", objCopy.GetObjectKind().GroupVersionKind().Kind, key, err)
 				}
-				ctx.t.Logf("waiting for deletion of resource type %+v with namespace/name \"%+v\"\n", objCopy.GetObjectKind().GroupVersionKind().Kind, key)
+				ctx.t.Logf("waiting for deletion of resource type %+v with namespace/name (%+v)\n", objCopy.GetObjectKind().GroupVersionKind().Kind, key)
 				return false, nil
 			})
 		}

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -107,7 +107,7 @@ func (ctx *TestCtx) CreateWithFinalizer(gCtx goctx.Context, obj runtime.Object) 
 		return err
 	}
 	key, err := dynclient.ObjectKeyFromObject(obj)
-	//ctx.t.Logf("Resource type %+v with namespace/name \"%+v\" created\n", obj.GetObjectKind(), key)
+	//ctx.t.Logf("resource type %+v with namespace/name \"%+v\" created\n", obj.GetObjectKind(), key)
 	ctx.AddFinalizerFn(func() error {
 		err = Global.DynamicClient.Delete(gCtx, obj)
 		if err != nil {
@@ -117,12 +117,12 @@ func (ctx *TestCtx) CreateWithFinalizer(gCtx goctx.Context, obj runtime.Object) 
 			err = Global.DynamicClient.Get(gCtx, key, obj)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
-					//ctx.t.Logf("Resource type %+v with namespace/name \"%+v\" successfully deleted\n", obj.GetObjectKind(), key)
+					//ctx.t.Logf("resource type %+v with namespace/name \"%+v\" successfully deleted\n", obj.GetObjectKind(), key)
 					return true, nil
 				}
-				return false, fmt.Errorf("Error encountered during deletion of resource type %v with namespace/name \"%+v\": %v", obj.GetObjectKind(), key, err)
+				return false, fmt.Errorf("error encountered during deletion of resource type %v with namespace/name \"%+v\": %v", obj.GetObjectKind(), key, err)
 			}
-			//ctx.t.Logf("Waiting for deletion of resource type %+v with namespace/name \"%+v\"\n", obj.GetObjectKind(), key)
+			//ctx.t.Logf("waiting for deletion of resource type %+v with namespace/name \"%+v\"\n", obj.GetObjectKind(), key)
 			return false, nil
 		})
 	})

--- a/pkg/test/main_entry.go
+++ b/pkg/test/main_entry.go
@@ -61,7 +61,7 @@ func MainEntry(m *testing.M) {
 		if err != nil {
 			log.Fatalf("failed to read global resource manifest: %v", err)
 		}
-		err = ctx.createFromYAML(globalYAML, true)
+		err = ctx.createFromYAML(globalYAML, true, nil)
 		if err != nil {
 			log.Fatalf("failed to create resource(s) in global resource manifest: %v", err)
 		}

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -76,14 +76,13 @@ func (ctx *TestCtx) createFromYAML(yamlFile []byte, skipIfExists bool) error {
 			return err
 		}
 
-		err = Global.DynamicClient.Create(goctx.TODO(), obj)
+		err = ctx.CreateWithFinalizer(goctx.TODO(), obj)
 		if skipIfExists && apierrors.IsAlreadyExists(err) {
 			continue
 		}
 		if err != nil {
 			return err
 		}
-		ctx.AddFinalizerFn(func() error { return Global.DynamicClient.Delete(goctx.TODO(), obj) })
 	}
 	return nil
 }

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -30,15 +30,9 @@ func (ctx *TestCtx) GetNamespace() (string, error) {
 	if ctx.namespace != "" {
 		return ctx.namespace, nil
 	}
-<<<<<<< HEAD
 	if Global.SingleNamespace {
-		ctx.Namespace = Global.Namespace
-		return ctx.Namespace, nil
-=======
-	if Global.InCluster {
-		ctx.namespace = os.Getenv(TestNamespaceEnv)
+		ctx.namespace = Global.Namespace
 		return ctx.namespace, nil
->>>>>>> pkg/test,doc: change finalizer to cleanup and make TestCtx fields unexported
 	}
 	// create namespace
 	ctx.namespace = ctx.GetID()

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -59,7 +59,7 @@ func setNamespaceYAML(yamlFile []byte, namespace string) ([]byte, error) {
 	return yaml.Marshal(yamlMap)
 }
 
-func (ctx *TestCtx) createFromYAML(yamlFile []byte, skipIfExists bool) error {
+func (ctx *TestCtx) createFromYAML(yamlFile []byte, skipIfExists bool, cleanupOptions *CleanupOptions) error {
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
 		return err
@@ -76,7 +76,7 @@ func (ctx *TestCtx) createFromYAML(yamlFile []byte, skipIfExists bool) error {
 			return err
 		}
 
-		err = ctx.CreateWithFinalizer(goctx.TODO(), obj)
+		err = ctx.CreateWithFinalizer(goctx.TODO(), obj, cleanupOptions)
 		if skipIfExists && apierrors.IsAlreadyExists(err) {
 			continue
 		}
@@ -87,11 +87,11 @@ func (ctx *TestCtx) createFromYAML(yamlFile []byte, skipIfExists bool) error {
 	return nil
 }
 
-func (ctx *TestCtx) InitializeClusterResources() error {
+func (ctx *TestCtx) InitializeClusterResources(cleanupOptions *CleanupOptions) error {
 	// create namespaced resources
 	namespacedYAML, err := ioutil.ReadFile(*Global.NamespacedManPath)
 	if err != nil {
 		return fmt.Errorf("failed to read namespaced manifest: %v", err)
 	}
-	return ctx.createFromYAML(namespacedYAML, false)
+	return ctx.createFromYAML(namespacedYAML, false, cleanupOptions)
 }

--- a/test/e2e/incluster-test-code/memcached_test.go.tmpl
+++ b/test/e2e/incluster-test-code/memcached_test.go.tmpl
@@ -70,13 +70,11 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 			Size: 3,
 		},
 	}
-	err = f.DynamicClient.Create(goctx.TODO(), exampleMemcached)
+	// use TestCtx's create helper to create the object and add a finalizer for the new object
+	err = ctx.CreateWithFinalizer(goctx.TODO(), exampleMemcached)
 	if err != nil {
 		return err
 	}
-	ctx.AddFinalizerFn(func() error {
-		return f.DynamicClient.Delete(goctx.TODO(), exampleMemcached)
-	})
 	// wait for example-memcached to reach 3 replicas
 	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-memcached", 3, retryInterval, timeout)
 	if err != nil {
@@ -100,7 +98,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 func MemcachedCluster(t *testing.T) {
 	t.Parallel()
 	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
+	defer ctx.Cleanup()
 	err := ctx.InitializeClusterResources()
 	if err != nil {
 		t.Fatalf("failed to initialize cluster resources: %v", err)

--- a/test/e2e/incluster-test-code/memcached_test.go.tmpl
+++ b/test/e2e/incluster-test-code/memcached_test.go.tmpl
@@ -29,8 +29,10 @@ import (
 )
 
 var (
-	retryInterval = time.Second * 5
-	timeout       = time.Second * 30
+	retryInterval          = time.Second * 5
+	timeout                = time.Second * 30
+	finalizerRetryInterval = time.Second * 1
+	finalizerTimeout       = time.Second * 5
 )
 
 func TestMemcached(t *testing.T) {
@@ -71,7 +73,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 		},
 	}
 	// use TestCtx's create helper to create the object and add a finalizer for the new object
-	err = ctx.CreateWithFinalizer(goctx.TODO(), exampleMemcached)
+	err = ctx.CreateWithFinalizer(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{Timeout: finalizerTimeout, RetryInterval: finalizerRetryInterval})
 	if err != nil {
 		return err
 	}
@@ -99,7 +101,7 @@ func MemcachedCluster(t *testing.T) {
 	t.Parallel()
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
-	err := ctx.InitializeClusterResources()
+	err := ctx.InitializeClusterResources(&framework.CleanupOptions{Timeout: finalizerTimeout, RetryInterval: finalizerRetryInterval})
 	if err != nil {
 		t.Fatalf("failed to initialize cluster resources: %v", err)
 	}

--- a/test/e2e/incluster-test-code/memcached_test.go.tmpl
+++ b/test/e2e/incluster-test-code/memcached_test.go.tmpl
@@ -31,8 +31,8 @@ import (
 var (
 	retryInterval          = time.Second * 5
 	timeout                = time.Second * 30
-	finalizerRetryInterval = time.Second * 1
-	finalizerTimeout       = time.Second * 5
+	cleanupRetryInterval = time.Second * 1
+	cleanupTimeout       = time.Second * 5
 )
 
 func TestMemcached(t *testing.T) {
@@ -72,8 +72,8 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 			Size: 3,
 		},
 	}
-	// use TestCtx's create helper to create the object and add a finalizer for the new object
-	err = ctx.CreateWithFinalizer(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{Timeout: finalizerTimeout, RetryInterval: finalizerRetryInterval})
+	// use TestCtx's create helper to create the object and add a cleanup for the new object
+	err = ctx.CreateWithCleanup(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func MemcachedCluster(t *testing.T) {
 	t.Parallel()
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
-	err := ctx.InitializeClusterResources(&framework.CleanupOptions{Timeout: finalizerTimeout, RetryInterval: finalizerRetryInterval})
+	err := ctx.InitializeClusterResources(&framework.CleanupOptions{Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatalf("failed to initialize cluster resources: %v", err)
 	}

--- a/test/test-framework/memcached_test.go
+++ b/test/test-framework/memcached_test.go
@@ -32,7 +32,7 @@ var (
 	retryInterval        = time.Second * 5
 	timeout              = time.Second * 30
 	cleanupRetryInterval = time.Second * 1
-	finalizerTimeout     = time.Second * 5
+	cleanupTimeout       = time.Second * 5
 )
 
 func TestMemcached(t *testing.T) {
@@ -73,7 +73,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 		},
 	}
 	// use TestCtx's create helper to create the object and add a finalizer for the new object
-	err = ctx.CreateWithCleanup(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{Timeout: finalizerTimeout, RetryInterval: cleanupRetryInterval})
+	err = ctx.CreateWithCleanup(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func MemcachedCluster(t *testing.T) {
 	t.Parallel()
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
-	err := ctx.InitializeClusterResources(&framework.CleanupOptions{Timeout: finalizerTimeout, RetryInterval: cleanupRetryInterval})
+	err := ctx.InitializeClusterResources(&framework.CleanupOptions{Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatalf("failed to initialize cluster resources: %v", err)
 	}

--- a/test/test-framework/memcached_test.go
+++ b/test/test-framework/memcached_test.go
@@ -73,7 +73,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 		},
 	}
 	// use TestCtx's create helper to create the object and add a finalizer for the new object
-	err = ctx.CreateWithFinalizer(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{Timeout: finalizerTimeout, RetryInterval: finalizerRetryInterval})
+	err = ctx.CreateWithCleanup(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{Timeout: finalizerTimeout, RetryInterval: finalizerRetryInterval})
 	if err != nil {
 		return err
 	}

--- a/test/test-framework/memcached_test.go
+++ b/test/test-framework/memcached_test.go
@@ -29,8 +29,10 @@ import (
 )
 
 var (
-	retryInterval = time.Second * 5
-	timeout       = time.Second * 30
+	retryInterval          = time.Second * 5
+	timeout                = time.Second * 30
+	finalizerRetryInterval = time.Second * 1
+	finalizerTimeout       = time.Second * 5
 )
 
 func TestMemcached(t *testing.T) {
@@ -71,7 +73,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 		},
 	}
 	// use TestCtx's create helper to create the object and add a finalizer for the new object
-	err = ctx.CreateWithFinalizer(goctx.TODO(), exampleMemcached)
+	err = ctx.CreateWithFinalizer(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{Timeout: finalizerTimeout, RetryInterval: finalizerRetryInterval})
 	if err != nil {
 		return err
 	}
@@ -99,7 +101,7 @@ func MemcachedCluster(t *testing.T) {
 	t.Parallel()
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
-	err := ctx.InitializeClusterResources()
+	err := ctx.InitializeClusterResources(&framework.CleanupOptions{Timeout: finalizerTimeout, RetryInterval: finalizerRetryInterval})
 	if err != nil {
 		t.Fatalf("failed to initialize cluster resources: %v", err)
 	}

--- a/test/test-framework/memcached_test.go
+++ b/test/test-framework/memcached_test.go
@@ -70,13 +70,11 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 			Size: 3,
 		},
 	}
-	err = f.DynamicClient.Create(goctx.TODO(), exampleMemcached)
+	// use TestCtx's create helper to create the object and add a finalizer for the new object
+	err = ctx.CreateWithFinalizer(goctx.TODO(), exampleMemcached)
 	if err != nil {
 		return err
 	}
-	ctx.AddFinalizerFn(func() error {
-		return f.DynamicClient.Delete(goctx.TODO(), exampleMemcached)
-	})
 	// wait for example-memcached to reach 3 replicas
 	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-memcached", 3, retryInterval, timeout)
 	if err != nil {

--- a/test/test-framework/memcached_test.go
+++ b/test/test-framework/memcached_test.go
@@ -98,7 +98,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 func MemcachedCluster(t *testing.T) {
 	t.Parallel()
 	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
+	defer ctx.Cleanup()
 	err := ctx.InitializeClusterResources()
 	if err != nil {
 		t.Fatalf("failed to initialize cluster resources: %v", err)

--- a/test/test-framework/memcached_test.go
+++ b/test/test-framework/memcached_test.go
@@ -29,10 +29,10 @@ import (
 )
 
 var (
-	retryInterval          = time.Second * 5
-	timeout                = time.Second * 30
-	finalizerRetryInterval = time.Second * 1
-	finalizerTimeout       = time.Second * 5
+	retryInterval        = time.Second * 5
+	timeout              = time.Second * 30
+	cleanupRetryInterval = time.Second * 1
+	finalizerTimeout     = time.Second * 5
 )
 
 func TestMemcached(t *testing.T) {
@@ -73,7 +73,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 		},
 	}
 	// use TestCtx's create helper to create the object and add a finalizer for the new object
-	err = ctx.CreateWithCleanup(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{Timeout: finalizerTimeout, RetryInterval: finalizerRetryInterval})
+	err = ctx.CreateWithCleanup(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{Timeout: finalizerTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func MemcachedCluster(t *testing.T) {
 	t.Parallel()
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
-	err := ctx.InitializeClusterResources(&framework.CleanupOptions{Timeout: finalizerTimeout, RetryInterval: finalizerRetryInterval})
+	err := ctx.InitializeClusterResources(&framework.CleanupOptions{Timeout: finalizerTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatalf("failed to initialize cluster resources: %v", err)
 	}


### PR DESCRIPTION
This commit adds a new helper function that creates a provided
object and then creates a finalizer for the function to make sure
it is cleaned up properly. This is especially useful for single
namespace testing. The finalizer has a wait.PollImmediate to make
sure that the resource is fully deleted before returning