### PR TITLE
doc/test-framework: add service account flag to cluster test cmd

### DIFF
--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -287,7 +287,7 @@ $ kubectl create -f deploy/role_binding.yaml -n memcached-test
 Once you have your environment properly configured, you can start the tests using the `operator-sdk test cluster` command:
 
 ```shell
-$ operator-sdk test cluster quay.io/example/memcached-operator:v0.0.1 --namespace memcached-test
+$ operator-sdk test cluster quay.io/example/memcached-operator:v0.0.1 --namespace memcached-test --service-account memcached-operator
 
 Example Output:
 Test Successfully Completed


### PR DESCRIPTION
**Description of the change:** Add service account flag to cluster test command example


**Motivation for the change:** The command will fail due to permissions if the service account is not specified