### PR TITLE
Adds travis support for push builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
 
 before_install:
   - |
-      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md)|(\.MD)|(\.png)|(\.pdf)|^(doc/)|^(MAINTAINERS)|^(LICENSE)'; then
+      if [ "$TRAVIS_COMMIT_RANGE" != "" ] && ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md)|(\.MD)|(\.png)|(\.pdf)|^(doc/)|^(MAINTAINERS)|^(LICENSE)'; then
         echo "Only doc files were updated, not running the CI."
         exit
       fi

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -82,10 +82,16 @@ func TestMemcached(t *testing.T) {
 	ctx.AddFinalizerFn(func() error { return os.RemoveAll(absProjectPath) })
 
 	os.Chdir("memcached-operator")
-	prSlug, ok := os.LookupEnv("TRAVIS_PULL_REQUEST_SLUG")
-	if ok && prSlug != "" {
-		prSha, ok := os.LookupEnv("TRAVIS_PULL_REQUEST_SHA")
-		if ok && prSha != "" {
+	repo, ok := os.LookupEnv("TRAVIS_PULL_REQUEST_SLUG")
+	if repo == "" {
+		repo, ok = os.LookupEnv("TRAVIS_REPO_SLUG")
+	}
+	if ok && repo != "" {
+		commitSha, ok := os.LookupEnv("TRAVIS_PULL_REQUEST_SHA")
+		if commitSha == "" {
+			commitSha, ok = os.LookupEnv("TRAVIS_COMMIT")
+		}
+		if ok && commitSha != "" {
 			gopkg, err := ioutil.ReadFile("Gopkg.toml")
 			if err != nil {
 				t.Fatal(err)
@@ -98,7 +104,7 @@ func TestMemcached(t *testing.T) {
 			// correctly.
 			gopkgString := string(gopkg)
 			gopkgLoc := strings.LastIndex(gopkgString, "\n  name = \"github.com/operator-framework/operator-sdk\"\n")
-			gopkgString = gopkgString[:gopkgLoc] + "\n  source = \"https://github.com/" + prSlug + "\"\n  revision = \"" + prSha + "\"\n" + gopkgString[gopkgLoc+1:]
+			gopkgString = gopkgString[:gopkgLoc] + "\n  source = \"https://github.com/" + repo + "\"\n  revision = \"" + commitSha + "\"\n" + gopkgString[gopkgLoc+1:]
 			err = ioutil.WriteFile("Gopkg.toml", []byte(gopkgString), filemode)
 			if err != nil {
 				t.Fatalf("failed to write updated Gopkg.toml: %v", err)
@@ -111,7 +117,7 @@ func TestMemcached(t *testing.T) {
 	}
 	cmdOut, err = exec.Command("dep", "ensure").CombinedOutput()
 	if err != nil {
-		t.Fatalf("error: %v\nCommand Output: %s\n", err, string(cmdOut))
+		t.Fatalf("error after modifying Gopkg.toml: %v\nCommand Output: %s\n", err, string(cmdOut))
 	}
 
 	cmdOut, err = exec.Command("operator-sdk",
@@ -191,7 +197,7 @@ func TestMemcached(t *testing.T) {
 		t.Fatalf("dep ensure failed: %v\nCommand Output:\n%v", err, string(cmdOut))
 	}
 	// link local sdk to vendor if not in travis
-	if prSlug == "" {
+	if repo == "" {
 		os.RemoveAll("vendor/github.com/operator-framework/operator-sdk/pkg")
 		os.Symlink(filepath.Join(gopath, "src/github.com/operator-framework/operator-sdk/pkg"),
 			"vendor/github.com/operator-framework/operator-sdk/pkg")


### PR DESCRIPTION
This enables a developer to activate travis-ci on their own namespace and have
branches tested upon push. It's an effective way to test the CI before making a
pull request to operator-sdk.