### PR TITLE
doc/migration: skip git for new project

### DIFF
--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -18,7 +18,7 @@ operator-sdk version 0.1.0
 # Create new project
 $ cd $GOPATH/src/github.com/example-inc/
 $ mv memcached-operator old-memcached-operator
-$ operator-sdk new memcached-operator
+$ operator-sdk new memcached-operator --skip-git-init
 $ ls
 memcached-operator old-memcached-operator
 


### PR DESCRIPTION
We have to copy and overwrite the `.git` directory from the old project into the new project, so we can skip it for the new project.