### PR TITLE
pkg/ansible/runner; Set role path as env var for runner

### DIFF
--- a/pkg/ansible/runner/runner.go
+++ b/pkg/ansible/runner/runner.go
@@ -173,11 +173,14 @@ func (r *runner) Run(u *unstructured.Unstructured, kubeconfig string) (chan even
 	if err != nil {
 		return nil, err
 	}
+	path := strings.TrimRight(r.Path, "/")
+	rolePath, _ := filepath.Split(path)
 	inputDir := inputdir.InputDir{
 		Path:       filepath.Join("/tmp/ansible-operator/runner/", r.GVK.Group, r.GVK.Version, r.GVK.Kind, u.GetNamespace(), u.GetName()),
 		Parameters: r.makeParameters(u),
 		EnvVars: map[string]string{
 			"K8S_AUTH_KUBECONFIG": kubeconfig,
+			"ANSIBLE_ROLES_PATH":  rolePath,
 		},
 		Settings: map[string]string{
 			"runner_http_url":  receiver.SocketPath,


### PR DESCRIPTION
This is a short-term fix for https://github.com/ansible/ansible-runner/issues/152. Setting the role path as an environment variable works since `--roles-path` is not respected from the CLI.