### PR TITLE
tests/e2e-ansible: ansible tests should not run in Golang environment

### DIFF
--- a/test/ansible-operator/Dockerfile
+++ b/test/ansible-operator/Dockerfile
@@ -11,11 +11,11 @@ RUN echo "localhost ansible_connection=local" > /etc/ansible/hosts \
 
 ENV OPERATOR=/usr/local/bin/ansible-operator \
     USER_UID=1001 \
-    USER_NAME=ansible-operator\
+    USER_NAME=ansible-operator \
     HOME=/opt/ansible
 
 # install operator binary
-ADD ansible-operator ${OPERATOR}
+COPY ansible-operator ${OPERATOR}
 
 COPY bin /usr/local/bin
 RUN  /usr/local/bin/user_setup


### PR DESCRIPTION
**Description of the change:** make a temporary directory in the current directory for Ansible test files and unset Golang environmental variables within script process.


**Motivation for the change:** we should test Ansible operators outside of a Golang environment. Brought up by @shawn-hurley when re-assessing #712.
