### PR TITLE
Exit if not a Go project

### DIFF
--- a/commands/operator-sdk/cmd/add/api.go
+++ b/commands/operator-sdk/cmd/add/api.go
@@ -63,6 +63,9 @@ Example:
 }
 
 func apiRun(cmd *cobra.Command, args []string) {
+	// Only Go projects can add apis.
+	projutil.MustGoProjectCmd(cmd)
+
 	// Create and validate new resource
 	projutil.MustInProjectRoot()
 	r, err := scaffold.NewResource(apiVersion, kind)

--- a/commands/operator-sdk/cmd/add/controller.go
+++ b/commands/operator-sdk/cmd/add/controller.go
@@ -57,6 +57,9 @@ Example:
 }
 
 func controllerRun(cmd *cobra.Command, args []string) {
+	// Only Go projects can add controllers.
+	projutil.MustGoProjectCmd(cmd)
+
 	projutil.MustInProjectRoot()
 	// Create and validate new resource
 	r, err := scaffold.NewResource(apiVersion, kind)

--- a/commands/operator-sdk/cmd/generate/k8s.go
+++ b/commands/operator-sdk/cmd/generate/k8s.go
@@ -43,11 +43,16 @@ func k8sFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 0 {
 		log.Fatalf("k8s command doesn't accept any arguments.")
 	}
+
+	// Only Go projects can generate k8s deepcopy code.
+	projutil.MustGoProjectCmd(cmd)
+
 	K8sCodegen()
 }
 
 // K8sCodegen performs deepcopy code-generation for all custom resources under pkg/apis
 func K8sCodegen() {
+
 	projutil.MustInProjectRoot()
 	repoPkg := projutil.CheckAndGetCurrPkg()
 	outputPkg := filepath.Join(repoPkg, "pkg/generated")

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -19,11 +19,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 const (
 	SrcDir          = "src"
-	gopkgToml       = "./Gopkg.toml"
+	mainFile        = "./cmd/manager/main.go"
 	buildDockerfile = "./build/Dockerfile"
 )
 
@@ -49,6 +51,15 @@ func MustInProjectRoot() {
 	_, err := os.Stat(buildDockerfile)
 	if err != nil && os.IsNotExist(err) {
 		log.Fatalf("must run command in project root dir: %v", err)
+	}
+}
+
+func MustGoProjectCmd(cmd *cobra.Command) {
+	t := GetOperatorType()
+	switch t {
+	case OperatorTypeGo:
+	default:
+		log.Fatalf("'%s' can only be run for Go operators.", cmd.CommandPath())
 	}
 }
 
@@ -82,8 +93,8 @@ func CheckAndGetCurrPkg() string {
 // This function should be called after verifying the user is in project root
 // e.g: "go", "ansible"
 func GetOperatorType() OperatorType {
-	// Assuming that if Gopkg.toml exists then this is a Go operator
-	_, err := os.Stat(gopkgToml)
+	// Assuming that if main.go exists then this is a Go operator
+	_, err := os.Stat(mainFile)
 	if err != nil && os.IsNotExist(err) {
 		return OperatorTypeAnsible
 	}


### PR DESCRIPTION
**Description of the change:** add `MustGoProject` function to exit if the current operator project is not a Go project.

**Motivation for the change:** see #670 