### PR TITLE
pkg/scaffold: remove TODO for metrics port

### DIFF
--- a/pkg/scaffold/cmd.go
+++ b/pkg/scaffold/cmd.go
@@ -67,9 +67,6 @@ func main() {
 		log.Fatalf("failed to get watch namespace: %v", err)
 	}
 
-	// TODO: Expose metrics port after SDK uses controller-runtime's dynamic client
-	// sdk.ExposeMetricsPort()
-
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {

--- a/pkg/scaffold/cmd_test.go
+++ b/pkg/scaffold/cmd_test.go
@@ -63,9 +63,6 @@ func main() {
 		log.Fatalf("failed to get watch namespace: %v", err)
 	}
 
-	// TODO: Expose metrics port after SDK uses controller-runtime's dynamic client
-	// sdk.ExposeMetricsPort()
-
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {


### PR DESCRIPTION
**Description of the change:**
Remove the commented out TODO for exposing the metrics port in `main.go` template.

**Motivation for the change:**
We're still waiting for an upstream PR on the runtime before the controller metrics will be exposed. So for the purposes of the v0.1.0 release we can remove that from the template until the upstream PR is merged.