### PR TITLE
Improves output available for troubleshooting ansible

### DIFF
--- a/pkg/ansible/events/log_events.go
+++ b/pkg/ansible/events/log_events.go
@@ -36,20 +36,21 @@ const (
 
 // EventHandler - knows how to handle job events.
 type EventHandler interface {
-	Handle(*unstructured.Unstructured, eventapi.JobEvent)
+	Handle(string, *unstructured.Unstructured, eventapi.JobEvent)
 }
 
 type loggingEventHandler struct {
 	LogLevel LogLevel
 }
 
-func (l loggingEventHandler) Handle(u *unstructured.Unstructured, e eventapi.JobEvent) {
+func (l loggingEventHandler) Handle(ident string, u *unstructured.Unstructured, e eventapi.JobEvent) {
 	log := logrus.WithFields(logrus.Fields{
 		"component":  "logging_event_handler",
 		"name":       u.GetName(),
 		"namespace":  u.GetNamespace(),
 		"gvk":        u.GroupVersionKind().String(),
 		"event_type": e.Event,
+		"job":        ident,
 	})
 	if l.LogLevel == Nothing {
 		return
@@ -71,6 +72,10 @@ func (l loggingEventHandler) Handle(u *unstructured.Unstructured, e eventapi.Job
 		if e.Event == eventapi.EventRunnerOnFailed {
 			log.Errorf("[failed]: [playbook task] '%s' failed with task_args - %v",
 				t, e.EventData["task_args"])
+			taskPath, ok := e.EventData["task_path"]
+			if ok {
+				log.Errorf("failed task: %s\n", taskPath)
+			}
 			return
 		}
 	}

--- a/pkg/ansible/runner/eventapi/eventapi.go
+++ b/pkg/ansible/runner/eventapi/eventapi.go
@@ -165,7 +165,7 @@ func (e *EventReceiver) handleEvents(w http.ResponseWriter, r *http.Request) {
 	// we're not currently interested in.
 	// https://ansible-runner.readthedocs.io/en/latest/external_interface.html#event-structure
 	if event.UUID == "" {
-		e.logger.Info("dropping event that is not a JobEvent")
+		e.logger.Debug("dropping event that is not a JobEvent")
 	} else {
 		// timeout if the channel blocks for too long
 		timeout := time.NewTimer(10 * time.Second)

--- a/pkg/ansible/runner/internal/inputdir/inputdir.go
+++ b/pkg/ansible/runner/internal/inputdir/inputdir.go
@@ -56,6 +56,14 @@ func (i *InputDir) addFile(path string, content []byte) error {
 	return err
 }
 
+// Stdout reads the stdout from the ansible artifact that corresponds to the
+// given ident and returns it as a string.
+func (i *InputDir) Stdout(ident string) (string, error) {
+	errorPath := filepath.Join(i.Path, "artifacts", ident, "stdout")
+	errorText, err := ioutil.ReadFile(errorPath)
+	return string(errorText), err
+}
+
 // Write commits the object's state to the filesystem at i.Path.
 func (i *InputDir) Write() error {
 	paramBytes, err := json.Marshal(i.Parameters)


### PR DESCRIPTION
* When a specific task fails, the path and line number are logged.
* When ansible fails to run any tasks, such as if a syntax error exists in a role, ansible's stdout gets logged.
* log messages from the reconciler now include the job ID.
* The message "dropping event that is not a JobEvent" is now logged at debug level instead of info, since it isn't normally helpful.

Example log output when a task fails:

```
INFO[0001] [playbook task]: Gathering Facts              component=logging_event_handler event_type=playbook_on_task_start gvk="cache.example.com/v1alpha1, Kind=Memcached" name=example-memcached namespace=default
INFO[0002] [playbook task]: dymurray.memcached_operator_role : foo  component=logging_event_handler event_type=playbook_on_task_start gvk="cache.example.com/v1alpha1, Kind=Memcached" name=example-memcached namespace=default
ERRO[0002] failed task: /home/mhrivnak/golang/src/delme/ansible/memcached-operator/roles/dymurray.memcached_operator_role/tasks/main.yml:2  component=reconciler job=3616419306046219210 name=example-memcached namespace=default
ERRO[0002] [failed]: [playbook task] 'foo' failed with task_args - msg=bar  component=logging_event_handler event_type=runner_on_failed gvk="cache.example.com/v1alpha1, Kind=Memcached" name=example-memcached namespace=default
ERRO[0002] error from ansible-runner: exit status 2      component=runner job=3616419306046219210 name=example-memcached namespace=default
```

Example log output when ansible can't run:

```
ERRO[0001] error from ansible-runner: exit status 4      component=runner job=5610496959638236402 name=example-memcached namespace=default
ERRO[0001] did not receive playbook_on_stats event       component=reconciler job=5610496959638236402 name=example-memcached namespace=default
ERRO[0001] ansible-playbook 2.6.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mhrivnak/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mhrivnak/pythons/ansible-events/lib/python2.7/site-packages/ansible
  executable location = /home/mhrivnak/pythons/ansible-events/bin/ansible-playbook
  python version = 2.7.15 (default, Oct 15 2018, 15:24:06) [GCC 8.1.1 20180712 (Red Hat 8.1.1-5)]
Using /etc/ansible/ansible.cfg as config file

ERROR! no action detected in task. This often indicates a misspelled module name, or incorrect module path.

The error appears to have been in '/home/mhrivnak/golang/src/delme/ansible/memcached-operator/roles/dymurray.memcached_operator_role/tasks/main.yml': line 2, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
- name: foo
  ^ here

  component=reconciler job=5610496959638236402 name=example-memcached namespace=default
```