### PR TITLE
pkg/scaffold: fixing main printVersion

### DIFF
--- a/pkg/scaffold/cmd.go
+++ b/pkg/scaffold/cmd.go
@@ -54,14 +54,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+var log = logf.Log.WithName("cmd")
+
 func printVersion() {
-	logf.Log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	logf.Log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	logf.Log.Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
+	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
+	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+	log.Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
 }
 
 func main() {
-	printVersion()
 	flag.Parse()
 
 	// The logger instantiated here can be changed to any logger
@@ -69,7 +70,8 @@ func main() {
 	// be propagated through the whole operator, generating
 	// uniform and structured logs.
 	logf.SetLogger(logf.ZapLogger(false))
-	log := logf.Log.WithName("cmd")
+
+	printVersion()
 
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {

--- a/pkg/scaffold/cmd_test.go
+++ b/pkg/scaffold/cmd_test.go
@@ -52,14 +52,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+var log = logf.Log.WithName("cmd")
+
 func printVersion() {
-	logf.Log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	logf.Log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	logf.Log.Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
+	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
+	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+	log.Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
 }
 
 func main() {
-	printVersion()
 	flag.Parse()
 
 	// The logger instantiated here can be changed to any logger
@@ -67,7 +68,8 @@ func main() {
 	// be propagated through the whole operator, generating
 	// uniform and structured logs.
 	logf.SetLogger(logf.ZapLogger(false))
-	log := logf.Log.WithName("cmd")
+
+	printVersion()
 
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Modifying the `cmd/manager/main.go` template so that the call to `printVersion()` occurs after the logger has been set.

**Motivation for the change:**
`printVersion()` does not currently print the version information.

If we're concerned that moving `printVersion()` beyond the very first call in `main()` will cause problems, we can also just use `fmt.Printf()` in `printVersion()` instead of using the logger.
