### PR TITLE
test/e2e/memcached_test.go: fix e2e testing on local machines

### DIFF
--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -147,6 +147,12 @@ func TestMemcached(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dep ensure failed: %v\nCommand Output:\n%v", err, string(cmdOut))
 	}
+	// link local sdk to vendor if not in travis
+	if prSlug == "" {
+		os.RemoveAll("vendor/github.com/operator-framework/operator-sdk/pkg")
+		os.Symlink(path.Join(gopath, "/src/github.com/operator-framework/operator-sdk/pkg"),
+			"vendor/github.com/operator-framework/operator-sdk/pkg")
+	}
 
 	// create crd
 	crdYAML, err := ioutil.ReadFile("deploy/crd.yaml")


### PR DESCRIPTION
PR #525 changed the way that dep worked to fix dependency issues
when doing e2e tests on travis. The PR breaks e2e testing on local
machines though, as the tests will just use the master branch
instead of a local branch. This commit symlinks the local sdk
into vendor on non-travis tests. The tests will still fail on local
machines if there is a dependency change, but we are unable to fix
this on local machines unless `dep` adds local repo support.

/cc @hasbro17 @fanminshi 