### PR TITLE
Add Issue and PR templates to the project

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+<!---
+Thanks for filing an issue! Before you submit, please read the following:
+
+Check the other issue templates if you are trying to submit a bug report, feature request, or question. Search open/closed issues before submitting since someone might have asked the same thing before!
+-->

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,42 @@
+---
+me: Bug Report
+about: If things aren't working as expected.
+
+---
+
+## Bug Report
+
+<!-- 
+Thanks for filing an issue! Before hitting the button, please answer these questions.
+
+Fill in as much of the template below as you can. If you leave out information, we can't help you as well.
+-->
+
+**What did you do?**
+A clear and concise description of the steps you took (or insert a code snippet).
+
+**What did you expect to see?**
+A clear and concise description of what you expected to happen (or insert a code snippet).
+
+**What did you see instead? Under which circumstances?**
+A clear and concise description of what you expected to happen (or insert a code snippet).
+
+
+**Environment**
+* operator-sdk version:
+
+  Insert operator-sdk release or Git SHA here. If you have paste the Gopkg.lock operator-sdk information here. 
+
+* Kubernetes version information:
+
+  Insert output of `kubectl version` here
+
+* Kubernetes cluster kind: 
+
+* Are you writing your operator in ansible or go?
+
+**Possible Solution**
+<!--- Only if you have suggestions on a fix for the bug -->
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,14 @@
+---
+me: Feature Request
+about: Suggest a feature
+
+---
+
+## Feature Request
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Example: "I have an issue when [...]"
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen. Add any considered drawbacks.
+

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -1,0 +1,44 @@
+---
+me: Question 
+about: Any support questions you might have.
+
+---
+<!-- 
+Thanks for filing an issue! Before hitting the button, please answer these questions.
+
+Fill in as much of the template below as you can. If you leave out information, we can't help you as well.
+
+We will try our best to answer the question, but we also have a mailing list and slack channel for any other questions.
+-->
+
+## Type of question
+
+**Are you asking about community best practices, how to implement a specific feature, or about general context and help around the operator-sdk?**
+
+
+## Question
+
+**What did you do?**
+A clear and concise description of the steps you took (or insert a code snippet).
+
+**What did you expect to see?**
+A clear and concise description of what you expected to happen (or insert a code snippet).
+
+**What did you see instead? Under which circumstances?**
+A clear and concise description of what you expected to happen (or insert a code snippet).
+
+
+**Environment**
+* operator-sdk version:
+
+  insert release or Git SHA here
+
+* Kubernetes version information:
+
+  insert output of `kubectl version` here
+
+* Kubernetes cluster kind: 
+
+**Additional context**
+Add any other context about the question here.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+
+Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
+
+Note: Make sure your branch is rebased to the latest upstream master.
+
+--!>
+
+**Description of the change:**
+
+
+**Motivation for the change:**
+
+<!--
+
+Note: If this PR is fixing an issue make sure to add a note saying:
+Closes #<ISSUE_NUMBER>
+
+--!>


### PR DESCRIPTION
As per the suggestion in the issue #585 I opened, we went with using the `.github` directory to store all the issue and PR templates. Inspired by https://github.com/babel/babel.

Suggestions are very welcome, especially for the PR template.

Closes #585