### PR TITLE
test/e2e/memcached_test.go: regexp branch substitution

### DIFF
--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -141,8 +142,12 @@ func TestMemcached(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			// TODO: make this match more complete in case we add another repo tracking master
-			gopkg = bytes.Replace(gopkg, []byte("branch = \"refactor/controller-runtime\""), []byte("# branch = \"refactor/controller-runtime\""), -1)
+			// Match against the '#osdk_branch_annotation' used for version substitution
+			// and comment out the current branch.
+			branchRe := regexp.MustCompile("([ ]+)(.+#osdk_branch_annotation)")
+			gopkg = branchRe.ReplaceAll(gopkg, []byte("$1# $2"))
+			// Plug in the fork to test against so `dep ensure` can resolve dependencies
+			// correctly.
 			gopkgString := string(gopkg)
 			gopkgLoc := strings.LastIndex(gopkgString, "\n  name = \"github.com/operator-framework/operator-sdk\"\n")
 			gopkgString = gopkgString[:gopkgLoc] + "\n  source = \"https://github.com/" + prSlug + "\"\n  revision = \"" + prSha + "\"\n" + gopkgString[gopkgLoc+1:]


### PR DESCRIPTION
This PR enables the e2e tests to substitute any branch fixed in the SDK-generated `Gopkg.toml`.

Test: https://play.golang.org/p/eY5PQj-ulxt