### PR TITLE
Fix sed issue on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,10 @@ $ operator-sdk add controller --api-version=app.example.com/v1alpha1 --kind=AppS
 $ operator-sdk build quay.io/example/app-operator
 $ docker push quay.io/example/app-operator
 
-# Update the operator manifest to use the built image name
+# Update the operator manifest to use the built image name (if you run on OSX, see note below)
 $ sed -i 's|REPLACE_IMAGE|quay.io/example/app-operator|g' deploy/operator.yaml
+# On OSX use:
+$ sed -i "" 's|REPLACE_IMAGE|quay.io/example/app-operator|g' deploy/operator.yaml
 
 # Setup Service Account
 $ kubectl create -f deploy/service_account.yaml

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ operator-sdk add controller --api-version=app.example.com/v1alpha1 --kind=AppS
 $ operator-sdk build quay.io/example/app-operator
 $ docker push quay.io/example/app-operator
 
-# Update the operator manifest to use the built image name (if you run on OSX, see note below)
+# Update the operator manifest to use the built image name (if you are performing these steps on OSX, see note below)
 $ sed -i 's|REPLACE_IMAGE|quay.io/example/app-operator|g' deploy/operator.yaml
 # On OSX use:
 $ sed -i "" 's|REPLACE_IMAGE|quay.io/example/app-operator|g' deploy/operator.yaml

--- a/doc/ansible/dev/developer_guide.md
+++ b/doc/ansible/dev/developer_guide.md
@@ -370,6 +370,12 @@ deployment image in this file needs to be modified from the placeholder
 $ sed -i 's|REPLACE_IMAGE|quay.io/example/foo-operator:v0.0.1|g' deploy/operator.yaml
 ```
 
+**Note**  
+If you run sed on OSX, use syntax instead:
+```
+$ sed -i "" 's|REPLACE_IMAGE|quay.io/example/foo-operator:v0.0.1|g' deploy/operator.yaml
+```
+
 Deploy the foo-operator:
 
 ```sh

--- a/doc/ansible/dev/developer_guide.md
+++ b/doc/ansible/dev/developer_guide.md
@@ -371,7 +371,7 @@ $ sed -i 's|REPLACE_IMAGE|quay.io/example/foo-operator:v0.0.1|g' deploy/operator
 ```
 
 **Note**  
-If you run sed on OSX, use syntax instead:
+If you are performing these steps on OSX, use the following command:
 ```
 $ sed -i "" 's|REPLACE_IMAGE|quay.io/example/foo-operator:v0.0.1|g' deploy/operator.yaml
 ```

--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -205,6 +205,12 @@ deployment image in this file needs to be modified from the placeholder
 $ sed -i 's|REPLACE_IMAGE|quay.io/example/memcached-operator:v0.0.1|g' deploy/operator.yaml
 ```
 
+**Note**  
+If you run sed on OSX, use syntax instead:
+```
+$ sed -i "" 's|REPLACE_IMAGE|quay.io/example/memcached-operator:v0.0.1|g' deploy/operator.yaml
+```
+
 Deploy the memcached-operator:
 
 ```sh

--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -206,7 +206,7 @@ $ sed -i 's|REPLACE_IMAGE|quay.io/example/memcached-operator:v0.0.1|g' deploy/op
 ```
 
 **Note**  
-If you run sed on OSX, use syntax instead:
+If you are performing these steps on OSX, use the following command:
 ```
 $ sed -i "" 's|REPLACE_IMAGE|quay.io/example/memcached-operator:v0.0.1|g' deploy/operator.yaml
 ```

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -193,6 +193,12 @@ $ sed -i 's|REPLACE_IMAGE|quay.io/example/memcached-operator:v0.0.1|g' deploy/op
 $ docker push quay.io/example/memcached-operator:v0.0.1
 ```
 
+**Note**  
+If you run sed on OSX, use syntax instead:
+```
+$ sed -i "" 's|REPLACE_IMAGE|quay.io/example/memcached-operator:v0.0.1|g' deploy/operator.yaml
+```
+
 The Deployment manifest is generated at `deploy/operator.yaml`. Be sure to update the deployment image as shown above since the default is just a placeholder.
 
 Setup RBAC and deploy the memcached-operator:

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -194,7 +194,7 @@ $ docker push quay.io/example/memcached-operator:v0.0.1
 ```
 
 **Note**  
-If you run sed on OSX, use syntax instead:
+If you are performing these steps on OSX, use the following command:
 ```
 $ sed -i "" 's|REPLACE_IMAGE|quay.io/example/memcached-operator:v0.0.1|g' deploy/operator.yaml
 ```


### PR DESCRIPTION
On OSX `sed` throws an error if you do not specify a file extension when
`-i` is given. Fixing the docs to address this on OSX.

Error:

`sed: 1: "deploy/operator.yaml": extra characters at the end of d command`

From `man sed` on OSX:

```
-i extension
             Edit files in-place, saving backups with the specified
	     extension.  If a zero-length extension is given, no backup
	     will be saved.  It is not recommended to give a
	                  zero-length extension when in-place editing
			  files, as you risk corruption or partial
			  content in situations where disk space is
			  exhausted, etc.
```