### PR TITLE
pkg/scaffold/gopkgtoml.go: enable more aggressive vendor pruning

### DIFF
--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -88,7 +88,7 @@ required = [
   [[prune.project]]
     name = "github.com/operator-framework/operator-sdk"
     unused-packages = false
-    
+
   [[prune.project]]
     name = "sigs.k8s.io/controller-runtime"
     unused-packages = false

--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -78,9 +78,18 @@ required = [
 [prune]
   go-tests = true
   non-go = true
-  
+  unused-packages = true
+
   [[prune.project]]
     name = "k8s.io/code-generator"
     non-go = false
+    unused-packages = false
+
+  [[prune.project]]
+    name = "github.com/operator-framework/operator-sdk"
+    unused-packages = false
+    
+  [[prune.project]]
+    name = "sigs.k8s.io/controller-runtime"
     unused-packages = false
 `

--- a/pkg/scaffold/gopkgtoml_test.go
+++ b/pkg/scaffold/gopkgtoml_test.go
@@ -84,9 +84,18 @@ required = [
 [prune]
   go-tests = true
   non-go = true
-  
+  unused-packages = true
+
   [[prune.project]]
     name = "k8s.io/code-generator"
     non-go = false
+    unused-packages = false
+
+  [[prune.project]]
+    name = "github.com/operator-framework/operator-sdk"
+    unused-packages = false
+
+  [[prune.project]]
+    name = "sigs.k8s.io/controller-runtime"
     unused-packages = false
 `


### PR DESCRIPTION
We disabled unused-package pruning as that was causing some problems when creating projects. We are re-enabling it and just setting unused-package pruning to false for the `operator-sdk` and `controller-runtime` packages