### PR TITLE
test/e2e/memcached_test.go: comment out gopkg version during tests

### DIFF
--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -93,6 +93,8 @@ func TestMemcached(t *testing.T) {
 			// and comment out the current branch.
 			branchRe := regexp.MustCompile("([ ]+)(.+#osdk_branch_annotation)")
 			gopkg = branchRe.ReplaceAll(gopkg, []byte("$1# $2"))
+			versionRe := regexp.MustCompile("([ ]+)(.+#osdk_version_annotation)")
+			gopkg = versionRe.ReplaceAll(gopkg, []byte("$1# $2"))
 			// Plug in the fork to test against so `dep ensure` can resolve dependencies
 			// correctly.
 			gopkgString := string(gopkg)


### PR DESCRIPTION
**Description of the change:** Comment out version during tests


**Motivation for the change:** Release PRs would always fail, requiring us to disable branch protection temporarily to merge the PR before creating a matching tag. This should fix that
