### PR TITLE
Makefile: build signature target performs correct comparison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,10 @@ build/%:
 	$(Q)$(GOARGS) go build -o $@ $(BUILD_PATH)
 	
 DEFAULT_KEY = $(shell gpgconf --list-options gpg \
-								| awk -F: '$$1 == "default-key" { gsub(/"/,""); print $$10}')
+								| awk -F: '$$1 == "default-key" { gsub(/"/,""); print toupper($$10)}')
+GIT_KEY = $(shell git config --get user.signingkey | awk '{ print toupper($$0) }')
 build/%.asc:
-ifeq ("$(DEFAULT_KEY)","$(shell git config --get user.signingkey)")
+ifeq ("$(DEFAULT_KEY)","$(GIT_KEY)")
 	$(Q)gpg --output $@ --detach-sig build/$*
 	$(Q)gpg --verify $@ build/$*
 else


### PR DESCRIPTION
The `build/%.asc` target conditional `git` operand was being evaluated after the conditional itself, so the conditional was not evaluating correctly. Now `make build/%.asc`'s conditional evaluates correctly and normalizes alphabetical case.