### PR TITLE
pkg/test: create new frameworkClient

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -462,9 +462,7 @@
   packages = [
     "pkg/apis/apiextensions",
     "pkg/apis/apiextensions/v1beta1",
-    "pkg/client/clientset/clientset",
     "pkg/client/clientset/clientset/scheme",
-    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
   pruneopts = ""
   revision = "408db4a50408e2149acbd657bceb2480c13cb0a4"
@@ -647,7 +645,6 @@
     "github.com/spf13/cobra",
     "gopkg.in/yaml.v2",
     "k8s.io/api/core/v1",
-    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -141,14 +141,28 @@ if err != nil {
 
 #### 4. Write the test specific code
 
-Now that the operator is ready, we can create a custom resource. As mentioned when speaking about the
-`InitializeClusterResources` function, the test framework provides a modified `Create` function that
-creates the resource with the controller-runtime's dynamic client and then adds a cleanup function
-to the context. This function should be used to create all resources. To ignore the wait polling that
-verifies a resource is fully deleted on cleanup before moving on, set `Timeout` and `RetryInterval` to `0`.
-To skip creation of a cleanup function, `cleanupOptions` can be set to `nil`. Since the controller-runtime's
-dynamic client uses go contexts, make sure to import the go context library. In this example, we imported
-it as `goctx`:
+Now that the operator is ready, we can create a custom resource.
+
+##### How to use the Framework Client `Create`'s `CleanupOptions`
+
+The test framework provides `Client`, which exposes most of the controller-runtime's client unmodified, but the `Create`
+function has added functionality to create cleanup functions for these resources as well. To manage how cleanup
+is handled, we use a `CleanupOptions` struct. Here are some examples of how to use it:
+
+```go
+// Create with no cleanup
+Create(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{})
+Create(goctx.TODO(), exampleMemcached, nil)
+
+// Create with cleanup but no polling for resources to be deleted
+Create(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{TestContext: ctx})
+
+// Create with cleanup and polling wait for resources to be deleted
+Create(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+```
+
+Since the controller-runtime's dynamic client uses go contexts, make sure to import the go context library.
+In this example, we imported it as `goctx`:
 
 ```go
 // create memcached custom resource

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -144,7 +144,9 @@ if err != nil {
 Now that the operator is ready, we can create a custom resource. As mentioned when speaking about the
 `InitializeClusterResources` function, the test framework provides a modified `Create` function that
 creates the resource with the controller-runtime's dynamic client and then adds a cleanup function
-to the context. This function should be used to create all resources. Since the controller-runtime's
+to the context. This function should be used to create all resources. To ignore the wait polling that
+verifies a resource is fully deleted on cleanup before moving on, set `Timeout` and `RetryInterval` to `0`.
+To skip creation of a cleanup function, `cleanupOptions` can be set to `nil`. Since the controller-runtime's
 dynamic client uses go contexts, make sure to import the go context library. In this example, we imported
 it as `goctx`:
 

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -109,7 +109,7 @@ Service Account, RBAC, and Operator deployment in `local` testing; just the Oper
 in `cluster` testing) can be initialized:
 
 ```go
-err := ctx.InitializeClusterResources(&framework.CleanupOptions{Timeout: time.Duration * 5, RetryInterval: time.Duration * 1})
+err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 if err != nil {
     t.Fatalf("failed to initialize cluster resources: %v", err)
 }
@@ -163,7 +163,7 @@ exampleMemcached := &cachev1alpha1.Memcached{
         Size: 3,
     },
 }
-err = f.Client.Create(goctx.TODO(), exampleMemcached, ctx, &framework.CleanupOptions{Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+err = f.Client.Create(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 if err != nil {
     return err
 }

--- a/pkg/test/client.go
+++ b/pkg/test/client.go
@@ -1,0 +1,95 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	goctx "context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type frameworkClient struct {
+	dynclient.Client
+}
+
+type FrameworkClient interface {
+	Get(gCtx goctx.Context, key dynclient.ObjectKey, obj runtime.Object) error
+	List(gCtx goctx.Context, opts *dynclient.ListOptions, list runtime.Object) error
+	Create(gCtx goctx.Context, obj runtime.Object) error
+	Delete(gCtx goctx.Context, obj runtime.Object, opts ...dynclient.DeleteOptionFunc) error
+	Update(gCtx goctx.Context, obj runtime.Object) error
+}
+
+// Create uses the dynamic client to create an object and then adds a
+// cleanup function to delete it when Cleanup is called. In addition to
+// the standard controller-runtime client options
+func (f *frameworkClient) Create(gCtx goctx.Context, obj runtime.Object, tCtx *TestCtx, cleanupOptions *CleanupOptions) error {
+	objCopy := obj.DeepCopyObject()
+	err := f.Client.Create(gCtx, obj)
+	if err != nil {
+		return err
+	}
+	key, err := dynclient.ObjectKeyFromObject(objCopy)
+	// this function fails silently if t is nil
+	if tCtx.t != nil {
+		tCtx.t.Logf("resource type %+v with namespace/name (%+v) created\n", objCopy.GetObjectKind().GroupVersionKind().Kind, key)
+	}
+	tCtx.AddCleanupFn(func() error {
+		err = f.Client.Delete(gCtx, objCopy)
+		if err != nil {
+			return err
+		}
+		if cleanupOptions != nil && !cleanupOptions.SkipPolling {
+			return wait.PollImmediate(cleanupOptions.RetryInterval, cleanupOptions.Timeout, func() (bool, error) {
+				err = f.Client.Get(gCtx, key, objCopy)
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						if tCtx.t != nil {
+							tCtx.t.Logf("resource type %+v with namespace/name (%+v) successfully deleted\n", objCopy.GetObjectKind().GroupVersionKind().Kind, key)
+						}
+						return true, nil
+					}
+					return false, fmt.Errorf("error encountered during deletion of resource type %v with namespace/name (%+v): %v", objCopy.GetObjectKind().GroupVersionKind().Kind, key, err)
+				}
+				if tCtx.t != nil {
+					tCtx.t.Logf("waiting for deletion of resource type %+v with namespace/name (%+v)\n", objCopy.GetObjectKind().GroupVersionKind().Kind, key)
+				}
+				return false, nil
+			})
+		}
+		return nil
+	})
+	return nil
+}
+
+func (f *frameworkClient) Get(gCtx goctx.Context, key dynclient.ObjectKey, obj runtime.Object) error {
+	return f.Client.Get(gCtx, key, obj)
+}
+
+func (f *frameworkClient) List(gCtx goctx.Context, opts *dynclient.ListOptions, list runtime.Object) error {
+	return f.Client.List(gCtx, opts, list)
+}
+
+func (f *frameworkClient) Delete(gCtx goctx.Context, obj runtime.Object, opts ...dynclient.DeleteOptionFunc) error {
+	return f.Client.Delete(gCtx, obj, opts...)
+}
+
+func (f *frameworkClient) Update(gCtx goctx.Context, obj runtime.Object) error {
+	return f.Client.Update(gCtx, obj)
+}

--- a/pkg/test/client.go
+++ b/pkg/test/client.go
@@ -28,10 +28,12 @@ type frameworkClient struct {
 	dynclient.Client
 }
 
+var _ FrameworkClient = &frameworkClient{}
+
 type FrameworkClient interface {
 	Get(gCtx goctx.Context, key dynclient.ObjectKey, obj runtime.Object) error
 	List(gCtx goctx.Context, opts *dynclient.ListOptions, list runtime.Object) error
-	Create(gCtx goctx.Context, obj runtime.Object) error
+	Create(gCtx goctx.Context, obj runtime.Object, tCtx *TestCtx, cleanupOptions *CleanupOptions) error
 	Delete(gCtx goctx.Context, obj runtime.Object, opts ...dynclient.DeleteOptionFunc) error
 	Update(gCtx goctx.Context, obj runtime.Object) error
 }

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -30,6 +30,7 @@ type TestCtx struct {
 }
 
 type CleanupOptions struct {
+	TestContext   *TestCtx
 	Timeout       time.Duration
 	RetryInterval time.Duration
 	SkipPolling   bool

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -23,12 +23,19 @@ import (
 )
 
 type TestCtx struct {
-	ID         string
-	CleanUpFns []finalizerFn
-	Namespace  string
+	id         string
+	cleanupFns []cleanupFn
+	namespace  string
+	t          *testing.T
 }
 
-type finalizerFn func() error
+type CleanupOptions struct {
+	Timeout       time.Duration
+	RetryInterval time.Duration
+	SkipPolling   bool
+}
+
+type cleanupFn func() error
 
 func NewTestCtx(t *testing.T) *TestCtx {
 	var prefix string
@@ -49,19 +56,20 @@ func NewTestCtx(t *testing.T) *TestCtx {
 
 	id := prefix + "-" + strconv.FormatInt(time.Now().Unix(), 10)
 	return &TestCtx{
-		ID: id,
+		id: id,
+		t:  t,
 	}
 }
 
 func (ctx *TestCtx) GetID() string {
-	return ctx.ID
+	return ctx.id
 }
 
-func (ctx *TestCtx) Cleanup(t *testing.T) {
-	for i := len(ctx.CleanUpFns) - 1; i >= 0; i-- {
-		err := ctx.CleanUpFns[i]()
+func (ctx *TestCtx) Cleanup() {
+	for i := len(ctx.cleanupFns) - 1; i >= 0; i-- {
+		err := ctx.cleanupFns[i]()
 		if err != nil {
-			t.Errorf("a cleanup function failed with error: %v\n", err)
+			ctx.t.Errorf("a cleanup function failed with error: %v\n", err)
 		}
 	}
 }
@@ -70,8 +78,8 @@ func (ctx *TestCtx) Cleanup(t *testing.T) {
 // intended for use by MainEntry, which does not have a testing.T
 func (ctx *TestCtx) CleanupNoT() {
 	failed := false
-	for i := len(ctx.CleanUpFns) - 1; i >= 0; i-- {
-		err := ctx.CleanUpFns[i]()
+	for i := len(ctx.cleanupFns) - 1; i >= 0; i-- {
+		err := ctx.cleanupFns[i]()
 		if err != nil {
 			failed = true
 			log.Printf("a cleanup function failed with error: %v\n", err)
@@ -82,6 +90,6 @@ func (ctx *TestCtx) CleanupNoT() {
 	}
 }
 
-func (ctx *TestCtx) AddFinalizerFn(fn finalizerFn) {
-	ctx.CleanUpFns = append(ctx.CleanUpFns, fn)
+func (ctx *TestCtx) AddCleanupFn(fn cleanupFn) {
+	ctx.cleanupFns = append(ctx.cleanupFns, fn)
 }

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -33,7 +33,6 @@ type CleanupOptions struct {
 	TestContext   *TestCtx
 	Timeout       time.Duration
 	RetryInterval time.Duration
-	SkipPolling   bool
 }
 
 type cleanupFn func() error

--- a/pkg/test/main_entry.go
+++ b/pkg/test/main_entry.go
@@ -36,14 +36,14 @@ func MainEntry(m *testing.M) {
 	kubeconfigPath := flag.String(KubeConfigFlag, "", "path to kubeconfig")
 	globalManPath := flag.String(GlobalManPathFlag, "", "path to operator manifest")
 	namespacedManPath := flag.String(NamespacedManPathFlag, "", "path to rbac manifest")
-	singleNamespace := flag.Bool(SingleNamespaceFlag, false, "enable single namespace mode")
+	singleNamespace = flag.Bool(SingleNamespaceFlag, false, "enable single namespace mode")
 	flag.Parse()
 	// go test always runs from the test directory; change to project root
 	err := os.Chdir(*projRoot)
 	if err != nil {
 		log.Fatalf("failed to change directory to project root: %v", err)
 	}
-	if err := setup(kubeconfigPath, namespacedManPath, singleNamespace); err != nil {
+	if err := setup(kubeconfigPath, namespacedManPath); err != nil {
 		log.Fatalf("failed to set up framework: %v", err)
 	}
 	// setup context to use when setting up crd
@@ -61,7 +61,7 @@ func MainEntry(m *testing.M) {
 		if err != nil {
 			log.Fatalf("failed to read global resource manifest: %v", err)
 		}
-		err = ctx.createFromYAML(globalYAML, true)
+		err = ctx.createFromYAML(globalYAML, true, nil)
 		if err != nil {
 			log.Fatalf("failed to create resource(s) in global resource manifest: %v", err)
 		}

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -27,26 +27,26 @@ import (
 )
 
 func (ctx *TestCtx) GetNamespace() (string, error) {
-	if ctx.Namespace != "" {
-		return ctx.Namespace, nil
+	if ctx.namespace != "" {
+		return ctx.namespace, nil
 	}
-	if Global.SingleNamespace {
-		ctx.Namespace = Global.Namespace
-		return ctx.Namespace, nil
+	if *singleNamespace {
+		ctx.namespace = Global.Namespace
+		return ctx.namespace, nil
 	}
 	// create namespace
-	ctx.Namespace = ctx.GetID()
-	namespaceObj := &core.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ctx.Namespace}}
+	ctx.namespace = ctx.GetID()
+	namespaceObj := &core.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ctx.namespace}}
 	_, err := Global.KubeClient.CoreV1().Namespaces().Create(namespaceObj)
 	if apierrors.IsAlreadyExists(err) {
-		return "", fmt.Errorf("namespace %s already exists: %v", ctx.Namespace, err)
+		return "", fmt.Errorf("namespace %s already exists: %v", ctx.namespace, err)
 	} else if err != nil {
 		return "", err
 	}
-	ctx.AddFinalizerFn(func() error {
-		return Global.KubeClient.CoreV1().Namespaces().Delete(ctx.Namespace, metav1.NewDeleteOptions(0))
+	ctx.AddCleanupFn(func() error {
+		return Global.KubeClient.CoreV1().Namespaces().Delete(ctx.namespace, metav1.NewDeleteOptions(0))
 	})
-	return ctx.Namespace, nil
+	return ctx.namespace, nil
 }
 
 func setNamespaceYAML(yamlFile []byte, namespace string) ([]byte, error) {
@@ -59,7 +59,7 @@ func setNamespaceYAML(yamlFile []byte, namespace string) ([]byte, error) {
 	return yaml.Marshal(yamlMap)
 }
 
-func (ctx *TestCtx) createFromYAML(yamlFile []byte, skipIfExists bool) error {
+func (ctx *TestCtx) createFromYAML(yamlFile []byte, skipIfExists bool, cleanupOptions *CleanupOptions) error {
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
 		return err
@@ -71,28 +71,27 @@ func (ctx *TestCtx) createFromYAML(yamlFile []byte, skipIfExists bool) error {
 			return err
 		}
 
-		obj, _, err := Global.DynamicDecoder.Decode(yamlSpec, nil, nil)
+		obj, _, err := dynamicDecoder.Decode(yamlSpec, nil, nil)
 		if err != nil {
 			return err
 		}
 
-		err = Global.DynamicClient.Create(goctx.TODO(), obj)
+		err = Global.Client.Create(goctx.TODO(), obj, ctx, cleanupOptions)
 		if skipIfExists && apierrors.IsAlreadyExists(err) {
 			continue
 		}
 		if err != nil {
 			return err
 		}
-		ctx.AddFinalizerFn(func() error { return Global.DynamicClient.Delete(goctx.TODO(), obj) })
 	}
 	return nil
 }
 
-func (ctx *TestCtx) InitializeClusterResources() error {
+func (ctx *TestCtx) InitializeClusterResources(cleanupOptions *CleanupOptions) error {
 	// create namespaced resources
 	namespacedYAML, err := ioutil.ReadFile(*Global.NamespacedManPath)
 	if err != nil {
 		return fmt.Errorf("failed to read namespaced manifest: %v", err)
 	}
-	return ctx.createFromYAML(namespacedYAML, false)
+	return ctx.createFromYAML(namespacedYAML, false, cleanupOptions)
 }

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -76,7 +76,7 @@ func (ctx *TestCtx) createFromYAML(yamlFile []byte, skipIfExists bool, cleanupOp
 			return err
 		}
 
-		err = Global.Client.Create(goctx.TODO(), obj, ctx, cleanupOptions)
+		err = Global.Client.Create(goctx.TODO(), obj, cleanupOptions)
 		if skipIfExists && apierrors.IsAlreadyExists(err) {
 			continue
 		}

--- a/test/e2e/incluster-test-code/memcached_test.go.tmpl
+++ b/test/e2e/incluster-test-code/memcached_test.go.tmpl
@@ -29,8 +29,8 @@ import (
 )
 
 var (
-	retryInterval          = time.Second * 5
-	timeout                = time.Second * 30
+	retryInterval        = time.Second * 5
+	timeout              = time.Second * 30
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 5
 )
@@ -72,7 +72,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 			Size: 3,
 		},
 	}
-	// use TestCtx's create helper to create the object and add a finalizer for the new object
+	// use TestCtx's create helper to create the object and add a cleanup function for the new object
 	err = f.Client.Create(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		return err

--- a/test/e2e/incluster-test-code/memcached_test.go.tmpl
+++ b/test/e2e/incluster-test-code/memcached_test.go.tmpl
@@ -29,8 +29,10 @@ import (
 )
 
 var (
-	retryInterval = time.Second * 5
-	timeout       = time.Second * 30
+	retryInterval          = time.Second * 5
+	timeout                = time.Second * 30
+	cleanupRetryInterval = time.Second * 1
+	cleanupTimeout       = time.Second * 5
 )
 
 func TestMemcached(t *testing.T) {
@@ -70,25 +72,23 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 			Size: 3,
 		},
 	}
-	err = f.DynamicClient.Create(goctx.TODO(), exampleMemcached)
+	// use TestCtx's create helper to create the object and add a finalizer for the new object
+	err = f.Client.Create(goctx.TODO(), exampleMemcached, ctx, &framework.CleanupOptions{Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		return err
 	}
-	ctx.AddFinalizerFn(func() error {
-		return f.DynamicClient.Delete(goctx.TODO(), exampleMemcached)
-	})
 	// wait for example-memcached to reach 3 replicas
 	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-memcached", 3, retryInterval, timeout)
 	if err != nil {
 		return err
 	}
 
-	err = f.DynamicClient.Get(goctx.TODO(), types.NamespacedName{Name: "example-memcached", Namespace: namespace}, exampleMemcached)
+	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-memcached", Namespace: namespace}, exampleMemcached)
 	if err != nil {
 		return err
 	}
 	exampleMemcached.Spec.Size = 4
-	err = f.DynamicClient.Update(goctx.TODO(), exampleMemcached)
+	err = f.Client.Update(goctx.TODO(), exampleMemcached)
 	if err != nil {
 		return err
 	}
@@ -100,8 +100,8 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 func MemcachedCluster(t *testing.T) {
 	t.Parallel()
 	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	err := ctx.InitializeClusterResources()
+	defer ctx.Cleanup()
+	err := ctx.InitializeClusterResources(&framework.CleanupOptions{Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatalf("failed to initialize cluster resources: %v", err)
 	}

--- a/test/e2e/incluster-test-code/memcached_test.go.tmpl
+++ b/test/e2e/incluster-test-code/memcached_test.go.tmpl
@@ -73,7 +73,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 		},
 	}
 	// use TestCtx's create helper to create the object and add a finalizer for the new object
-	err = f.Client.Create(goctx.TODO(), exampleMemcached, ctx, &framework.CleanupOptions{Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err = f.Client.Create(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func MemcachedCluster(t *testing.T) {
 	t.Parallel()
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
-	err := ctx.InitializeClusterResources(&framework.CleanupOptions{Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatalf("failed to initialize cluster resources: %v", err)
 	}

--- a/test/test-framework/memcached_test.go
+++ b/test/test-framework/memcached_test.go
@@ -29,8 +29,10 @@ import (
 )
 
 var (
-	retryInterval = time.Second * 5
-	timeout       = time.Second * 30
+	retryInterval        = time.Second * 5
+	timeout              = time.Second * 30
+	cleanupRetryInterval = time.Second * 1
+	cleanupTimeout       = time.Second * 5
 )
 
 func TestMemcached(t *testing.T) {
@@ -70,25 +72,23 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 			Size: 3,
 		},
 	}
-	err = f.DynamicClient.Create(goctx.TODO(), exampleMemcached)
+	// use TestCtx's create helper to create the object and add a finalizer for the new object
+	err = f.Client.Create(goctx.TODO(), exampleMemcached, ctx, &framework.CleanupOptions{Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		return err
 	}
-	ctx.AddFinalizerFn(func() error {
-		return f.DynamicClient.Delete(goctx.TODO(), exampleMemcached)
-	})
 	// wait for example-memcached to reach 3 replicas
 	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-memcached", 3, retryInterval, timeout)
 	if err != nil {
 		return err
 	}
 
-	err = f.DynamicClient.Get(goctx.TODO(), types.NamespacedName{Name: "example-memcached", Namespace: namespace}, exampleMemcached)
+	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-memcached", Namespace: namespace}, exampleMemcached)
 	if err != nil {
 		return err
 	}
 	exampleMemcached.Spec.Size = 4
-	err = f.DynamicClient.Update(goctx.TODO(), exampleMemcached)
+	err = f.Client.Update(goctx.TODO(), exampleMemcached)
 	if err != nil {
 		return err
 	}
@@ -100,8 +100,8 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 func MemcachedCluster(t *testing.T) {
 	t.Parallel()
 	ctx := framework.NewTestCtx(t)
-	defer ctx.Cleanup(t)
-	err := ctx.InitializeClusterResources()
+	defer ctx.Cleanup()
+	err := ctx.InitializeClusterResources(&framework.CleanupOptions{Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatalf("failed to initialize cluster resources: %v", err)
 	}

--- a/test/test-framework/memcached_test.go
+++ b/test/test-framework/memcached_test.go
@@ -72,7 +72,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 			Size: 3,
 		},
 	}
-	// use TestCtx's create helper to create the object and add a finalizer for the new object
+	// use TestCtx's create helper to create the object and add a cleanup function for the new object
 	err = f.Client.Create(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		return err

--- a/test/test-framework/memcached_test.go
+++ b/test/test-framework/memcached_test.go
@@ -73,7 +73,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 		},
 	}
 	// use TestCtx's create helper to create the object and add a finalizer for the new object
-	err = f.Client.Create(goctx.TODO(), exampleMemcached, ctx, &framework.CleanupOptions{Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err = f.Client.Create(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func MemcachedCluster(t *testing.T) {
 	t.Parallel()
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
-	err := ctx.InitializeClusterResources(&framework.CleanupOptions{Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatalf("failed to initialize cluster resources: %v", err)
 	}


### PR DESCRIPTION
This commit create a new FrameworkClient type accesible as
Global.Client. It is a simple wrapper of the controller-runtime's
client with the exception of Create, which now adds cleanup
functions. This also changes "Finalizer" to "Cleanup" and trims
the Framework struct to only include variables that are useful
to the user. All other variables required in the framework are
now separate, unexported variables.

/cc @hasbro17 @shawn-hurley 