### PR TITLE
pkg/leader: allow setting the pod name explicitly.

### DIFF
--- a/pkg/leader/doc.go
+++ b/pkg/leader/doc.go
@@ -41,6 +41,14 @@ The lock record in this case is a ConfigMap whose OwnerReference is set to the
 Pod that is the leader. When the leader is destroyed, the ConfigMap gets
 garbage-collected, enabling a different candidate Pod to become the leader.
 
-Leader for Life requires that all candidate Pods be in the same Namespace.
+Leader for Life requires that all candidate Pods be in the same Namespace. It
+uses the downwards API to determine the pod name, as hostname is not reliable.
+You should run it configured with:
+
+env:
+  - name: POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
 */
 package leader

--- a/pkg/scaffold/operator.go
+++ b/pkg/scaffold/operator.go
@@ -62,6 +62,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "{{.ProjectName}}"
 `

--- a/pkg/scaffold/operator_test.go
+++ b/pkg/scaffold/operator_test.go
@@ -61,6 +61,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "app-operator"
 `


### PR DESCRIPTION
This is useful for pods running in hostNetwork, where the hostname is not the pod name.