### PR TITLE
hack/test/e2e-helm.sh: use hack/lib/test_lib.sh

### DIFF
--- a/hack/tests/e2e-helm.sh
+++ b/hack/tests/e2e-helm.sh
@@ -1,35 +1,6 @@
 #!/usr/bin/env bash
 
-#===================================================================
-# FUNCTION trap_add ()
-#
-# Purpose:  prepends a command to a trap
-#
-# - 1st arg:  code to add
-# - remaining args:  names of traps to modify
-#
-# Example:  trap_add 'echo "in trap DEBUG"' DEBUG
-#
-# See: http://stackoverflow.com/questions/3338030/multiple-bash-traps-for-the-same-signal
-#===================================================================
-trap_add() {
-    trap_add_cmd=$1; shift || fatal "${FUNCNAME} usage error"
-    new_cmd=
-    for trap_add_name in "$@"; do
-        # Grab the currently defined trap commands for this trap
-        existing_cmd=`trap -p "${trap_add_name}" |  awk -F"'" '{print $2}'`
-
-        # Define default command
-        [ -z "${existing_cmd}" ] && existing_cmd="echo exiting @ `date`"
-
-        # Generate the new command
-        new_cmd="${trap_add_cmd};${existing_cmd}"
-
-        # Assign the test
-         trap   "${new_cmd}" "${trap_add_name}" || \
-                fatal "unable to add to trap ${trap_add_name}"
-    done
-}
+source hack/lib/test_lib.sh
 
 DEST_IMAGE="quay.io/example/nginx-operator:v0.0.2"
 


### PR DESCRIPTION
**Description of the change:**
For Helm e2e test, use `hack/lib/test_lib.sh` for `trap_add` function

**Motivation for the change:**
Reduce duplication