### PR TITLE
Fix kubeconfig pointer override

### DIFF
--- a/hack/tests/test-subcommand.sh
+++ b/hack/tests/test-subcommand.sh
@@ -21,6 +21,11 @@ kubectl create namespace test-memcached
 operator-sdk test local ./test/e2e --up-local --namespace=test-memcached
 kubectl delete namespace test-memcached
 
+# test operator in up local mode with kubeconfig
+kubectl create namespace test-memcached
+operator-sdk test local ./test/e2e --up-local --namespace=test-memcached --kubeconfig $HOME/.kube/config
+kubectl delete namespace test-memcached
+
 # test operator in no-setup mode
 kubectl create namespace test-memcached
 kubectl create -f deploy/crds/cache_v1alpha1_memcached_crd.yaml

--- a/pkg/test/main_entry.go
+++ b/pkg/test/main_entry.go
@@ -80,7 +80,7 @@ func MainEntry(m *testing.M) {
 			os.Exit(0)
 		}()
 		if *kubeconfigPath != "" {
-			localCmd.Env = append(os.Environ(), fmt.Sprintf("%v=%v", k8sutil.KubeConfigEnvVar, kubeconfigPath))
+			localCmd.Env = append(os.Environ(), fmt.Sprintf("%v=%v", k8sutil.KubeConfigEnvVar, *kubeconfigPath))
 		} else {
 			// we can hardcode index 0 as that is the highest priority kubeconfig to be loaded and will always
 			// be populated by NewDefaultClientConfigLoadingRules()


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Dereference kubeconfig pointer instead of using it directly.

**Motivation for the change:**
As of now, go test local won't work if we are passing kubeconfig.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
