### PR TITLE
version: set to v0.0.7-git

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -15,5 +15,5 @@
 package version
 
 var (
-	Version = "0.0.6+git"
+	Version = "0.0.7+git"
 )


### PR DESCRIPTION
**Description of the change:** Set version in `version/version.go` to v0.0.7-git


**Motivation for the change:** v0.0.7 was released, so the git version on master needed to be bumped