### PR TITLE
pkg/scaffold/gopkgtoml: point to master branch

### DIFF
--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -74,7 +74,7 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  branch = "refactor/controller-runtime" #osdk_branch_annotation
+  branch = "master" #osdk_branch_annotation
   # version = "=v0.0.6" #osdk_version_annotation
 
 [prune]

--- a/pkg/scaffold/gopkgtoml_test.go
+++ b/pkg/scaffold/gopkgtoml_test.go
@@ -78,7 +78,7 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  branch = "refactor/controller-runtime" #osdk_branch_annotation
+  branch = "master" #osdk_branch_annotation
   # version = "=v0.0.6" #osdk_version_annotation
 
 [prune]


### PR DESCRIPTION
**Description of the change:** Make scaffolded Gopkg.toml point to master


**Motivation for the change:** The master branch version of the sdk should point to master

/cc @hasbro17 @shawn-hurley @estroz 