### PR TITLE
test/ansible-operator/Dockerfile: fix e2e ownerref issue

### DIFF
--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -102,7 +102,18 @@ then
 fi
 
 kubectl delete -f ${DIR2}/deploy/crds/ansible_v1alpha1_memcached_cr.yaml --wait=true
-kubectl logs deployment/memcached-operator | grep "this is a finalizer"
+if ! kubectl logs deployment/memcached-operator | grep "this is a finalizer";
+then
+    kubectl logs deployment/memcached-operator
+    exit 1
+fi
+
+# The deployment should get garbage collected, so we expect to fail getting the deployment.
+if ! timeout 20s bash -c -- "while kubectl get deployment ${memcached_deployment}; do sleep 1; done";
+then
+    kubectl logs deployment/memcached-operator
+    exit 1
+fi
 
 popd
 popd

--- a/test/ansible-operator/Dockerfile
+++ b/test/ansible-operator/Dockerfile
@@ -1,10 +1,13 @@
 FROM ansible/ansible-runner
 
-RUN pip install --upgrade setuptools
-RUN pip install urllib3==1.23
-RUN pip install openshift ansible-runner-http
+RUN yum remove -y ansible python-idna
+RUN pip uninstall ansible-runner -y
 
-RUN echo "localhost ansible_connection=local" > /etc/ansible/hosts \
+RUN pip install --upgrade setuptools
+RUN pip install ansible ansible-runner openshift kubernetes ansible-runner-http
+
+RUN mkdir -p /etc/ansible \
+    && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
     && echo '[defaults]' > /etc/ansible/ansible.cfg \
     && echo 'roles_path = /opt/ansible/roles' >> /etc/ansible/ansible.cfg \
     && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg


### PR DESCRIPTION
There is an issue in the latest ansible/ansible-runner image
that causes the ansible-operator proxy not to be used to add
owner references as expected. This commit ensures the latest
versions of ansible and ansible-runner are installed.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Aligning ansible-operator e2e Dockerfile with the Dockerfile in `water-hole/ansible-operator` and ensure that latest ansible version is installed.


**Motivation for the change:**
1. Consistency.
2. The current Dockerfile results in a broken image. In e2e tests, the memcached deployment does not have an owner ref, which causes it not be be garbage collected. I think this is caused by a [bug in ansible 2.7.0](https://github.com/ansible/ansible/issues/47149), which is what currently exists in the `ansible/ansible-runner` image.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
