### PR TITLE
commands/operator-sdk,pkg/generator: Fix project root function and rbac updates for Ansible Operator

### DIFF
--- a/commands/operator-sdk/cmd/cmdutil/util.go
+++ b/commands/operator-sdk/cmd/cmdutil/util.go
@@ -30,12 +30,13 @@ import (
 )
 
 const configYaml = "./config/config.yaml"
+const tmpDockerfile = "./tmp/build/Dockerfile"
 
 // MustInProjectRoot checks if the current dir is the project root.
 func MustInProjectRoot() {
-	// if the current directory has the "./config/config.yaml" file, then it is safe to say
+	// if the current directory has the "./tmp/build/Dockerfile" file, then it is safe to say
 	// we are at the project root.
-	_, err := os.Stat(configYaml)
+	_, err := os.Stat(tmpDockerfile)
 	if err != nil && os.IsNotExist(err) {
 		cmdError.ExitWithError(cmdError.ExitError, fmt.Errorf("must in project root dir: %v", err))
 	}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -366,8 +366,9 @@ func RenderDeployCrdFiles(deployPath, apiVersion, kind string) error {
 
 func renderDeployFiles(deployDir, projectName, apiVersion, kind, operatorType string) error {
 	rbacTd := tmplData{
-		ProjectName: projectName,
-		GroupName:   groupName(apiVersion),
+		ProjectName:  projectName,
+		GroupName:    groupName(apiVersion),
+		IsGoOperator: isGoOperator(operatorType),
 	}
 	if err := renderWriteFile(filepath.Join(deployDir, rbacYaml), rbacTmplName, rbacYamlTmpl, rbacTd); err != nil {
 		return err

--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -476,7 +476,11 @@ spec:
               value: "{{.ProjectName}}"
 `
 
-const rbacYamlTmpl = `kind: Role
+// For Ansible Operator we are assuming namespace: default on ClusterRoleBinding
+// Documentation will tell user to update
+const rbacYamlTmpl = `{{ if .IsGoOperator }}kind: Role
+{{- else }}
+kind: ClusterRole{{ end }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{.ProjectName}}
@@ -510,14 +514,20 @@ rules:
   - "*"
 
 ---
-
+{{- if .IsGoOperator }}
 kind: RoleBinding
+{{- else }}
+kind: ClusterRoleBinding{{ end }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: {{.ProjectName}}
 subjects:
 - kind: ServiceAccount
+{{- if .IsGoOperator }}
   name: {{.ProjectName}}
+{{- else }}
+  name: default
+  namespace: default{{ end }}
 roleRef:
   kind: Role
   name: {{.ProjectName}}

--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -514,7 +514,7 @@ rules:
   - "*"
 
 ---
-{{- if .IsGoOperator }}
+{{ if .IsGoOperator }}
 kind: RoleBinding
 {{- else }}
 kind: ClusterRoleBinding{{ end }}

--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -478,8 +478,8 @@ spec:
 
 // For Ansible Operator we are assuming namespace: default on ClusterRoleBinding
 // Documentation will tell user to update
-const rbacYamlTmpl = `{{ if .IsGoOperator }}kind: Role
-{{- else }}
+const rbacYamlTmpl = `{{- if .IsGoOperator }}kind: Role
+{{- else -}}
 kind: ClusterRole{{ end }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:

--- a/pkg/generator/templates.go
+++ b/pkg/generator/templates.go
@@ -529,7 +529,10 @@ subjects:
   name: default
   namespace: default{{ end }}
 roleRef:
+{{- if .IsGoOperator }}
   kind: Role
+{{- else }}
+  kind: ClusterRole{{ end }}
   name: {{.ProjectName}}
   apiGroup: rbac.authorization.k8s.io
 `


### PR DESCRIPTION
This fixes a regression introduced in: https://github.com/operator-framework/operator-sdk/pull/561

To determine if we are in the project root I've changed it to look for `tmp/build/Dockerfile`.

I also changed the rbac files to have Jinja templating for required differences in Ansible Operator RBAC. It sounds like the Jinja can go away when master is rebased on controller-runtime but I could be wrong on that.