### PR TITLE
commands/operator-sdk/cmd: set composed GOPATH for Go projects (fix #712)

### DIFF
--- a/commands/operator-sdk/cmd/add/api.go
+++ b/commands/operator-sdk/cmd/add/api.go
@@ -76,7 +76,7 @@ func apiRun(cmd *cobra.Command, args []string) {
 	absProjectPath := projutil.MustGetwd()
 
 	cfg := &input.Config{
-		Repo:           projutil.CheckAndGetCurrPkg(),
+		Repo:           projutil.CheckAndGetProjectGoPkg(),
 		AbsProjectPath: absProjectPath,
 	}
 

--- a/commands/operator-sdk/cmd/add/controller.go
+++ b/commands/operator-sdk/cmd/add/controller.go
@@ -68,7 +68,7 @@ func controllerRun(cmd *cobra.Command, args []string) {
 	}
 
 	cfg := &input.Config{
-		Repo:           projutil.CheckAndGetCurrPkg(),
+		Repo:           projutil.CheckAndGetProjectGoPkg(),
 		AbsProjectPath: projutil.MustGetwd(),
 	}
 

--- a/commands/operator-sdk/cmd/build.go
+++ b/commands/operator-sdk/cmd/build.go
@@ -146,7 +146,7 @@ func buildFunc(cmd *cobra.Command, args []string) {
 
 	// Don't need to build go code if Ansible Operator
 	if mainExists() {
-		managerDir := filepath.Join(projutil.CheckAndGetCurrPkg(), scaffold.ManagerDir)
+		managerDir := filepath.Join(projutil.CheckAndGetProjectGoPkg(), scaffold.ManagerDir)
 		outputBinName := filepath.Join(wd, scaffold.BuildBinDir, filepath.Base(wd))
 		buildCmd := exec.Command("go", "build", "-o", outputBinName, managerDir)
 		buildCmd.Env = goBuildEnv
@@ -192,7 +192,7 @@ func buildFunc(cmd *cobra.Command, args []string) {
 
 			absProjectPath := projutil.MustGetwd()
 			cfg := &input.Config{
-				Repo:           projutil.CheckAndGetCurrPkg(),
+				Repo:           projutil.CheckAndGetProjectGoPkg(),
 				AbsProjectPath: absProjectPath,
 				ProjectName:    filepath.Base(wd),
 			}

--- a/commands/operator-sdk/cmd/generate/k8s.go
+++ b/commands/operator-sdk/cmd/generate/k8s.go
@@ -54,7 +54,7 @@ func k8sFunc(cmd *cobra.Command, args []string) {
 func K8sCodegen() {
 
 	projutil.MustInProjectRoot()
-	repoPkg := projutil.CheckAndGetCurrPkg()
+	repoPkg := projutil.CheckAndGetProjectGoPkg()
 	outputPkg := filepath.Join(repoPkg, "pkg/generated")
 	apisPkg := filepath.Join(repoPkg, scaffold.ApisDir)
 	groupVersions, err := parseGroupVersions()

--- a/commands/operator-sdk/cmd/new.go
+++ b/commands/operator-sdk/cmd/new.go
@@ -68,8 +68,6 @@ var (
 )
 
 const (
-	gopath    = "GOPATH"
-	src       = "src"
 	dep       = "dep"
 	ensureCmd = "ensure"
 )
@@ -120,7 +118,7 @@ func mustBeNewProject() {
 
 func doScaffold() {
 	cfg := &input.Config{
-		Repo:           filepath.Join(projutil.CheckAndGetCurrPkg(), projectName),
+		Repo:           filepath.Join(projutil.CheckAndGetProjectGoPkg(), projectName),
 		AbsProjectPath: filepath.Join(projutil.MustGetwd(), projectName),
 		ProjectName:    projectName,
 	}
@@ -227,7 +225,7 @@ func repoPath() string {
 	// We only care about GOPATH constraint checks if we are a Go operator
 	wd := projutil.MustGetwd()
 	if operatorType == projutil.OperatorTypeGo {
-		gp := os.Getenv(gopath)
+		gp := os.Getenv(projutil.GopathEnv)
 		if len(gp) == 0 {
 			log.Fatal("$GOPATH env not set")
 		}
@@ -236,7 +234,7 @@ func repoPath() string {
 			log.Fatalf("project's repository path (%v) is not rooted under GOPATH (%v)", wd, gp)
 		}
 		// compute the repo path by stripping "$GOPATH/src/" from the path of the current directory.
-		rp := filepath.Join(string(wd[len(filepath.Join(gp, src)):]), projectName)
+		rp := filepath.Join(string(wd[len(filepath.Join(gp, projutil.SrcDir)):]), projectName)
 		// strip any "/" prefix from the repo path.
 		return strings.TrimPrefix(rp, string(filepath.Separator))
 	}

--- a/commands/operator-sdk/cmd/new.go
+++ b/commands/operator-sdk/cmd/new.go
@@ -219,28 +219,6 @@ func doAnsibleScaffold() {
 	}
 }
 
-// repoPath checks if this project's repository path is rooted under $GOPATH and returns project's repository path.
-// repoPath field on generator is used primarily in generation of Go operator. For Ansible we will set it to cwd
-func repoPath() string {
-	// We only care about GOPATH constraint checks if we are a Go operator
-	wd := projutil.MustGetwd()
-	if operatorType == projutil.OperatorTypeGo {
-		gp := os.Getenv(projutil.GopathEnv)
-		if len(gp) == 0 {
-			log.Fatal("$GOPATH env not set")
-		}
-		// check if this project's repository path is rooted under $GOPATH
-		if !strings.HasPrefix(wd, gp) {
-			log.Fatalf("project's repository path (%v) is not rooted under GOPATH (%v)", wd, gp)
-		}
-		// compute the repo path by stripping "$GOPATH/src/" from the path of the current directory.
-		rp := filepath.Join(string(wd[len(filepath.Join(gp, projutil.SrcDir)):]), projectName)
-		// strip any "/" prefix from the repo path.
-		return strings.TrimPrefix(rp, string(filepath.Separator))
-	}
-	return wd
-}
-
 func verifyFlags() {
 	if operatorType != projutil.OperatorTypeGo && operatorType != projutil.OperatorTypeAnsible {
 		log.Fatal("--type can only be `go` or `ansible`")

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -71,27 +71,13 @@ func MustGetwd() string {
 	return wd
 }
 
-// CheckAndGetCurrPkg checks if this project's repository path is rooted under $GOPATH and returns the current directory's import path
+// CheckAndGetProjectGoPkg checks if this project's repository path is rooted under $GOPATH and returns the current directory's import path
 // e.g: "github.com/example-inc/app-operator"
-func CheckAndGetCurrPkg() string {
-	gopath := os.Getenv(GopathEnv)
-	if len(gopath) == 0 {
-		log.Fatalf("get current pkg failed: GOPATH env not set")
-	}
-	var goSrc string
-	cwdInGopath := false
+func CheckAndGetProjectGoPkg() string {
+	gopath := GetGopath()
+	SetGopath(gopath)
+	goSrc := filepath.Join(gopath, SrcDir)
 	wd := MustGetwd()
-	for _, path := range strings.Split(gopath, ":") {
-		goSrc = filepath.Join(path, SrcDir)
-
-		if strings.HasPrefix(filepath.Dir(wd), goSrc) {
-			cwdInGopath = true
-			break
-		}
-	}
-	if !cwdInGopath {
-		log.Fatalf("check current pkg failed: must run from gopath")
-	}
 	currPkg := strings.Replace(wd, goSrc+string(filepath.Separator), "", 1)
 	// strip any "/" prefix from the repo path.
 	return strings.TrimPrefix(currPkg, string(filepath.Separator))
@@ -107,4 +93,30 @@ func GetOperatorType() OperatorType {
 		return OperatorTypeAnsible
 	}
 	return OperatorTypeGo
+}
+
+func GetGopath() string {
+	gopath, ok := os.LookupEnv(GopathEnv)
+	if !ok || len(gopath) == 0 {
+		log.Fatal("get current pkg failed: GOPATH env not set")
+	}
+	return gopath
+}
+
+func SetGopath(currentGopath string) {
+	var newGopath string
+	cwdInGopath := false
+	wd := MustGetwd()
+	for _, newGopath = range strings.Split(currentGopath, ":") {
+		if strings.HasPrefix(filepath.Dir(wd), newGopath) {
+			cwdInGopath = true
+			break
+		}
+	}
+	if !cwdInGopath {
+		log.Fatalf("check current pkg failed: must run from gopath")
+	}
+	if err := os.Setenv(GopathEnv, newGopath); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -74,8 +74,7 @@ func MustGetwd() string {
 // CheckAndGetProjectGoPkg checks if this project's repository path is rooted under $GOPATH and returns the current directory's import path
 // e.g: "github.com/example-inc/app-operator"
 func CheckAndGetProjectGoPkg() string {
-	gopath := GetGopath()
-	SetGopath(gopath)
+	gopath := SetGopath(GetGopath())
 	goSrc := filepath.Join(gopath, SrcDir)
 	wd := MustGetwd()
 	currPkg := strings.Replace(wd, goSrc+string(filepath.Separator), "", 1)
@@ -95,6 +94,7 @@ func GetOperatorType() OperatorType {
 	return OperatorTypeGo
 }
 
+// GetGopath gets GOPATH and makes sure it is set and non-empty.
 func GetGopath() string {
 	gopath, ok := os.LookupEnv(GopathEnv)
 	if !ok || len(gopath) == 0 {
@@ -103,7 +103,9 @@ func GetGopath() string {
 	return gopath
 }
 
-func SetGopath(currentGopath string) {
+// SetGopath sets GOPATH=currentGopath after processing a path list,
+// if any, then returns the set path.
+func SetGopath(currentGopath string) string {
 	var newGopath string
 	cwdInGopath := false
 	wd := MustGetwd()
@@ -115,8 +117,11 @@ func SetGopath(currentGopath string) {
 	}
 	if !cwdInGopath {
 		log.Fatalf("project not in $GOPATH")
+		return ""
 	}
 	if err := os.Setenv(GopathEnv, newGopath); err != nil {
 		log.Fatal(err)
+		return ""
 	}
+	return newGopath
 }

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -98,7 +98,7 @@ func GetOperatorType() OperatorType {
 func GetGopath() string {
 	gopath, ok := os.LookupEnv(GopathEnv)
 	if !ok || len(gopath) == 0 {
-		log.Fatal("get current pkg failed: GOPATH env not set")
+		log.Fatal("GOPATH env not set")
 	}
 	return gopath
 }
@@ -114,7 +114,7 @@ func SetGopath(currentGopath string) {
 		}
 	}
 	if !cwdInGopath {
-		log.Fatalf("check current pkg failed: must run from gopath")
+		log.Fatalf("project not in $GOPATH")
 	}
 	if err := os.Setenv(GopathEnv, newGopath); err != nil {
 		log.Fatal(err)

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 	"github.com/operator-framework/operator-sdk/test/e2e/e2eutil"
 	framework "github.com/operator-framework/operator-sdk/test/e2e/framework"
 
@@ -42,7 +43,7 @@ func TestMemcached(t *testing.T) {
 	f := framework.Global
 	ctx := f.NewTestCtx(t)
 	defer ctx.Cleanup(t)
-	gopath, ok := os.LookupEnv("GOPATH")
+	gopath, ok := os.LookupEnv(projutil.GopathEnv)
 	if !ok {
 		t.Fatalf("$GOPATH not set")
 	}


### PR DESCRIPTION
**Description of the change:** see #712 for main change. Also changed `CheckAndGetCurrPkg()` to `CheckAndGetProjectGoPkg()`, and removed local constants in favor of `projutil` contstants.

**Motivation for the change:** see #712, and make function name more obvious. We had to revert #712 in #721 so Ansible operator users don't see errors when they shouldn't. Now the `GOPATH` check only occurs when calling `CheckAndGetProjectGoPkg()`. 

@nrobert13 