### PR TITLE
doc/user: document refactor to controller-runtime

### DIFF
--- a/doc/design/milestone-0.1.0/client-api.md
+++ b/doc/design/milestone-0.1.0/client-api.md
@@ -1,0 +1,290 @@
+# Operator-SDK: Controller Runtime Client API
+
+## Goal
+
+Elaborate on how the Operator SDK uses the [controller-runtime][repo-controller-runtime] controller API to build operators. Specifically, this doc addresses how to interface with a client object and use CRUD operations (Create, Update, Delete, Get, List) to produce the same results as the pre-v0.1.0 SDK would have.
+
+## Background
+
+The [kubernetes-sigs][org-kubernetes-sigs] organization builds tools to call the [Kubernetes][site-kubernetes] API in a clean, abstracted manner, much like the Operator SDK. The [controller-runtime][repo-controller-runtime] project is meant to help users build [controllers][site-kubernetes-controllers] easily by generating a controller project that interacts with a k8s cluster via CRUD operations. A user-defined controller can perform a specific functions in a cluster; [operators][site-operators] can use multiple controllers to perform a variety of tasks. As operators use at least one controller, the SDK can rely on controller-runtime's k8s API code rather than develop a parallel set of API calls to execute the same cluster operations, namely CRUD operations.
+
+controller-runtime defines several interfaces used for cluster interaction:
+- `client.Client`: implementers perform CRUD operations on a k8s cluster.
+- `manager.Manager`: manages shared dependencies, such as Caches and Clients.
+- `reconcile.Reconciler`: compares provided state with actual cluster state and updates the cluster on finding state differences using a Client.
+
+## Proposed Solution
+
+The SDK will implement controller-runtime's `client.Client` interface to Create, Update, Delete, Get, and List cluster objects within a `reconcile.Reconciler`'s Reconcile function. The particular Client the SDK will use is referred to as a [split client][doc-split-client], created when instantiating a `manager.Manager`. A split client reads (Get and List) from the Cache and writes (Create, Update, Delete) to the API server. Reading from the Cache only significantly reduces request load on the API server; as long as the Cache is updated by the API server, read operations are eventually consistent. 
+
+## Creating a Manager and default Client
+
+### Manager
+
+The SDK will generate a `cmd/manager/main.go` file with an operator entrypoint that creates a Manager. Managers hold a Cache and a Client that are used in CRUD operations and interface with the API server. A cluster namespace, created on cluster creation, and a [`*rest.Config`][doc-rest-config] object retrieved from the cluster configure the Managers' Cache and Client to point at the clusters' API server.
+
+```Go
+import (
+	"github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	
+	...
+)
+
+func main() {
+	// Get the namespace being watched in the k8s cluster.
+	namespace, _ := k8sutil.GetWatchNamespace()
+
+	// Get a config to talk to the apiserver
+	cfg, _ := config.GetConfig()
+
+	// Create a new manager to provide shared dependencies and start components.
+	mgr, _ := manager.New(cfg, manager.Options{Namespace: namespace})
+	
+	...
+}
+```
+
+### Non-default Client
+
+An operator developer may wish to create their own Client with different read/write optimzations, for example. controller-runtime provides a [constructor][doc-client-constr] for Clients, requiring a `*rest.Config` object, like that above, and a [`client.Options`][doc-client-options], which can be empty.
+
+```Go
+// New returns a new Client using the provided config and Options.
+func New(config *rest.Config, options client.Options) (client.Client, error)
+```
+
+The Manager's client field must be set with the new Client:
+
+```Go
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	
+	...
+)
+
+func main() {
+	...
+
+	cfg, _ := config.GetConfig()
+	mgr, _ := manager.New(cfg, manager.Options{Namespace: namespace})
+	
+	// Create a new Client with cfg and set the Manager's corresponding field.
+	newClient := client.New(cfg, client.Options{})
+	mgr.SetFields(newClient)
+	
+	...
+}
+```
+
+## Reconcile and Client API
+
+A Reconciler implements the [`reconcile.Reconciler`][doc-reconcile-reconciler] interface, which exposes the Reconcile method. Reconcilers are added to a corresponding Controller for a Kind; Reconcile is called in response to cluster or external Events, with a `reconcile.Request` object argument, to read and write cluster state by the Controller, and returns a `reconcile.Result`. SDK Reconcilers have access to a Client in order to make k8s API calls.
+
+**Note**: For those familiar with the SDK's old project structure, Reconcile replaces [Handle][doc-osdk-handle].
+
+```Go
+// ReconcileMemcached reconciles a Kind object
+type ReconcileKind struct {
+	// client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+
+	// scheme defines methods for serializing and deserializing API objects,
+	// a type registry for converting group, version, and kind information
+	// to and from Go schemas, and mappings between Go schemas of different
+	// versions. A scheme is the foundation for a versioned API and versioned
+	// configuration over time. 
+	scheme *runtime.Scheme
+}
+
+// Reconcile watches for Events and reconciles cluster state with desired
+// state defined in the method body.
+// The Controller will requeue the Request to be processed again if an error
+// is non-nil or Result.Requeue is true, otherwise upon completion it will
+// remove the work from the queue.
+func (r *ReconcileKind) Reconcile(request reconcile.Request) (reconcile.Result, error)
+```
+
+Reconcile is where Controller business logic lives, i.e. where Client API calls are made via `ReconcileKind.client`. A `client.Client` implementer performs the following operations:
+
+```Go
+// Create saves the object obj in the k8s cluster.
+// Returns an error 
+func (c *ClientImpl) Create(ctx context.Context, obj runtime.Object) error
+```
+
+```Go
+// Update updates the given obj in the k8s cluster. obj must be a
+// struct pointer so that obj can be updated with the content returned
+// by the API server.
+func (c *ClientImpl) Update(ctx context.Context, obj runtime.Object) error
+```
+
+```Go
+// Delete deletes the given obj from k8s cluster.
+func (c *ClientImpl) Delete(ctx context.Context, obj runtime.Object, opts ...DeleteOptionFunc) error
+```
+
+```Go
+// Get retrieves an API object for a given object key from the k8s cluster
+// and stores it in obj.
+func (c *ClientImpl) Get(ctx context.Context, key ObjectKey, obj runtime.Object) error
+```
+
+```Go
+// List retrieves a list of objects for a given namespace and list options
+// and stores the list in obj.
+func (c *ClientImpl) List(ctx context.Context, opts *ListOptions, obj runtime.Object) error
+```
+
+### Example usage
+
+```Go
+import (
+	"context"
+	"reflect"
+
+	appv1alpha1 "github.com/example-org/app-operator/pkg/apis/app/v1alpha1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type ReconcileApp struct {
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+
+	// Fetch the App instance.
+	app := &appv1alpha1.App{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, app)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	// Check if the deployment already exists, if not create a new deployment.
+	found := &appsv1.Deployment{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, found)
+	if err != nil {
+	 	if errors.IsNotFound(err) {
+			// Define and create a new deployment.
+			dep := r.deploymentForMemcached(app)
+			if err = r.client.Create(context.TODO(), dep); err != nil {
+				return reconcile.Result{}, err
+			}
+			return reconcile.Result{Requeue: true}, nil
+		} else {
+			return reconcile.Result{}, err			
+		}
+	}
+
+	// Ensure the deployment size is the same as the spec.
+	size := app.Spec.Size
+	if *found.Spec.Replicas != size {
+		found.Spec.Replicas = &size
+		if err = r.client.Update(context.TODO(), found); err != nil {
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{Requeue: true}, nil
+	}
+
+	// Update the App status with the pod names.
+	// List the pods for this app's deployment.
+	podList := &corev1.PodList{}
+	labelSelector := labels.SelectorFromSet(labelsForApp(app.Name))
+	listOps := &client.ListOptions{Namespace: app.Namespace, LabelSelector: labelSelector}
+	if err = r.client.List(context.TODO(), listOps, podList); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Update status.Nodes if needed.
+	podNames := getPodNames(podList.Items)
+	if !reflect.DeepEqual(podNames, app.Status.Nodes) {
+		app.Status.Nodes = podNames
+		if err := r.client.Update(context.TODO(), app); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// deploymentForApp returns a app Deployment object.
+func (r *ReconcileMemcached) deploymentForApp(m *appv1alpha1.App) *appsv1.Deployment {
+	lbls := labelsForApp(m.Name)
+	replicas := m.Spec.Size
+
+	dep := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      m.Name,
+			Namespace: m.Namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: lbls,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: lbls,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image:   "app:alpine",
+						Name:    "app",
+						Command: []string{"app", "-a=64", "-b"},
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 10000,
+							Name:          "app",
+						}},
+					}},
+				},
+			},
+		},
+	}
+
+	// Set App instance as the owner and controller.
+	// NOTE: calling SetControllerReference, and setting owner references in
+	// general, is important as it allows deleted objects to be garbage collected.
+	controllerutil.SetControllerReference(m, dep, r.scheme)
+	return dep
+}
+
+// labelsForApp creates a simple set of labels for App.
+func labelsForApp(name string) map[string]string {
+	return map[string]string{"app_name": "app", "app_cr": name}
+}
+```
+
+[repo-controller-runtime]:https://github.com/kubernetes-sigs/controller-runtime
+[org-kubernetes-sigs]:https://github.com/kubernetes-sigs
+[site-kubernetes]:https://kubernetes.io/
+[site-kubernetes-controllers]:https://kubernetes.io/docs/concepts/workloads/controllers/
+[site-operators]:https://coreos.com/blog/introducing-operator-framework
+[doc-split-client]:https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/split.go#L26-L28
+[doc-rest-config]:https://godoc.org/k8s.io/client-go/rest#Config
+[doc-client-constr]:https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/client.go#L44
+[doc-client-options]:https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/client.go#L35
+[doc-reconcile-reconciler]:https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/reconcile/reconcile.go#L35
+[doc-osdk-handle]:https://github.com/operator-framework/operator-sdk/blob/master/doc/design/milestone-0.0.2/action-api.md#handler

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -156,7 +156,15 @@ return reconcile.Result{}, err
 return reconcile.Result{Requeue: true}, nil
 ```
 
-**// TODO:** Doc on controller-runtime client and examples on how to use it.
+You can set the `Resulte.RequeueAfter` to requeue the `Request` after a grace period as well:
+```Go
+import "time"
+
+// Reconcile for any reason than error after 5 seconds
+return reconcile.Result{RequeueAfter: time.Duration(5)}, nil
+```
+
+For a guide on Reconcilers, Clients, and interacting with resource Events, see the [Client API doc][doc_client_api].
 
 ## Build and run the operator
 
@@ -363,5 +371,6 @@ func main() {
 [manager_scheme]: https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/manager/manager.go#L61
 [simple_resource]: https://book.kubebuilder.io/basics/simple_resource.html
 [deployments_register]: https://github.com/kubernetes/api/blob/master/apps/v1/register.go#L41
+[doc_client_api]:./user/client.md
 [runtime_package]: https://godoc.org/k8s.io/apimachinery/pkg/runtime
 [osdk_add_to_scheme]: https://github.com/operator-framework/operator-sdk/blob/4179b6ac459b2b0cb04ab3a1b438c280bd28d1a5/pkg/util/k8sutil/k8sutil.go#L67

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -161,7 +161,7 @@ You can set the `Result.RequeueAfter` to requeue the `Request` after a grace per
 import "time"
 
 // Reconcile for any reason than error after 5 seconds
-return reconcile.Result{RequeueAfter: time.Duration(5)}, nil
+return reconcile.Result{RequeueAfter: time.Second*5}, nil
 ```
 
 For a guide on Reconcilers, Clients, and interacting with resource Events, see the [Client API doc][doc_client_api].

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -156,7 +156,7 @@ return reconcile.Result{}, err
 return reconcile.Result{Requeue: true}, nil
 ```
 
-You can set the `Resulte.RequeueAfter` to requeue the `Request` after a grace period as well:
+You can set the `Result.RequeueAfter` to requeue the `Request` after a grace period as well:
 ```Go
 import "time"
 

--- a/doc/user/client.md
+++ b/doc/user/client.md
@@ -53,6 +53,19 @@ type Options struct {
 	Mapper meta.RESTMapper
 }
 ```
+Example:
+```Go
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+    "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+	cfg, err := config.GetConfig()
+	...
+	c, err := client.New(cfg, client.Options{})
+
+	...
+```
 
 **Note**: defaults are set by `client.New` when Options are empty. The default [scheme][code-scheme-default] will have the [core][doc-k8s-core] Kubernetes resource types registered. The caller *must* set a scheme that has custom operator types registered for the new Client to recognize these types.
 

--- a/doc/user/client.md
+++ b/doc/user/client.md
@@ -233,8 +233,7 @@ func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, e
 	
 	app := &v1alpha1.App{}
 	ctx := context.TODO()
-	name := request.NamespacedName
-	err := r.client.Get(ctx, name, app)
+	err := r.client.Get(ctx, request.NamespacedName, app)
 
 	...
 }

--- a/doc/user/client.md
+++ b/doc/user/client.md
@@ -220,6 +220,8 @@ func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, e
 // and stores it in obj.
 func (c Client) Get(ctx context.Context, key ObjectKey, obj runtime.Object) error
 ```
+**Note**: An `ObjectKey` is simply a `client` package alias for [`types.NamespacedName`][doc-types-nsname].
+
 Example:
 ```Go
 import (
@@ -438,3 +440,4 @@ func labelsForApp(name string) map[string]string {
 [doc-k8s-core]:https://godoc.org/k8s.io/api/core/v1
 [doc-reconcile-reconciler]:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Reconciler
 [doc-osdk-handle]:https://github.com/operator-framework/operator-sdk/blob/master/doc/design/milestone-0.0.2/action-api.md#handler
+[doc-types-nsname]:https://godoc.org/k8s.io/apimachinery/pkg/types#NamespacedName

--- a/doc/user/client.md
+++ b/doc/user/client.md
@@ -11,7 +11,9 @@ controller-runtime defines several interfaces used for cluster interaction:
 
 The SDK relies on a `manager.Manager` to create a split `client.Client` interface that performs Create, Update, Delete, Get, and List operations within a `reconcile.Reconciler`'s Reconcile function.
 
-## The default Client
+## Client Usage
+
+### Default Client
 
 The SDK will generate code creating a Manager. Managers hold a Cache and a Client that are used in CRUD operations and interface with the API server. The particular Client the SDK uses by default is referred to as a [split client][doc-split-client], created when instantiating a Manager. A split client reads (Get and List) from the Cache and writes (Create, Update, Delete) to the API server. Reading from the Cache significantly reduces request load on the API server; as long as the Cache is updated by the API server, read operations are eventually consistent. 
 
@@ -49,7 +51,7 @@ func main() {
 }
 ```
 
-## Reconcile and Client API
+### Reconcile and the Client API
 
 A Reconciler implements the [`reconcile.Reconciler`][doc-reconcile-reconciler] interface, which exposes the Reconcile method. Reconcilers are added to a corresponding Controller for a Kind; Reconcile is called in response to cluster or external Events, with a `reconcile.Request` object argument, to read and write cluster state by the Controller, and returns a `reconcile.Result`. SDK Reconcilers have access to a Client in order to make k8s API calls.
 

--- a/doc/user/client.md
+++ b/doc/user/client.md
@@ -15,7 +15,7 @@ Clients are the focus of this document. A separate document will discuss Manager
 
 ### Default Client
 
-The SDK relies on a `manager.Manager` to create a `client.Client` interface that performs Create, Update, Delete, Get, and List operations within a `reconcile.Reconciler`'s Reconcile function. The SDK will generate code to create a Manager, which holds a Cache and a Client to be used in CRUD operations and communicate with the API server. By default a Controller's Reconciler will be populated with the Manager's Client which is a [split-client][code-split-client].
+The SDK relies on a `manager.Manager` to create a `client.Client` interface that performs Create, Update, Delete, Get, and List operations within a `reconcile.Reconciler`'s Reconcile function. The SDK will generate code to create a Manager, which holds a Cache and a Client to be used in CRUD operations and communicate with the API server. By default a Controller's Reconciler will be populated with the Manager's Client which is a [split-client][doc-split-client].
 
 `pkg/controller/<kind>/<kind>_controller.go`:
 ```Go
@@ -34,7 +34,7 @@ A split client reads (Get and List) from the Cache and writes (Create, Update, D
 
 ### Non-default Client
 
-An operator developer may wish to create their own Client that serves read requests(Get List) from the API server instead of the cache, for example. controller-runtime provides a [constructor][code-client-constr] for Clients:
+An operator developer may wish to create their own Client that serves read requests(Get List) from the API server instead of the cache, for example. controller-runtime provides a [constructor][doc-client-constr] for Clients:
 
 ```Go
 // New returns a new Client using the provided config and Options.
@@ -60,7 +60,7 @@ Creating a new Client is not usually necessary nor advised, as the default Clien
 
 ### Reconcile and the Client API
 
-A Reconciler implements the [`reconcile.Reconciler`][code-reconcile-reconciler] interface, which exposes the Reconcile method. Reconcilers are added to a corresponding Controller for a Kind; Reconcile is called in response to cluster or external Events, with a `reconcile.Request` object argument, to read and write cluster state by the Controller, and returns a `reconcile.Result`. SDK Reconcilers have access to a Client in order to make k8s API calls.
+A Reconciler implements the [`reconcile.Reconciler`][doc-reconcile-reconciler] interface, which exposes the Reconcile method. Reconcilers are added to a corresponding Controller for a Kind; Reconcile is called in response to cluster or external Events, with a `reconcile.Request` object argument, to read and write cluster state by the Controller, and returns a `reconcile.Result`. SDK Reconcilers have access to a Client in order to make k8s API calls.
 
 **Note**: For those familiar with the SDK's old project semantics, [Handle][doc-osdk-handle] received resource events and reconciled state for multiple resource types, whereas Reconcile receives resource events and reconciles state for a single resource type.
 
@@ -403,9 +403,9 @@ func labelsForApp(name string) map[string]string {
 
 [repo-controller-runtime]:https://github.com/kubernetes-sigs/controller-runtime
 [doc-client-client]:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/client#Client
-[code-split-client]:https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/split.go#L26-L28
-[code-client-constr]:https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/client.go#L44
+[doc-split-client]:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/client#DelegatingClient
+[doc-client-constr]:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/client#New
 [code-scheme-default]:https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/client.go#L51
 [doc-k8s-core]:https://godoc.org/k8s.io/api/core/v1
-[code-reconcile-reconciler]:https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/reconcile/reconcile.go#L35
+[doc-reconcile-reconciler]:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Reconciler
 [doc-osdk-handle]:https://github.com/operator-framework/operator-sdk/blob/master/doc/design/milestone-0.0.2/action-api.md#handler

--- a/doc/user/client.md
+++ b/doc/user/client.md
@@ -41,6 +41,21 @@ An operator developer may wish to create their own Client that serves read reque
 func New(config *rest.Config, options client.Options) (client.Client, error)
 ```
 
+`client.Options` allow the caller to specify how the new Client should communicate with the API server.
+
+```Go
+// Options are creation options for a Client
+type Options struct {
+	// Scheme, if provided, will be used to map go structs to GroupVersionKinds
+	Scheme *runtime.Scheme
+
+	// Mapper, if provided, will be used to map GroupVersionKinds to Resources
+	Mapper meta.RESTMapper
+}
+```
+
+**Note**: defaults are set by `client.New` when Options are empty. The default [scheme][code-scheme-default] will have the [core][doc-k8s-core] k8s resource types registered. The caller *must* set a scheme that has custom operator types registered for the new Client to recognize these types.
+
 Creating a new Client is not usually necessary nor advised, as the default Client is sufficient for most use cases.
 
 ### Reconcile and the Client API
@@ -390,5 +405,7 @@ func labelsForApp(name string) map[string]string {
 [doc-client-client]:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/client#Client
 [code-split-client]:https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/split.go#L26-L28
 [code-client-constr]:https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/client.go#L44
+[code-scheme-default]:https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/client.go#L51
+[doc-k8s-core]:https://godoc.org/k8s.io/api/core/v1
 [code-reconcile-reconciler]:https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/reconcile/reconcile.go#L35
 [doc-osdk-handle]:https://github.com/operator-framework/operator-sdk/blob/master/doc/design/milestone-0.0.2/action-api.md#handler

--- a/doc/user/client.md
+++ b/doc/user/client.md
@@ -62,7 +62,7 @@ Creating a new Client is not usually necessary nor advised, as the default Clien
 
 A Reconciler implements the [`reconcile.Reconciler`][code-reconcile-reconciler] interface, which exposes the Reconcile method. Reconcilers are added to a corresponding Controller for a Kind; Reconcile is called in response to cluster or external Events, with a `reconcile.Request` object argument, to read and write cluster state by the Controller, and returns a `reconcile.Result`. SDK Reconcilers have access to a Client in order to make k8s API calls.
 
-**Note**: For those familiar with the SDK's old project structure, Reconcile replaces [Handle][doc-osdk-handle].
+**Note**: For those familiar with the SDK's old project semantics, [Handle][doc-osdk-handle] received resource events and reconciled state for multiple resource types, whereas Reconcile receives resource events and reconciles state for a single resource type.
 
 ```Go
 // ReconcileMemcached reconciles a Kind object

--- a/doc/user/client.md
+++ b/doc/user/client.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-The [`controller-runtime`][repo-controller-runtime] library provides various abstractions to watch and reconcile resources in a k8s cluster via CRUD (Create, Update, Delete, as well as Get and List in this case) operations. Operators use at least one controller to perform a coherent set of tasks within a cluster, usually through a combination of CRUD operations. The Operator SDK uses controller-runtime's [Client][doc-client-client] interface, which provides the interface for these operations.
+The [`controller-runtime`][repo-controller-runtime] library provides various abstractions to watch and reconcile resources in a Kubernetes cluster via CRUD (Create, Update, Delete, as well as Get and List in this case) operations. Operators use at least one controller to perform a coherent set of tasks within a cluster, usually through a combination of CRUD operations. The Operator SDK uses controller-runtime's [Client][doc-client-client] interface, which provides the interface for these operations.
 
 controller-runtime defines several interfaces used for cluster interaction:
-- `client.Client`: implementers perform CRUD operations on a k8s cluster.
+- `client.Client`: implementers perform CRUD operations on a Kubernetes cluster.
 - `manager.Manager`: manages shared dependencies, such as Caches and Clients.
 - `reconcile.Reconciler`: compares provided state with actual cluster state and updates the cluster on finding state differences using a Client.
 
@@ -54,18 +54,18 @@ type Options struct {
 }
 ```
 
-**Note**: defaults are set by `client.New` when Options are empty. The default [scheme][code-scheme-default] will have the [core][doc-k8s-core] k8s resource types registered. The caller *must* set a scheme that has custom operator types registered for the new Client to recognize these types.
+**Note**: defaults are set by `client.New` when Options are empty. The default [scheme][code-scheme-default] will have the [core][doc-k8s-core] Kubernetes resource types registered. The caller *must* set a scheme that has custom operator types registered for the new Client to recognize these types.
 
 Creating a new Client is not usually necessary nor advised, as the default Client is sufficient for most use cases.
 
 ### Reconcile and the Client API
 
-A Reconciler implements the [`reconcile.Reconciler`][doc-reconcile-reconciler] interface, which exposes the Reconcile method. Reconcilers are added to a corresponding Controller for a Kind; Reconcile is called in response to cluster or external Events, with a `reconcile.Request` object argument, to read and write cluster state by the Controller, and returns a `reconcile.Result`. SDK Reconcilers have access to a Client in order to make k8s API calls.
+A Reconciler implements the [`reconcile.Reconciler`][doc-reconcile-reconciler] interface, which exposes the Reconcile method. Reconcilers are added to a corresponding Controller for a Kind; Reconcile is called in response to cluster or external Events, with a `reconcile.Request` object argument, to read and write cluster state by the Controller, and returns a `reconcile.Result`. SDK Reconcilers have access to a Client in order to make Kubernetes API calls.
 
 **Note**: For those familiar with the SDK's old project semantics, [Handle][doc-osdk-handle] received resource events and reconciled state for multiple resource types, whereas Reconcile receives resource events and reconciles state for a single resource type.
 
 ```Go
-// ReconcileMemcached reconciles a Kind object
+// ReconcileKind reconciles a Kind object
 type ReconcileKind struct {
 	// client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
@@ -92,7 +92,7 @@ Reconcile is where Controller business logic lives, i.e. where Client API calls 
 #### Create
 
 ```Go
-// Create saves the object obj in the k8s cluster.
+// Create saves the object obj in the Kubernetes cluster.
 // Returns an error 
 func (c Client) Create(ctx context.Context, obj runtime.Object) error
 ```
@@ -120,7 +120,7 @@ func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, e
 #### Update
 
 ```Go
-// Update updates the given obj in the k8s cluster. obj must be a
+// Update updates the given obj in the Kubernetes cluster. obj must be a
 // struct pointer so that obj can be updated with the content returned
 // by the API server.
 func (c Client) Update(ctx context.Context, obj runtime.Object) error
@@ -152,7 +152,7 @@ func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, e
 #### Delete
 
 ```Go
-// Delete deletes the given obj from k8s cluster.
+// Delete deletes the given obj from Kubernetes cluster.
 func (c Client) Delete(ctx context.Context, obj runtime.Object, opts ...DeleteOptionFunc) error
 ```
 A `client.DeleteOptionFunc` sets fields of `client.DeleteOptions` to configure a `Delete` call:
@@ -216,7 +216,7 @@ func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, e
 #### Get
 
 ```Go
-// Get retrieves an API object for a given object key from the k8s cluster
+// Get retrieves an API object for a given object key from the Kubernetes cluster
 // and stores it in obj.
 func (c Client) Get(ctx context.Context, key ObjectKey, obj runtime.Object) error
 ```
@@ -340,7 +340,7 @@ func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, e
 	if err != nil {
 	 	if errors.IsNotFound(err) {
 			// Define and create a new deployment.
-			dep := r.deploymentForMemcached(app)
+			dep := r.deploymentForApp(app)
 			if err = r.client.Create(context.TODO(), dep); err != nil {
 				return reconcile.Result{}, err
 			}
@@ -382,7 +382,7 @@ func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, e
 }
 
 // deploymentForApp returns a app Deployment object.
-func (r *ReconcileMemcached) deploymentForApp(m *appv1alpha1.App) *appsv1.Deployment {
+func (r *ReconcileKind) deploymentForApp(m *appv1alpha1.App) *appsv1.Deployment {
 	lbls := labelsForApp(m.Name)
 	replicas := m.Spec.Size
 

--- a/doc/user/client.md
+++ b/doc/user/client.md
@@ -96,7 +96,7 @@ Reconcile is where Controller business logic lives, i.e. where Client API calls 
 // Returns an error 
 func (c Client) Create(ctx context.Context, obj runtime.Object) error
 ```
-
+Example:
 ```Go
 import (
 	"context"
@@ -125,7 +125,7 @@ func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, e
 // by the API server.
 func (c Client) Update(ctx context.Context, obj runtime.Object) error
 ```
-
+Example:
 ```Go
 import (
 	"context"
@@ -155,7 +155,7 @@ func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, e
 // Delete deletes the given obj from k8s cluster.
 func (c Client) Delete(ctx context.Context, obj runtime.Object, opts ...DeleteOptionFunc) error
 ```
-
+A `client.DeleteOptionFunc` sets fields of `client.DeleteOptions` to configurate a `Delete` call:
 ```Go
 // DeleteOptionFunc is a function that mutates a DeleteOptions struct.
 type DeleteOptionFunc func(*DeleteOptions)
@@ -185,7 +185,7 @@ type DeleteOptions struct {
     Raw *metav1.DeleteOptions
 }
 ```
-
+Example:
 ```Go
 import (
 	"context"
@@ -220,7 +220,7 @@ func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, e
 // and stores it in obj.
 func (c Client) Get(ctx context.Context, key ObjectKey, obj runtime.Object) error
 ```
-
+Example:
 ```Go
 import (
 	"context"
@@ -246,7 +246,7 @@ func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, e
 // and stores the list in obj.
 func (c Client) List(ctx context.Context, opts *ListOptions, obj runtime.Object) error
 ```
-
+A `client.ListOptions` sets filters and options for a `List` call:
 ```Go
 type ListOptions struct {
     // LabelSelector filters results by label.  Use SetLabelSelector to
@@ -268,7 +268,7 @@ type ListOptions struct {
     Raw *metav1.ListOptions
 }
 ```
-
+Example:
 ```Go
 import (
 	"context"

--- a/doc/user/client.md
+++ b/doc/user/client.md
@@ -155,7 +155,7 @@ func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, e
 // Delete deletes the given obj from k8s cluster.
 func (c Client) Delete(ctx context.Context, obj runtime.Object, opts ...DeleteOptionFunc) error
 ```
-A `client.DeleteOptionFunc` sets fields of `client.DeleteOptions` to configurate a `Delete` call:
+A `client.DeleteOptionFunc` sets fields of `client.DeleteOptions` to configure a `Delete` call:
 ```Go
 // DeleteOptionFunc is a function that mutates a DeleteOptions struct.
 type DeleteOptionFunc func(*DeleteOptions)

--- a/doc/user/client.md
+++ b/doc/user/client.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The [kubernetes-sigs][org-kubernetes-sigs] organization builds tools to call the [Kubernetes][site-kubernetes] API in a clean, abstracted manner, much like the Operator SDK. The [controller-runtime][repo-controller-runtime] project is meant to help users build [controllers][site-kubernetes-controllers] easily by generating a controller project that interacts with a k8s cluster via CRUD operations. A user-defined controller can perform a specific functions in a cluster; [operators][site-operators] can use multiple controllers to perform a variety of tasks. As operators use at least one controller, the SDK can rely on controller-runtime's k8s API code rather than develop a parallel set of API calls to execute the same cluster operations, namely CRUD operations.
+The [kubernetes-sigs][org-kubernetes-sigs] organization builds tools to call the [Kubernetes][site-kubernetes] API in a clean, abstracted manner, much like the Operator SDK. The [controller-runtime][repo-controller-runtime] project is meant to help users build [controllers][site-kubernetes-controllers] easily by generating a controller project that interacts with a k8s cluster via CRUD operations. User-defined controller can perform specific tasks in a cluster; [operators][site-operators] can use multiple controllers to perform a variety of tasks. As operators use at least one controller, the SDK can rely on controller-runtime's k8s API code rather than develop a parallel set of API calls to execute the same cluster operations, namely CRUD operations.
 
 controller-runtime defines several interfaces used for cluster interaction:
 - `client.Client`: implementers perform CRUD operations on a k8s cluster.

--- a/pkg/scaffold/controller_kind.go
+++ b/pkg/scaffold/controller_kind.go
@@ -108,7 +108,6 @@ var _ reconcile.Reconciler = &Reconcile{{ .Resource.Kind }}{}
 
 // Reconcile{{ .Resource.Kind }} reconciles a {{ .Resource.Kind }} object
 type Reconcile{{ .Resource.Kind }} struct {
-	// TODO: Clarify the split client
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
 	client client.Client

--- a/pkg/scaffold/controller_kind_test.go
+++ b/pkg/scaffold/controller_kind_test.go
@@ -108,7 +108,6 @@ var _ reconcile.Reconciler = &ReconcileAppService{}
 
 // ReconcileAppService reconciles a AppService object
 type ReconcileAppService struct {
-	// TODO: Clarify the split client
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
 	client client.Client


### PR DESCRIPTION
The refactor from SDK-specific k8s API calls to `kubernetes-sigs/controller-runtime` was
a large undertaking that changed project structure and how generated projects interact
with a k8s cluster. This document attempts to explain these changes to both new users
and developers of existing operators generated with SDK `<= v0.7.0`.
