### PR TITLE
'operator-sdk print-deps' command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:e4b30804a381d7603b8a344009987c1ba351c26043501b23b8c7ce21f0b67474"
+  name = "github.com/BurntSushi/toml"
+  packages = ["."]
+  pruneopts = ""
+  revision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
+  version = "v0.3.1"
+
+[[projects]]
   digest = "1:8e47871087b94913898333f37af26732faaab30cdb41571136cf7aec9921dae7"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
@@ -791,6 +799,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/BurntSushi/toml",
     "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1",
     "github.com/ghodss/yaml",
     "github.com/go-logr/logr",

--- a/commands/operator-sdk/cmd/print_deps.go
+++ b/commands/operator-sdk/cmd/print_deps.go
@@ -21,6 +21,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var toml bool
+
 func NewPrintDepsCmd() *cobra.Command {
 	printDepsCmd := &cobra.Command{
 		Use:   "print-deps",
@@ -31,6 +33,8 @@ in an operators' Gopkg.toml file.`,
 		Run: printDepsFunc,
 	}
 
+	printDepsCmd.Flags().BoolVar(&toml, "toml", false, "Print dependencies in Gopkg.toml format.")
+
 	return printDepsCmd
 }
 
@@ -38,7 +42,11 @@ func printDepsFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 0 {
 		log.Fatal("print-deps command does not take any arguments")
 	}
-	if err := scaffold.PrintGopkgDeps(); err != nil {
-		log.Fatalf("print deps: (%v)", err)
+	if toml {
+		scaffold.PrintGopkgToml()
+	} else {
+		if err := scaffold.PrintGopkgDeps(); err != nil {
+			log.Fatalf("print deps: (%v)", err)
+		}
 	}
 }

--- a/commands/operator-sdk/cmd/print_deps.go
+++ b/commands/operator-sdk/cmd/print_deps.go
@@ -1,0 +1,44 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/operator-framework/operator-sdk/pkg/scaffold"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func NewPrintDepsCmd() *cobra.Command {
+	printDepsCmd := &cobra.Command{
+		Use:   "print-deps",
+		Short: "Print dependencies expected by the Operator SDK",
+		Long: `The operator-sdk print-deps command prints all dependencies expected by this
+version of the Operator SDK. Versions for these dependencies should match those
+in an operators' Gopkg.toml file.`,
+		Run: printDepsFunc,
+	}
+
+	return printDepsCmd
+}
+
+func printDepsFunc(cmd *cobra.Command, args []string) {
+	if len(args) != 0 {
+		log.Fatal("print-deps command does not take any arguments")
+	}
+	if err := scaffold.PrintGopkgDeps(); err != nil {
+		log.Fatalf("print deps: (%v)", err)
+	}
+}

--- a/commands/operator-sdk/cmd/print_deps.go
+++ b/commands/operator-sdk/cmd/print_deps.go
@@ -26,10 +26,10 @@ var asFile bool
 func NewPrintDepsCmd() *cobra.Command {
 	printDepsCmd := &cobra.Command{
 		Use:   "print-deps",
-		Short: "Print dependencies expected by the Operator SDK",
-		Long: `The operator-sdk print-deps command prints all dependencies expected by this
-version of the Operator SDK. Versions for these dependencies should match those
-in an operators' Gopkg.toml file.
+		Short: "Print Golang packages and versions required to run the operator",
+		Long: `The operator-sdk print-deps command prints all Golang packages and versions expected
+by this version of the Operator SDK. Versions for these packages should match
+those in an operators' Gopkg.toml file.
 
 print-deps prints in columnar format by default. Use the --as-file flag to
 print in Gopkg.toml file format.

--- a/commands/operator-sdk/cmd/print_deps.go
+++ b/commands/operator-sdk/cmd/print_deps.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var toml bool
+var asFile bool
 
 func NewPrintDepsCmd() *cobra.Command {
 	printDepsCmd := &cobra.Command{
@@ -29,11 +29,15 @@ func NewPrintDepsCmd() *cobra.Command {
 		Short: "Print dependencies expected by the Operator SDK",
 		Long: `The operator-sdk print-deps command prints all dependencies expected by this
 version of the Operator SDK. Versions for these dependencies should match those
-in an operators' Gopkg.toml file.`,
+in an operators' Gopkg.toml file.
+
+print-deps prints in columnar format by default. Use the --as-file flag to
+print in Gopkg.toml file format.
+`,
 		Run: printDepsFunc,
 	}
 
-	printDepsCmd.Flags().BoolVar(&toml, "toml", false, "Print dependencies in Gopkg.toml format.")
+	printDepsCmd.Flags().BoolVar(&asFile, "as-file", false, "Print dependencies in Gopkg.toml file format.")
 
 	return printDepsCmd
 }
@@ -42,10 +46,10 @@ func printDepsFunc(cmd *cobra.Command, args []string) {
 	if len(args) != 0 {
 		log.Fatal("print-deps command does not take any arguments")
 	}
-	if toml {
-		scaffold.PrintGopkgToml()
+	if asFile {
+		scaffold.PrintDepsAsFile()
 	} else {
-		if err := scaffold.PrintGopkgDeps(); err != nil {
+		if err := scaffold.PrintDeps(); err != nil {
 			log.Fatalf("print deps: (%v)", err)
 		}
 	}

--- a/commands/operator-sdk/cmd/root.go
+++ b/commands/operator-sdk/cmd/root.go
@@ -34,6 +34,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(NewUpCmd())
 	cmd.AddCommand(NewCompletionCmd())
 	cmd.AddCommand(NewTestCmd())
+	cmd.AddCommand(NewPrintDepsCmd())
 
 	return cmd
 }

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -88,9 +88,17 @@ operator-sdk completion bash
 # ex: ts=4 sw=4 et filetype=sh
 ```
 
+## print-deps
+
+Prints the most recent dependencies and their versions known by the `operator-sdk` binary. Prints in columnar format by default.
+
+### Flags
+
+* `--as-file` Print dependencies and versions in Gopkg.toml format.
+
 ## generate
 
-### k8s 
+### k8s
 
 Runs the Kubernetes [code-generators][k8s-code-generator] for all Custom Resource Definitions (CRD) apis under `pkg/apis/...`.
 Currently only runs `deepcopy-gen` to generate the required `DeepCopy()` functions for all custom resource types.

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -90,11 +90,11 @@ operator-sdk completion bash
 
 ## print-deps
 
-Prints the most recent dependencies and their versions known by the `operator-sdk` binary. Prints in columnar format by default.
+Prints the most recent Golang packages and versions required by operators. Prints in columnar format by default.
 
 ### Flags
 
-* `--as-file` Print dependencies and versions in Gopkg.toml format.
+* `--as-file` Print packages and versions in Gopkg.toml format.
 
 ## generate
 

--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -97,11 +97,11 @@ required = [
     non-go = false
 `
 
-func PrintGopkgToml() {
+func PrintDepsAsFile() {
 	fmt.Println(gopkgTomlTmpl)
 }
 
-func PrintGopkgDeps() error {
+func PrintDeps() error {
 	gopkgData := make(map[string]interface{})
 	_, err := toml.Decode(gopkgTomlTmpl, &gopkgData)
 	if err != nil {

--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -97,6 +97,10 @@ required = [
     non-go = false
 `
 
+func PrintGopkgToml() {
+	fmt.Println(gopkgTomlTmpl)
+}
+
 func PrintGopkgDeps() error {
 	gopkgData := make(map[string]interface{})
 	_, err := toml.Decode(gopkgTomlTmpl, &gopkgData)

--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -110,7 +110,7 @@ func PrintDeps() error {
 
 	buf := &bytes.Buffer{}
 	w := tabwriter.NewWriter(buf, 16, 8, 0, '\t', 0)
-	_, err = w.Write([]byte("NAME\tVERSION\tBRANCH\tREVISION\n"))
+	_, err = w.Write([]byte("NAME\tVERSION\tBRANCH\tREVISION\t\n"))
 	if err != nil {
 		return err
 	}
@@ -159,17 +159,17 @@ func PrintDeps() error {
 
 func writeDepRow(w *tabwriter.Writer, dep map[string]interface{}) error {
 	name := dep["name"].(string)
-	pkg, col := "", 0
+	ver, col := "", 0
 	if v, ok := dep["version"]; ok {
-		pkg, col = v.(string), 1
+		ver, col = v.(string), 1
 	} else if v, ok = dep["branch"]; ok {
-		pkg, col = v.(string), 2
+		ver, col = v.(string), 2
 	} else if v, ok = dep["revision"]; ok {
-		pkg, col = v.(string), 3
+		ver, col = v.(string), 3
 	} else {
 		return fmt.Errorf("no version, revision, or branch found for %s", name)
 	}
 
-	_, err := w.Write([]byte(name + strings.Repeat("\t", col) + pkg + "\n"))
+	_, err := w.Write([]byte(name + strings.Repeat("\t", col) + ver + "\t\n"))
 	return err
 }

--- a/pkg/scaffold/gopkgtoml_test.go
+++ b/pkg/scaffold/gopkgtoml_test.go
@@ -83,7 +83,7 @@ required = [
 [prune]
   go-tests = true
   non-go = true
-  
+
   [[prune.project]]
     name = "k8s.io/code-generator"
     non-go = false


### PR DESCRIPTION
**Description of the change:** add an `operator-sdk print-deps` sub-command to print the most recent operator dependencies and versions. The sub-command will print pretty (below) by default, or the full `Gopkg.toml` when passed the `--as-file` flag.


**Motivation for the change:** updating operator versions when upgrading to new binary versions requires looking at SDK source code. This command prints all version information for packages pre-defined by the SDK that can be copy and pasted into an operators' `Gopkg.toml`, or written over directly with the `--as-file` flag.

Sample of output:
```
NAME						VERSION		BRANCH		REVISION
github.com/operator-framework/operator-sdk			master
k8s.io/code-generator								6702109cc68eb6fe6350b83e14407c8d7309fd1a
k8s.io/api									2d6f90ab1293a1fb871cf149423ebb72aa7423aa
k8s.io/apiextensions-apiserver							408db4a50408e2149acbd657bceb2480c13cb0a4
k8s.io/apimachinery								103fd098999dc9c0c88536f5c9ad2e5da39373ae
k8s.io/client-go								1f13a808da65775f22cbf47862c4e5898d8f4ca1
sigs.k8s.io/controller-runtime			v0.1.4

required = [
 "k8s.io/code-generator/cmd/defaulter-gen",
 "k8s.io/code-generator/cmd/deepcopy-gen",
 "k8s.io/code-generator/cmd/conversion-gen",
 "k8s.io/code-generator/cmd/client-gen",
 "k8s.io/code-generator/cmd/lister-gen",
 "k8s.io/code-generator/cmd/informer-gen",
 "k8s.io/code-generator/cmd/openapi-gen",
 "k8s.io/gengo/args"
]
```

Closes #638 