### PR TITLE
.travisl.yml: skip CI on change to docs or untestable project files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ services:
 go:
 - 1.10.3
 
+before_install:
+  - |
+      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md)|(\.MD)|(\.png)|(\.pdf)|^(doc/)|^(MAINTAINERS)|^(LICENSE)'; then
+        echo "Only doc files were updated, not running the CI."
+        exit
+      fi
+
 jobs:
   include:
     - before_script: hack/ci/setup-openshift.sh


### PR DESCRIPTION
**Description of the change:** skip any files containing:
`.md | .MD | .png | .pdf | docs | MAINTAINERS | LICENSE`

**Motivation for the change:** running CI on these files is unnecessary.