### PR TITLE
commands/.../test,internal/util: use clientcmd's kubeconfig getter

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -821,6 +821,7 @@
     "k8s.io/client-go/rest",
     "k8s.io/client-go/restmapper",
     "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/clientcmd/api",
     "k8s.io/client-go/transport",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",

--- a/commands/operator-sdk/cmd/test/local.go
+++ b/commands/operator-sdk/cmd/test/local.go
@@ -49,12 +49,7 @@ func NewTestLocalCmd() *cobra.Command {
 		Short: "Run End-To-End tests locally",
 		Run:   testLocalFunc,
 	}
-	defaultKubeConfig := ""
-	homedir, ok := os.LookupEnv("HOME")
-	if ok {
-		defaultKubeConfig = homedir + "/.kube/config"
-	}
-	testCmd.Flags().StringVar(&tlConfig.kubeconfig, "kubeconfig", defaultKubeConfig, "Kubeconfig path")
+	testCmd.Flags().StringVar(&tlConfig.kubeconfig, "kubeconfig", "", "Kubeconfig path")
 	testCmd.Flags().StringVar(&tlConfig.globalManPath, "global-manifest", "", "Path to manifest for Global resources (e.g. CRD manifests)")
 	testCmd.Flags().StringVar(&tlConfig.namespacedManPath, "namespaced-manifest", "", "Path to manifest for per-test, namespaced resources (e.g. RBAC and Operator manifest)")
 	testCmd.Flags().StringVar(&tlConfig.goTestFlags, "go-test-flags", "", "Additional flags to pass to go test")

--- a/internal/util/k8sutil/k8sutil.go
+++ b/internal/util/k8sutil/k8sutil.go
@@ -19,6 +19,7 @@ import (
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // GetKubeconfigAndNamespace returns the *rest.Config and defualt namespace defined in the
@@ -26,19 +27,20 @@ import (
 // and namespace
 func GetKubeconfigAndNamespace(configPath string) (*rest.Config, string, error) {
 	var clientConfig clientcmd.ClientConfig
+	var apiConfig *clientcmdapi.Config
+	var err error
 	if configPath != "" {
-		apiConfig, err := clientcmd.LoadFromFile(configPath)
+		apiConfig, err = clientcmd.LoadFromFile(configPath)
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to load user provided kubeconfig: %v", err)
 		}
-		clientConfig = clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{})
 	} else {
-		apiConfig, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+		apiConfig, err = clientcmd.NewDefaultClientConfigLoadingRules().Load()
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to get kubeconfig: %v", err)
 		}
-		clientConfig = clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{})
 	}
+	clientConfig = clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{})
 	kubeconfig, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, "", err

--- a/internal/util/k8sutil/k8sutil.go
+++ b/internal/util/k8sutil/k8sutil.go
@@ -28,10 +28,10 @@ func GetKubeconfigAndNamespace(configPath string) (*rest.Config, string, error) 
 	var clientConfig clientcmd.ClientConfig
 	if configPath != "" {
 		apiConfig, err := clientcmd.LoadFromFile(configPath)
-		clientConfig = clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{})
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to load user provided kubeconfig: %v", err)
 		}
+		clientConfig = clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{})
 	} else {
 		apiConfig, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
 		if err != nil {

--- a/internal/util/k8sutil/k8sutil.go
+++ b/internal/util/k8sutil/k8sutil.go
@@ -1,0 +1,51 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sutil
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// GetKubeconfigAndNamespace returns the *rest.Config and defualt namespace defined in the
+// kubeconfig at the specified path. If no path is provided, returns the default *rest.Config
+// and namespace
+func GetKubeconfigAndNamespace(configPath string) (*rest.Config, string, error) {
+	var clientConfig clientcmd.ClientConfig
+	if configPath != "" {
+		apiConfig, err := clientcmd.LoadFromFile(configPath)
+		clientConfig = clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{})
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to load user provided kubeconfig: %v", err)
+		}
+	} else {
+		apiConfig, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to get kubeconfig: %v", err)
+		}
+		clientConfig = clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{})
+	}
+	kubeconfig, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, "", err
+	}
+	namespace, _, err := clientConfig.Namespace()
+	if err != nil {
+		return nil, "", err
+	}
+	return kubeconfig, namespace, nil
+}

--- a/pkg/test/framework.go
+++ b/pkg/test/framework.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"time"
 
+	k8sInternal "github.com/operator-framework/operator-sdk/internal/util/k8sutil"
+
 	extscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -31,7 +33,6 @@ import (
 	cgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
-	"k8s.io/client-go/tools/clientcmd"
 	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -73,7 +74,7 @@ func setup(kubeconfigPath, namespacedManPath *string) error {
 		kubeconfig, err = rest.InClusterConfig()
 		*singleNamespace = true
 	} else {
-		kubeconfig, err = clientcmd.BuildConfigFromFlags("", *kubeconfigPath)
+		kubeconfig, _, err = k8sInternal.GetKubeconfigAndNamespace(*kubeconfigPath)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to build the kubeconfig: %v", err)


### PR DESCRIPTION
**Description of the change:** The clientcmd package provides utilities to retrieve `ClientConfig` objects using sane defaults (checking the environment variable first, which we didn't do, then falling back to `$HOME/.kube/config`). `ClientConfig`s contain the `*rest.Config` (kubeconfig) and other useful information like the active default namespace, which is useful for the `test cluster` subcommand, as we previously just assumed `default` was the default.


**Motivation for the change:** Using kubernetes utils will likely be more reliable in the long term and require less maintenance from us. Also, this allows the cluster test to correctly identify the default namespace.