### PR TITLE
internal/../project_util.go: Adjust error msg

### DIFF
--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -50,7 +50,7 @@ func MustInProjectRoot() {
 	// we are at the project root.
 	_, err := os.Stat(buildDockerfile)
 	if err != nil && os.IsNotExist(err) {
-		log.Fatalf("must run command in project root dir: (%v)", err)
+		log.Fatalf("must run command in project root dir: project structure requires ./build/Dockerfile: (%v)", err)
 	}
 }
 


### PR DESCRIPTION
We want to convey to the user that the commands must be run from the
project root directory, but also that the operator must have certain
files present otherwise we cannot execute the command.

Closes https://github.com/operator-framework/operator-sdk/issues/655

cc @cmoulliard

