### PR TITLE
pkg/{scaffold,util}: fix execute mode and container user

### DIFF
--- a/pkg/scaffold/build_dockerfile.go
+++ b/pkg/scaffold/build_dockerfile.go
@@ -34,8 +34,7 @@ func (s *Dockerfile) GetInput() (input.Input, error) {
 
 const dockerfileTmpl = `FROM alpine:3.6
 
-RUN adduser -D {{.ProjectName}}
-USER {{.ProjectName}}
+USER nobody
 
 ADD build/_output/bin/{{.ProjectName}} /usr/local/bin/{{.ProjectName}}
 `

--- a/pkg/scaffold/build_dockerfile_test.go
+++ b/pkg/scaffold/build_dockerfile_test.go
@@ -36,8 +36,7 @@ func TestDockerfile(t *testing.T) {
 
 const dockerfileExp = `FROM alpine:3.6
 
-RUN adduser -D app-operator
-USER app-operator
+USER nobody
 
 ADD build/_output/bin/app-operator /usr/local/bin/app-operator
 `

--- a/pkg/util/file_util.go
+++ b/pkg/util/file_util.go
@@ -31,7 +31,7 @@ const (
 	// file modes
 	DefaultDirFileMode  = 0750
 	DefaultFileMode     = 0644
-	DefaultExecFileMode = 0744
+	DefaultExecFileMode = 0755
 
 	DefaultFileFlags = os.O_WRONLY | os.O_CREATE | os.O_TRUNC
 )


### PR DESCRIPTION
The e2e tests were passing in travis due to the travis user and the container user being the same, but if the user building the image is different from the in-image uid, there will be permission errors. This changes to default exec file mode to `0755` and the in-image user to `nobody`