### PR TITLE
doc: add migration guide

### DIFF
--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -255,7 +255,7 @@ At this point you should be able to build and run your operator to verify that i
 
 [v0.1.0-changes-doc]: ./v0.1.0-changes.md
 [v0.0.7-memcached-operator]: https://github.com/operator-framework/operator-sdk-samples/tree/aa15bd278eec0959595e0a0a7282a26055d7f9d6/memcached-operator
-[v0.1.0-memcached-operator]: https://github.com/operator-framework/operator-sdk-samples/tree/master/memcached-operator
+[v0.1.0-memcached-operator]: https://github.com/operator-framework/operator-sdk-samples/tree/4c6934448684a6953ece4d3d9f3f77494b1c125e/memcached-operator
 [controller-conventions]: https://github.com/kubernetes/community/blob/master/contributors/devel/controllers.md#guidelines
 [reconciler-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Reconciler
 [watching-eventhandling-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg#hdr-Watching_and_EventHandling

--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -4,7 +4,7 @@ This document describes how to migrate an operator project built using Operator 
 
 The recommended way to migrate your project is to initialize a new `v0.1.0` project, then copy your code into the new project and modify as described below.
 
-This guide goes over the example of migrating the memcached-operator from the user guide to illustrate the migration steps. See the example [v0.0.7 memcached-operator][v0.0.7-memcached-operator] for the project before the migration and [v0.1.0 memcached-operator][v0.1.0-memcached-operator] after migration.
+This guide goes over migrating the memcached-operator, an example project from the user guide, to illustrate migration steps. See the [v0.0.7 memcached-operator][v0.0.7-memcached-operator] and [v0.1.0 memcached-operator][v0.1.0-memcached-operator] project structures for pre- and post-migration examples, respectively.
 
 ## Create a new v0.1.0 project
 

--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -2,7 +2,7 @@
 
 This document describes how to migrate an operator project built using Operator SDK `v0.0.x` to the project structure required by `v0.1.0`. For an overview of the major changes in the `v0.1.0` project layout and APIs see the [v0.1.0 changes doc][v0.1.0-changes-doc].
 
-The recommended way to migrate your project is to initialize a new `v0.1.0` project and copy and modify your code into the new project.
+The recommended way to migrate your project is to initialize a new `v0.1.0` project, then copy your code into the new project and modify as described below.
 
 This guide goes over the example of migrating the memcached-operator from the user guide to illustrate the migration steps. See the example [v0.0.7 memcached-operator][v0.0.7-memcached-operator] for the project before the migration and [v0.1.0 memcached-operator][v0.1.0-memcached-operator] after migration.
 

--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -1,6 +1,6 @@
 # Migration Guide from v0.0.x to v0.1.0
 
-This document describes how to migrate an operator project built using Operator SDK `v0.0.x` to the project structure required by `v0.1.0`. For an overview of the major changes in the `v0.1.0` project layout and APIs see the [v0.1.0 changes doc][v0.1.0-changes-doc].
+This document describes how to migrate an operator project built using Operator SDK `v0.0.x` to the project structure required by `v0.1.0`. 
 
 The recommended way to migrate your project is to initialize a new `v0.1.0` project, then copy your code into the new project and modify as described below.
 
@@ -102,14 +102,13 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	})
 }
 ```
+Remove the second `Watch()` or modify it to watch a secondary resource type that is owned by your CR.
 
 Watching multiple resources lets you trigger the reconcile loop for multiple resources relevant to your application. See the [watching and eventhandling][watching-eventhandling-doc] doc and the Kubernetes [controller conventions][controller-conventions] doc for more details. 
 
-Remove the second `Watch()` or modify it to watch a secondary resource type that is owned by your CR.
-
 #### Multiple custom resources
 
-If your operator is watching more than 1 CR type then you can do one of the following depending on you application:
+If your operator is watching more than 1 CR type then you can do one of the following depending on your application:
 -  If the CR is owned by your primary CR then watch it as a secondary resource in the same controller to trigger the reconcile loop for the primary resource.
     ```Go
     // Watch for changes to the primary resource Memcached
@@ -172,6 +171,15 @@ Change the following in your reconcile code:
 - Replace the calls to the SDK client(Create, Update, Delete, Get, List) with the reconciler's client
 
 See the examples below and the controller-runtime [client API doc][client-api-doc] for more details.
+
+|        | v0.0.x                                                          | v.0.1                                                 |
+|--------|-----------------------------------------------------------------|-------------------------------------------------------|
+| Create | `dep := &appsv1.Deployment{...}` <br> ```err := sdk.Create(dep) ``` | `err := r.client.Create(context.TODO(), dep)` |
+|   Update     | `err := sdk.Update(dep)` | `err := r.client.Update(context.TODO(), dep)` |
+|  Delete      |`err := sdk.Delete(dep)`|`err := r.client.Delete(context.TODO(), dep)`|
+|  List      | `podList := &corev1.PodList{}`<br>`labelSelector := labels.SelectorFromSet(labelsForMemcached(memcached.Name))`<br> `listOps := &metav1.ListOptions{LabelSelector: labelSelector}` <br> `err := sdk.List(memcached.Namespace, podList, sdk.WithListOptions(listOps))`| `listOps := &client.ListOptions{Namespace: memcached.Namespace, LabelSelector: labelSelector}` <br> `err := r.client.List(context.TODO(), listOps, podList)`|
+|  Get      | `dep := &appsv1.Deployment{APIVersion: "apps/v1", Kind: "Deployment", Name: name, Namespace: namespace}` <br> `err := sdk.Get(dep)`| `dep := &appsv1.Deployment{}` <br> `err = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, dep)`|
+
 ```Go
 // Create
 dep := &appsv1.Deployment{...}
@@ -191,10 +199,10 @@ err := r.client.Delete(context.TODO(), dep)
 
 // List
 podList := &corev1.PodList{}
+labelSelector := labels.SelectorFromSet(labelsForMemcached(memcached.Name))
 listOps := &metav1.ListOptions{LabelSelector: labelSelector}
 err := sdk.List(memcached.Namespace, podList, sdk.WithListOptions(listOps))
 // v0.1.0
-labelSelector := labels.SelectorFromSet(labelsForMemcached(memcached.Name))
 listOps := &client.ListOptions{Namespace: memcached.Namespace, LabelSelector: labelSelector}
 err := r.client.List(context.TODO(), listOps, podList)
 
@@ -206,7 +214,7 @@ dep := &appsv1.Deployment{}
 err = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, dep)
 ```
 
-Lastly copy and intialize any other fields that you may have had in your `Handler` struct into the `Reconcile<Kind>` struct:
+Lastly copy and initialize any other fields that you may have had in your `Handler` struct into the `Reconcile<Kind>` struct:
 
 ```Go
 // newReconciler returns a new reconcile.Reconciler
@@ -238,8 +246,10 @@ If you have any 3rd party resource types registered with the SDK's scheme, then 
 If there are any user defined pkgs, scripts, and docs in the older project, copy these files into the new project. 
 
 ### Copy changes to deployment manifests
+
 For any updates made to the following manifests in the old project, copy over the changes to their corresponding files in the new project:
 - `tmp/build/Dockerfile` to `build/Dockerfile`
+  - There is no tmp directory in the new project layout
 - RBAC rules updates from `deploy/rbac.yaml` to `deploy/role.yaml` and `deploy/role_binding.yaml`
 - `deploy/cr.yaml` to `deploy/crds/<group>_<version>_<kind>_cr.yaml`
 - `deploy/crd.yaml` to `deploy/crds/<group>_<version>_<kind>_crd.yaml`

--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -1,6 +1,6 @@
 # Migration Guide from v0.0.x to v0.1.0
 
-This document describes how to migrate an operator project from Operator SDK `v0.0.x` to `v0.1.0`. For an overview of the major changes in the `v0.1.0` project layout and APIs see the [v0.1.0 changes doc][v0.1.0-changes-doc].
+This document describes how to migrate an operator project built using Operator SDK `v0.0.x` to the project structure required by `v0.1.0`. For an overview of the major changes in the `v0.1.0` project layout and APIs see the [v0.1.0 changes doc][v0.1.0-changes-doc].
 
 The recommended way to migrate your project is to initialize a new `v0.1.0` project and copy and modify your code into the new project.
 

--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -30,7 +30,7 @@ $ cp -rf memcached-operator/.git old-memcached-operator/.git
 
 ### Scaffold api for custom types
 
-Create the api for your custom resource(CR) in the new project with `operator-sdk add api --api-version=<apiversion> --kind=<kind>`
+Create the api for your custom resource (CR) in the new project with `operator-sdk add api --api-version=<apiversion> --kind=<kind>`
 ```sh
 $ cd memcached-operator
 $ operator-sdk add api --api-version=cache.example.com/v1alpha1 --kind=Memcached
@@ -53,7 +53,7 @@ Repeat the above command for as many custom types as you had defined in your old
 
 Copy the `Spec` and `Status` contents of the `pkg/apis/<group>/<version>/types.go` file from the old project to the new project's `pkg/apis/<group>/<version>/<kind>_types.go` file.
 
-**Note:** Each `<kind>_types.go` file has an `init()` function. Be sure not to remove that since that registers the type with the manager's scheme.
+**Note:** Each `<kind>_types.go` file has an `init()` function. Be sure not to remove that since that registers the type with the Manager's scheme.
 ```Go
 func init() {
 	SchemeBuilder.Register(&Memcached{}, &MemcachedList{})
@@ -169,7 +169,7 @@ func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Res
 
 Change the following in your reconcile code:
 - Replace `return err` with `return reconcile.Result{}, err`
-- Replace the calls to the sdk client(Create, Update, Delete, Get, List) with the reconciler's client
+- Replace the calls to the SDK client(Create, Update, Delete, Get, List) with the reconciler's client
 
 See the examples below and the controller-runtime [client API doc][client-api-doc] for more details.
 ```Go
@@ -227,11 +227,11 @@ type ReconcileMemcached struct {
 
 The main function for a `v0.1.0` operator in `cmd/manager/main.go` sets up the [Manager][manager-go-doc] which registers the custom resources and starts all the controllers.
 
-There is no need to migrate the sdk functions `sdk.Watch()`,`sdk.Handle()`, and `sdk.Run()` from the old `main.go` since that logic is now defined in a controller.
+There is no need to migrate the SDK functions `sdk.Watch()`,`sdk.Handle()`, and `sdk.Run()` from the old `main.go` since that logic is now defined in a controller.
 
 However if there are any operator specific flags or settings defined in the old main file copy those over.
 
-If you have any 3rd party resource types registered with the sdk's scheme, then register those with the manager's scheme in the new project. See how to [register 3rd party resources][register-3rd-party-resources].
+If you have any 3rd party resource types registered with the SDK's scheme, then register those with the Manager's scheme in the new project. See how to [register 3rd party resources][register-3rd-party-resources].
 
 ### Copy user defined files
 

--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -23,7 +23,7 @@ $ ls
 memcached-operator old-memcached-operator
 
 # Copy over .git from old project
-$ cp -rf memcached-operator/.git old-memcached-operator/.git 
+$ cp -rf old-memcached-operator/.git memcached-operator/.git
 ```
 
 ## Migrate custom types from pkg/apis
@@ -132,13 +132,21 @@ If your operator is watching more than 1 CR type then you can do one of the foll
 ### Copy and modify reconcile code from pkg/stub/handler.go
 
 In a `v0.1.0` project the reconcile code is defined in the `Reconcile()` method of a controller's [Reconciler][reconciler-go-doc]. This is similar to the `Handle()` function in the older project. Note the difference in the arguments and return values:
-- `func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Result, error)`
-- `func (h *Handler) Handle(ctx context.Context, event sdk.Event) error`
+- Reconcile
+    ```Go
+    func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Result, error)
+    ```
+- Handle
+    ```Go
+    func (h *Handler) Handle(ctx context.Context, event sdk.Event) error
+    ```
 
-Instead of receiving an sdk.Event (with the object), the Reconcile function receives a [Request][request-go-doc] (Name/Namespace key) to lookup the object. If an error is returned the Request will be retried. Otherwise the [Result][result-go-doc] can be explicitly configured to retry immediately or periodically after a timeout.
+Instead of receiving an `sdk.Event` (with the object), the `Reconcile()` function receives a [Request][request-go-doc] (Name/Namespace key) to lookup the object.
+
+If the `Reconcile()` function returns an error, the controller will requeue and retry the `Request`. If no error is returned, then depending on the [Result][result-go-doc] the controller will either not retry the `Request`, immediately retry, or retry after a specified duration.
 
 Copy the code from the old project's `Handle()` function over the existing code in your controller's `Reconcile()` function.
-Be sure to keep the initial section in the `Reconcile()` code that looks up the object for the Request and checks to see if it's deleted.
+Be sure to keep the initial section in the `Reconcile()` code that looks up the object for the `Request` and checks to see if it's deleted.
 
 ```Go
 import (
@@ -147,38 +155,55 @@ import (
     ...
 )
 func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	// Fetch the Memcached instance
+    // Fetch the Memcached instance
 	instance := &cachev1alpha1.Memcached{}
-	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected.
-			// Return and don't requeue
-			return reconcile.Result{}, nil
-		}
-		// Error reading the object - requeue the request.
-		return reconcile.Result{}, err
+    err := r.client.Get(context.TODO()
+    request.NamespacedName, instance)
+    if err != nil {
+        if apierrors.IsNotFound(err) {
+            // Request object not found, could have been deleted after reconcile request.
+            // Owned objects are automatically garbage collected.
+            // Return and don't requeue
+            return reconcile.Result{}, nil
+        }
+        // Error reading the object - requeue the request.
+        return reconcile.Result{}, err
     }
-
+    
     // Rest of your reconcile code goes here.
     ...
 }
 ```
+#### Update return values
 
-Change the following in your reconcile code:
+Change the return values in your reconcile code:
 - Replace `return err` with `return reconcile.Result{}, err`
-- Replace the calls to the SDK client(Create, Update, Delete, Get, List) with the reconciler's client
+- Replace `return nil` with `return reconcile.Result{}, nil`
+
+#### Periodic reconcile
+In order to periodically reconcile a CR in your controller you can set the [RequeueAfter][result-go-doc] field for reconcile.Result.
+This will cause the controller to requeue the `Request` and trigger the reconcile after the desired duration. Note that the default value of 0 means no requeue.
+
+```Go
+reconcilePeriod := 30 * time.Second
+reconcileResult := reconcile.Result{RequeueAfter: reconcilePeriod}
+...
+
+// Update the status
+err := r.client.Update(context.TODO(), memcached)
+if err != nil {
+    log.Printf("failed to update memcached status: %v", err)
+    return reconcileResult, err
+}
+return reconcileResult, nil
+
+```
+
+#### Update client
+
+Replace the calls to the SDK client(Create, Update, Delete, Get, List) with the reconciler's client.
 
 See the examples below and the controller-runtime [client API doc][client-api-doc] for more details.
-
-|        | v0.0.x                                                          | v.0.1                                                 |
-|--------|-----------------------------------------------------------------|-------------------------------------------------------|
-| Create | `dep := &appsv1.Deployment{...}` <br> ```err := sdk.Create(dep) ``` | `err := r.client.Create(context.TODO(), dep)` |
-|   Update     | `err := sdk.Update(dep)` | `err := r.client.Update(context.TODO(), dep)` |
-|  Delete      |`err := sdk.Delete(dep)`|`err := r.client.Delete(context.TODO(), dep)`|
-|  List      | `podList := &corev1.PodList{}`<br>`labelSelector := labels.SelectorFromSet(labelsForMemcached(memcached.Name))`<br> `listOps := &metav1.ListOptions{LabelSelector: labelSelector}` <br> `err := sdk.List(memcached.Namespace, podList, sdk.WithListOptions(listOps))`| `listOps := &client.ListOptions{Namespace: memcached.Namespace, LabelSelector: labelSelector}` <br> `err := r.client.List(context.TODO(), listOps, podList)`|
-|  Get      | `dep := &appsv1.Deployment{APIVersion: "apps/v1", Kind: "Deployment", Name: name, Namespace: namespace}` <br> `err := sdk.Get(dep)`| `dep := &appsv1.Deployment{}` <br> `err = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, dep)`|
 
 ```Go
 // Create
@@ -247,7 +272,7 @@ If there are any user defined pkgs, scripts, and docs in the older project, copy
 
 ### Copy changes to deployment manifests
 
-For any updates made to the following manifests in the old project, copy over the changes to their corresponding files in the new project:
+For any updates made to the following manifests in the old project, copy over the changes to their corresponding files in the new project. Be careful not to directly overwrite the files but inspect and make any changes necessary.
 - `tmp/build/Dockerfile` to `build/Dockerfile`
   - There is no tmp directory in the new project layout
 - RBAC rules updates from `deploy/rbac.yaml` to `deploy/role.yaml` and `deploy/role_binding.yaml`
@@ -272,7 +297,7 @@ At this point you should be able to build and run your operator to verify that i
 [controller-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg#hdr-Controller
 [request-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Request
 [result-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Result
-[client-api-doc]: ./../doc/user/client.md
+[client-api-doc]: ./../user/client.md
 [manager-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/manager
-[register-3rd-party-resources]: ./../doc/user-guide.md#adding-3rd-party-resources-to-your-operator
-[user-guide-build-run]: ./../doc/user-guide.md#build-and-run-the-operator
+[register-3rd-party-resources]: ./../user-guide.md#adding-3rd-party-resources-to-your-operator
+[user-guide-build-run]: ./../user-guide.md#build-and-run-the-operator

--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -105,7 +105,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 Watching multiple resources lets you trigger the reconcile loop for multiple resources relevant to your application. See the [watching and eventhandling][watching-eventhandling-doc] doc and the Kubernetes [controller conventions][controller-conventions] doc for more details. 
 
-Remove the second `Watch()` or modify it to watch a secondary resouce type that is owned by your CR.
+Remove the second `Watch()` or modify it to watch a secondary resource type that is owned by your CR.
 
 #### Multiple custom resources
 

--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -71,7 +71,7 @@ sdk.Watch("cache.example.com/v1alpha1", "Memcached", "default", time.Duration(5)
 
 For a `v0.1.0` project you define a [Controller][controller-go-doc] to watch resources.
 
-Add a controller to watch your CR type with `operator-sdk add api --api-version=<apiversion> --kind=<kind>`.
+Add a controller to watch your CR type with `operator-sdk add controller --api-version=<apiversion> --kind=<kind>`.
 ```
 $ operator-sdk add controller --api-version=cache.example.com/v1alpha1 --kind=Memcached
 $ tree pkg/controller

--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -240,7 +240,7 @@ If there are any user defined pkgs, scripts, and docs in the older project, copy
 ### Copy changes to deployment manifests
 For any updates made to the following manifests in the old project, copy over the changes to their corresponding files in the new project:
 - `tmp/build/Dockerfile` to `build/Dockerfile`
-- RBAC rules updates from `deploy/rbac.yaml` to `deploy/role.yaml`
+- RBAC rules updates from `deploy/rbac.yaml` to `deploy/role.yaml` and `deploy/role_binding.yaml`
 - `deploy/cr.yaml` to `deploy/crds/<group>_<version>_<kind>_cr.yaml`
 - `deploy/crd.yaml` to `deploy/crds/<group>_<version>_<kind>_crd.yaml`
 

--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -136,7 +136,7 @@ In a `v0.1.0` project the reconcile code is defined in the `Reconcile()` method 
 - `func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Result, error)`
 - `func (h *Handler) Handle(ctx context.Context, event sdk.Event) error`
 
-Instead of receving an sdk.Event(with the object), the Reconcile function recevies a [Request][request-go-doc](Name/Namespace key) to lookup the object. If an error is returned the Request will be retried. Otherwise the [Result][result-go-doc] can be explicitly cofigured to retry immediately or after a timeout to periodically resync.
+Instead of receiving an sdk.Event (with the object), the Reconcile function receives a [Request][request-go-doc] (Name/Namespace key) to lookup the object. If an error is returned the Request will be retried. Otherwise the [Result][result-go-doc] can be explicitly configured to retry immediately or periodically after a timeout.
 
 Copy the code from the old project's `Handle()` function over the existing code in your controller's `Reconcile()` function.
 Be sure to keep the initial section in the `Reconcile()` code that looks up the object for the Request and checks to see if it's deleted.

--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -1,0 +1,268 @@
+# Migration Guide from v0.0.x to v0.1.0
+
+This document describes how to migrate an operator project from Operator SDK `v0.0.x` to `v0.1.0`. For an overview of the major changes in the `v0.1.0` project layout and APIs see the [v0.1.0 changes doc][v0.1.0-changes-doc].
+
+The recommended way to migrate your project is to initialize a new `v0.1.0` project and copy and modify your code into the new project.
+
+This guide goes over the example of migrating the memcached-operator from the user guide to illustrate the migration steps. See the example [v0.0.7 memcached-operator][v0.0.7-memcached-operator] for the project before the migration and [v0.1.0 memcached-operator][v0.1.0-memcached-operator] after migration.
+
+## Create a new v0.1.0 project
+
+Rename your `v0.0.x` project and create a new `v0.1.0` project in its place.
+
+```sh
+# Ensure SDK version is v0.1.0
+$ operator-sdk --version
+operator-sdk version 0.1.0
+
+# Create new project
+$ cd $GOPATH/src/github.com/example-inc/
+$ mv memcached-operator old-memcached-operator
+$ operator-sdk new memcached-operator
+$ ls
+memcached-operator old-memcached-operator
+
+# Copy over .git from old project
+$ cp -rf memcached-operator/.git old-memcached-operator/.git 
+```
+
+## Migrate custom types from pkg/apis
+
+### Scaffold api for custom types
+
+Create the api for your custom resource(CR) in the new project with `operator-sdk add api --api-version=<apiversion> --kind=<kind>`
+```sh
+$ cd memcached-operator
+$ operator-sdk add api --api-version=cache.example.com/v1alpha1 --kind=Memcached
+
+$ tree pkg/apis
+pkg/apis/
+├── addtoscheme_cache_v1alpha1.go
+├── apis.go
+└── cache
+    └── v1alpha1
+        ├── doc.go
+        ├── memcached_types.go
+        ├── register.go
+        └── zz_generated.deepcopy.go
+```
+
+Repeat the above command for as many custom types as you had defined in your old project. Each type will be defined in the file `pkg/apis/<group>/<version>/<kind>_types.go`.
+
+### Copy the contents of the type
+
+Copy the `Spec` and `Status` contents of the `pkg/apis/<group>/<version>/types.go` file from the old project to the new project's `pkg/apis/<group>/<version>/<kind>_types.go` file.
+
+**Note:** Each `<kind>_types.go` file has an `init()` function. Be sure not to remove that since that registers the type with the manager's scheme.
+```Go
+func init() {
+	SchemeBuilder.Register(&Memcached{}, &MemcachedList{})
+}
+```
+
+## Migrate reconcile code
+
+### Add a controller to watch your CR
+
+In a `v0.0.x` project you would define what resource to watch in `cmd/<operator-name>/main.go`
+```Go
+sdk.Watch("cache.example.com/v1alpha1", "Memcached", "default", time.Duration(5)*time.Second)
+```
+
+For a `v0.1.0` project you define a [Controller][controller-go-doc] to watch resources.
+
+Add a controller to watch your CR type with `operator-sdk add api --api-version=<apiversion> --kind=<kind>`.
+```
+$ operator-sdk add controller --api-version=cache.example.com/v1alpha1 --kind=Memcached
+$ tree pkg/controller
+pkg/controller/
+├── add_memcached.go
+├── controller.go
+└── memcached
+    └── memcached_controller.go
+```
+
+Inspect the `add()` function in your `pkg/controller/<kind>/<kind>_controller.go` file:
+```Go
+import (
+    cachev1alpha1 "github.com/example-inc/memcached-operator/pkg/apis/cache/v1alpha1"
+    ...
+)
+
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+    c, err := controller.New("memcached-controller", mgr, controller.Options{Reconciler: r})
+
+    // Watch for changes to the primary resource Memcached
+    err = c.Watch(&source.Kind{Type: &cachev1alpha1.Memcached{}}, &handler.EnqueueRequestForObject{})
+
+    // Watch for changes to the secondary resource Pods and enqueue reconcile requests for the owner Memcached
+    err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &cachev1alpha1.Memcached{},
+	})
+}
+```
+
+Watching multiple resources lets you trigger the reconcile loop for multiple resources relevant to your application. See the [watching and eventhandling][watching-eventhandling-doc] doc and the Kubernetes [controller conventions][controller-conventions] doc for more details. 
+
+Remove the second `Watch()` or modify it to watch a secondary resouce type that is owned by your CR.
+
+#### Multiple custom resources
+
+If your operator is watching more than 1 CR type then you can do one of the following depending on you application:
+-  If the CR is owned by your primary CR then watch it as a secondary resource in the same controller to trigger the reconcile loop for the primary resource.
+    ```Go
+    // Watch for changes to the primary resource Memcached
+    err = c.Watch(&source.Kind{Type: &cachev1alpha1.Memcached{}}, &handler.EnqueueRequestForObject{})
+
+    // Watch for changes to the secondary resource AppService and enqueue reconcile requests for the owner Memcached
+    err = c.Watch(&source.Kind{Type: &appv1alpha1.AppService{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &cachev1alpha1.Memcached{},
+	})
+    ```
+-  Add a new controller to watch and reconcile the CR independently of the other CR.
+    ```sh
+    $ operator-sdk add controller --api-version=app.example.com/v1alpha1 --kind=AppService
+    ```
+    ```Go
+    // Watch for changes to the primary resource AppService
+    err = c.Watch(&source.Kind{Type: &appv1alpha1.AppService{}}, &handler.EnqueueRequestForObject{})
+    ```
+
+### Copy and modify reconcile code from pkg/stub/handler.go
+
+In a `v0.1.0` project the reconcile code is defined in the `Reconcile()` method of a controller's [Reconciler][reconciler-go-doc]. This is similar to the `Handle()` function in the older project. Note the difference in the arguments and return values:
+- `func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Result, error)`
+- `func (h *Handler) Handle(ctx context.Context, event sdk.Event) error`
+
+Instead of receving an sdk.Event(with the object), the Reconcile function recevies a [Request][request-go-doc](Name/Namespace key) to lookup the object. If an error is returned the Request will be retried. Otherwise the [Result][result-go-doc] can be explicitly cofigured to retry immediately or after a timeout to periodically resync.
+
+Copy the code from the old project's `Handle()` function over the existing code in your controller's `Reconcile()` function.
+Be sure to keep the initial section in the `Reconcile()` code that looks up the object for the Request and checks to see if it's deleted.
+
+```Go
+import (
+    apierrors "k8s.io/apimachinery/pkg/api/errors"
+    cachev1alpha1 "github.com/example-inc/memcached-operator/pkg/apis/cache/v1alpha1"
+    ...
+)
+func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	// Fetch the Memcached instance
+	instance := &cachev1alpha1.Memcached{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+    }
+
+    // Rest of your reconcile code goes here.
+    ...
+}
+```
+
+Change the following in your reconcile code:
+- Replace `return err` with `return reconcile.Result{}, err`
+- Replace the calls to the sdk client(Create, Update, Delete, Get, List) with the reconciler's client
+
+See the examples below and the controller-runtime [client API doc][client-api-doc] for more details.
+```Go
+// Create
+dep := &appsv1.Deployment{...}
+err := sdk.Create(dep)
+// v0.0.1
+err := r.client.Create(context.TODO(), dep)
+
+// Update
+err := sdk.Update(dep)
+// v0.0.1
+err := r.client.Update(context.TODO(), dep)
+
+// Delete
+err := sdk.Delete(dep)
+// v0.0.1
+err := r.client.Delete(context.TODO(), dep)
+
+// List
+podList := &corev1.PodList{}
+listOps := &metav1.ListOptions{LabelSelector: labelSelector}
+err := sdk.List(memcached.Namespace, podList, sdk.WithListOptions(listOps))
+// v0.1.0
+labelSelector := labels.SelectorFromSet(labelsForMemcached(memcached.Name))
+listOps := &client.ListOptions{Namespace: memcached.Namespace, LabelSelector: labelSelector}
+err := r.client.List(context.TODO(), listOps, podList)
+
+// Get
+dep := &appsv1.Deployment{APIVersion: "apps/v1", Kind: "Deployment", Name: name, Namespace: namespace}
+err := sdk.Get(dep)
+// v0.1.0
+dep := &appsv1.Deployment{}
+err = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, dep)
+```
+
+Lastly copy and intialize any other fields that you may have had in your `Handler` struct into the `Reconcile<Kind>` struct:
+
+```Go
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileMemcached{client: mgr.GetClient(), scheme: mgr.GetScheme(), foo: "bar"}
+}
+
+// ReconcileMemcached reconciles a Memcached object
+type ReconcileMemcached struct {
+    client client.Client
+    scheme *runtime.Scheme
+    // Other fields
+    foo string
+}
+```
+
+### Copy changes from main.go
+
+The main function for a `v0.1.0` operator in `cmd/manager/main.go` sets up the [Manager][manager-go-doc] which registers the custom resources and starts all the controllers.
+
+There is no need to migrate the sdk functions `sdk.Watch()`,`sdk.Handle()`, and `sdk.Run()` from the old `main.go` since that logic is now defined in a controller.
+
+However if there are any operator specific flags or settings defined in the old main file copy those over.
+
+If you have any 3rd party resource types registered with the sdk's scheme, then register those with the manager's scheme in the new project. See how to [register 3rd party resources][register-3rd-party-resources].
+
+### Copy user defined files
+
+If there are any user defined pkgs, scripts, and docs in the older project, copy these files into the new project. 
+
+### Copy changes to deployment manifests
+For any updates made to the following manifests in the old project, copy over the changes to their corresponding files in the new project:
+- `tmp/build/Dockerfile` to `build/Dockerfile`
+- RBAC rules updates from `deploy/rbac.yaml` to `deploy/role.yaml`
+- `deploy/cr.yaml` to `deploy/crds/<group>_<version>_<kind>_cr.yaml`
+- `deploy/crd.yaml` to `deploy/crds/<group>_<version>_<kind>_crd.yaml`
+
+### Copy user defined dependencies
+
+For any user defined dependencies added to the old project's Gopkg.toml, copy and append them to the new project's Gopkg.toml.
+Run `dep ensure` to update the vendor in the new project.
+
+### Confirmation
+
+At this point you should be able to build and run your operator to verify that it works. See the [user-guide][user-guide-build-run] on how to build and run your operator.
+
+[v0.1.0-changes-doc]: ./v0.1.0-changes.md
+[v0.0.7-memcached-operator]: https://github.com/operator-framework/operator-sdk-samples/tree/aa15bd278eec0959595e0a0a7282a26055d7f9d6/memcached-operator
+[v0.1.0-memcached-operator]: https://github.com/operator-framework/operator-sdk-samples/tree/master/memcached-operator
+[controller-conventions]: https://github.com/kubernetes/community/blob/master/contributors/devel/controllers.md#guidelines
+[reconciler-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Reconciler
+[watching-eventhandling-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg#hdr-Watching_and_EventHandling
+[controller-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg#hdr-Controller
+[request-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Request
+[result-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Result
+[client-api-doc]: ./../doc/user/client.md
+[manager-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/manager
+[register-3rd-party-resources]: ./../doc/user-guide.md#adding-3rd-party-resources-to-your-operator
+[user-guide-build-run]: ./../doc/user-guide.md#build-and-run-the-operator

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -326,25 +326,23 @@ $ kubectl delete -f deploy/service_account.yaml
 
 ## Advanced Topics
 ### Adding 3rd Party Resources To Your Operator
-To add a resource to an operator, you must add it to a scheme. By creating an `AddToScheme` method or reusing one you can easily add a resource to your scheme. An [example][deployments_register] shows that you define a function and then use the [runtime][runtime_package] package to create a `SchemeBuilder`
-
-#### Current Operator-SDK
-You then need to tell the operators to use these functions to add the resources to its scheme. In operator-sdk you use [AddToSDKScheme][osdk_add_to_scheme] to add this.
-Example of you main.go:
-```go
+By default the operator's manager will register all custom resource types defined in your project under `pkg/apis` with its scheme.
+```Go
 import (
-    ....
-    appsv1 "k8s.io/api/apps/v1"
+  "github.com/example-inc/memcached-operator/pkg/apis"
+  ...
 )
-
-func main() {
-    k8sutil.AddToSDKScheme(appsv1.AddToScheme)`
-    sdk.Watch(appsv1.SchemeGroupVersion.String(), "Deployments", <namespace>, <resyncPeriod>)
+// Setup Scheme for all resources
+if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+  log.Fatal(err)
 }
 ```
 
-#### Future with Controller Runtime
-When using controller runtime, you will also need to tell its scheme about your resourece. In controller runtime to add to the scheme, you can get the managers [scheme][manager_scheme].  If you would like to see what kubebuilder generates to add the resoureces to the [scheme][simple_resource].
+To add a 3rd party resource to an operator, you must add it to the manager's scheme. By creating an `AddToScheme` method or reusing one you can easily add a resource to your scheme. An [example][deployments_register] shows that you define a function and then use the [runtime][runtime_package] package to create a `SchemeBuilder`.
+
+#### Register with the manager's scheme
+Call the `AddToScheme()` function for your 3rd party resource and pass it the manager's scheme via `mgr.GetScheme()`.
+
 Example:
 ```go
 import (
@@ -371,8 +369,6 @@ func main() {
 [docker_tool]:https://docs.docker.com/install/
 [kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [minikube_tool]:https://github.com/kubernetes/minikube#installation
-[manager_scheme]: https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/manager/manager.go#L61
-[simple_resource]: https://book.kubebuilder.io/basics/simple_resource.html
 [deployments_register]: https://github.com/kubernetes/api/blob/master/apps/v1/register.go#L41
 [doc_client_api]:./user/client.md
 [runtime_package]: https://godoc.org/k8s.io/apimachinery/pkg/runtime

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -48,7 +48,7 @@ $ cd memcached-operator
 To learn about the project directory structure, see [project layout][layout_doc] doc.
 
 ### Manager
-The main program for the operator is the manager `cmd/manager/main.go`.
+The main program for the operator is the Manager `cmd/manager/main.go`.
 
 The manager will automatically register the scheme for all custom resources defined under `pkg/apis/...` and run all controllers under `pkg/controller/...`.
 
@@ -326,7 +326,7 @@ $ kubectl delete -f deploy/service_account.yaml
 
 ## Advanced Topics
 ### Adding 3rd Party Resources To Your Operator
-By default the operator's manager will register all custom resource types defined in your project under `pkg/apis` with its scheme.
+By default the operator's Manager will register all custom resource types defined in your project under `pkg/apis` with its scheme.
 ```Go
 import (
   "github.com/example-inc/memcached-operator/pkg/apis"
@@ -338,10 +338,10 @@ if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
 }
 ```
 
-To add a 3rd party resource to an operator, you must add it to the manager's scheme. By creating an `AddToScheme` method or reusing one you can easily add a resource to your scheme. An [example][deployments_register] shows that you define a function and then use the [runtime][runtime_package] package to create a `SchemeBuilder`.
+To add a 3rd party resource to an operator, you must add it to the Manager's scheme. By creating an `AddToScheme` method or reusing one you can easily add a resource to your scheme. An [example][deployments_register] shows that you define a function and then use the [runtime][runtime_package] package to create a `SchemeBuilder`.
 
 #### Register with the manager's scheme
-Call the `AddToScheme()` function for your 3rd party resource and pass it the manager's scheme via `mgr.GetScheme()`.
+Call the `AddToScheme()` function for your 3rd party resource and pass it the Manager's scheme via `mgr.GetScheme()`.
 
 Example:
 ```go


### PR DESCRIPTION
[skip ci]

**Description of the change:**
- Added a migration guide to migrate a Go operator project to use SDK `v0.1.0` with the new controller-runtime changes.
-  Update the user-guide for adding 3rd party resources.
- The `v0.1.0-changes.md` doc referenced in the migration guide will be added in a followup PR. But even without that the migration guide should be sufficient to understand the changes.

**Motivation for the change:**
- Need a migration guide before making the `v0.1.0` release.

/cc @shawn-hurley @joelanford @LiliC @AlexNPavel @estroz 