### PR TITLE
pkg/scaffold/internal/testutil/test_util.go: scaffold unit test utilities

### DIFF
--- a/pkg/scaffold/add_controller_test.go
+++ b/pkg/scaffold/add_controller_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestAddController(t *testing.T) {
@@ -30,7 +32,7 @@ func TestAddController(t *testing.T) {
 	}
 
 	if addControllerExp != buf.String() {
-		diffs := diff(addControllerExp, buf.String())
+		diffs := testutil.Diff(addControllerExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/addtoscheme_test.go
+++ b/pkg/scaffold/addtoscheme_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestAddToScheme(t *testing.T) {
@@ -30,7 +32,7 @@ func TestAddToScheme(t *testing.T) {
 	}
 
 	if addtoschemeExp != buf.String() {
-		diffs := diff(addtoschemeExp, buf.String())
+		diffs := testutil.Diff(addtoschemeExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/apis_test.go
+++ b/pkg/scaffold/apis_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestApis(t *testing.T) {
@@ -26,7 +28,7 @@ func TestApis(t *testing.T) {
 	}
 
 	if apisExp != buf.String() {
-		diffs := diff(apisExp, buf.String())
+		diffs := testutil.Diff(apisExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/build_dockerfile_test.go
+++ b/pkg/scaffold/build_dockerfile_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestDockerfile(t *testing.T) {
@@ -26,7 +28,7 @@ func TestDockerfile(t *testing.T) {
 	}
 
 	if dockerfileExp != buf.String() {
-		diffs := diff(dockerfileExp, buf.String())
+		diffs := testutil.Diff(dockerfileExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/cmd_test.go
+++ b/pkg/scaffold/cmd_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestCmd(t *testing.T) {
@@ -26,7 +28,7 @@ func TestCmd(t *testing.T) {
 	}
 
 	if cmdExp != buf.String() {
-		diffs := diff(cmdExp, buf.String())
+		diffs := testutil.Diff(cmdExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/controller_kind_test.go
+++ b/pkg/scaffold/controller_kind_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestControllerKind(t *testing.T) {
@@ -30,7 +32,7 @@ func TestControllerKind(t *testing.T) {
 	}
 
 	if controllerKindExp != buf.String() {
-		diffs := diff(controllerKindExp, buf.String())
+		diffs := testutil.Diff(controllerKindExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/controller_test.go
+++ b/pkg/scaffold/controller_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestController(t *testing.T) {
@@ -26,7 +28,7 @@ func TestController(t *testing.T) {
 	}
 
 	if controllerExp != buf.String() {
-		diffs := diff(controllerKindExp, buf.String())
+		diffs := testutil.Diff(controllerKindExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/cr_test.go
+++ b/pkg/scaffold/cr_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestCr(t *testing.T) {
@@ -30,7 +32,7 @@ func TestCr(t *testing.T) {
 	}
 
 	if crExp != buf.String() {
-		diffs := diff(crExp, buf.String())
+		diffs := testutil.Diff(crExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/crd_test.go
+++ b/pkg/scaffold/crd_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestCRD(t *testing.T) {
@@ -30,7 +32,7 @@ func TestCRD(t *testing.T) {
 	}
 
 	if crdExp != buf.String() {
-		diffs := diff(crdExp, buf.String())
+		diffs := testutil.Diff(crdExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/doc_test.go
+++ b/pkg/scaffold/doc_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestDoc(t *testing.T) {
@@ -30,7 +32,7 @@ func TestDoc(t *testing.T) {
 	}
 
 	if docExp != buf.String() {
-		diffs := diff(docExp, buf.String())
+		diffs := testutil.Diff(docExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/gitignore_test.go
+++ b/pkg/scaffold/gitignore_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestGitignore(t *testing.T) {
@@ -26,7 +28,7 @@ func TestGitignore(t *testing.T) {
 	}
 
 	if gitignoreExp != buf.String() {
-		diffs := diff(gitignoreExp, buf.String())
+		diffs := testutil.Diff(gitignoreExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/go_test_script_test.go
+++ b/pkg/scaffold/go_test_script_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestGoTestScript(t *testing.T) {
@@ -26,7 +28,7 @@ func TestGoTestScript(t *testing.T) {
 	}
 
 	if goTestScriptExp != buf.String() {
-		diffs := diff(goTestScriptExp, buf.String())
+		diffs := testutil.Diff(goTestScriptExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/gopkgtoml_test.go
+++ b/pkg/scaffold/gopkgtoml_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestGopkgtoml(t *testing.T) {
@@ -26,7 +28,7 @@ func TestGopkgtoml(t *testing.T) {
 	}
 
 	if gopkgtomlExp != buf.String() {
-		diffs := diff(gopkgtomlExp, buf.String())
+		diffs := testutil.Diff(gopkgtomlExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/internal/testutil/test_util.go
+++ b/pkg/scaffold/internal/testutil/test_util.go
@@ -14,7 +14,7 @@
 
 // Modified from github.com/kubernetes-sigs/controller-tools/pkg/util/util.go
 
-package scaffold
+package testutil
 
 import (
 	"bytes"
@@ -24,7 +24,7 @@ import (
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
-func diff(a, b string) string {
+func Diff(a, b string) string {
 	dmp := diffmatchpatch.New()
 
 	wSrc, wDst, warray := dmp.DiffLinesToRunes(a, b)

--- a/pkg/scaffold/operator_test.go
+++ b/pkg/scaffold/operator_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestOperator(t *testing.T) {
@@ -26,7 +28,7 @@ func TestOperator(t *testing.T) {
 	}
 
 	if operatorExp != buf.String() {
-		diffs := diff(operatorExp, buf.String())
+		diffs := testutil.Diff(operatorExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/register_test.go
+++ b/pkg/scaffold/register_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestRegister(t *testing.T) {
@@ -30,7 +32,7 @@ func TestRegister(t *testing.T) {
 	}
 
 	if registerExp != buf.String() {
-		diffs := diff(registerExp, buf.String())
+		diffs := testutil.Diff(registerExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/role_test.go
+++ b/pkg/scaffold/role_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestRole(t *testing.T) {
@@ -26,7 +28,7 @@ func TestRole(t *testing.T) {
 	}
 
 	if roleExp != buf.String() {
-		diffs := diff(roleExp, buf.String())
+		diffs := testutil.Diff(roleExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/rolebinding_test.go
+++ b/pkg/scaffold/rolebinding_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestRoleBinding(t *testing.T) {
@@ -26,7 +28,7 @@ func TestRoleBinding(t *testing.T) {
 	}
 
 	if rolebindingExp != buf.String() {
-		diffs := diff(rolebindingExp, buf.String())
+		diffs := testutil.Diff(rolebindingExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/service_account_test.go
+++ b/pkg/scaffold/service_account_test.go
@@ -17,7 +17,7 @@ package scaffold
 import (
 	"testing"
 
-	"github.com/sergi/go-diff/diffmatchpatch"
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestServiceAccount(t *testing.T) {
@@ -28,9 +28,8 @@ func TestServiceAccount(t *testing.T) {
 	}
 
 	if serviceAccountExp != buf.String() {
-		dmp := diffmatchpatch.New()
-		diffs := diffmatchpatch.New().DiffMain(serviceAccountExp, buf.String(), false)
-		t.Fatalf("expected vs actual differs. Red text is missing and green text is extra.\n%v", dmp.DiffPrettyText(diffs))
+		diffs := testutil.Diff(serviceAccountExp, buf.String())
+		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }
 

--- a/pkg/scaffold/test_framework_dockerfile_test.go
+++ b/pkg/scaffold/test_framework_dockerfile_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestTestFrameworkDockerfile(t *testing.T) {
@@ -26,7 +28,7 @@ func TestTestFrameworkDockerfile(t *testing.T) {
 	}
 
 	if testFrameworkDockerfileExp != buf.String() {
-		diffs := diff(testFrameworkDockerfileExp, buf.String())
+		diffs := testutil.Diff(testFrameworkDockerfileExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/test_pod_test.go
+++ b/pkg/scaffold/test_pod_test.go
@@ -17,6 +17,7 @@ package scaffold
 import (
 	"testing"
 
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 	"github.com/operator-framework/operator-sdk/pkg/test"
 )
 
@@ -32,7 +33,7 @@ func TestPodTest(t *testing.T) {
 	}
 
 	if testPodExp != buf.String() {
-		diffs := diff(testPodExp, buf.String())
+		diffs := testutil.Diff(testPodExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/types_test.go
+++ b/pkg/scaffold/types_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestTypes(t *testing.T) {
@@ -30,7 +32,7 @@ func TestTypes(t *testing.T) {
 	}
 
 	if typesExp != buf.String() {
-		diffs := diff(typesExp, buf.String())
+		diffs := testutil.Diff(typesExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }

--- a/pkg/scaffold/version_test.go
+++ b/pkg/scaffold/version_test.go
@@ -16,6 +16,8 @@ package scaffold
 
 import (
 	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/scaffold/internal/testutil"
 )
 
 func TestVersion(t *testing.T) {
@@ -26,7 +28,7 @@ func TestVersion(t *testing.T) {
 	}
 
 	if versionExp != buf.String() {
-		diffs := diff(versionExp, buf.String())
+		diffs := testutil.Diff(versionExp, buf.String())
 		t.Fatalf("expected vs actual differs.\n%v", diffs)
 	}
 }


### PR DESCRIPTION
**Description of the change:** move `pkg/scaffold/util.go` to `pkg/scaffold/internal/testutil/test_util.go` and update deps.


**Motivation for the change:** sub-packages of `pkg/scaffold` need to access unit test helpers.
