### PR TITLE
Fix validation check for when API version is missed

### DIFF
--- a/pkg/scaffold/resource.go
+++ b/pkg/scaffold/resource.go
@@ -129,11 +129,12 @@ func (r *Resource) checkAndSetGroups() error {
 }
 
 func (r *Resource) checkAndSetVersion() error {
-	r.Version = strings.Split(r.APIVersion, "/")[1]
-
-	if len(r.Version) == 0 {
+	api := strings.Split(r.APIVersion, "/")
+	if len(api) < 2 {
 		return errors.New("version cannot be empty")
 	}
+	r.Version = api[1]
+
 	if !ResourceVersionRegexp.MatchString(r.Version) {
 		return errors.New("version is not in the correct Kubernetes version format, ex. v1alpha1")
 	}


### PR DESCRIPTION
In the current validation code for api version, it causes go panic
when the version was missed. This patch changes to check the length of
splitted API by "/". Then, use the value and output produce error
message if version was missed.

- Before:
~~~
$ operator-sdk add api --api-version=foo  --kind=AppService
INFO[0000] Generating api version foo for kind AppService. 
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/operator-framework/operator-sdk/pkg/scaffold.(*Resource).checkAndSetVersion(0xc000436380, 0x0, 0x0)
	/Users/knakayam/.go/src/github.com/operator-framework/operator-sdk/pkg/scaffold/resource.go:132 +0x183
github.com/operator-framework/operator-sdk/pkg/scaffold.(*Resource).Validate(0xc000436380, 0xc000436380, 0x2)
	/Users/knakayam/.go/src/github.com/operator-framework/operator-sdk/pkg/scaffold/resource.go:90 +0xd1
github.com/operator-framework/operator-sdk/pkg/scaffold.NewResource(0x7fff5fbff9a3, 0x3, 0x7fff5fbff9ae, 0xa, 0x2, 0xc0003f1f80, 0x1f0754c)
	/Users/knakayam/.go/src/github.com/operator-framework/operator-sdk/pkg/scaffold/resource.go:72 +0x7d
github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/add.apiRun(0xc000409400, 0xc0002cb5a0, 0x0, 0x2)
	/Users/knakayam/.go/src/github.com/operator-framework/operator-sdk/commands/operator-sdk/cmd/add/api.go:73 +0x133
github.com/operator-framework/operator-sdk/vendor/github.com/spf13/cobra.(*Command).execute(0xc000409400, 0xc0002cb560, 0x2, 0x2, 0xc000409400, 0xc0002cb560)
	/Users/knakayam/.go/src/github.com/operator-framework/operator-sdk/vendor/github.com/spf13/cobra/command.go:766 +0x2cc
github.com/operator-framework/operator-sdk/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc000408c80, 0xc000439180, 0xc000438a00, 0xc000438500)
	/Users/knakayam/.go/src/github.com/operator-framework/operator-sdk/vendor/github.com/spf13/cobra/command.go:852 +0x2fd
github.com/operator-framework/operator-sdk/vendor/github.com/spf13/cobra.(*Command).Execute(0xc000408c80, 0x0, 0x0)
	/Users/knakayam/.go/src/github.com/operator-framework/operator-sdk/vendor/github.com/spf13/cobra/command.go:800 +0x2b
main.main()
	/Users/knakayam/.go/src/github.com/operator-framework/operator-sdk/commands/operator-sdk/main.go:23 +0x27
~~~	

- After this patch:
~~~
$ operator-sdk add api --api-version=foo  --kind=AppService
INFO[0000] Generating api version foo for kind AppService.
FATA[0000] version cannot be empty
~~~

Fix https://github.com/operator-framework/operator-sdk/issues/801
