### PR TITLE
Constants refactor

### DIFF
--- a/commands/operator-sdk/cmd/add/crd.go
+++ b/commands/operator-sdk/cmd/add/crd.go
@@ -28,11 +28,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	goDir        = "GOPATH"
-	deployCrdDir = "deploy"
-)
-
 // NewAddCrdCmd - add crd command
 func NewAddCrdCmd() *cobra.Command {
 	crdCmd := &cobra.Command{
@@ -111,8 +106,8 @@ func verifyCrdDeployPath() {
 		log.Fatalf("failed to determine the full path of the current directory: %v", err)
 	}
 	// check if the deploy sub-directory exist
-	_, err = os.Stat(filepath.Join(wd, deployCrdDir))
+	_, err = os.Stat(filepath.Join(wd, scaffold.DeployDir))
 	if err != nil {
-		log.Fatalf("the path (./%v) does not exist. run this command in your project directory", deployCrdDir)
+		log.Fatalf("the path (./%v) does not exist. run this command in your project directory", scaffold.DeployDir)
 	}
 }

--- a/commands/operator-sdk/cmd/build.go
+++ b/commands/operator-sdk/cmd/build.go
@@ -132,10 +132,6 @@ func verifyTestManifest(image string) {
 	}
 }
 
-const (
-	mainGo = "./cmd/manager/main.go"
-)
-
 func buildFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		log.Fatalf("build command needs exactly 1 argument")
@@ -150,8 +146,8 @@ func buildFunc(cmd *cobra.Command, args []string) {
 
 	// Don't need to buld go code if Ansible Operator
 	if mainExists() {
-		managerDir := filepath.Join(cmdutil.CheckAndGetCurrPkg(), "cmd/manager")
-		outputBinName := filepath.Join(wd, "build/_output/bin", filepath.Base(wd))
+		managerDir := filepath.Join(cmdutil.CheckAndGetCurrPkg(), scaffold.ManagerDir)
+		outputBinName := filepath.Join(wd, scaffold.BuildBinDir, filepath.Base(wd))
 		buildCmd := exec.Command("go", "build", "-o", outputBinName, managerDir)
 		buildCmd.Env = goBuildEnv
 		o, err := buildCmd.CombinedOutput()
@@ -178,7 +174,8 @@ func buildFunc(cmd *cobra.Command, args []string) {
 	fmt.Fprintln(os.Stdout, string(o))
 
 	if enableTests {
-		buildTestCmd := exec.Command("go", "test", "-c", "-o", filepath.Join(wd, "build/_output/bin", filepath.Base(wd)+"-test"), testLocationBuild+"/...")
+		testBinary := filepath.Join(wd, scaffold.BuildBinDir, filepath.Base(wd)+"-test")
+		buildTestCmd := exec.Command("go", "test", "-c", "-o", testBinary, testLocationBuild+"/...")
 		buildTestCmd.Env = goBuildEnv
 		o, err := buildTestCmd.CombinedOutput()
 		if err != nil {
@@ -186,7 +183,8 @@ func buildFunc(cmd *cobra.Command, args []string) {
 		}
 		fmt.Fprintln(os.Stdout, string(o))
 		// if a user is using an older sdk repo as their library, make sure they have required build files
-		_, err = os.Stat("build/test-framework/Dockerfile")
+		testDockerfile := filepath.Join(scaffold.BuildTestDir, scaffold.DockerfileFile)
+		_, err = os.Stat(testDockerfile)
 		if err != nil && os.IsNotExist(err) {
 
 			absProjectPath := cmdutil.MustGetwd()
@@ -207,7 +205,7 @@ func buildFunc(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		testDbcmd := exec.Command("docker", "build", ".", "-f", "build/test-framework/Dockerfile", "-t", image, "--build-arg", "NAMESPACEDMAN="+namespacedManBuild, "--build-arg", "BASEIMAGE="+baseImageName)
+		testDbcmd := exec.Command("docker", "build", ".", "-f", testDockerfile, "-t", image, "--build-arg", "NAMESPACEDMAN="+namespacedManBuild, "--build-arg", "BASEIMAGE="+baseImageName)
 		o, err = testDbcmd.CombinedOutput()
 		if err != nil {
 			log.Fatalf("failed to output build image %s: %v (%s)", image, err, string(o))
@@ -219,8 +217,6 @@ func buildFunc(cmd *cobra.Command, args []string) {
 }
 
 func mainExists() bool {
-	if _, err := os.Stat(mainGo); err == nil {
-		return true
-	}
-	return false
+	_, err := os.Stat(filepath.Join(scaffold.ManagerDir, scaffold.CmdFile))
+	return err == nil
 }

--- a/commands/operator-sdk/cmd/generate/k8s.go
+++ b/commands/operator-sdk/cmd/generate/k8s.go
@@ -51,7 +51,7 @@ func K8sCodegen() {
 	cmdutil.MustInProjectRoot()
 	repoPkg := cmdutil.CheckAndGetCurrPkg()
 	outputPkg := filepath.Join(repoPkg, "pkg/generated")
-	apisPkg := filepath.Join(repoPkg, "pkg/apis")
+	apisPkg := filepath.Join(repoPkg, scaffold.ApisDir)
 	groupVersions, err := parseGroupVersions()
 	if err != nil {
 		log.Fatalf("failed to parse group versions: (%v)", err)
@@ -79,16 +79,15 @@ func K8sCodegen() {
 // in the format "groupA:v1,v2 groupB:v1 groupC:v2",
 // as required by the generate-groups.sh script
 func parseGroupVersions() (string, error) {
-	groupVersions := ""
-	apisDir := filepath.Join("pkg", "apis")
-	groups, err := ioutil.ReadDir(apisDir)
+	var groupVersions string
+	groups, err := ioutil.ReadDir(scaffold.ApisDir)
 	if err != nil {
 		return "", fmt.Errorf("could not read pkg/apis directory to find api Versions: %v", err)
 	}
 
 	for _, g := range groups {
 		if g.IsDir() {
-			groupDir := filepath.Join(apisDir, g.Name())
+			groupDir := filepath.Join(scaffold.ApisDir, g.Name())
 			versions, err := ioutil.ReadDir(groupDir)
 			if err != nil {
 				return "", fmt.Errorf("could not read %s directory to find api Versions: %v", groupDir, err)

--- a/commands/operator-sdk/cmd/test/cluster.go
+++ b/commands/operator-sdk/cmd/test/cluster.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/operator-framework/operator-sdk/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/pkg/test"
 
 	"github.com/spf13/cobra"
@@ -89,7 +90,7 @@ func testClusterFunc(cmd *cobra.Command, args []string) error {
 				Name:            "operator-test",
 				Image:           args[0],
 				ImagePullPolicy: pullPolicy,
-				Command:         []string{"/go-test.sh"},
+				Command:         []string{"/" + scaffold.GoTestScriptFile},
 				Env: []v1.EnvVar{{
 					Name:      test.TestNamespaceEnv,
 					ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},

--- a/commands/operator-sdk/cmd/test/local.go
+++ b/commands/operator-sdk/cmd/test/local.go
@@ -24,10 +24,13 @@ import (
 	"strings"
 
 	"github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/cmdutil"
+	"github.com/operator-framework/operator-sdk/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/pkg/test"
 
 	"github.com/spf13/cobra"
 )
+
+var deployTestDir = filepath.Join(scaffold.DeployDir, "test")
 
 type testLocalConfig struct {
 	kubeconfig        string
@@ -65,25 +68,26 @@ func testLocalFunc(cmd *cobra.Command, args []string) {
 	}
 	// if no namespaced manifest path is given, combine deploy/service_account.yaml, deploy/role.yaml, deploy/role_binding.yaml and deploy/operator.yaml
 	if tlConfig.namespacedManPath == "" {
-		err := os.MkdirAll("deploy/test", os.FileMode(cmdutil.DefaultDirFileMode))
+		err := os.MkdirAll(deployTestDir, os.FileMode(cmdutil.DefaultDirFileMode))
 		if err != nil {
-			log.Fatalf("could not create deploy/test: %v", err)
+			log.Fatalf("could not create %s: %v", deployTestDir, err)
 		}
-		tlConfig.namespacedManPath = "deploy/test/namespace-manifests.yaml"
+		tlConfig.namespacedManPath = filepath.Join(deployTestDir, "namespace-manifests.yaml")
 
-		sa, err := ioutil.ReadFile("deploy/service_account.yaml")
+		saFile := filepath.Join(scaffold.DeployDir, scaffold.ServiceAccountYamlFile)
+		sa, err := ioutil.ReadFile(saFile)
 		if err != nil {
-			log.Fatalf("could not find the manifest deploy/service_account.yaml: %v", err)
+			log.Fatalf("could not find the manifest %s: %v", saFile, err)
 		}
-		role, err := ioutil.ReadFile("deploy/role.yaml")
+		role, err := ioutil.ReadFile(filepath.Join(scaffold.DeployDir, scaffold.RoleYamlFile))
 		if err != nil {
 			log.Fatalf("could not find role manifest: %v", err)
 		}
-		roleBinding, err := ioutil.ReadFile("deploy/role_binding.yaml")
+		roleBinding, err := ioutil.ReadFile(filepath.Join(scaffold.DeployDir, scaffold.RoleBindingYamlFile))
 		if err != nil {
 			log.Fatalf("could not find role_binding manifest: %v", err)
 		}
-		operator, err := ioutil.ReadFile("deploy/operator.yaml")
+		operator, err := ioutil.ReadFile(filepath.Join(scaffold.DeployDir, scaffold.OperatorYamlFile))
 		if err != nil {
 			log.Fatalf("could not find operator manifest: %v", err)
 		}
@@ -105,21 +109,21 @@ func testLocalFunc(cmd *cobra.Command, args []string) {
 		}()
 	}
 	if tlConfig.globalManPath == "" {
-		err := os.MkdirAll("deploy/test", os.FileMode(cmdutil.DefaultDirFileMode))
+		err := os.MkdirAll(deployTestDir, os.FileMode(cmdutil.DefaultDirFileMode))
 		if err != nil {
-			log.Fatalf("could not create deploy/test: %v", err)
+			log.Fatalf("could not create %s: %v", deployTestDir, err)
 		}
-		tlConfig.globalManPath = "deploy/test/global-manifests.yaml"
-		files, err := ioutil.ReadDir("deploy/crds")
+		tlConfig.globalManPath = filepath.Join(deployTestDir, "global-manifests.yaml")
+		files, err := ioutil.ReadDir(scaffold.CrdsDir)
 		if err != nil {
 			log.Fatalf("could not read deploy directory: %v", err)
 		}
 		var combined []byte
 		for _, file := range files {
 			if strings.HasSuffix(file.Name(), "crd.yaml") {
-				fileBytes, err := ioutil.ReadFile(filepath.Join("deploy/crds", file.Name()))
+				fileBytes, err := ioutil.ReadFile(filepath.Join(scaffold.CrdsDir, file.Name()))
 				if err != nil {
-					log.Fatalf("could not read file deploy/crds/%s: %v", file.Name(), err)
+					log.Fatalf("could not read file %s: %v", filepath.Join(scaffold.CrdsDir, file.Name()), err)
 				}
 				if combined == nil {
 					combined = []byte{}

--- a/commands/operator-sdk/cmd/up/local.go
+++ b/commands/operator-sdk/cmd/up/local.go
@@ -29,8 +29,11 @@ import (
 	"github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/cmdutil"
 	ansibleOperator "github.com/operator-framework/operator-sdk/pkg/ansible/operator"
 	proxy "github.com/operator-framework/operator-sdk/pkg/ansible/proxy"
+	"github.com/operator-framework/operator-sdk/pkg/scaffold"
+	ansibleScaffold "github.com/operator-framework/operator-sdk/pkg/scaffold/ansible"
 	"github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -96,7 +99,7 @@ func mustKubeConfig() {
 }
 
 func upLocal() {
-	args := []string{"run", filepath.Join("cmd", "manager", "main.go")}
+	args := []string{"run", filepath.Join(scaffold.ManagerDir, scaffold.CmdFile)}
 	if operatorFlags != "" {
 		extraArgs := strings.Split(operatorFlags, " ")
 		args = append(args, extraArgs...)
@@ -142,7 +145,7 @@ func upLocalAnsible() {
 	}
 
 	// start the operator
-	go ansibleOperator.Run(done, mgr, "./watches.yaml")
+	go ansibleOperator.Run(done, mgr, "./"+ansibleScaffold.WatchesYamlFile)
 
 	// wait for either to finish
 	err = <-done

--- a/pkg/scaffold/add_controller.go
+++ b/pkg/scaffold/add_controller.go
@@ -31,7 +31,7 @@ type AddController struct {
 func (s *AddController) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		fileName := "add_" + s.Resource.LowerKind + ".go"
-		s.Path = filepath.Join(controllerDir, fileName)
+		s.Path = filepath.Join(ControllerDir, fileName)
 	}
 	s.TemplateBody = addControllerTemplate
 	return s.Input, nil

--- a/pkg/scaffold/addtoscheme.go
+++ b/pkg/scaffold/addtoscheme.go
@@ -35,7 +35,7 @@ func (s *AddToScheme) GetInput() (input.Input, error) {
 		fileName := fmt.Sprintf("addtoscheme_%s_%s.go",
 			strings.ToLower(s.Resource.Group),
 			strings.ToLower(s.Resource.Version))
-		s.Path = filepath.Join(apisDir, fileName)
+		s.Path = filepath.Join(ApisDir, fileName)
 	}
 	s.TemplateBody = addToSchemeTemplate
 	return s.Input, nil

--- a/pkg/scaffold/ansible/dockerfile.go
+++ b/pkg/scaffold/ansible/dockerfile.go
@@ -17,6 +17,7 @@ package ansible
 import (
 	"path/filepath"
 
+	"github.com/operator-framework/operator-sdk/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
@@ -30,7 +31,7 @@ type Dockerfile struct {
 // GetInput - gets the input
 func (d *Dockerfile) GetInput() (input.Input, error) {
 	if d.Path == "" {
-		d.Path = filepath.Join("build", "Dockerfile")
+		d.Path = filepath.Join(scaffold.BuildDir, scaffold.DockerfileFile)
 	}
 	d.TemplateBody = dockerFileAnsibleTmpl
 	return d.Input, nil

--- a/pkg/scaffold/ansible/operator.go
+++ b/pkg/scaffold/ansible/operator.go
@@ -17,6 +17,7 @@ package ansible
 import (
 	"path/filepath"
 
+	"github.com/operator-framework/operator-sdk/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
@@ -26,7 +27,7 @@ type Operator struct {
 
 func (s *Operator) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join("deploy", "operator.yaml")
+		s.Path = filepath.Join(scaffold.DeployDir, scaffold.OperatorYamlFile)
 	}
 	s.TemplateBody = operatorTemplate
 	return s.Input, nil

--- a/pkg/scaffold/ansible/playbook.go
+++ b/pkg/scaffold/ansible/playbook.go
@@ -19,6 +19,8 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const PlaybookYamlFile = "playbook.yaml"
+
 // Playbook - the playbook tmpl wrapper
 type Playbook struct {
 	input.Input
@@ -28,7 +30,7 @@ type Playbook struct {
 // GetInput - gets the input
 func (p *Playbook) GetInput() (input.Input, error) {
 	if p.Path == "" {
-		p.Path = "playbook.yaml"
+		p.Path = PlaybookYamlFile
 	}
 	p.TemplateBody = playbookTmpl
 	return p.Input, nil

--- a/pkg/scaffold/ansible/watches.go
+++ b/pkg/scaffold/ansible/watches.go
@@ -19,9 +19,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
-const (
-	watchesFile = "watches.yaml"
-)
+const WatchesYamlFile = "watches.yaml"
 
 // WatchesYAML - watches yaml input wrapper
 type WatchesYAML struct {
@@ -34,7 +32,7 @@ type WatchesYAML struct {
 // GetInput - gets the input
 func (s *WatchesYAML) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = watchesFile
+		s.Path = WatchesYamlFile
 	}
 	s.TemplateBody = watchesYAMLTmpl
 	return s.Input, nil

--- a/pkg/scaffold/apis.go
+++ b/pkg/scaffold/apis.go
@@ -28,7 +28,7 @@ type Apis struct {
 
 func (s *Apis) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(apisDir, ApisFile)
+		s.Path = filepath.Join(ApisDir, ApisFile)
 	}
 	s.TemplateBody = apisTmpl
 	return s.Input, nil

--- a/pkg/scaffold/apis.go
+++ b/pkg/scaffold/apis.go
@@ -20,13 +20,15 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const ApisFile = "apis.go"
+
 type Apis struct {
 	input.Input
 }
 
 func (s *Apis) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(apisDir, apisFile)
+		s.Path = filepath.Join(apisDir, ApisFile)
 	}
 	s.TemplateBody = apisTmpl
 	return s.Input, nil

--- a/pkg/scaffold/build_dockerfile.go
+++ b/pkg/scaffold/build_dockerfile.go
@@ -20,13 +20,15 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const DockerfileFile = "Dockerfile"
+
 type Dockerfile struct {
 	input.Input
 }
 
 func (s *Dockerfile) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(buildDir, dockerfileFile)
+		s.Path = filepath.Join(buildDir, DockerfileFile)
 	}
 	s.TemplateBody = dockerfileTmpl
 	return s.Input, nil

--- a/pkg/scaffold/build_dockerfile.go
+++ b/pkg/scaffold/build_dockerfile.go
@@ -28,7 +28,7 @@ type Dockerfile struct {
 
 func (s *Dockerfile) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(buildDir, DockerfileFile)
+		s.Path = filepath.Join(BuildDir, DockerfileFile)
 	}
 	s.TemplateBody = dockerfileTmpl
 	return s.Input, nil

--- a/pkg/scaffold/cmd.go
+++ b/pkg/scaffold/cmd.go
@@ -20,13 +20,15 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const CmdFile = "main.go"
+
 type Cmd struct {
 	input.Input
 }
 
 func (s *Cmd) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(managerDir, cmdFile)
+		s.Path = filepath.Join(managerDir, CmdFile)
 	}
 	s.TemplateBody = cmdTmpl
 	return s.Input, nil

--- a/pkg/scaffold/cmd.go
+++ b/pkg/scaffold/cmd.go
@@ -28,7 +28,7 @@ type Cmd struct {
 
 func (s *Cmd) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(managerDir, CmdFile)
+		s.Path = filepath.Join(ManagerDir, CmdFile)
 	}
 	s.TemplateBody = cmdTmpl
 	return s.Input, nil

--- a/pkg/scaffold/constants.go
+++ b/pkg/scaffold/constants.go
@@ -23,15 +23,15 @@ const (
 	filePathSep = string(filepath.Separator)
 
 	// dirs
-	cmdDir        = "cmd"
-	managerDir    = cmdDir + filePathSep + "manager"
-	pkgDir        = "pkg"
-	apisDir       = pkgDir + filePathSep + "apis"
-	controllerDir = pkgDir + filePathSep + "controller"
-	buildDir      = "build"
-	buildTestDir  = buildDir + filePathSep + "test-framework"
-	deployDir     = "deploy"
-	olmCatalogDir = deployDir + filePathSep + "olm-catalog"
-	crdsDir       = deployDir + filePathSep + "crds"
-	versionDir    = "version"
+	CmdDir        = "cmd"
+	ManagerDir    = CmdDir + filePathSep + "manager"
+	PkgDir        = "pkg"
+	ApisDir       = PkgDir + filePathSep + "apis"
+	ControllerDir = PkgDir + filePathSep + "controller"
+	BuildDir      = "build"
+	BuildTestDir  = BuildDir + filePathSep + "test-framework"
+	DeployDir     = "deploy"
+	OlmCatalogDir = DeployDir + filePathSep + "olm-catalog"
+	CrdsDir       = DeployDir + filePathSep + "crds"
+	VersionDir    = "version"
 )

--- a/pkg/scaffold/constants.go
+++ b/pkg/scaffold/constants.go
@@ -30,6 +30,7 @@ const (
 	ControllerDir = PkgDir + filePathSep + "controller"
 	BuildDir      = "build"
 	BuildTestDir  = BuildDir + filePathSep + "test-framework"
+	BuildBinDir   = BuildDir + filePathSep + "_output" + filePathSep + "bin"
 	DeployDir     = "deploy"
 	OlmCatalogDir = DeployDir + filePathSep + "olm-catalog"
 	CrdsDir       = DeployDir + filePathSep + "crds"

--- a/pkg/scaffold/constants.go
+++ b/pkg/scaffold/constants.go
@@ -19,10 +19,6 @@ import (
 )
 
 const (
-	// Boolean values for Input.IsExec
-	isExecTrue  = true
-	isExecFalse = false
-
 	// Separator to statically create directories.
 	filePathSep = string(filepath.Separator)
 
@@ -38,24 +34,4 @@ const (
 	olmCatalogDir = deployDir + filePathSep + "olm-catalog"
 	crdsDir       = deployDir + filePathSep + "crds"
 	versionDir    = "version"
-
-	// files
-	cmdFile                = "main.go"
-	apisFile               = "apis.go"
-	controllerFile         = "controller.go"
-	dockerfileFile         = "Dockerfile"
-	goTestScriptFile       = "go-test.sh"
-	versionFile            = "version.go"
-	docFile                = "doc.go"
-	registerFile           = "register.go"
-	serviceAccountYamlFile = "service_account.yaml"
-	roleYamlFile           = "role.yaml"
-	roleBindingYamlFile    = "role_binding.yaml"
-	operatorYamlFile       = "operator.yaml"
-	catalogPackageYamlFile = "package.yaml"
-	catalogCSVYamlFile     = "csv.yaml"
-	testPodYamlFile        = "test-pod.yaml"
-	gitignoreFile          = ".gitignore"
-	gopkgtomlFile          = "Gopkg.toml"
-	gopkglockFile          = "Gopkg.lock"
 )

--- a/pkg/scaffold/controller.go
+++ b/pkg/scaffold/controller.go
@@ -20,13 +20,15 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const ControllerFile = "controller.go"
+
 type Controller struct {
 	input.Input
 }
 
 func (s *Controller) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(controllerDir, controllerFile)
+		s.Path = filepath.Join(controllerDir, ControllerFile)
 	}
 	s.TemplateBody = controllerTmpl
 	return s.Input, nil

--- a/pkg/scaffold/controller.go
+++ b/pkg/scaffold/controller.go
@@ -28,7 +28,7 @@ type Controller struct {
 
 func (s *Controller) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(controllerDir, ControllerFile)
+		s.Path = filepath.Join(ControllerDir, ControllerFile)
 	}
 	s.TemplateBody = controllerTmpl
 	return s.Input, nil

--- a/pkg/scaffold/controller_kind.go
+++ b/pkg/scaffold/controller_kind.go
@@ -31,7 +31,7 @@ type ControllerKind struct {
 func (s *ControllerKind) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		fileName := s.Resource.LowerKind + "_controller.go"
-		s.Path = filepath.Join(controllerDir, s.Resource.LowerKind, fileName)
+		s.Path = filepath.Join(ControllerDir, s.Resource.LowerKind, fileName)
 	}
 	// Error if this file exists.
 	s.IfExistsAction = input.Error

--- a/pkg/scaffold/cr.go
+++ b/pkg/scaffold/cr.go
@@ -36,7 +36,7 @@ func (s *Cr) GetInput() (input.Input, error) {
 			strings.ToLower(s.Resource.Group),
 			strings.ToLower(s.Resource.Version),
 			s.Resource.LowerKind)
-		s.Path = filepath.Join(crdsDir, fileName)
+		s.Path = filepath.Join(CrdsDir, fileName)
 	}
 	s.TemplateBody = crTemplate
 	return s.Input, nil

--- a/pkg/scaffold/crd.go
+++ b/pkg/scaffold/crd.go
@@ -36,7 +36,7 @@ func (s *Crd) GetInput() (input.Input, error) {
 			strings.ToLower(s.Resource.Group),
 			strings.ToLower(s.Resource.Version),
 			s.Resource.LowerKind)
-		s.Path = filepath.Join(crdsDir, fileName)
+		s.Path = filepath.Join(CrdsDir, fileName)
 	}
 	s.TemplateBody = crdTemplate
 	return s.Input, nil

--- a/pkg/scaffold/doc.go
+++ b/pkg/scaffold/doc.go
@@ -21,6 +21,8 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const DocFile = "doc.go"
+
 // Doc is the input needed to generate a pkg/apis/<group>/<version>/doc.go file
 type Doc struct {
 	input.Input
@@ -34,7 +36,7 @@ func (s *Doc) GetInput() (input.Input, error) {
 		s.Path = filepath.Join(apisDir,
 			strings.ToLower(s.Resource.Group),
 			strings.ToLower(s.Resource.Version),
-			docFile)
+			DocFile)
 	}
 	s.IfExistsAction = input.Skip
 	s.TemplateBody = docTemplate

--- a/pkg/scaffold/doc.go
+++ b/pkg/scaffold/doc.go
@@ -33,7 +33,7 @@ type Doc struct {
 
 func (s *Doc) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(apisDir,
+		s.Path = filepath.Join(ApisDir,
 			strings.ToLower(s.Resource.Group),
 			strings.ToLower(s.Resource.Version),
 			DocFile)

--- a/pkg/scaffold/gitignore.go
+++ b/pkg/scaffold/gitignore.go
@@ -18,13 +18,15 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const GitignoreFile = ".gitignore"
+
 type Gitignore struct {
 	input.Input
 }
 
 func (s *Gitignore) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = gitignoreFile
+		s.Path = GitignoreFile
 	}
 	s.TemplateBody = gitignoreTmpl
 	return s.Input, nil

--- a/pkg/scaffold/go_test_script.go
+++ b/pkg/scaffold/go_test_script.go
@@ -28,7 +28,7 @@ type GoTestScript struct {
 
 func (s *GoTestScript) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(buildTestDir, GoTestScriptFile)
+		s.Path = filepath.Join(BuildTestDir, GoTestScriptFile)
 	}
 	s.IsExec = true
 	s.TemplateBody = goTestScriptTmpl

--- a/pkg/scaffold/go_test_script.go
+++ b/pkg/scaffold/go_test_script.go
@@ -20,15 +20,17 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const GoTestScriptFile = "go-test.sh"
+
 type GoTestScript struct {
 	input.Input
 }
 
 func (s *GoTestScript) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(buildTestDir, goTestScriptFile)
+		s.Path = filepath.Join(buildTestDir, GoTestScriptFile)
 	}
-	s.IsExec = isExecTrue
+	s.IsExec = true
 	s.TemplateBody = goTestScriptTmpl
 	return s.Input, nil
 }

--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -18,13 +18,15 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const GopkgTomlFile = "Gopkg.toml"
+
 type GopkgToml struct {
 	input.Input
 }
 
 func (s *GopkgToml) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = gopkgtomlFile
+		s.Path = GopkgTomlFile
 	}
 	s.TemplateBody = gopkgTomlTmpl
 	return s.Input, nil

--- a/pkg/scaffold/operator.go
+++ b/pkg/scaffold/operator.go
@@ -28,7 +28,7 @@ type Operator struct {
 
 func (s *Operator) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(deployDir, OperatorYamlFile)
+		s.Path = filepath.Join(DeployDir, OperatorYamlFile)
 	}
 	s.TemplateBody = operatorTemplate
 	return s.Input, nil

--- a/pkg/scaffold/operator.go
+++ b/pkg/scaffold/operator.go
@@ -20,13 +20,15 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const OperatorYamlFile = "operator.yaml"
+
 type Operator struct {
 	input.Input
 }
 
 func (s *Operator) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(deployDir, operatorYamlFile)
+		s.Path = filepath.Join(deployDir, OperatorYamlFile)
 	}
 	s.TemplateBody = operatorTemplate
 	return s.Input, nil

--- a/pkg/scaffold/register.go
+++ b/pkg/scaffold/register.go
@@ -21,6 +21,8 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const RegisterFile = "register.go"
+
 // Register is the input needed to generate a pkg/apis/<group>/<version>/register.go file
 type Register struct {
 	input.Input
@@ -34,7 +36,7 @@ func (s *Register) GetInput() (input.Input, error) {
 		s.Path = filepath.Join(apisDir,
 			strings.ToLower(s.Resource.Group),
 			strings.ToLower(s.Resource.Version),
-			registerFile)
+			RegisterFile)
 	}
 	// Do not overwrite this file if it exists.
 	s.IfExistsAction = input.Skip

--- a/pkg/scaffold/register.go
+++ b/pkg/scaffold/register.go
@@ -33,7 +33,7 @@ type Register struct {
 
 func (s *Register) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(apisDir,
+		s.Path = filepath.Join(ApisDir,
 			strings.ToLower(s.Resource.Group),
 			strings.ToLower(s.Resource.Version),
 			RegisterFile)

--- a/pkg/scaffold/role.go
+++ b/pkg/scaffold/role.go
@@ -28,7 +28,7 @@ type Role struct {
 
 func (s *Role) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(deployDir, RoleYamlFile)
+		s.Path = filepath.Join(DeployDir, RoleYamlFile)
 	}
 	s.TemplateBody = roleTemplate
 	return s.Input, nil

--- a/pkg/scaffold/role.go
+++ b/pkg/scaffold/role.go
@@ -20,13 +20,15 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const RoleYamlFile = "role.yaml"
+
 type Role struct {
 	input.Input
 }
 
 func (s *Role) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(deployDir, roleYamlFile)
+		s.Path = filepath.Join(deployDir, RoleYamlFile)
 	}
 	s.TemplateBody = roleTemplate
 	return s.Input, nil

--- a/pkg/scaffold/rolebinding.go
+++ b/pkg/scaffold/rolebinding.go
@@ -20,13 +20,15 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const RoleBindingYamlFile = "role_binding.yaml"
+
 type RoleBinding struct {
 	input.Input
 }
 
 func (s *RoleBinding) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(deployDir, roleBindingYamlFile)
+		s.Path = filepath.Join(deployDir, RoleBindingYamlFile)
 	}
 	s.TemplateBody = roleBindingTemplate
 	return s.Input, nil

--- a/pkg/scaffold/rolebinding.go
+++ b/pkg/scaffold/rolebinding.go
@@ -28,7 +28,7 @@ type RoleBinding struct {
 
 func (s *RoleBinding) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(deployDir, RoleBindingYamlFile)
+		s.Path = filepath.Join(DeployDir, RoleBindingYamlFile)
 	}
 	s.TemplateBody = roleBindingTemplate
 	return s.Input, nil

--- a/pkg/scaffold/service_account.go
+++ b/pkg/scaffold/service_account.go
@@ -20,13 +20,15 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const ServiceAccountYamlFile = "service_account.yaml"
+
 type ServiceAccount struct {
 	input.Input
 }
 
 func (s *ServiceAccount) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(deployDir, serviceAccountYamlFile)
+		s.Path = filepath.Join(deployDir, ServiceAccountYamlFile)
 	}
 	s.TemplateBody = serviceAccountTemplate
 	return s.Input, nil

--- a/pkg/scaffold/service_account.go
+++ b/pkg/scaffold/service_account.go
@@ -28,7 +28,7 @@ type ServiceAccount struct {
 
 func (s *ServiceAccount) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(deployDir, ServiceAccountYamlFile)
+		s.Path = filepath.Join(DeployDir, ServiceAccountYamlFile)
 	}
 	s.TemplateBody = serviceAccountTemplate
 	return s.Input, nil

--- a/pkg/scaffold/test_framework_dockerfile.go
+++ b/pkg/scaffold/test_framework_dockerfile.go
@@ -26,7 +26,7 @@ type TestFrameworkDockerfile struct {
 
 func (s *TestFrameworkDockerfile) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(buildTestDir, dockerfileFile)
+		s.Path = filepath.Join(buildTestDir, DockerfileFile)
 	}
 	s.TemplateBody = testFrameworkDockerfileTmpl
 	return s.Input, nil

--- a/pkg/scaffold/test_framework_dockerfile.go
+++ b/pkg/scaffold/test_framework_dockerfile.go
@@ -26,7 +26,7 @@ type TestFrameworkDockerfile struct {
 
 func (s *TestFrameworkDockerfile) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(buildTestDir, DockerfileFile)
+		s.Path = filepath.Join(BuildTestDir, DockerfileFile)
 	}
 	s.TemplateBody = testFrameworkDockerfileTmpl
 	return s.Input, nil

--- a/pkg/scaffold/test_pod.go
+++ b/pkg/scaffold/test_pod.go
@@ -34,7 +34,7 @@ type TestPod struct {
 
 func (s *TestPod) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(deployDir, TestPodYamlFile)
+		s.Path = filepath.Join(DeployDir, TestPodYamlFile)
 	}
 	s.TemplateBody = testPodTmpl
 	return s.Input, nil

--- a/pkg/scaffold/test_pod.go
+++ b/pkg/scaffold/test_pod.go
@@ -20,6 +20,8 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const TestPodYamlFile = "test-pod.yaml"
+
 type TestPod struct {
 	input.Input
 
@@ -32,7 +34,7 @@ type TestPod struct {
 
 func (s *TestPod) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(deployDir, testPodYamlFile)
+		s.Path = filepath.Join(deployDir, TestPodYamlFile)
 	}
 	s.TemplateBody = testPodTmpl
 	return s.Input, nil

--- a/pkg/scaffold/types.go
+++ b/pkg/scaffold/types.go
@@ -31,7 +31,7 @@ type Types struct {
 
 func (s *Types) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(apisDir,
+		s.Path = filepath.Join(ApisDir,
 			strings.ToLower(s.Resource.Group),
 			strings.ToLower(s.Resource.Version),
 			s.Resource.LowerKind+"_types.go")

--- a/pkg/scaffold/version.go
+++ b/pkg/scaffold/version.go
@@ -20,13 +20,15 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
+const VersionFile = "version.go"
+
 type Version struct {
 	input.Input
 }
 
 func (s *Version) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(versionDir, versionFile)
+		s.Path = filepath.Join(versionDir, VersionFile)
 	}
 	s.TemplateBody = versionTemplate
 	return s.Input, nil

--- a/pkg/scaffold/version.go
+++ b/pkg/scaffold/version.go
@@ -28,7 +28,7 @@ type Version struct {
 
 func (s *Version) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(versionDir, VersionFile)
+		s.Path = filepath.Join(VersionDir, VersionFile)
 	}
 	s.TemplateBody = versionTemplate
 	return s.Input, nil


### PR DESCRIPTION
**Description of the change:** `scaffold`-specific file names were moved from `pkg/scaffold/constants.go` to scaffold files that use them. Both file and directory constants were exported, and are now used in `commands/operator-sdk/cmd` instead of hard-coded strings.

**Motivation for the change:** we want to prevent data drift on changes to the SDK's structure, and solidify naming conventions so files and directories can be used properly as arguments. Moving file names to their respective scaffold files agrees with the idea that utility packages and files containing disparate data are best avoided.