### PR TITLE
pkg/ansible/runner: logs the stdout and stderr from ansible-runner if…

### DIFF
--- a/pkg/ansible/runner/runner.go
+++ b/pkg/ansible/runner/runner.go
@@ -245,9 +245,9 @@ func (r *runner) Run(ident string, u *unstructured.Unstructured, kubeconfig stri
 			dc = r.cmdFunc(ident, inputDir.Path)
 		}
 
-		err := dc.Run()
+		output, err := dc.CombinedOutput()
 		if err != nil {
-			logger.Error(err, "error from ansible-runner")
+			logger.Error(err, string(output))
 		} else {
 			logger.Info("ansible-runner exited successfully")
 		}


### PR DESCRIPTION
… the command exits non-zero

This is helpful in a case where ansible-runner itself is broken, such as when a
python library it depends on gets installed at an incompatible version (a
problem we've encountered multile times).