### PR TITLE
.travis.yml: remove minikube tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,6 @@ go:
 
 jobs:
   include:
-    - before_script: hack/ci/setup-minikube.sh
-      env:
-        - CLUSTER=minikube
-        - CHANGE_MINIKUBE_NONE_USER=true
-      script: test/test-go.sh
-      name: Go on minikube
-    - before_script: hack/ci/setup-minikube.sh
-      env:
-        - CLUSTER=minikube
-        - CHANGE_MINIKUBE_NONE_USER=true
-      script: test/test-ansible.sh
-      name: Ansible on minikube
     - before_script: hack/ci/setup-openshift.sh
       env: CLUSTER=openshift
       script: test/test-go.sh


### PR DESCRIPTION
We are hitting a bottleneck in travis jobs (at ~10 jobs) since
each PR/commit results in 4 jobs being started to testing. New
versions of minikube do not work properly on travis anymore due
to travis not yet supporting systemd, so we would be stuck on
an old version of minikube anyway. This commit means that all
tests will run on openshift (currently 3.11), which should be the
same as vanilla kubernetes (1.11), but with a bit more restrictions.