### PR TITLE
test/ansible-operator/Dockerfile: lock idna to 2.7

### DIFF
--- a/test/ansible-operator/Dockerfile
+++ b/test/ansible-operator/Dockerfile
@@ -4,7 +4,7 @@ RUN yum remove -y ansible python-idna
 RUN pip uninstall ansible-runner -y
 
 RUN pip install --upgrade setuptools
-RUN pip install ansible ansible-runner openshift kubernetes ansible-runner-http
+RUN pip install ansible ansible-runner openshift kubernetes ansible-runner-http idna==2.7
 
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \


### PR DESCRIPTION
**Description of the change:**
Locks python idna package to 2.7

**Motivation for the change:**
Fixes broken ansible-operator base image, which installs incompatible idna version 2.8