### PR TITLE
Revert "pkg/scaffold,version,changelog: bump to v0.2.0 (again)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.2.0
+## Unreleased
 
 ### Changed
 

--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -85,8 +85,8 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "v0.2.x" #osdk_branch_annotation
-  version = "=v0.2.0" #osdk_version_annotation
+  branch = "master" #osdk_branch_annotation
+  # version = "=v0.1.1" #osdk_version_annotation
 
 [prune]
   go-tests = true

--- a/pkg/scaffold/gopkgtoml_test.go
+++ b/pkg/scaffold/gopkgtoml_test.go
@@ -77,8 +77,8 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "v0.2.x" #osdk_branch_annotation
-  version = "=v0.2.0" #osdk_version_annotation
+  branch = "master" #osdk_branch_annotation
+  # version = "=v0.1.1" #osdk_version_annotation
 
 [prune]
   go-tests = true

--- a/version/version.go
+++ b/version/version.go
@@ -15,5 +15,5 @@
 package version
 
 var (
-	Version = "v0.2.0"
+	Version = "v0.1.1+git"
 )


### PR DESCRIPTION
Reverts operator-framework/operator-sdk#794

We need to fix the `before_install` section of travis.yml to make the CI run