### PR TITLE
Turns on leader election by default and adds e2e tests

### DIFF
--- a/pkg/ready/ready.go
+++ b/pkg/ready/ready.go
@@ -1,0 +1,58 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ready
+
+import (
+	"os"
+)
+
+const FileName = "/tmp/operator-sdk-ready"
+
+// Ready holds state about whether the operator is ready and communicates that
+// to a Kubernetes readiness probe.
+type Ready interface {
+	// Set ensures that future readiness probes will indicate that the operator
+	// is ready.
+	Set() error
+
+	// Unset ensures that future readiness probes will indicate that the
+	// operator is not ready.
+	Unset() error
+}
+
+// NewFileReady returns a Ready that uses the presence of a file on disk to
+// communicate whether the operator is ready. The operator's Pod definition
+// should include a readinessProbe of "exec" type that calls
+// "stat /tmp/operator-sdk-ready".
+func NewFileReady() Ready {
+	return fileReady{}
+}
+
+type fileReady struct{}
+
+// Set creates a file on disk whose presense can be used by a readiness probe
+// to determine that the operator is ready.
+func (r fileReady) Set() error {
+	f, err := os.Create(FileName)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+// Unset removes the file on disk that was created by Set().
+func (r fileReady) Unset() error {
+	return os.Remove(FileName)
+}

--- a/pkg/ready/ready_test.go
+++ b/pkg/ready/ready_test.go
@@ -1,0 +1,46 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ready
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFileReady(t *testing.T) {
+	r := NewFileReady()
+	err := r.Set()
+	if err != nil {
+		t.Errorf("could not set ready file: %v", err)
+	}
+
+	_, err = os.Stat(FileName)
+	if err != nil {
+		t.Errorf("did not find expected file at %s: %v", FileName, err)
+	}
+
+	err = r.Unset()
+	if err != nil {
+		t.Errorf("could not unset ready file: %v", err)
+	}
+
+	_, err = os.Stat(FileName)
+	if err == nil {
+		t.Errorf("file still exists at %s", FileName)
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("error determining if file still exists at %s: %v", FileName, err)
+	}
+}

--- a/pkg/scaffold/cmd.go
+++ b/pkg/scaffold/cmd.go
@@ -37,6 +37,7 @@ func (s *Cmd) GetInput() (input.Input, error) {
 const cmdTmpl = `package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -46,6 +47,8 @@ import (
 	"{{ .Repo }}/pkg/controller"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"github.com/operator-framework/operator-sdk/pkg/leader"
+	"github.com/operator-framework/operator-sdk/pkg/ready"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -85,6 +88,17 @@ func main() {
 		log.Error(err, "")
 		os.Exit(1)
 	}
+
+	// Become the leader before proceeding
+	leader.Become(context.TODO(), "{{ .ProjectName }}-lock")
+
+	r := ready.NewFileReady()
+	err = r.Set()
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+	defer r.Unset()
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})

--- a/pkg/scaffold/operator.go
+++ b/pkg/scaffold/operator.go
@@ -61,6 +61,14 @@ spec:
           command:
           - {{.ProjectName}}
           imagePullPolicy: Always
+          readinessProbe:
+            exec:
+              command:
+                - stat
+                - /tmp/operator-sdk-ready
+            initialDelaySeconds: 4
+            periodSeconds: 10
+            failureThreshold: 1
           env:
             - name: WATCH_NAMESPACE
               {{- if .IsClusterScoped }}

--- a/pkg/scaffold/operator_test.go
+++ b/pkg/scaffold/operator_test.go
@@ -71,6 +71,14 @@ spec:
           command:
           - app-operator
           imagePullPolicy: Always
+          readinessProbe:
+            exec:
+              command:
+                - stat
+                - /tmp/operator-sdk-ready
+            initialDelaySeconds: 4
+            periodSeconds: 10
+            failureThreshold: 1
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -109,6 +117,14 @@ spec:
           command:
           - app-operator
           imagePullPolicy: Always
+          readinessProbe:
+            exec:
+              command:
+                - stat
+                - /tmp/operator-sdk-ready
+            initialDelaySeconds: 4
+            periodSeconds: 10
+            failureThreshold: 1
           env:
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
Adds a readiness probe by default that reflects whether a pod is the leader.

fixes #598

**Motivation for the change:**

see #530 
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
