### PR TITLE
commands/{build,cmdutil},pkg/generator: remove build.sh

### DIFF
--- a/commands/operator-sdk/cmd/build.go
+++ b/commands/operator-sdk/cmd/build.go
@@ -158,7 +158,7 @@ func buildFunc(cmd *cobra.Command, args []string) {
 		buildCmd.Env = goBuildEnv
 		o, err := buildCmd.CombinedOutput()
 		if err != nil {
-			cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to build: (%v)", string(o)))
+			log.Fatalf("failed to build operator binary: %v (%v)", err, string(o))
 		}
 		fmt.Fprintln(os.Stdout, string(o))
 	}
@@ -184,7 +184,7 @@ func buildFunc(cmd *cobra.Command, args []string) {
 		buildTestCmd.Env = goBuildEnv
 		o, err := buildTestCmd.CombinedOutput()
 		if err != nil {
-			cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to build: (%v)", string(o)))
+			log.Fatalf("failed to build test binary: %v (%v)", err, string(o))
 		}
 		fmt.Fprintln(os.Stdout, string(o))
 		// if a user is using an older sdk repo as their library, make sure they have required build files

--- a/commands/operator-sdk/cmd/cmdutil/util.go
+++ b/commands/operator-sdk/cmd/cmdutil/util.go
@@ -15,9 +15,13 @@
 package cmdutil
 
 import (
+	"errors"
 	"fmt"
+	gobuild "go/build"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strings"
 
 	cmdError "github.com/operator-framework/operator-sdk/commands/operator-sdk/error"
 	"github.com/operator-framework/operator-sdk/pkg/generator"
@@ -48,4 +52,24 @@ func GetConfig() *generator.Config {
 		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to unmarshal config file %v: (%v)", configYaml, err))
 	}
 	return c
+}
+
+// GetCurrPkg returns the current directory's import path
+// e.g: "github.com/example-inc/app-operator"
+func GetCurrPkg() string {
+	gopath := os.Getenv("GOPATH")
+	if len(gopath) == 0 {
+		gopath = gobuild.Default.GOPATH
+	}
+	goSrc := filepath.Join(gopath, "src")
+
+	wd, err := os.Getwd()
+	if err != nil {
+		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("failed to get working directory: (%v)", err))
+	}
+	if !strings.HasPrefix(filepath.Dir(wd), goSrc) {
+		cmdError.ExitWithError(cmdError.ExitError, errors.New("must run from gopath"))
+	}
+	currPkg := strings.Replace(wd, goSrc+string(filepath.Separator), "", 1)
+	return currPkg
 }

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -532,11 +532,17 @@ func renderBuildFiles(buildDir, repoPath, projectName, operatorType string, gene
 		return err
 	}
 
+	return RenderTestingContainerFiles(buildDir, projectName)
+}
+
+func RenderTestingContainerFiles(buildDir, projectName string) error {
+	dTd := tmplData{
+		ProjectName: projectName,
+	}
 	if err := renderWriteFile(filepath.Join(buildDir, "test-framework", testingDockerfile), "tmp/build/test-framework/Dockerfile", testingDockerFileTmpl, dTd); err != nil {
 		return err
 	}
-
-	buf = &bytes.Buffer{}
+	buf := &bytes.Buffer{}
 	if err := renderFile(buf, filepath.Join(buildDir, goTest), goTestScript, tmplData{}); err != nil {
 		return err
 	}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -503,22 +503,10 @@ func (g *Generator) renderVersion() error {
 }
 
 func renderBuildFiles(buildDir, repoPath, projectName, operatorType string, generatePlaybook bool) error {
-	buf := &bytes.Buffer{}
-	bTd := tmplData{
-		ProjectName: projectName,
-		RepoPath:    repoPath,
-	}
-
 	var dockerFileTmplName string
 	switch operatorType {
 	case goOperatorType:
 		dockerFileTmplName = dockerFileTmpl
-		if err := renderFile(buf, "tmp/build/build.sh", buildTmpl, bTd); err != nil {
-			return err
-		}
-		if err := writeFileAndPrint(filepath.Join(buildDir, build), buf.Bytes(), defaultExecFileMode); err != nil {
-			return err
-		}
 	case ansibleOperatorType:
 		dockerFileTmplName = dockerFileAnsibleTmpl
 	}

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -593,21 +593,6 @@ COPY watches.yaml ${HOME}/watches.yaml
 
 func TestGenBuild(t *testing.T) {
 	buf := &bytes.Buffer{}
-	bTd := tmplData{
-		ProjectName: appProjectName,
-		RepoPath:    appRepoPath,
-	}
-	if err := renderFile(buf, "tmp/build/build.sh", buildTmpl, bTd); err != nil {
-		t.Error(err)
-		return
-	}
-	if buildExp != buf.String() {
-		dmp := diffmatchpatch.New()
-		diffs := dmp.DiffMain(buildExp, buf.String(), false)
-		t.Errorf("\nTest failed. Below is the diff of the expected vs actual results.\nRed text is missing and green text is extra.\n\n" + dmp.DiffPrettyText(diffs))
-	}
-
-	buf = &bytes.Buffer{}
 	dTd := tmplData{
 		ProjectName: appProjectName,
 	}

--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -551,30 +551,6 @@ deepcopy \
 {{.APIDirName}}:{{.Version}} \
 --go-header-file "./tmp/codegen/boilerplate.go.txt"
 `
-const buildTmpl = `#!/usr/bin/env bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-if ! which go > /dev/null; then
-	echo "golang needs to be installed"
-	exit 1
-fi
-
-BIN_DIR="$(pwd)/tmp/_output/bin"
-mkdir -p ${BIN_DIR}
-PROJECT_NAME="{{.ProjectName}}"
-REPO_PATH="{{.RepoPath}}"
-BUILD_PATH="${REPO_PATH}/cmd/${PROJECT_NAME}"
-TEST_PATH="${REPO_PATH}/${TEST_LOCATION}"
-echo "building "${PROJECT_NAME}"..."
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ${BIN_DIR}/${PROJECT_NAME} $BUILD_PATH
-if $ENABLE_TESTS ; then
-	echo "building "${PROJECT_NAME}-test"..."
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o ${BIN_DIR}/${PROJECT_NAME}-test $TEST_PATH
-fi
-`
 
 const goTestScript = `#!/bin/sh
 


### PR DESCRIPTION
This commit moves all functionality of build.sh into the build.go
file to embed the functionality into the binary. It also allows the
binary to generate the files needed when making tests (Dockerfile
and go-test.sh) in case someone tries to build testing enabled
images using a project made before that functionality was added.

See #541