### PR TITLE
Minor travis improvments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ install:
 - sudo pip install ansible
 
 after_success:
-- echo 'Build succeeded, operator was generated, memcached operator is running on $CLUSTER, and unit/integration tests pass'
+- echo "Build succeeded, operator was generated, memcached operator is running on $CLUSTER, and unit/integration tests pass"
 
 after_failure:
-- echo 'Build failed, operator failed to generate, memcached operator is not running on $CLUSTER, or unit/integration tests failed'
+- echo "Build failed, operator failed to generate, memcached operator is not running on $CLUSTER, or unit/integration tests failed"
 - kubectl get all --all-namespaces
 - kubectl get events --all-namespaces --field-selector=type=Warning

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,5 @@ after_success:
 
 after_failure:
 - echo 'Build failed, operator failed to generate, memcached operator is not running on $CLUSTER, or unit/integration tests failed'
+- kubectl get all --all-namespaces
+- kubectl get events --all-namespaces --field-selector=type=Warning


### PR DESCRIPTION
**Description of the change:**

- When tests fail we want to see the output of the cluster state to more easily see the problem, so adding events and displaying the resources helps with that.
- Single quotes output the variable name, double quotes outputs the value. See https://bash.cyberciti.biz/guide/Quoting