### PR TITLE
decompose GOPATH and set it according to the current working dir.

### DIFF
--- a/commands/operator-sdk/main.go
+++ b/commands/operator-sdk/main.go
@@ -19,11 +19,16 @@ import (
 	"os"
 
 	"github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd"
+	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 )
 
 func main() {
+	gopath := projutil.SaveGopath()
+	projutil.SetGopath(gopath)
+
 	if err := cmd.NewRootCmd().Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
 	}
+	projutil.RestoreGopath(gopath)
 }

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -67,18 +67,9 @@ func CheckAndGetCurrPkg() string {
 	if len(gopath) == 0 {
 		log.Fatalf("get current pkg failed: GOPATH env not set")
 	}
-	var goSrc string
-	cwdInGopath := false
+	goSrc := filepath.Join(gopath, SrcDir)
 	wd := MustGetwd()
-	for _, path := range strings.Split(gopath, ":") {
-		goSrc = filepath.Join(path, SrcDir)
-
-		if strings.HasPrefix(filepath.Dir(wd), goSrc) {
-			cwdInGopath = true
-			break
-		}
-	}
-	if !cwdInGopath {
+	if !strings.HasPrefix(filepath.Dir(wd), goSrc) {
 		log.Fatalf("check current pkg failed: must run from gopath")
 	}
 	currPkg := strings.Replace(wd, goSrc+string(filepath.Separator), "", 1)
@@ -96,4 +87,28 @@ func GetOperatorType() OperatorType {
 		return OperatorTypeAnsible
 	}
 	return OperatorTypeGo
+}
+
+func SaveGopath() string {
+	return os.Getenv(GopathEnv)
+}
+
+func SetGopath(currentGopath string) {
+	var newGopath string
+	cwdInGopath := false
+	wd := MustGetwd()
+	for _, newGopath = range strings.Split(currentGopath, ":") {
+		if strings.HasPrefix(filepath.Dir(wd), newGopath) {
+			cwdInGopath = true
+			break
+		}
+	}
+	if !cwdInGopath {
+		log.Fatalf("check current pkg failed: must run from gopath")
+	}
+	os.Setenv(GopathEnv, newGopath)
+}
+
+func RestoreGopath(oldGopath string) {
+	os.Setenv(GopathEnv, oldGopath)
 }


### PR DESCRIPTION
there are different places in the project where the value of env var GOPATH is used, and cannot handle composed GOPATHs
this will determine the correct GOPATH based on the current working dir and set it during the execution.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
