### PR TITLE
cmd: initial resource validation

### DIFF
--- a/commands/operator-sdk/cmd/generate/k8s.go
+++ b/commands/operator-sdk/cmd/generate/k8s.go
@@ -75,8 +75,6 @@ func K8sCodegen() {
 	fmt.Fprintln(os.Stdout, string(out))
 }
 
-const goExt = ".go"
-
 // getGroupVersions parses the layout of pkg/apis to return the API groups and versions
 // in the format "groupA:v1,v2 groupB:v1 groupC:v2",
 // as required by the generate-groups.sh script

--- a/commands/operator-sdk/cmd/generate/k8s.go
+++ b/commands/operator-sdk/cmd/generate/k8s.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 
 	"github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/cmdutil"
+	"github.com/operator-framework/operator-sdk/pkg/scaffold"
 
 	"github.com/spf13/cobra"
 )
@@ -94,10 +94,9 @@ func parseGroupVersions() (string, error) {
 				return "", fmt.Errorf("could not read %s directory to find api Versions: %v", groupDir, err)
 			}
 
-			versionRe := regexp.MustCompile("^v[1-9][0-9]*((alpha|beta)[1-9][0-9]*)?$")
 			groupVersion := ""
 			for _, v := range versions {
-				if v.IsDir() && versionRe.MatchString(v.Name()) {
+				if v.IsDir() && scaffold.ResourceVersionRegexp.MatchString(v.Name()) {
 					groupVersion = groupVersion + v.Name() + ","
 				}
 			}

--- a/commands/operator-sdk/cmd/generate/k8s.go
+++ b/commands/operator-sdk/cmd/generate/k8s.go
@@ -81,15 +81,16 @@ const goExt = ".go"
 // in the format "groupA:v1,v2 groupB:v1 groupC:v2",
 // as required by the generate-groups.sh script
 func parseGroupVersions() (string, error) {
-	groupVersions := make(map[string]string)
-	apisRoot := filepath.Join("pkg", "apis")
-	groups, err := ioutil.ReadDir(apisRoot)
+	groupVersions := ""
+	apisDir := filepath.Join("pkg", "apis")
+	groups, err := ioutil.ReadDir(apisDir)
 	if err != nil {
 		return "", fmt.Errorf("could not read pkg/apis directory to find api Versions: %v", err)
 	}
+
 	for _, g := range groups {
 		if g.IsDir() {
-			groupDir := filepath.Join(apisRoot, g.Name())
+			groupDir := filepath.Join(apisDir, g.Name())
 			versions, err := ioutil.ReadDir(groupDir)
 			if err != nil {
 				return "", fmt.Errorf("could not read %s directory to find api Versions: %v", groupDir, err)
@@ -102,14 +103,9 @@ func parseGroupVersions() (string, error) {
 					groupVersion = groupVersion + v.Name() + ","
 				}
 			}
-
-			groupVersions[g.Name()] = groupVersion
+			groupVersions += fmt.Sprintf("%s:%s ", g.Name(), groupVersion)
 		}
 	}
 
-	mapStr := ""
-	for k, v := range groupVersions {
-		mapStr += fmt.Sprintf("%s:%s ", k, v)
-	}
-	return mapStr, nil
+	return groupVersions, nil
 }

--- a/pkg/scaffold/resource.go
+++ b/pkg/scaffold/resource.go
@@ -135,7 +135,7 @@ func (r *Resource) checkAndSetVersion() error {
 		return errors.New("version cannot be empty")
 	}
 	if !ResourceVersionRegexp.MatchString(r.Version) {
-		return errors.New("version is not in the correct Kubernetes version format")
+		return errors.New("version is not in the correct Kubernetes version format, ex. v1alpha1")
 	}
 	return nil
 }

--- a/pkg/scaffold/resource.go
+++ b/pkg/scaffold/resource.go
@@ -19,10 +19,15 @@ package scaffold
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/markbates/inflect"
 )
+
+// ResourceVersionRegexp matches Kubernetes API versions.
+// See https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning
+var ResourceVersionRegexp = regexp.MustCompile("^v[1-9][0-9]*((alpha|beta)[1-9][0-9]*)?$")
 
 // Resource contains the information required to scaffold files for a resource.
 type Resource struct {
@@ -98,7 +103,9 @@ func (r *Resource) Validate() error {
 
 	// TODO: regex match group (without subdomain) must be lowercased [a-z]
 
-	// TODO: regex match version to be v1, v1alpha1, v1beta1 etc
+	if !ResourceVersionRegexp.MatchString(r.Version) {
+		return errors.New("version is not of correct format")
+	}
 
 	return nil
 }

--- a/pkg/scaffold/resource.go
+++ b/pkg/scaffold/resource.go
@@ -25,9 +25,15 @@ import (
 	"github.com/markbates/inflect"
 )
 
-// ResourceVersionRegexp matches Kubernetes API versions.
-// See https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning
-var ResourceVersionRegexp = regexp.MustCompile("^v[1-9][0-9]*((alpha|beta)[1-9][0-9]*)?$")
+var (
+	// ResourceVersionRegexp matches Kubernetes API versions.
+	// See https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning
+	ResourceVersionRegexp = regexp.MustCompile("^v[1-9][0-9]*((alpha|beta)[1-9][0-9]*)?$")
+	// ResourceKindRegexp matches Kubernetes API Kind's.
+	ResourceKindRegexp = regexp.MustCompile("^[a-zA-Z]+$")
+	// ResourceGroupRegexp matches Kubernetes API Group's.
+	ResourceGroupRegexp = regexp.MustCompile("^[a-z]+$")
+)
 
 // Resource contains the information required to scaffold files for a resource.
 type Resource struct {
@@ -75,25 +81,14 @@ func (r *Resource) Validate() error {
 		return errors.New("api-version cannot be empty")
 	}
 
-	r.FullGroup = strings.Split(r.APIVersion, "/")[0]
-	r.Version = strings.Split(r.APIVersion, "/")[1]
-	r.Group = strings.Split(r.FullGroup, ".")[0]
-
-	if len(r.Group) == 0 {
-		return errors.New("group cannot be empty")
+	if err := r.checkAndSetKinds(); err != nil {
+		return err
 	}
-	if len(r.Version) == 0 {
-		return errors.New("version cannot be empty")
+	if err := r.checkAndSetGroups(); err != nil {
+		return err
 	}
-	if len(r.Kind) == 0 {
-		return errors.New("kind cannot be empty")
-	}
-
-	r.LowerKind = strings.ToLower(r.Kind)
-
-	// TODO: regex match kind to only be [aA-zZ]]
-	if strings.Title(r.Kind) != r.Kind {
-		return fmt.Errorf("kind must begin with uppercase (was %v)", r.Kind)
+	if err := r.checkAndSetVersion(); err != nil {
+		return err
 	}
 
 	rs := inflect.NewDefaultRuleset()
@@ -101,11 +96,46 @@ func (r *Resource) Validate() error {
 		r.Resource = rs.Pluralize(strings.ToLower(r.Kind))
 	}
 
-	// TODO: regex match group (without subdomain) must be lowercased [a-z]
+	return nil
+}
 
-	if !ResourceVersionRegexp.MatchString(r.Version) {
-		return errors.New("version is not of correct format")
+func (r *Resource) checkAndSetKinds() error {
+	if len(r.Kind) == 0 {
+		return errors.New("kind cannot be empty")
 	}
 
+	r.LowerKind = strings.ToLower(r.Kind)
+
+	if strings.Title(r.Kind) != r.Kind {
+		return fmt.Errorf("kind must begin with uppercase (was %v)", r.Kind)
+	}
+	if !ResourceKindRegexp.MatchString(r.Kind) {
+		return errors.New("kind should consist of lower and uppercase alphabetical characters")
+	}
+	return nil
+}
+
+func (r *Resource) checkAndSetGroups() error {
+	r.FullGroup = strings.Split(r.APIVersion, "/")[0]
+	r.Group = strings.Split(r.FullGroup, ".")[0]
+
+	if len(r.Group) == 0 {
+		return errors.New("group cannot be empty")
+	}
+	if !ResourceGroupRegexp.MatchString(r.Group) {
+		return errors.New("group should consist of lowercase alphabetical characters")
+	}
+	return nil
+}
+
+func (r *Resource) checkAndSetVersion() error {
+	r.Version = strings.Split(r.APIVersion, "/")[1]
+
+	if len(r.Version) == 0 {
+		return errors.New("version cannot be empty")
+	}
+	if !ResourceVersionRegexp.MatchString(r.Version) {
+		return errors.New("version is not in the correct Kubernetes version format")
+	}
 	return nil
 }


### PR DESCRIPTION
**Description of the change:** `K8sCodegen()` requires groups and versions of operator API's when generating `deepcopy` functions and types. This change ensures only specific directories are used when parsing groups and versions for generating `deepcopy` code. Furthermore, resource fields such as API versions should be validated on creation.

**Motivation for the change:** currently, `deepcopy` generation looks at all files and directories in `pkg/api` in a brute-force manner. We need filtering to produce better user-facing output. Resources with invalid field names cannot be understood by the Kubernetes API and should be validated before they are created by the SDK