### PR TITLE
pkg/scaffold,version,changelog: bump to v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.1.1
+
+### Bug fixes
+- Fix hardcoded CRD version in crd scaffold ([#690](https://github.com/operator-framework/operator-sdk/pull/690))
+
 ## v0.1.0
 
 ### Changed

--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -76,8 +76,8 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  branch = "v0.1.x" #osdk_branch_annotation
-  # version = "=v0.1.0" #osdk_version_annotation
+  # branch = "v0.1.x" #osdk_branch_annotation
+  version = "=v0.1.1" #osdk_version_annotation
 
 [prune]
   go-tests = true

--- a/pkg/scaffold/gopkgtoml_test.go
+++ b/pkg/scaffold/gopkgtoml_test.go
@@ -75,8 +75,8 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  branch = "v0.1.x" #osdk_branch_annotation
-  # version = "=v0.1.0" #osdk_version_annotation
+  # branch = "v0.1.x" #osdk_branch_annotation
+  version = "=v0.1.1" #osdk_version_annotation
 
 [prune]
   go-tests = true

--- a/version/version.go
+++ b/version/version.go
@@ -15,5 +15,5 @@
 package version
 
 var (
-	Version = "v0.1.0+git"
+	Version = "v0.1.1"
 )


### PR DESCRIPTION
**Description of the change:** Release v0.1.1


**Motivation for the change:** Bug fixes

NOTE: This will not pass CI due to pointing to a non-existant tag and will require an override to merge