### PR TITLE
Add metrics example to the generated operator

### DIFF
--- a/example/memcached-operator/handler.go.tmpl
+++ b/example/memcached-operator/handler.go.tmpl
@@ -8,6 +8,7 @@ import (
 	v1alpha1 "github.com/example-inc/memcached-operator/pkg/apis/cache/v1alpha1"
 
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
+	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -15,11 +16,21 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func NewHandler() sdk.Handler {
-	return &Handler{}
+func NewHandler(m *Metrics) sdk.Handler {
+	return &Handler{
+    metrics: m,
+  }
+}
+
+type Metrics struct {
+	operatorErrors prometheus.Counter
 }
 
 type Handler struct {
+	// Metrics example
+	metrics *Metrics
+
+	// Fill me
 }
 
 func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
@@ -156,3 +167,16 @@ func getPodNames(pods []v1.Pod) []string {
 	}
 	return podNames
 }
+
+func RegisterOperatorMetrics() (*Metrics, error) {
+	operatorErrors := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "memcached_operator_reconcile_errors_total",
+		Help: "Number of errors that occurred while reconciling the memcached deployment",
+	})
+	err := prometheus.Register(operatorErrors)
+	if err != nil {
+		return &Metrics{}, err
+	}
+	return &Metrics{operatorErrors: operatorErrors}, nil
+}
+

--- a/example/memcached-operator/handler.go.tmpl
+++ b/example/memcached-operator/handler.go.tmpl
@@ -29,8 +29,6 @@ type Metrics struct {
 type Handler struct {
 	// Metrics example
 	metrics *Metrics
-
-	// Fill me
 }
 
 func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {

--- a/example/memcached-operator/handler.go.tmpl
+++ b/example/memcached-operator/handler.go.tmpl
@@ -173,7 +173,7 @@ func RegisterOperatorMetrics() (*Metrics, error) {
 	})
 	err := prometheus.Register(operatorErrors)
 	if err != nil {
-		return &Metrics{}, err
+		return nil, err
 	}
 	return &Metrics{operatorErrors: operatorErrors}, nil
 }

--- a/example/memcached-operator/handler.go.tmpl
+++ b/example/memcached-operator/handler.go.tmpl
@@ -1,9 +1,9 @@
 package stub
 
 import (
+	"context"
 	"fmt"
 	"reflect"
-	"context"
 
 	v1alpha1 "github.com/example-inc/memcached-operator/pkg/apis/cache/v1alpha1"
 
@@ -18,8 +18,8 @@ import (
 
 func NewHandler(m *Metrics) sdk.Handler {
 	return &Handler{
-    metrics: m,
-  }
+		metrics: m,
+	}
 }
 
 type Metrics struct {
@@ -179,4 +179,3 @@ func RegisterOperatorMetrics() (*Metrics, error) {
 	}
 	return &Metrics{operatorErrors: operatorErrors}, nil
 }
-

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -91,13 +91,23 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
-func NewHandler() sdk.Handler {
-	return &Handler{}
+func NewHandler(m *Metrics) sdk.Handler {
+	return &Handler{
+		metrics: m,
+	}
+}
+
+type Metrics struct {
+	operatorErrors prometheus.Counter
 }
 
 type Handler struct {
+	// Metrics example
+	metrics *Metrics
+
 	// Fill me
 }
 
@@ -107,6 +117,8 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 		err := sdk.Create(newbusyBoxPod(o))
 		if err != nil && !errors.IsAlreadyExists(err) {
 			logrus.Errorf("failed to create busybox pod : %v", err)
+			// increment error metric
+			h.metrics.operatorErrors.Inc()
 			return err
 		}
 	}
@@ -145,6 +157,18 @@ func newbusyBoxPod(cr *v1alpha1.AppService) *corev1.Pod {
 			},
 		},
 	}
+}
+
+func RegisterOperatorMetrics() (*Metrics, error) {
+	operatorErrors := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "memcached_operator_reconcile_errors_total",
+		Help: "Number of errors that occurred while reconciling the memcached deployment",
+	})
+	err := prometheus.Register(operatorErrors)
+	if err != nil {
+		return &Metrics{}, err
+	}
+	return &Metrics{operatorErrors: operatorErrors}, nil
 }
 `
 
@@ -566,7 +590,16 @@ func printVersion() {
 func main() {
 	printVersion()
 
-	sdk.ExposeMetricsPort()
+	metrics, err := stub.RegisterOperatorMetrics()
+	if err != nil {
+		logrus.Errorf("failed to register operator specific metrics: %v", err)
+	}
+	h := stub.NewHandler(metrics)
+	projectName, err := k8sutil.GetOperatorName("app-operator")
+	if err != nil {
+		logrus.Errorf("failed to get project name: %v", err)
+	}
+	sdk.ExposeMetricsPort(projectName)
 
 	resource := "app.example.com/v1alpha1"
 	kind := "AppService"
@@ -577,7 +610,7 @@ func main() {
 	resyncPeriod := time.Duration(5) * time.Second
 	logrus.Infof("Watching %s, %s, %s, %d", resource, kind, namespace, resyncPeriod)
 	sdk.Watch(resource, kind, namespace, resyncPeriod)
-	sdk.Handle(stub.NewHandler())
+	sdk.Handle(h)
 	sdk.Run(context.TODO())
 }
 `
@@ -591,6 +624,7 @@ func TestGenMain(t *testing.T) {
 		SDKVersionImport:  versionImport,
 		APIVersion:        appAPIVersion,
 		Kind:              appKind,
+		ProjectName:       appProjectName,
 	}
 	if err := renderFile(buf, "cmd/<projectName>/main.go", mainTmpl, td); err != nil {
 		t.Error(err)

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -166,7 +166,7 @@ func RegisterOperatorMetrics() (*Metrics, error) {
 	})
 	err := prometheus.Register(operatorErrors)
 	if err != nil {
-		return &Metrics{}, err
+		return nil, err
 	}
 	return &Metrics{operatorErrors: operatorErrors}, nil
 }

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -590,16 +590,12 @@ func printVersion() {
 func main() {
 	printVersion()
 
+	sdk.ExposeMetricsPort()
 	metrics, err := stub.RegisterOperatorMetrics()
 	if err != nil {
 		logrus.Errorf("failed to register operator specific metrics: %v", err)
 	}
 	h := stub.NewHandler(metrics)
-	projectName, err := k8sutil.GetOperatorName("app-operator")
-	if err != nil {
-		logrus.Errorf("failed to get project name: %v", err)
-	}
-	sdk.ExposeMetricsPort(projectName)
 
 	resource := "app.example.com/v1alpha1"
 	kind := "AppService"

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -620,7 +620,6 @@ func TestGenMain(t *testing.T) {
 		SDKVersionImport:  versionImport,
 		APIVersion:        appAPIVersion,
 		Kind:              appKind,
-		ProjectName:       appProjectName,
 	}
 	if err := renderFile(buf, "cmd/<projectName>/main.go", mainTmpl, td); err != nil {
 		t.Error(err)

--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -262,7 +262,7 @@ func RegisterOperatorMetrics() (*Metrics, error) {
 	})
 	err := prometheus.Register(operatorErrors)
 	if err != nil {
-		return &Metrics{}, err
+		return nil, err
 	}
 	return &Metrics{operatorErrors: operatorErrors}, nil
 }


### PR DESCRIPTION
- This PR primarily introduces a metric example in the generated operator. As an example it registers the `operatorErrors` operator specific metric. 
- Fixes https://github.com/operator-framework/operator-sdk/issues/462 when running locally the metrics `Service` was not created as the project/operator name was never known when running locally as the env. variable was not set. This passes the name of the project directly to the `ExposeMetricsPort`, if it's empty it still takes the env variable. This way it is us to the user which method they would prefer to take.

Closes https://github.com/operator-framework/operator-sdk/issues/479
