### PR TITLE
moves controller creation and startup out of ansible's main.go

### DIFF
--- a/commands/operator-sdk/cmd/up/local.go
+++ b/commands/operator-sdk/cmd/up/local.go
@@ -132,14 +132,17 @@ func upLocalAnsible() {
 	done := make(chan error)
 
 	// start the proxy
-	proxy.RunProxy(done, proxy.Options{
+	err = proxy.Run(done, proxy.Options{
 		Address:    "localhost",
 		Port:       8888,
 		KubeConfig: mgr.GetConfig(),
 	})
+	if err != nil {
+		logrus.Fatalf("error starting proxy: %v", err)
+	}
 
 	// start the operator
-	go ansibleOperator.Run(done, mgr)
+	go ansibleOperator.Run(done, mgr, "./watches.yaml")
 
 	// wait for either to finish
 	err = <-done

--- a/pkg/ansible/operator/operator.go
+++ b/pkg/ansible/operator/operator.go
@@ -15,7 +15,6 @@
 package operator
 
 import (
-	"log"
 	"math/rand"
 	"time"
 
@@ -30,8 +29,8 @@ import (
 // Run - A blocking function which starts a controller-runtime manager
 // It starts an Operator by reading in the values in `./watches.yaml`, adds a controller
 // to the manager, and finally running the manager.
-func Run(done chan error, mgr manager.Manager) {
-	watches, err := runner.NewFromWatches("./watches.yaml")
+func Run(done chan error, mgr manager.Manager, watchesPath string) {
+	watches, err := runner.NewFromWatches(watchesPath)
 	if err != nil {
 		logrus.Error("Failed to get watches")
 		done <- err
@@ -46,6 +45,5 @@ func Run(done chan error, mgr manager.Manager) {
 			Runner: runner,
 		})
 	}
-	log.Fatal(mgr.Start(c))
-	done <- nil
+	done <- mgr.Start(c)
 }

--- a/pkg/ansible/proxy/proxy.go
+++ b/pkg/ansible/proxy/proxy.go
@@ -108,13 +108,13 @@ type Options struct {
 	KubeConfig       *rest.Config
 }
 
-// RunProxy will start a proxy server in a go routine and return on the error
-// channel if something is not correct on startup.
-func RunProxy(done chan error, o Options) {
+// Run will start a proxy server in a go routine that returns on the error
+// channel if something is not correct on startup. Run will not return until
+// the network socket is listening.
+func Run(done chan error, o Options) error {
 	server, err := newServer("/", o.KubeConfig)
 	if err != nil {
-		done <- err
-		return
+		return err
 	}
 	if o.Handler != nil {
 		server.Handler = o.Handler(server.Handler)
@@ -125,11 +125,11 @@ func RunProxy(done chan error, o Options) {
 	}
 	l, err := server.Listen(o.Address, o.Port)
 	if err != nil {
-		done <- err
-		return
+		return err
 	}
 	go func() {
 		logrus.Infof("Starting to serve on %s\n", l.Addr().String())
 		done <- server.ServeOnListener(l)
 	}()
+	return nil
 }


### PR DESCRIPTION
main.go should be as minimal as is reasonable, so this moves startup logic to a
more appropriate place. It also slightly changes the proxy startup code to
better match controller startup.

The new error handling avoids a race between the proxy being available and
ansible trying to use it.
