### PR TITLE
release.sh: compare file versions against new version

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -29,8 +29,8 @@ VER_FILE="version/version.go"
 TOML_TMPL_FILE="pkg/generator/templates.go"
 CURR_VER_VER_FILE="$(sed -nr 's/Version = "(.+)"/\1/p' "$VER_FILE" | tr -d '\s\t\n')"
 CURR_VER_TMPL_FILE="$(sed -nr 's/.*".*v(.+)".*#osdk_version_annotation/v\1/p' "$TOML_TMPL_FILE" | tr -d '\s\t\n')"
-if [ "$CURR_VER" != "$CURR_VER_VER_FILE" ] \
-	|| [ "$CURR_VER" != "$CURR_VER_TMPL_FILE" ]; then
+if [ "$VER" != "$CURR_VER_VER_FILE" ] \
+	|| [ "$VER" != "$CURR_VER_TMPL_FILE" ]; then
 	echo "versions are not set correctly in $VER_FILE or $TOML_TMPL_FILE"
 	exit 1
 fi


### PR DESCRIPTION
Backport of change made in `refactor/controller-runtime` branch. See [this PR comment](https://github.com/operator-framework/operator-sdk/pull/604#discussion_r224573690) for details.