### PR TITLE
pkg/scaffold,version,changelog: bump to v0.2.0 (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v0.2.0
 
 ### Changed
 

--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -85,8 +85,8 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  branch = "master" #osdk_branch_annotation
-  # version = "=v0.1.1" #osdk_version_annotation
+  # branch = "master" #osdk_branch_annotation
+  version = "=v0.2.0" #osdk_version_annotation
 
 [prune]
   go-tests = true

--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -85,7 +85,7 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
+  # branch = "v0.2.x" #osdk_branch_annotation
   version = "=v0.2.0" #osdk_version_annotation
 
 [prune]

--- a/pkg/scaffold/gopkgtoml_test.go
+++ b/pkg/scaffold/gopkgtoml_test.go
@@ -77,7 +77,7 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
+  # branch = "v0.2.x" #osdk_branch_annotation
   version = "=v0.2.0" #osdk_version_annotation
 
 [prune]

--- a/pkg/scaffold/gopkgtoml_test.go
+++ b/pkg/scaffold/gopkgtoml_test.go
@@ -77,8 +77,8 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  branch = "master" #osdk_branch_annotation
-  # version = "=v0.1.1" #osdk_version_annotation
+  # branch = "master" #osdk_branch_annotation
+  version = "=v0.2.0" #osdk_version_annotation
 
 [prune]
   go-tests = true

--- a/version/version.go
+++ b/version/version.go
@@ -15,5 +15,5 @@
 package version
 
 var (
-	Version = "v0.1.1+git"
+	Version = "v0.2.0"
 )


### PR DESCRIPTION
Due to a CI issue, we had to revert the previous release PR and the PR that was causing problems. This creates the release after those results (and hopefully will allow CI to pass)