### PR TITLE
test/ansible-operator: remove binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ tags
 
 # Build artifacts
 build/*
+test/ansible-operator/ansible-operator


### PR DESCRIPTION
**Description of the change:** The ansible-operator binary was unintentionally committed in a
previous PR. This commit removes the binary and adds its path to
the gitignore.


**Motivation for the change:** We shouldn't have binaries in our repo