### PR TITLE
pkg/ansible,cmd/up/local: Add ansible operator flags to your CLI

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1416,6 +1416,7 @@
     "github.com/sirupsen/logrus",
     "github.com/spf13/afero",
     "github.com/spf13/cobra",
+    "github.com/spf13/pflag",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "golang.org/x/tools/imports",

--- a/commands/operator-sdk/cmd/up/local.go
+++ b/commands/operator-sdk/cmd/up/local.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
+	"github.com/operator-framework/operator-sdk/pkg/ansible/flags"
 	ansibleOperator "github.com/operator-framework/operator-sdk/pkg/ansible/operator"
 	proxy "github.com/operator-framework/operator-sdk/pkg/ansible/proxy"
 	"github.com/operator-framework/operator-sdk/pkg/helm/client"
@@ -36,7 +37,6 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/helm/release"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold"
-	ansibleScaffold "github.com/operator-framework/operator-sdk/pkg/scaffold/ansible"
 	helmScaffold "github.com/operator-framework/operator-sdk/pkg/scaffold/helm"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"k8s.io/helm/pkg/storage"
@@ -49,6 +49,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
+// NewLocalCmd - up local command to run an operator loccally
 func NewLocalCmd() *cobra.Command {
 	upLocalCmd := &cobra.Command{
 		Use:   "local",
@@ -64,15 +65,18 @@ kubernetes cluster using a kubeconfig file.
 	upLocalCmd.Flags().StringVar(&operatorFlags, "operator-flags", "", "The flags that the operator needs. Example: \"--flag1 value1 --flag2=value2\"")
 	upLocalCmd.Flags().StringVar(&namespace, "namespace", "default", "The namespace where the operator watches for changes.")
 	upLocalCmd.Flags().StringVar(&ldFlags, "go-ldflags", "", "Set Go linker options")
-
+	if projutil.GetOperatorType() == projutil.OperatorTypeAnsible {
+		ansibleOperatorFlags = flags.AddTo(upLocalCmd.Flags(), "(ansible operator)")
+	}
 	return upLocalCmd
 }
 
 var (
-	kubeConfig    string
-	operatorFlags string
-	namespace     string
-	ldFlags       string
+	kubeConfig           string
+	operatorFlags        string
+	namespace            string
+	ldFlags              string
+	ansibleOperatorFlags *flags.AnsibleOperatorFlags
 )
 
 const (
@@ -173,7 +177,7 @@ func upLocalAnsible() {
 	}
 
 	// start the operator
-	go ansibleOperator.Run(done, mgr, "./"+ansibleScaffold.WatchesYamlFile, time.Minute)
+	go ansibleOperator.Run(done, mgr, ansibleOperatorFlags)
 
 	// wait for either to finish
 	err = <-done

--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -59,7 +59,6 @@ fi
 
 # create CR
 kubectl create -f deploy/crds/ansible_v1alpha1_memcached_cr.yaml
-trap_add 'kubectl delete --ignore-not-found -f ${DIR2}/deploy/crds/ansible_v1alpha1_memcached_cr.yaml' EXIT
 if ! timeout 20s bash -c -- 'until kubectl get deployment -l app=memcached | grep memcached; do sleep 1; done';
 then
     kubectl logs deployment/memcached-operator

--- a/pkg/ansible/flags/flag.go
+++ b/pkg/ansible/flags/flag.go
@@ -1,0 +1,45 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+import (
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+// AnsibleOperatorFlags - Options to be used by an ansible operator
+type AnsibleOperatorFlags struct {
+	ReconcilePeriod time.Duration
+	WatchesFile     string
+}
+
+// AddTo - Add the ansible operator flags to the the flagset
+// helpTextPrefix will allow you add a prefix to default help text. Joined by a space.
+func AddTo(flagSet *pflag.FlagSet, helpTextPrefix ...string) *AnsibleOperatorFlags {
+	aof := &AnsibleOperatorFlags{}
+	flagSet.DurationVar(&aof.ReconcilePeriod,
+		"reconcile-period",
+		time.Minute,
+		strings.Join(append(helpTextPrefix, "Default reconcile period for controllers"), " "),
+	)
+	flagSet.StringVar(&aof.WatchesFile,
+		"watches-file",
+		"./watches.yaml",
+		strings.Join(append(helpTextPrefix, "Path to the watches file to use"), " "),
+	)
+	return aof
+}

--- a/test/ansible-operator/bin/entrypoint
+++ b/test/ansible-operator/bin/entrypoint
@@ -9,4 +9,5 @@ if ! whoami &>/dev/null; then
   fi
 fi
 
-exec "${OPERATOR:-/usr/local/bin/ansible-operator}"
+#Watches file will be overridden if the flag is provided again.
+exec ${OPERATOR} --watches-file=/opt/ansible/watches.yaml $@

--- a/test/ansible-operator/cmd/ansible-operator/main.go
+++ b/test/ansible-operator/cmd/ansible-operator/main.go
@@ -15,16 +15,16 @@
 package main
 
 import (
-	"flag"
 	"runtime"
-	"time"
 
+	aoflags "github.com/operator-framework/operator-sdk/pkg/ansible/flags"
 	"github.com/operator-framework/operator-sdk/pkg/ansible/operator"
 	proxy "github.com/operator-framework/operator-sdk/pkg/ansible/proxy"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -37,7 +37,8 @@ func printVersion() {
 }
 
 func main() {
-	flag.Parse()
+	aflags := aoflags.AddTo(pflag.CommandLine)
+	pflag.Parse()
 
 	logf.SetLogger(logf.ZapLogger(true))
 
@@ -67,7 +68,7 @@ func main() {
 	}
 
 	// start the operator
-	go operator.Run(done, mgr, "/opt/ansible/watches.yaml", time.Minute)
+	go operator.Run(done, mgr, aflags)
 
 	// wait for either to finish
 	err = <-done


### PR DESCRIPTION
* Add the ability add flags to your binary
* Change to `operator.Run` to take the flags
* Adding ability to pass in the watches file location


**Description of the change:**
Adding the ability to add the ansible operator flags to the command line. An example is for `operator-sdk up local`. If we sense that this is an ansible operator, then we will add the ansible operator flags so that the same testing can happen locally as it can in a container image.

**Motivation for the change:**
Adding some infrastructure to make adding flags/options easier.
