### PR TITLE
Add proposal for user-driven Ansible Operator status management

### DIFF
--- a/doc/proposals/ansible-operator-status.md
+++ b/doc/proposals/ansible-operator-status.md
@@ -10,8 +10,8 @@ There is currently no way to intentionally surface information to the status obj
 
 There are two main approaches we see for users wanting to manage the status:
 
-1. The user wants to pass a message to the operator to set on the status field, but otherwise wants the operator to manage the status as normal (ie, setting the conditions and failure messages)
-2. The user wants to manage the entire status manually from Ansible, and the Go-side of Ansible Operator does nothing with statuses
+1. The user wants to change the status of the Custom Resource over the course of an Ansible reconciliation run, but still wants to make use of the operator's builtin status management utilities to set certain conditions and failure messages
+1. The user wants to manage the entire status manually from Ansible, and the Go-side of Ansible Operator does nothing with statuses
 
 
 ## Proposal
@@ -20,13 +20,13 @@ Add a new field to the watches.yaml entry, which tells the operator whether or n
 
 Add a new Ansible module, named `k8s_status` that is usable when running inside Ansible Operator.
 
-The `k8s_status` module would take the apiVersion, kind, name, namespace as well as a status blob. It would then set the status on the specified resource using that blob.\
+The `k8s_status` module would take the apiVersion, kind, name, namespace as well as a status blob and list of conditions. It would then set the status on the specified resource using that blob. The conditions would be validated to conform to the [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties). It would then take this status blob and call to update the status subresource for the specified resource (which should be the CR that is being reconciled).\
 _**Note - likely this module would inherit from k8s_common, and include the same general authentication/etc options as the other k8s modules*_
 
-In the Ansible Operator proxy, any update calls to the status subresource will be intercepted:
+The Go-side of the Ansible Operator would need two changes:
+1. It needs to not attempt to manage the status when the watches.yaml tells it not to
+1. It needs to `GET` the current state of the object before updating the status after an Ansible reconciliation run, so that it does not attempt to write a stale version of the object.
 
-- If the operator is managing status, it will prevent this call from reaching the real k8s API (without failing the request). Then, when a task event for the `k8s_status` module reaches the event handler, the operator will read the status update and perform it, in addition to the normal status condition management the operator is responsible for.
-- If the operator is not managing status, it will allow the call to go forward as normal.
 
 
 ## Complications / Further Discussion
@@ -34,6 +34,4 @@ In the Ansible Operator proxy, any update calls to the status subresource will b
 Not all clusters and Custom Resource Definitions have the status subresource enabled. In the case where the status subresource is not enabled for a CRD, we can do one of two things:
 
 1. Error out - if the user is attempting to manage the status of an object that doesn’t have the subresource enabled, we call it a misconfiguration and fail without attempting to update the status.
-2. If a resource doesn’t have the status subresource enabled, the status field can still be updated. Instead of updating the status subresource, you would `GET` the resource in its current state, update the status field manually, and `PUT` the whole object back. 
-
-    The major downside to this approach is that it would be much more difficult to intercept the status updates from the proxy, as there is no difference in appearance from a status update and a normal resource update.
+2. If a resource doesn’t have the status subresource enabled, the status field can still be updated. Instead of updating the status subresource, you would `GET` the resource in its current state, update the status field manually, and `PUT` the whole object back.


### PR DESCRIPTION
Signed-off-by: Fabian von Feilitzsch <fabian@fabianism.us>

**Description of the change:**
Add a proposal to allow the users to manage the status of the CR from Ansible when using Ansible Operator

**Motivation for the change:**
Users have requested the ability to have more fine-grained control of the content of the status. This proposal is intended to begin a discussion on the proper way to surface that functionality.