### PR TITLE
pkg/scaffold: fix hardcoded crd version

### DIFF
--- a/pkg/scaffold/crd.go
+++ b/pkg/scaffold/crd.go
@@ -55,5 +55,5 @@ spec:
     plural: {{ .Resource.Resource }}
     singular: {{ .Resource.LowerKind }}
   scope: Namespaced
-  version: v1alpha1
+  version: {{ .Resource.Version }}
 `


### PR DESCRIPTION
**Description of the change:**

Use requested version in CRD example.


**Motivation for the change:**

Examples could mismatch on versions.


Closes #689
