### PR TITLE
*: better docs and error reporting for project type issue

### DIFF
--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -272,6 +272,8 @@ However if there are any operator specific flags or settings defined in the old 
 
 If you have any 3rd party resource types registered with the SDK's scheme, then register those with the Manager's scheme in the new project. See how to [register 3rd party resources][register-3rd-party-resources].
 
+`operator-sdk` now expects `cmd/manager/main.go` to be present in Go operator projects. Go project-specific commands, ex. `add [api, controller]`, will error if `main.go` is not found in its expected path.
+
 ### Copy user defined files
 
 If there are any user defined pkgs, scripts, and docs in the older project, copy these files into the new project. 

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -59,7 +59,7 @@ func MustGoProjectCmd(cmd *cobra.Command) {
 	switch t {
 	case OperatorTypeGo:
 	default:
-		log.Fatalf("'%s' can only be run for Go operators.", cmd.CommandPath())
+		log.Fatalf("'%s' can only be run for Go operators; %s does not exist.", cmd.CommandPath(), mainFile)
 	}
 }
 


### PR DESCRIPTION
**Description of the change:** state `main.go` must be present for Go operators, and better error message.


**Motivation for the change:** see #726 

Closes #726 
