### PR TITLE
test/test-framework/memcached_test.go: bump timeout

### DIFF
--- a/test/test-framework/memcached_test.go
+++ b/test/test-framework/memcached_test.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	retryInterval        = time.Second * 5
-	timeout              = time.Second * 30
+	timeout              = time.Second * 60
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 5
 )


### PR DESCRIPTION
**Description of the change:** Bump `up local` subcommand test deployment check timeout from 30 seconds to 60 seconds.


**Motivation for the change:** The `up local` test is very flaky on travis. It seems to be mostly
a timeout issue, so we should be able to just bump it to fix the
flakes.