### PR TITLE
commands/.../build.go: run operator builds in docker containers

### DIFF
--- a/pkg/scaffold/build_dockerfile.go
+++ b/pkg/scaffold/build_dockerfile.go
@@ -34,11 +34,24 @@ func (s *Dockerfile) GetInput() (input.Input, error) {
 	return s.Input, nil
 }
 
-const dockerfileTmpl = `FROM alpine:3.8
+const dockerfileTmpl = `# Binary builder image
+FROM golang:1.10.3 AS builder
+
+ENV GOPATH /go
+ENV CGO_ENABLED 0
+ENV GOOS linux
+ENV GOARCH amd64
+
+WORKDIR /go/src/{{ .Repo }}
+COPY . /go/src/{{ .Repo }}
+
+RUN go build -o /go/bin/{{ .ProjectName }} {{ .Repo }}/cmd/manager
+
+# Base image
+FROM alpine:3.6
 
 RUN apk upgrade --update --no-cache
-
 USER nobody
 
-ADD build/_output/bin/{{.ProjectName}} /usr/local/bin/{{.ProjectName}}
+COPY --from=builder /go/bin/{{ .ProjectName }} /usr/local/bin/{{ .ProjectName }}
 `

--- a/pkg/scaffold/build_dockerfile_test.go
+++ b/pkg/scaffold/build_dockerfile_test.go
@@ -31,11 +31,24 @@ func TestDockerfile(t *testing.T) {
 	}
 }
 
-const dockerfileExp = `FROM alpine:3.8
+const dockerfileExp = `# Binary builder image
+FROM golang:1.10.3 AS builder
+
+ENV GOPATH /go
+ENV CGO_ENABLED 0
+ENV GOOS linux
+ENV GOARCH amd64
+
+WORKDIR /go/src/github.com/example-inc/app-operator
+COPY . /go/src/github.com/example-inc/app-operator
+
+RUN go build -o /go/bin/app-operator github.com/example-inc/app-operator/cmd/manager
+
+# Base image
+FROM alpine:3.6
 
 RUN apk upgrade --update --no-cache
-
 USER nobody
 
-ADD build/_output/bin/app-operator /usr/local/bin/app-operator
+COPY --from=builder /go/bin/app-operator /usr/local/bin/app-operator
 `

--- a/pkg/scaffold/test_framework_dockerfile_test.go
+++ b/pkg/scaffold/test_framework_dockerfile_test.go
@@ -31,10 +31,29 @@ func TestTestFrameworkDockerfile(t *testing.T) {
 	}
 }
 
-const testFrameworkDockerfileExp = `ARG BASEIMAGE
+const testFrameworkDockerfileExp = `# ARG before FROM must always be before the first FROM
+ARG BASEIMAGE
+# Test binary builder image
+FROM golang:1.10.3 AS builder
+
+ENV GOPATH /go
+ENV CGO_ENABLED 0
+ENV GOOS linux
+ENV GOARCH amd64
+
+WORKDIR /go/src/github.com/example-inc/app-operator
+COPY . /go/src/github.com/example-inc/app-operator
+
+ARG TESTDIR
+RUN go test -c -o /go/bin/app-operator-test ${TESTDIR}/...
+
+# Base image containing "app-operator" binary
 FROM ${BASEIMAGE}
-ADD build/_output/bin/app-operator-test /usr/local/bin/app-operator-test
+
+COPY --from=builder /go/bin/app-operator-test /usr/local/bin/app-operator-test
+
 ARG NAMESPACEDMAN
 ADD $NAMESPACEDMAN /namespaced.yaml
+
 ADD build/test-framework/go-test.sh /go-test.sh
 `


### PR DESCRIPTION
**Description of the change:** run operator binary and test binary builds in Docker containers. This change has been refactored out of #563.

**Motivation for the change:** see #167 for details.

Closes #167 