### PR TITLE
pkg/scaffold/build_dockerfile: update base image

### DIFF
--- a/pkg/scaffold/build_dockerfile.go
+++ b/pkg/scaffold/build_dockerfile.go
@@ -34,7 +34,9 @@ func (s *Dockerfile) GetInput() (input.Input, error) {
 	return s.Input, nil
 }
 
-const dockerfileTmpl = `FROM alpine:3.6
+const dockerfileTmpl = `FROM alpine:3.8
+
+RUN apk upgrade --update --no-cache
 
 USER nobody
 

--- a/pkg/scaffold/build_dockerfile_test.go
+++ b/pkg/scaffold/build_dockerfile_test.go
@@ -31,7 +31,9 @@ func TestDockerfile(t *testing.T) {
 	}
 }
 
-const dockerfileExp = `FROM alpine:3.6
+const dockerfileExp = `FROM alpine:3.8
+
+RUN apk upgrade --update --no-cache
 
 USER nobody
 


### PR DESCRIPTION
**Description of the change:** Update base image used by generated dockerfile and run `apk update` to make sure bug and security fixes are applied to image.


**Motivation for the change:** Alpine 3.6 is an old image and may contains security vulnerabilities or otherwise be out of date. For our default generated dockerfile, we should try to remain up to date and also update the image's packages in case a vulnerability was fixed in the repos, but not the image