### PR TITLE
SDK log injection and uniform logging in operator-sdk binary

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -791,6 +791,7 @@
   input-imports = [
     "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1",
     "github.com/ghodss/yaml",
+    "github.com/go-logr/logr",
     "github.com/markbates/inflect",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",

--- a/commands/operator-sdk/cmd/add/api.go
+++ b/commands/operator-sdk/cmd/add/api.go
@@ -15,13 +15,12 @@
 package add
 
 import (
-	"log"
-
 	"github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/generate"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -95,7 +94,7 @@ func apiRun(cmd *cobra.Command, args []string) {
 
 	// update deploy/role.yaml for the given resource r.
 	if err := scaffold.UpdateRoleForResource(r, absProjectPath); err != nil {
-		log.Fatalf("failed to update the RBAC manifest for the resource (%v, %v): %v", r.APIVersion, r.Kind, err)
+		log.Fatalf("failed to update the RBAC manifest for the resource (%v, %v): (%v)", r.APIVersion, r.Kind, err)
 	}
 
 	// Run k8s codegen for deepcopy

--- a/commands/operator-sdk/cmd/add/api.go
+++ b/commands/operator-sdk/cmd/add/api.go
@@ -67,6 +67,9 @@ func apiRun(cmd *cobra.Command, args []string) {
 
 	// Create and validate new resource
 	projutil.MustInProjectRoot()
+
+	log.Infof("Generating api version %s for kind %s.", apiVersion, kind)
+
 	r, err := scaffold.NewResource(apiVersion, kind)
 	if err != nil {
 		log.Fatal(err)
@@ -99,4 +102,6 @@ func apiRun(cmd *cobra.Command, args []string) {
 
 	// Run k8s codegen for deepcopy
 	generate.K8sCodegen()
+
+	log.Info("Api generation complete.")
 }

--- a/commands/operator-sdk/cmd/add/controller.go
+++ b/commands/operator-sdk/cmd/add/controller.go
@@ -60,6 +60,9 @@ func controllerRun(cmd *cobra.Command, args []string) {
 	projutil.MustGoProjectCmd(cmd)
 
 	projutil.MustInProjectRoot()
+
+	log.Infof("Generating controller version %s for kind %s.", apiVersion, kind)
+
 	// Create and validate new resource
 	r, err := scaffold.NewResource(apiVersion, kind)
 	if err != nil {
@@ -79,4 +82,6 @@ func controllerRun(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("add scaffold failed: (%v)", err)
 	}
+
+	log.Info("Controller generation complete.")
 }

--- a/commands/operator-sdk/cmd/add/controller.go
+++ b/commands/operator-sdk/cmd/add/controller.go
@@ -15,12 +15,11 @@
 package add
 
 import (
-	"log"
-
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 

--- a/commands/operator-sdk/cmd/add/crd.go
+++ b/commands/operator-sdk/cmd/add/crd.go
@@ -16,7 +16,6 @@ package add
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,6 +24,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -60,26 +60,26 @@ func crdFunc(cmd *cobra.Command, args []string) {
 	verifyCrdFlags()
 	verifyCrdDeployPath()
 
-	fmt.Fprintln(os.Stdout, "Generating custom resource definition (CRD) file")
+	fmt.Println("Generating custom resource definition (CRD) file")
 
 	// generate CR/CRD file
 	resource, err := scaffold.NewResource(apiVersion, kind)
 	if err != nil {
-		log.Fatalf("%v", err)
+		log.Fatal(err)
 	}
+
 	s := scaffold.Scaffold{}
 	err = s.Execute(cfg,
 		&scaffold.Crd{Resource: resource},
 		&scaffold.Cr{Resource: resource},
 	)
-
 	if err != nil {
 		log.Fatalf("add scaffold failed: (%v)", err)
 	}
 
 	// update deploy/role.yaml for the given resource r.
 	if err := scaffold.UpdateRoleForResource(resource, cfg.AbsProjectPath); err != nil {
-		log.Fatalf("failed to update the RBAC manifest for the resource (%v, %v): %v", resource.APIVersion, resource.Kind, err)
+		log.Fatalf("failed to update the RBAC manifest for the resource (%v, %v): (%v)", resource.APIVersion, resource.Kind, err)
 	}
 }
 
@@ -103,7 +103,7 @@ func verifyCrdFlags() {
 func verifyCrdDeployPath() {
 	wd, err := os.Getwd()
 	if err != nil {
-		log.Fatalf("failed to determine the full path of the current directory: %v", err)
+		log.Fatalf("failed to determine the full path of the current directory: (%v)", err)
 	}
 	// check if the deploy sub-directory exist
 	_, err = os.Stat(filepath.Join(wd, scaffold.DeployDir))

--- a/commands/operator-sdk/cmd/add/crd.go
+++ b/commands/operator-sdk/cmd/add/crd.go
@@ -15,7 +15,6 @@
 package add
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,7 +59,7 @@ func crdFunc(cmd *cobra.Command, args []string) {
 	verifyCrdFlags()
 	verifyCrdDeployPath()
 
-	fmt.Println("Generating custom resource definition (CRD) file")
+	log.Infof("Generating Custom Resource Definition (CRD) version %s for kind %s.", apiVersion, kind)
 
 	// generate CR/CRD file
 	resource, err := scaffold.NewResource(apiVersion, kind)
@@ -81,6 +80,8 @@ func crdFunc(cmd *cobra.Command, args []string) {
 	if err := scaffold.UpdateRoleForResource(resource, cfg.AbsProjectPath); err != nil {
 		log.Fatalf("failed to update the RBAC manifest for the resource (%v, %v): (%v)", resource.APIVersion, resource.Kind, err)
 	}
+
+	log.Info("CRD generation complete.")
 }
 
 func verifyCrdFlags() {

--- a/commands/operator-sdk/cmd/build.go
+++ b/commands/operator-sdk/cmd/build.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,6 +29,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/test"
 
 	"github.com/ghodss/yaml"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -78,11 +78,11 @@ func verifyDeploymentImage(yamlFile []byte, imageName string) error {
 		yamlMap := make(map[string]interface{})
 		err := yaml.Unmarshal(yamlSpec, &yamlMap)
 		if err != nil {
-			log.Fatal("Could not unmarshal yaml namespaced spec")
+			log.Fatalf("could not unmarshal yaml namespaced spec: (%v)", err)
 		}
 		kind, ok := yamlMap["kind"].(string)
 		if !ok {
-			log.Fatal("Yaml manifest file contains a 'kind' field that is not a string")
+			log.Fatal("yaml manifest file contains a 'kind' field that is not a string")
 		}
 		if kind == "Deployment" {
 			// this is ugly and hacky; we should probably make this cleaner
@@ -122,13 +122,13 @@ func verifyDeploymentImage(yamlFile []byte, imageName string) error {
 func verifyTestManifest(image string) {
 	namespacedBytes, err := ioutil.ReadFile(namespacedManBuild)
 	if err != nil {
-		log.Fatalf("could not read namespaced manifest: %v", err)
+		log.Fatalf("could not read namespaced manifest: (%v)", err)
 	}
 
 	err = verifyDeploymentImage(namespacedBytes, image)
 	// the error from verifyDeploymentImage is just a warning, not fatal error
 	if err != nil {
-		fmt.Printf("%v\n", err)
+		log.Warn(err)
 	}
 }
 
@@ -141,7 +141,7 @@ func buildFunc(cmd *cobra.Command, args []string) {
 	goBuildEnv := append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0")
 	wd, err := os.Getwd()
 	if err != nil {
-		log.Fatalf("could not identify current working directory: %v", err)
+		log.Fatalf("could not identify current working directory: (%v)", err)
 	}
 
 	// Don't need to build go code if Ansible Operator
@@ -154,7 +154,7 @@ func buildFunc(cmd *cobra.Command, args []string) {
 		buildCmd.Stderr = os.Stderr
 		err = buildCmd.Run()
 		if err != nil {
-			log.Fatalf("failed to build operator binary: %v", err)
+			log.Fatalf("failed to build operator binary: (%v)", err)
 		}
 	}
 
@@ -169,9 +169,9 @@ func buildFunc(cmd *cobra.Command, args []string) {
 	err = dbcmd.Run()
 	if err != nil {
 		if enableTests {
-			log.Fatalf("failed to build intermediate image for %s image: %v", image, err)
+			log.Fatalf("failed to output intermediate image %s: (%v)", image, err)
 		} else {
-			log.Fatalf("failed to output build image %s: %v", image, err)
+			log.Fatalf("failed to output build image %s: (%v)", image, err)
 		}
 	}
 
@@ -183,7 +183,7 @@ func buildFunc(cmd *cobra.Command, args []string) {
 		buildTestCmd.Stderr = os.Stderr
 		err = buildTestCmd.Run()
 		if err != nil {
-			log.Fatalf("failed to build test binary: %v", err)
+			log.Fatalf("failed to build test binary: (%v)", err)
 		}
 		// if a user is using an older sdk repo as their library, make sure they have required build files
 		testDockerfile := filepath.Join(scaffold.BuildTestDir, scaffold.DockerfileFile)
@@ -204,7 +204,7 @@ func buildFunc(cmd *cobra.Command, args []string) {
 				&scaffold.TestPod{Image: image, TestNamespaceEnv: test.TestNamespaceEnv},
 			)
 			if err != nil {
-				log.Fatalf("build scaffold failed: (%v)", err)
+				log.Fatalf("test scaffold failed: (%v)", err)
 			}
 		}
 
@@ -213,7 +213,7 @@ func buildFunc(cmd *cobra.Command, args []string) {
 		testDbcmd.Stderr = os.Stderr
 		err = testDbcmd.Run()
 		if err != nil {
-			log.Fatalf("failed to output build image %s: %v", image, err)
+			log.Fatalf("failed to output test image %s: (%v)", image, err)
 		}
 		// Check image name of deployments in namespaced manifest
 		verifyTestManifest(image)

--- a/commands/operator-sdk/cmd/generate/k8s.go
+++ b/commands/operator-sdk/cmd/generate/k8s.go
@@ -17,7 +17,6 @@ package generate
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,6 +24,7 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -41,7 +41,7 @@ to comply with kube-API requirements.
 
 func k8sFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 0 {
-		log.Fatalf("k8s command doesn't accept any arguments.")
+		log.Fatal("k8s command doesn't accept any arguments")
 	}
 
 	// Only Go projects can generate k8s deepcopy code.
@@ -62,7 +62,7 @@ func K8sCodegen() {
 		log.Fatalf("failed to parse group versions: (%v)", err)
 	}
 
-	fmt.Fprintf(os.Stdout, "Running code-generation for custom resource group versions: [%s]\n", groupVersions)
+	log.Printf("Running code-generation for custom resource group versions: [%s]\n", groupVersions)
 	// TODO: Replace generate-groups.sh by building the vendored generators(deepcopy, lister etc)
 	// and running them directly
 	// TODO: remove dependency on boilerplate.go.txt
@@ -73,11 +73,13 @@ func K8sCodegen() {
 		apisPkg,
 		groupVersions,
 	}
-	out, err := exec.Command(genGroupsCmd, args...).CombinedOutput()
+	cgCmd := exec.Command(genGroupsCmd, args...)
+	cgCmd.Stdout = os.Stdout
+	cgCmd.Stderr = os.Stderr
+	err = cgCmd.Run()
 	if err != nil {
 		log.Fatalf("failed to perform code-generation: (%v)", err)
 	}
-	fmt.Fprintln(os.Stdout, string(out))
 }
 
 // getGroupVersions parses the layout of pkg/apis to return the API groups and versions
@@ -106,6 +108,10 @@ func parseGroupVersions() (string, error) {
 			}
 			groupVersions += fmt.Sprintf("%s:%s ", g.Name(), groupVersion)
 		}
+	}
+
+	if groupVersions == "" {
+		return "", fmt.Errorf("no groups or versions found in %s", scaffold.ApisDir)
 	}
 
 	return groupVersions, nil

--- a/commands/operator-sdk/cmd/generate/k8s.go
+++ b/commands/operator-sdk/cmd/generate/k8s.go
@@ -62,10 +62,10 @@ func K8sCodegen() {
 		log.Fatalf("failed to parse group versions: (%v)", err)
 	}
 
-	log.Printf("Running code-generation for custom resource group versions: [%s]\n", groupVersions)
+	log.Infof("Running code-generation for Custom Resource group versions: [%s]\n", groupVersions)
+
 	// TODO: Replace generate-groups.sh by building the vendored generators(deepcopy, lister etc)
 	// and running them directly
-	// TODO: remove dependency on boilerplate.go.txt
 	genGroupsCmd := "vendor/k8s.io/code-generator/generate-groups.sh"
 	args := []string{
 		"deepcopy",
@@ -80,6 +80,8 @@ func K8sCodegen() {
 	if err != nil {
 		log.Fatalf("failed to perform code-generation: (%v)", err)
 	}
+
+	log.Info("Code-generation complete.")
 }
 
 // getGroupVersions parses the layout of pkg/apis to return the API groups and versions

--- a/commands/operator-sdk/cmd/new.go
+++ b/commands/operator-sdk/cmd/new.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,6 +27,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/ansible"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -150,13 +150,13 @@ func doAnsibleScaffold() {
 
 	resource, err := scaffold.NewResource(apiVersion, kind)
 	if err != nil {
-		log.Fatal("Invalid apiVersion and kind.")
+		log.Fatalf("invalid apiVersion and kind: (%v)", err)
 	}
 
 	s := &scaffold.Scaffold{}
 	tmpdir, err := ioutil.TempDir("", "osdk")
 	if err != nil {
-		log.Fatal("unable to get temp directory")
+		log.Fatalf("unable to get temp directory: (%v)", err)
 	}
 
 	galaxyInit := &ansible.GalaxyInit{
@@ -196,7 +196,7 @@ func doAnsibleScaffold() {
 			},
 		)
 		if err != nil {
-			log.Fatalf("new scaffold failed: (%v)", err)
+			log.Fatalf("new playbook scaffold failed: (%v)", err)
 		}
 	}
 
@@ -210,12 +210,12 @@ func doAnsibleScaffold() {
 	// everything.
 	tmpDirectorySlice := strings.Split(os.TempDir(), "/")
 	if err = os.RemoveAll(filepath.Join(galaxyInit.AbsProjectPath, tmpDirectorySlice[1])); err != nil {
-		log.Fatalf("failed to remove the galaxy init script")
+		log.Fatalf("failed to remove the galaxy init script: (%v)", err)
 	}
 
 	// update deploy/role.yaml for the given resource r.
 	if err := scaffold.UpdateRoleForResource(resource, cfg.AbsProjectPath); err != nil {
-		log.Fatalf("failed to update the RBAC manifest for the resource (%v, %v): %v", resource.APIVersion, resource.Kind, err)
+		log.Fatalf("failed to update the RBAC manifest for the resource (%v, %v): (%v)", resource.APIVersion, resource.Kind, err)
 	}
 }
 
@@ -254,14 +254,14 @@ func execCmd(stdout *os.File, cmd string, args ...string) {
 	dc.Stderr = os.Stderr
 	err := dc.Run()
 	if err != nil {
-		log.Fatalf("failed to exec %s %#v: %v", cmd, args, err)
+		log.Fatalf("failed to exec %s %#v: (%v)", cmd, args, err)
 	}
 }
 
 func pullDep() {
 	_, err := exec.LookPath(dep)
 	if err != nil {
-		log.Fatalf("looking for dep in $PATH: %v", err)
+		log.Fatalf("looking for dep in $PATH: (%v)", err)
 	}
 	fmt.Fprintln(os.Stdout, "Run dep ensure ...")
 	execCmd(os.Stdout, dep, ensureCmd, "-v")

--- a/commands/operator-sdk/cmd/new.go
+++ b/commands/operator-sdk/cmd/new.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -80,6 +79,8 @@ func newFunc(cmd *cobra.Command, args []string) {
 	mustBeNewProject()
 	verifyFlags()
 
+	log.Infof("Creating new %s operator '%s'.", strings.Title(operatorType), projectName)
+
 	switch operatorType {
 	case projutil.OperatorTypeGo:
 		doScaffold()
@@ -88,6 +89,8 @@ func newFunc(cmd *cobra.Command, args []string) {
 		doAnsibleScaffold()
 	}
 	initGit()
+
+	log.Info("Project creation complete.")
 }
 
 func parse(args []string) {
@@ -190,6 +193,8 @@ func doAnsibleScaffold() {
 
 	// Decide on playbook.
 	if generatePlaybook {
+		log.Infof("Generating %s playbook.", strings.Title(operatorType))
+
 		err := s.Execute(cfg,
 			&ansible.Playbook{
 				Resource: *resource,
@@ -200,11 +205,14 @@ func doAnsibleScaffold() {
 		}
 	}
 
+	log.Info("Running galaxy-init.")
+
 	// Run galaxy init.
 	cmd := exec.Command(filepath.Join(galaxyInit.AbsProjectPath, galaxyInit.Path))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Run()
+
 	// Delete Galxy INIT
 	// Mac OS tmp directory is /var/folders/_c/..... this means we have to make sure that we get the top level directory to remove
 	// everything.
@@ -263,18 +271,18 @@ func pullDep() {
 	if err != nil {
 		log.Fatalf("looking for dep in $PATH: (%v)", err)
 	}
-	fmt.Fprintln(os.Stdout, "Run dep ensure ...")
+	log.Info("Run dep ensure ...")
 	execCmd(os.Stdout, dep, ensureCmd, "-v")
-	fmt.Fprintln(os.Stdout, "Run dep ensure done")
+	log.Info("Run dep ensure done")
 }
 
 func initGit() {
 	if skipGit {
 		return
 	}
-	fmt.Fprintln(os.Stdout, "Run git init ...")
+	log.Info("Run git init ...")
 	execCmd(os.Stdout, "git", "init")
 	execCmd(os.Stdout, "git", "add", "--all")
 	execCmd(os.Stdout, "git", "commit", "-q", "-m", "INITIAL COMMIT")
-	fmt.Fprintln(os.Stdout, "Run git init done")
+	log.Info("Run git init done")
 }

--- a/commands/operator-sdk/cmd/test/cluster.go
+++ b/commands/operator-sdk/cmd/test/cluster.go
@@ -63,6 +63,9 @@ func testClusterFunc(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("operator-sdk test cluster requires exactly 1 argument")
 	}
+
+	log.Info("Testing operator in cluster.")
+
 	var pullPolicy v1.PullPolicy
 	if strings.ToLower(tcConfig.imagePullPolicy) == "always" {
 		pullPolicy = v1.PullAlways
@@ -141,7 +144,7 @@ func testClusterFunc(cmd *cobra.Command, args []string) error {
 			time.Sleep(time.Second * 5)
 			continue
 		} else if testPod.Status.Phase == v1.PodSucceeded {
-			fmt.Println("Test Successfully Completed")
+			log.Info("Cluster test successfully completed.")
 			return nil
 		} else if testPod.Status.Phase == v1.PodFailed {
 			req := kubeclient.CoreV1().Pods(tcConfig.namespace).GetLogs(testPod.Name, &v1.PodLogOptions{})

--- a/commands/operator-sdk/cmd/test/cluster.go
+++ b/commands/operator-sdk/cmd/test/cluster.go
@@ -24,6 +24,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/pkg/test"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,7 +111,7 @@ func testClusterFunc(cmd *cobra.Command, args []string) error {
 	defer func() {
 		err = kubeclient.CoreV1().Pods(tcConfig.namespace).Delete(testPod.Name, &metav1.DeleteOptions{})
 		if err != nil {
-			fmt.Printf("Warning: failed to delete test pod")
+			log.Warn("failed to delete test pod")
 		}
 	}()
 	err = wait.Poll(time.Second*5, time.Second*time.Duration(tcConfig.pendingTimeout), func() (bool, error) {
@@ -140,7 +141,7 @@ func testClusterFunc(cmd *cobra.Command, args []string) error {
 			time.Sleep(time.Second * 5)
 			continue
 		} else if testPod.Status.Phase == v1.PodSucceeded {
-			fmt.Printf("Test Successfully Completed\n")
+			fmt.Println("Test Successfully Completed")
 			return nil
 		} else if testPod.Status.Phase == v1.PodFailed {
 			req := kubeclient.CoreV1().Pods(tcConfig.namespace).GetLogs(testPod.Name, &v1.PodLogOptions{})

--- a/commands/operator-sdk/cmd/test/local.go
+++ b/commands/operator-sdk/cmd/test/local.go
@@ -62,6 +62,9 @@ func testLocalFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		log.Fatal("operator-sdk test local requires exactly 1 argument")
 	}
+
+	log.Info("Testing operator locally.")
+
 	// if no namespaced manifest path is given, combine deploy/service_account.yaml, deploy/role.yaml, deploy/role_binding.yaml and deploy/operator.yaml
 	if tlConfig.namespacedManPath == "" {
 		err := os.MkdirAll(deployTestDir, os.FileMode(fileutil.DefaultDirFileMode))
@@ -134,7 +137,7 @@ func testLocalFunc(cmd *cobra.Command, args []string) {
 		defer func() {
 			err := os.Remove(tlConfig.globalManPath)
 			if err != nil {
-				log.Fatalf("could not delete global namespace manifest file: (%v)", err)
+				log.Fatalf("could not delete global manifest file: (%v)", err)
 			}
 		}()
 	}
@@ -160,6 +163,8 @@ func testLocalFunc(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("failed to exec `go %s`: (%v)", strings.Join(testArgs, " "), err)
 	}
+
+	log.Info("Local operator test successfully completed.")
 }
 
 // combineManifests combines a given manifest with a base manifest and adds yaml

--- a/commands/operator-sdk/cmd/up/local.go
+++ b/commands/operator-sdk/cmd/up/local.go
@@ -39,6 +39,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 func NewLocalCmd() *cobra.Command {
@@ -134,6 +135,9 @@ func upLocal() {
 func upLocalAnsible() {
 	// Set the kubeconfig that the manager will be able to grab
 	os.Setenv(k8sutil.KubeConfigEnvVar, kubeConfig)
+
+	logf.SetLogger(logf.ZapLogger(false))
+
 	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{Namespace: namespace})
 	if err != nil {
 		log.Fatal(err)

--- a/commands/operator-sdk/cmd/up/local.go
+++ b/commands/operator-sdk/cmd/up/local.go
@@ -16,7 +16,6 @@ package up
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -35,7 +34,7 @@ import (
 	ansibleScaffold "github.com/operator-framework/operator-sdk/pkg/scaffold/ansible"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -91,14 +90,14 @@ func mustKubeConfig() {
 	if len(kubeConfig) == 0 {
 		usr, err := user.Current()
 		if err != nil {
-			log.Fatalf("failed to determine user's home dir: %v", err)
+			log.Fatalf("failed to determine user's home dir: (%v)", err)
 		}
 		kubeConfig = filepath.Join(usr.HomeDir, defaultConfigPath)
 	}
 
 	_, err := os.Stat(kubeConfig)
 	if err != nil && os.IsNotExist(err) {
-		log.Fatalf("failed to find the kubeconfig file (%v): %v", kubeConfig, err)
+		log.Fatalf("failed to find the kubeconfig file (%v): (%v)", kubeConfig, err)
 	}
 }
 
@@ -119,16 +118,17 @@ func upLocal() {
 		<-c
 		err := dc.Process.Kill()
 		if err != nil {
-			log.Fatalf("failed to terminate the operator: %v", err)
+			log.Fatalf("failed to terminate the operator: (%v)", err)
 		}
 		os.Exit(0)
 	}()
 	dc.Stdout = os.Stdout
 	dc.Stderr = os.Stderr
-	dc.Env = append(os.Environ(), fmt.Sprintf("%v=%v", k8sutil.KubeConfigEnvVar, kubeConfig), fmt.Sprintf("%v=%v", k8sutil.WatchNamespaceEnvVar, namespace))
+	dc.Env = append(os.Environ(), fmt.Sprintf("%v=%v", k8sutil.KubeConfigEnvVar, kubeConfig))
+	dc.Env = append(dc.Env, fmt.Sprintf("%v=%v", k8sutil.WatchNamespaceEnvVar, namespace))
 	err := dc.Run()
 	if err != nil {
-		log.Fatalf("failed to run operator locally: %v", err)
+		log.Fatalf("failed to run operator locally: (%v)", err)
 	}
 }
 
@@ -144,7 +144,7 @@ func upLocalAnsible() {
 	}
 
 	printVersion()
-	logrus.Infof("watching namespace: %s", namespace)
+	log.Infof("watching namespace: %s", namespace)
 	done := make(chan error)
 
 	// start the proxy
@@ -154,7 +154,7 @@ func upLocalAnsible() {
 		KubeConfig: mgr.GetConfig(),
 	})
 	if err != nil {
-		logrus.Fatalf("error starting proxy: %v", err)
+		log.Fatalf("error starting proxy: (%v)", err)
 	}
 
 	// start the operator
@@ -162,15 +162,14 @@ func upLocalAnsible() {
 
 	// wait for either to finish
 	err = <-done
-	if err == nil {
-		logrus.Info("Exiting")
-	} else {
-		logrus.Fatal(err.Error())
+	if err != nil {
+		log.Fatal(err)
 	}
+	log.Info("Ansible operator started succesfully. Exiting.")
 }
 
 func printVersion() {
-	logrus.Infof("Go Version: %s", runtime.Version())
-	logrus.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
-	logrus.Infof("operator-sdk Version: %v", sdkVersion.Version)
+	log.Infof("Go Version: %s", runtime.Version())
+	log.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
+	log.Infof("operator-sdk Version: %v", sdkVersion.Version)
 }

--- a/commands/operator-sdk/cmd/up/local.go
+++ b/commands/operator-sdk/cmd/up/local.go
@@ -73,6 +73,9 @@ const (
 
 func upLocalFunc(cmd *cobra.Command, args []string) {
 	mustKubeConfig()
+
+	log.Info("Running the operator locally.")
+
 	switch projutil.GetOperatorType() {
 	case projutil.OperatorTypeGo:
 		projutil.MustInProjectRoot()
@@ -165,7 +168,7 @@ func upLocalAnsible() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Info("Ansible operator started succesfully. Exiting.")
+	log.Info("Exiting.")
 }
 
 func printVersion() {

--- a/commands/operator-sdk/main.go
+++ b/commands/operator-sdk/main.go
@@ -15,15 +15,12 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd"
+	log "github.com/sirupsen/logrus"
 )
 
 func main() {
 	if err := cmd.NewRootCmd().Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(-1)
+		log.Fatal(err)
 	}
 }

--- a/doc/dev/logging.md
+++ b/doc/dev/logging.md
@@ -1,0 +1,105 @@
+# Logging in operators
+
+Operator SDK-generated operators use the [`logr`][godoc_logr] interface to log. This log interface has several backends such as [`zap`][repo_zapr], which the SDK uses in generated code by default. [`logr.Logger`][godoc_logr_logger] exposes [structured logging][site_struct_logging] methods that help create machine-readable logs and adding a wealth of information to log records.
+
+## Setting the logger
+
+Operators set the logger for all operator logging in [`cmd/manager/main.go`][code_set_logger]:
+
+```Go
+import (
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+func main() {
+  logf.SetLogger(logf.ZapLogger(false))
+  log := logf.Log.WithName("cmd")
+
+  ...
+
+  log.Info("Starting the Cmd.")
+
+  ...
+}
+```
+
+By using `controller-runtime/pkg/runtime/log`, your logger is propagated through `controller-runtime`. Any logs produced by `controller-runtime` code will be through your logger, and therefore have the same formatting and destination.
+
+In the above example, `logf.ZapLogger()` takes a boolean flag to set development parameters. Passing in `true` will set the logger to log in development mode; debug log statements will trigger, and error log statements will include stack traces.
+
+## Creating a structured log statement
+
+There are two ways to create structured logs with `logr`. You can create new loggers using `log.WithValues(keyValues)` that include `keyValues`, a list of key-value pair `interface{}`'s, in each log record. Alternatively you can include `keyValues` directly in a log statement, as all `logr` log statements take some message and `keyValues`. The signature of `logr.Error()` has an `error`-type parameter, which can be `nil`.
+
+An example from [`memcached_controller.go`][code_memcached_controller]:
+
+```Go
+package memcached
+
+import (
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+// Set a global logger for the memcached package. Each log record produced
+// by this logger will have an identifier containing "controller_memcached".
+// These names are hierarchical; the name attached to memcached log statements
+// will be "operator-sdk.controller_memcached" because SDKLog has name
+// "operator-sdk".
+var log = logf.Log.WithName("controller_memcached")
+
+func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+  // Create a logger for Reconcile() that includes "Request.Namespace"
+  // and "Request.Name" in each log record from this log statement.
+  reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+  reqLogger.Info("Reconciling Memcached.")
+
+  memcached := &cachev1alpha1.Memcached{}
+  err := r.client.Get(context.TODO(), request.NamespacedName, memcached)
+  if err != nil {
+    if errors.IsNotFound(err) {
+      reqLogger.Info("Memcached resource not found. Ignoring since object must be deleted.")
+      return reconcile.Result{}, nil
+    }
+    return reconcile.Result{}, err
+  }
+
+  found := &appsv1.Deployment{}
+  err = r.client.Get(context.TODO(), types.NamespacedName{Name: memcached.Name, Namespace: memcached.Namespace}, found)
+  if err != nil {
+    if errors.IsNotFound(err) {
+      dep := r.deploymentForMemcached(memcached)
+      // Include "Deployment.Namespace" and "Deployment.Name" in records
+      // produced by this particular log statement. "Request.Namespace" and
+      // "Request.Name" will also be included from reqLogger.
+      reqLogger.Info("Creating a new Deployment", "Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
+      err = r.client.Create(context.TODO(), dep)
+      if err != nil {
+        // Include the error in records produced by this log statement.
+        reqLogger.Error(err, "failed to create new Deployment", "Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
+        return reconcile.Result{}, err
+      }
+    }
+    return reconcile.Result{}, err
+  }
+
+  ...
+}
+```
+
+Log records will look like the following (from `reqLogger.Error()` above):
+
+```
+2018-11-08T00:00:25.700Z	ERROR	operator-sdk.controller_memcached pkg/controller/memcached/memcached_controller.go:118	failed to create new Deployment	{"Request.Namespace", "memcached", "Request.Name", "memcached-operator", "Deployment.Namespace", "memcached", "Deployment.Name", "memcached-operator"}
+```
+
+## Non-default logging
+
+If you do not want to use `logr` as your logging tool, you can remove `logr`-specific statements without issue from your operator's code, including the `logr` [setup code][code_set_logger] in `cmd/manager/main.go`, and add your own. Note that removing `logr` setup code will prevent `controller-runtime` from logging.
+
+
+[godoc_logr]:https://godoc.org/github.com/go-logr/logr
+[repo_zapr]:https://godoc.org/github.com/go-logr/zapr
+[godoc_logr_logger]:https://godoc.org/github.com/go-logr/logr#Logger
+[site_struct_logging]:https://www.client9.com/structured-logging-in-golang/
+[code_memcached_controller]:../../example/memcached-operator/memcached_controller.go.tmpl
+[code_set_logger]:https://github.com/operator-framework/operator-sdk/blob/948139171fff0e802c9e68f87cb95939941772ef/pkg/scaffold/cmd.go#L68-L72

--- a/example/memcached-operator/memcached_controller.go.tmpl
+++ b/example/memcached-operator/memcached_controller.go.tmpl
@@ -2,7 +2,6 @@ package memcached
 
 import (
 	"context"
-	"log"
 	"reflect"
 
 	cachev1alpha1 "github.com/example-inc/memcached-operator/pkg/apis/cache/v1alpha1"
@@ -20,8 +19,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
+
+var log = logf.Log.WithName("controller_memcached")
 
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
@@ -85,7 +87,8 @@ type ReconcileMemcached struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.Printf("Reconciling Memcached %s/%s\n", request.Namespace, request.Name)
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Requst.Name", request.Name)
+	reqLogger.Info("Reconciling Memcached")
 
 	// Fetch the Memcached instance
 	memcached := &cachev1alpha1.Memcached{}
@@ -95,11 +98,11 @@ func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Res
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
-			log.Printf("Memcached %s/%s not found. Ignoring since object must be deleted\n", request.Namespace, request.Name)
+			reqLogger.Info("Memcached resource not found. Ignoring since object must be deleted")
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		log.Printf("Failed to get Memcached: %v", err)
+		reqLogger.Error(err, "failed to get Memcached")
 		return reconcile.Result{}, err
 	}
 
@@ -109,16 +112,16 @@ func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Res
 	if err != nil && errors.IsNotFound(err) {
 		// Define a new deployment
 		dep := r.deploymentForMemcached(memcached)
-		log.Printf("Creating a new Deployment %s/%s\n", dep.Namespace, dep.Name)
+		reqLogger.Info("Creating a new Deployment", "Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
 		err = r.client.Create(context.TODO(), dep)
 		if err != nil {
-			log.Printf("Failed to create new Deployment: %v\n", err)
+			reqLogger.Error(err, "failed to create new Deployment", "Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
 			return reconcile.Result{}, err
 		}
 		// Deployment created successfully - return and requeue
 		return reconcile.Result{Requeue: true}, nil
 	} else if err != nil {
-		log.Printf("Failed to get Deployment: %v\n", err)
+		reqLogger.Error(err, "failed to get Deployment")
 		return reconcile.Result{}, err
 	}
 
@@ -128,7 +131,7 @@ func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Res
 		found.Spec.Replicas = &size
 		err = r.client.Update(context.TODO(), found)
 		if err != nil {
-			log.Printf("Failed to update Deployment: %v\n", err)
+			reqLogger.Error(err, "failed to update Deployment", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
 			return reconcile.Result{}, err
 		}
 		// Spec updated - return and requeue
@@ -142,7 +145,7 @@ func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Res
 	listOps := &client.ListOptions{Namespace: memcached.Namespace, LabelSelector: labelSelector}
 	err = r.client.List(context.TODO(), listOps, podList)
 	if err != nil {
-		log.Printf("Failed to list pods: %v", err)
+		reqLogger.Error(err, "failed to list pods", "Memcached.Namespace", memcached.Namespace, "Memcached.Name", memcached.Name)
 		return reconcile.Result{}, err
 	}
 	podNames := getPodNames(podList.Items)
@@ -152,7 +155,7 @@ func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Res
 		memcached.Status.Nodes = podNames
 		err := r.client.Update(context.TODO(), memcached)
 		if err != nil {
-			log.Printf("failed to update memcached status: %v", err)
+			reqLogger.Error(err, "failed to update Memcached status")
 			return reconcile.Result{}, err
 		}
 	}

--- a/example/memcached-operator/memcached_controller.go.tmpl
+++ b/example/memcached-operator/memcached_controller.go.tmpl
@@ -87,7 +87,7 @@ type ReconcileMemcached struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Requst.Name", request.Name)
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling Memcached")
 
 	// Fetch the Memcached instance

--- a/hack/check_error_case.sh
+++ b/hack/check_error_case.sh
@@ -7,7 +7,7 @@ source "hack/lib/test_lib.sh"
 
 echo "Checking case of error messages..."
 allfiles=$(listFiles)
-output=$(grep -Rn 'Fatalf("[[:upper:]]\|Errorf("[[:upper:]]\|errors.New("[[:upper:]]' $allfiles)
+output=$(grep -ERn 'Fatal(f)?\("[[:upper:]]|Error(f)?\("[[:upper:]]|Error\((err|nil), "[[:upper:]]|errors.New\("[[:upper:]]' $allfiles)
 if [ -n "${output}" ]; then
   echo "Error messages in wrong case:"
   echo "${output}"

--- a/internal/util/fileutil/file_util.go
+++ b/internal/util/fileutil/file_util.go
@@ -19,11 +19,11 @@ package fileutil
 import (
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"sync"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 )
 

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -15,11 +15,11 @@
 package projutil
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -50,7 +50,7 @@ func MustInProjectRoot() {
 	// we are at the project root.
 	_, err := os.Stat(buildDockerfile)
 	if err != nil && os.IsNotExist(err) {
-		log.Fatalf("must run command in project root dir: %v", err)
+		log.Fatalf("must run command in project root dir: (%v)", err)
 	}
 }
 

--- a/pkg/ansible/controller/status/types.go
+++ b/pkg/ansible/controller/status/types.go
@@ -18,10 +18,13 @@ import (
 	"time"
 
 	"github.com/operator-framework/operator-sdk/pkg/ansible/runner/eventapi"
-	"github.com/sirupsen/logrus"
+
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
+
+var log = logf.Log.WithName("controller.status")
 
 const (
 	host = "localhost"
@@ -128,7 +131,7 @@ func createConditionFromMap(cm map[string]interface{}) Condition {
 	if ok {
 		t, err := time.Parse("2006-01-02T15:04:05Z", ltts)
 		if err != nil {
-			logrus.Warningf("unable to parse time for status condition: %v", ltts)
+			log.Info("unable to parse time for status condition", "Time", ltts)
 		} else {
 			ltt = metav1.NewTime(t)
 		}
@@ -158,7 +161,7 @@ func CreateFromMap(statusMap map[string]interface{}) Status {
 	for _, ci := range conditionsInterface {
 		cm, ok := ci.(map[string]interface{})
 		if !ok {
-			logrus.Warningf("unknown condition, removing condition: %v", ci)
+			log.Info("unknown condition, removing condition", "ConditionInterface", ci)
 			continue
 		}
 		conditions = append(conditions, createConditionFromMap(cm))

--- a/pkg/ansible/events/log_events.go
+++ b/pkg/ansible/events/log_events.go
@@ -15,9 +15,12 @@
 package events
 
 import (
+	"errors"
+
 	"github.com/operator-framework/operator-sdk/pkg/ansible/runner/eventapi"
-	"github.com/sirupsen/logrus"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 // LogLevel - Levelt for the logging to take place.
@@ -44,44 +47,48 @@ type loggingEventHandler struct {
 }
 
 func (l loggingEventHandler) Handle(ident string, u *unstructured.Unstructured, e eventapi.JobEvent) {
-	log := logrus.WithFields(logrus.Fields{
-		"component":  "logging_event_handler",
-		"name":       u.GetName(),
-		"namespace":  u.GetNamespace(),
-		"gvk":        u.GroupVersionKind().String(),
-		"event_type": e.Event,
-		"job":        ident,
-	})
 	if l.LogLevel == Nothing {
 		return
 	}
-	// log only the following for the 'Tasks' LogLevel
+
+	logger := logf.Log.WithName("logging_event_handler").WithValues(
+		"name", u.GetName(),
+		"namespace", u.GetNamespace(),
+		"gvk", u.GroupVersionKind().String(),
+		"event_type", e.Event,
+		"job", ident,
+	)
+
+	// logger only the following for the 'Tasks' LogLevel
 	t, ok := e.EventData["task"]
 	if ok {
 		setFactAction := e.EventData["task_action"] == eventapi.TaskActionSetFact
 		debugAction := e.EventData["task_action"] == eventapi.TaskActionDebug
 
 		if e.Event == eventapi.EventPlaybookOnTaskStart && !setFactAction && !debugAction {
-			log.Infof("[playbook task]: %s", e.EventData["name"])
+			logger.Info("[playbook task]", "EventData.Name", e.EventData["name"])
 			return
 		}
 		if e.Event == eventapi.EventRunnerOnOk && debugAction {
-			log.Infof("[playbook debug]: %v", e.EventData["task_args"])
+			logger.V(1).Info("[playbook debug]", "EventData.TaskArgs", e.EventData["task_args"])
 			return
 		}
 		if e.Event == eventapi.EventRunnerOnFailed {
-			log.Errorf("[failed]: [playbook task] '%s' failed with task_args - %v",
-				t, e.EventData["task_args"])
-			taskPath, ok := e.EventData["task_path"]
-			if ok {
-				log.Errorf("failed task: %s\n", taskPath)
+			errKVs := []interface{}{
+				"EventData.Task", t,
+				"EventData.TaskArgs", e.EventData["task_args"],
 			}
+			if taskPath, ok := e.EventData["task_path"]; ok {
+				errKVs = append(errKVs, "EventData.FailedTaskPath", taskPath)
+			}
+			logger.Error(errors.New("[playbook task failed]"), "", errKVs...)
 			return
 		}
 	}
+
 	// log everything else for the 'Everything' LogLevel
 	if l.LogLevel == Everything {
-		log.Infof("event: %#v", e.EventData)
+		logger.Info("", "EventData", e.EventData)
 	}
 }
 

--- a/pkg/ansible/operator/operator.go
+++ b/pkg/ansible/operator/operator.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/operator-framework/operator-sdk/pkg/ansible/controller"
 	"github.com/operator-framework/operator-sdk/pkg/ansible/runner"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 
-	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
 // Run - A blocking function which starts a controller-runtime manager
@@ -32,7 +32,7 @@ import (
 func Run(done chan error, mgr manager.Manager, watchesPath string, reconcilePeriod time.Duration) {
 	watches, err := runner.NewFromWatches(watchesPath)
 	if err != nil {
-		logrus.Error("Failed to get watches")
+		logf.Log.WithName("manager").Error(err, "failed to get watches")
 		done <- err
 		return
 	}

--- a/pkg/ansible/proxy/kubectl.go
+++ b/pkg/ansible/proxy/kubectl.go
@@ -22,7 +22,6 @@ package proxy
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -36,7 +35,10 @@ import (
 	k8sproxy "k8s.io/apimachinery/pkg/util/proxy"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
+
+var log = logf.Log.WithName("proxy")
 
 const (
 	// DefaultHostAcceptRE is the default value for which hosts to accept.
@@ -91,7 +93,8 @@ func MakeRegexpArray(str string) ([]*regexp.Regexp, error) {
 func MakeRegexpArrayOrDie(str string) []*regexp.Regexp {
 	result, err := MakeRegexpArray(str)
 	if err != nil {
-		log.Fatalf("error compiling re: %v", err)
+		log.Error(err, "error compiling re")
+		os.Exit(1)
 	}
 	return result
 }
@@ -99,7 +102,7 @@ func MakeRegexpArrayOrDie(str string) []*regexp.Regexp {
 func matchesRegexp(str string, regexps []*regexp.Regexp) bool {
 	for _, re := range regexps {
 		if re.MatchString(str) {
-			log.Printf("%v matched %s", str, re)
+			log.Info("matched found", "MatchString", str, "Regexp", re)
 			return true
 		}
 	}
@@ -139,11 +142,11 @@ func extractHost(header string) (host string) {
 func (f *FilterServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	host := extractHost(req.Host)
 	if f.accept(req.Method, req.URL.Path, host) {
-		log.Printf("Filter accepting %v %v %v", req.Method, req.URL.Path, host)
+		log.Info("Filter acception", "Request.Method", req.Method, "Request.URL", req.URL.Path, "Host", host)
 		f.delegate.ServeHTTP(rw, req)
 		return
 	}
-	log.Printf("Filter rejecting %v %v %v", req.Method, req.URL.Path, host)
+	log.Info("Filter rejection", "Request.Method", req.Method, "Request.URL", req.URL.Path, "Host", host)
 	rw.WriteHeader(http.StatusForbidden)
 	rw.Write([]byte("<h3>Unauthorized</h3>"))
 }
@@ -156,7 +159,7 @@ type server struct {
 type responder struct{}
 
 func (r *responder) Error(w http.ResponseWriter, req *http.Request, err error) {
-	log.Printf("Error while proxying request: %v", err)
+	log.Error(err, "error while proxying request")
 	http.Error(w, err.Error(), http.StatusInternalServerError)
 }
 

--- a/pkg/ansible/runner/eventapi/types.go
+++ b/pkg/ansible/runner/eventapi/types.go
@@ -51,10 +51,7 @@ type EventTime struct {
 // UnmarshalJSON - override unmarshal json.
 func (e *EventTime) UnmarshalJSON(b []byte) (err error) {
 	e.Time, err = time.Parse("2006-01-02T15:04:05.999999999", strings.Trim(string(b[:]), "\"\\"))
-	if err != nil {
-		return err
-	}
-	return nil
+	return
 }
 
 // MarshalJSON - override the marshal json.

--- a/pkg/ansible/runner/internal/inputdir/inputdir.go
+++ b/pkg/ansible/runner/internal/inputdir/inputdir.go
@@ -21,8 +21,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
+
+var log = logf.Log.WithName("inputdir")
 
 // InputDir represents an input directory for ansible-runner.
 type InputDir struct {
@@ -39,7 +41,7 @@ func (i *InputDir) makeDirs() error {
 		fullPath := filepath.Join(i.Path, path)
 		err := os.MkdirAll(fullPath, os.ModePerm)
 		if err != nil {
-			logrus.Errorf("unable to create directory %v", fullPath)
+			log.Error(err, "unable to create directory", "Path", fullPath)
 			return err
 		}
 	}
@@ -51,7 +53,7 @@ func (i *InputDir) addFile(path string, content []byte) error {
 	fullPath := filepath.Join(i.Path, path)
 	err := ioutil.WriteFile(fullPath, content, 0644)
 	if err != nil {
-		logrus.Errorf("unable to write file %v", fullPath)
+		log.Error(err, "unable to write file", "Path", fullPath)
 	}
 	return err
 }
@@ -112,7 +114,7 @@ func (i *InputDir) Write() error {
 	if i.PlaybookPath != "" {
 		f, err := os.Open(i.PlaybookPath)
 		if err != nil {
-			logrus.Errorf("failed to open playbook file %v", i.PlaybookPath)
+			log.Error(err, "failed to open playbook file", "Path", i.PlaybookPath)
 			return err
 		}
 		defer f.Close()

--- a/pkg/scaffold/cmd.go
+++ b/pkg/scaffold/cmd.go
@@ -38,7 +38,8 @@ const cmdTmpl = `package main
 
 import (
 	"flag"
-	"log"
+	"fmt"
+	"os"
 	"runtime"
 
 	"{{ .Repo }}/pkg/apis"
@@ -49,51 +50,67 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
 func printVersion() {
-	log.Printf("Go Version: %s", runtime.Version())
-	log.Printf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
-	log.Printf("operator-sdk Version: %v", sdkVersion.Version)
+	logf.Log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
+	logf.Log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+	logf.Log.Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
 }
 
 func main() {
 	printVersion()
 	flag.Parse()
 
+	// The logger instantiated here can be changed to any logger
+	// implementing the logr.Logger interface. This logger will
+	// be propagated through the whole operator, generating
+	// uniform and structured logs.
+	logf.SetLogger(logf.ZapLogger(false))
+	log := logf.Log.WithName("cmd")
+
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
-		log.Fatalf("failed to get watch namespace: %v", err)
+		log.Error(err, "failed to get watch namespace")
+		os.Exit(1)
 	}
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err, "")
+		os.Exit(1)
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err, "")
+		os.Exit(1)
 	}
 
-	log.Print("Registering Components.")
+	log.Info("Registering Components.")
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Fatal(err)
+		log.Error(err, "")
+		os.Exit(1)
 	}
 
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {
-		log.Fatal(err)
+		log.Error(err, "")
+		os.Exit(1)
 	}
 
-	log.Print("Starting the Cmd.")
+	log.Info("Starting the Cmd.")
 
 	// Start the Cmd
-	log.Fatal(mgr.Start(signals.SetupSignalHandler()))
+	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+		log.Error(err, "manager exited non-zero")
+		os.Exit(1)
+	}
 }
 `

--- a/pkg/scaffold/cmd_test.go
+++ b/pkg/scaffold/cmd_test.go
@@ -37,7 +37,8 @@ const cmdExp = `package main
 
 import (
 	"flag"
-	"log"
+	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/example-inc/app-operator/pkg/apis"
@@ -47,51 +48,67 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
 func printVersion() {
-	log.Printf("Go Version: %s", runtime.Version())
-	log.Printf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
-	log.Printf("operator-sdk Version: %v", sdkVersion.Version)
+	logf.Log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
+	logf.Log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+	logf.Log.Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
 }
 
 func main() {
 	printVersion()
 	flag.Parse()
 
+	// The logger instantiated here can be changed to any logger
+	// implementing the logr.Logger interface. This logger will
+	// be propagated through the whole operator, generating
+	// uniform and structured logs.
+	logf.SetLogger(logf.ZapLogger(false))
+	log := logf.Log.WithName("cmd")
+
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
-		log.Fatalf("failed to get watch namespace: %v", err)
+		log.Error(err, "failed to get watch namespace")
+		os.Exit(1)
 	}
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err, "")
+		os.Exit(1)
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err, "")
+		os.Exit(1)
 	}
 
-	log.Print("Registering Components.")
+	log.Info("Registering Components.")
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Fatal(err)
+		log.Error(err, "")
+		os.Exit(1)
 	}
 
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {
-		log.Fatal(err)
+		log.Error(err, "")
+		os.Exit(1)
 	}
 
-	log.Print("Starting the Cmd.")
+	log.Info("Starting the Cmd.")
 
 	// Start the Cmd
-	log.Fatal(mgr.Start(signals.SetupSignalHandler()))
+	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+		log.Error(err, "manager exited non-zero")
+		os.Exit(1)
+	}
 }
 `

--- a/pkg/scaffold/controller_kind.go
+++ b/pkg/scaffold/controller_kind.go
@@ -43,7 +43,6 @@ const controllerKindTemplate = `package {{ .Resource.LowerKind }}
 
 import (
 	"context"
-	"log"
 
 	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .Repo }}/pkg/apis/{{ .Resource.Group}}/{{ .Resource.Version }}"
 
@@ -58,8 +57,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+  logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
+
+var log = logf.Log.WithName("controller_{{ .Resource.LowerKind }}")
 
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
@@ -122,7 +124,8 @@ type Reconcile{{ .Resource.Kind }} struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *Reconcile{{ .Resource.Kind }}) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.Printf("Reconciling {{ .Resource.Kind }} %s/%s\n", request.Namespace, request.Name)
+	reqLogger := reqLogger.WithValues("Request.Namespace", request.Namespace, "Requst.Name", request.Name)
+	reqLogger.Info("Reconciling {{ .Resource.Kind }}")
 
 	// Fetch the {{ .Resource.Kind }} instance
 	instance := &{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}
@@ -150,7 +153,7 @@ func (r *Reconcile{{ .Resource.Kind }}) Reconcile(request reconcile.Request) (re
 	found := &corev1.Pod{}
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
-		log.Printf("Creating a new Pod %s/%s\n", pod.Namespace, pod.Name)
+		reqLogger.Info("Creating a new Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
 		err = r.client.Create(context.TODO(), pod)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -163,11 +166,11 @@ func (r *Reconcile{{ .Resource.Kind }}) Reconcile(request reconcile.Request) (re
 	}
 
 	// Pod already exists - don't requeue
-	log.Printf("Skip reconcile: Pod %s/%s already exists", found.Namespace, found.Name)
+	reqLogger.Info("Skip reconcile: Pod already exists", "Pod.Namespace", found.Namespace, "Pod.Name", found.Name)
 	return reconcile.Result{}, nil
 }
 
-// newPodForCR returns a busybox pod with the same name/namespace as the cr 
+// newPodForCR returns a busybox pod with the same name/namespace as the cr
 func newPodForCR(cr *{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}) *corev1.Pod {
 	labels := map[string]string{
 		"app": cr.Name,

--- a/pkg/scaffold/controller_kind_test.go
+++ b/pkg/scaffold/controller_kind_test.go
@@ -41,7 +41,6 @@ const controllerKindExp = `package appservice
 
 import (
 	"context"
-	"log"
 
 	appv1alpha1 "github.com/example-inc/app-operator/pkg/apis/app/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -55,8 +54,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
+
+var log = logf.Log.WithName("controller_appservice")
 
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
@@ -119,7 +121,8 @@ type ReconcileAppService struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileAppService) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	log.Printf("Reconciling AppService %s/%s\n", request.Namespace, request.Name)
+	reqLogger := reqLogger.WithValues("Request.Namespace", request.Namespace, "Requst.Name", request.Name)
+	reqLogger.Info("Reconciling AppService")
 
 	// Fetch the AppService instance
 	instance := &appv1alpha1.AppService{}
@@ -147,7 +150,7 @@ func (r *ReconcileAppService) Reconcile(request reconcile.Request) (reconcile.Re
 	found := &corev1.Pod{}
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
-		log.Printf("Creating a new Pod %s/%s\n", pod.Namespace, pod.Name)
+		reqLogger.Info("Creating a new Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
 		err = r.client.Create(context.TODO(), pod)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -160,7 +163,7 @@ func (r *ReconcileAppService) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Pod already exists - don't requeue
-	log.Printf("Skip reconcile: Pod %s/%s already exists", found.Namespace, found.Name)
+	reqLogger.Info("Skip reconcile: Pod already exists", "Pod.Namespace", found.Namespace, "Pod.Name", found.Name)
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/scaffold/role.go
+++ b/pkg/scaffold/role.go
@@ -19,12 +19,12 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"path/filepath"
 
 	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 
+	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 	rbacv1 "k8s.io/api/rbac/v1"
 	cgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -70,7 +70,7 @@ func UpdateRoleForResource(r *Resource, absProjectPath string) error {
 		// check if the resource already exists
 		for _, resource := range pr.Resources {
 			if resource == r.Resource {
-				log.Printf("deploy/role.yaml RBAC rules already up to date for the resource (%v, %v)", r.APIVersion, r.Kind)
+				log.Infof("deploy/role.yaml RBAC rules already up to date for the resource (%v, %v)", r.APIVersion, r.Kind)
 				return nil
 			}
 		}
@@ -112,7 +112,7 @@ func UpdateRoleForResource(r *Resource, absProjectPath string) error {
 		// check if the resource already exists
 		for _, resource := range pr.Resources {
 			if resource == r.Resource {
-				log.Printf("deploy/role.yaml RBAC rules already up to date for the resource (%v, %v)", r.APIVersion, r.Kind)
+				log.Infof("deploy/role.yaml RBAC rules already up to date for the resource (%v, %v)", r.APIVersion, r.Kind)
 				return nil
 			}
 		}

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,6 +27,8 @@ import (
 
 	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
+
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/tools/imports"
 )
 
@@ -161,7 +162,7 @@ func (s *Scaffold) doTemplate(i input.Input, e input.File, absPath string) error
 	}
 
 	_, err = f.Write(b)
-	fmt.Printf("Create %s\n", i.Path)
+	log.Infoln("Create", i.Path)
 	return err
 }
 

--- a/pkg/scaffold/test_setup.go
+++ b/pkg/scaffold/test_setup.go
@@ -17,11 +17,12 @@ package scaffold
 import (
 	"bytes"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -43,7 +44,7 @@ var (
 func mustGetImportPath() string {
 	wd, err := os.Getwd()
 	if err != nil {
-		log.Fatal("mustGetImportPath: ", err)
+		log.Fatalf("mustGetImportPath: (%v)", err)
 	}
 	return filepath.Join(wd, appRepo)
 }

--- a/pkg/sdk/internal/metrics/metrics.go
+++ b/pkg/sdk/internal/metrics/metrics.go
@@ -18,7 +18,7 @@ import (
 	"sync"
 
 	prom "github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 const (
@@ -42,6 +42,7 @@ const (
 
 var (
 	once sync.Once
+	log  = logf.Log.WithName("metrics")
 )
 
 // Collector - metric collector for all the metrics the sdk will watch
@@ -69,7 +70,7 @@ func RegisterCollector(c *Collector) {
 	once.Do(func() {
 		err := prom.Register(c)
 		if err != nil {
-			logrus.Errorf("unable to register collector with prometheus: %v", err)
+			log.Error(err, "unable to register collector with prometheus")
 		}
 	})
 }

--- a/pkg/sdk/metrics.go
+++ b/pkg/sdk/metrics.go
@@ -20,13 +20,16 @@ import (
 	"strconv"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
+
+var log = logf.Log.WithName("metrics")
 
 // ExposeMetricsPort generate a Kubernetes Service to expose metrics port
 func ExposeMetricsPort() *v1.Service {
@@ -35,7 +38,7 @@ func ExposeMetricsPort() *v1.Service {
 
 	service, err := k8sutil.InitOperatorService()
 	if err != nil {
-		logrus.Errorf("failed to initialize service object for operator metrics: %v", err)
+		log.Error(err, "failed to initialize service object for operator metrics")
 		return nil
 	}
 	kubeconfig, err := config.GetConfig()
@@ -48,9 +51,10 @@ func ExposeMetricsPort() *v1.Service {
 	}
 	err = runtimeClient.Create(context.TODO(), service)
 	if err != nil && !errors.IsAlreadyExists(err) {
-		logrus.Errorf("failed to create service for operator metrics: %v", err)
+		log.Error(err, "failed to create service for operator metrics")
 		return nil
 	}
-	logrus.Infof("Metrics service %s created", service.Name)
+
+	log.Info("Metrics service created.", "ServiceName", service.Name)
 	return service
 }

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -15,11 +15,12 @@
 package test
 
 import (
-	"log"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type TestCtx struct {
@@ -69,7 +70,7 @@ func (ctx *TestCtx) Cleanup() {
 	for i := len(ctx.cleanupFns) - 1; i >= 0; i-- {
 		err := ctx.cleanupFns[i]()
 		if err != nil {
-			ctx.t.Errorf("a cleanup function failed with error: %v\n", err)
+			ctx.t.Errorf("a cleanup function failed with error: (%v)\n", err)
 		}
 	}
 }
@@ -82,7 +83,7 @@ func (ctx *TestCtx) CleanupNoT() {
 		err := ctx.cleanupFns[i]()
 		if err != nil {
 			failed = true
-			log.Printf("a cleanup function failed with error: %v\n", err)
+			log.Errorf("a cleanup function failed with error: (%v)", err)
 		}
 	}
 	if failed {

--- a/pkg/test/main_entry.go
+++ b/pkg/test/main_entry.go
@@ -17,9 +17,10 @@ package test
 import (
 	"flag"
 	"io/ioutil"
-	"log"
 	"os"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/test/ansible-operator/cmd/ansible-operator/main.go
+++ b/test/ansible-operator/cmd/ansible-operator/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"flag"
-	"log"
 	"runtime"
 	"time"
 
@@ -24,26 +23,27 @@ import (
 	proxy "github.com/operator-framework/operator-sdk/pkg/ansible/proxy"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
+
+	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-
-	"github.com/sirupsen/logrus"
 )
 
 func printVersion() {
-	logrus.Infof("Go Version: %s", runtime.Version())
-	logrus.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
-	logrus.Infof("operator-sdk Version: %v", sdkVersion.Version)
+	log.Infof("Go Version: %s", runtime.Version())
+	log.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
+	log.Infof("operator-sdk Version: %v", sdkVersion.Version)
 }
 
 func main() {
 	flag.Parse()
-	logf.SetLogger(logf.ZapLogger(false))
+
+	logf.SetLogger(logf.ZapLogger(true))
 
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
-		log.Fatalf("failed to get watch namespace: %v", err)
+		log.Fatalf("failed to get watch namespace: (%v)", err)
 	}
 
 	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{
@@ -63,7 +63,7 @@ func main() {
 		KubeConfig: mgr.GetConfig(),
 	})
 	if err != nil {
-		logrus.Fatalf("error starting proxy: %v", err)
+		log.Fatalf("error starting proxy: (%v)", err)
 	}
 
 	// start the operator
@@ -71,9 +71,8 @@ func main() {
 
 	// wait for either to finish
 	err = <-done
-	if err == nil {
-		logrus.Info("Exiting")
-	} else {
-		logrus.Fatal(err.Error())
+	if err != nil {
+		log.Fatal(err)
 	}
+	log.Info("Exiting.")
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -18,11 +18,11 @@ import (
 	goctx "context"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"sync"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	extscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"

--- a/test/e2e/framework/main_entry.go
+++ b/test/e2e/framework/main_entry.go
@@ -15,14 +15,15 @@
 package framework
 
 import (
-	"log"
 	"os"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func MainEntry(m *testing.M) {
 	if err := setup(); err != nil {
-		log.Fatalf("failed to set up framework: %v", err)
+		log.Fatalf("failed to set up framework: (%v)", err)
 	}
 
 	os.Exit(m.Run())


### PR DESCRIPTION
**Description of the change:**
1. Switch the `operator-sdk` binary's logger from a mix of std `log` and [`logrus`](https://github.com/sirupsen/logrus) to only `logrus`.
1. Use [`controller-runtime/pkg/runtime/log.SetLogger()`](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/runtime/log#SetLogger) to inject [`logr.Logger`](https://github.com/go-logr/logr) that users can define into their operator.
    - The SDK injects [`zap`](https://godoc.org/go.uber.org/zap) by default in this PR.
    - `pkg/sdk/*metrics*` and `pkg/ansible` are used by generated operators, which is why these packages don't use `logrus`.

**Motivation for the change:** Operators generated by the SDK did not have a uniform logging interface pre-`v0.1.0`. Now that `controller-runtime` is the main source of logs in a generated operator, the decision was made to expose a log injection mechanism so users can choose what logger to use and operators emit uniform, structured logs. See #503 for our detailed discussion. The `operator-sdk` binary similarly did not have uniform logging. `logrus` is a reasonable choice for the binary's logger because warnings are used frequently.

Closes #503, closes #732 
