### PR TITLE
.travis.yml: Only run markdown checker on doc dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       install: true
       after_success: echo 'Markdown links are correct'
       after_failure: echo 'Incorrect markdown link detected'
-      script: ./hack/ci/marker
+      script: ./hack/ci/marker --root=./doc
 
 install:
 - curl -Lo dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x dep && sudo mv dep /usr/local/bin/


### PR DESCRIPTION

**Description of the change:**

In the https://github.com/operator-framework/operator-sdk/pull/764 PR `pkg/sdk` directory was removed and when that was merged it [broke the markdown check](https://travis-ci.org/operator-framework/operator-sdk/jobs/459670676#L358), as we have some links in CHANGELOG that point to that directory. I decided against changing the CHANGELOG and instead added so we now run the `marker` only on doc.

The https://github.com/crawford/marker does not support excluding certain files, so here we introduce the check in `doc` directory only, until the support for the `--exclude` flag is added. Opened issue https://github.com/crawford/marker/issues/18


