### PR TITLE
test/e2e: make running e2e tests locally easier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ jobs:
 install: 
 - curl -Lo dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x dep && sudo mv dep /usr/local/bin/
 - dep ensure
-# Create example operator directory
-- mkdir -p $GOPATH/src/github.com/example-inc
 
 script:
 - make install


### PR DESCRIPTION
This PR moves `$GOPATH/src/github.com/example-inc` creation logic from `.travis.yml` into the test itself so devs can re-run tests without having to create the dir manually.