### PR TITLE
pkg/scaffold/resource.go: robust validators and avoid panics

### DIFF
--- a/pkg/scaffold/resource.go
+++ b/pkg/scaffold/resource.go
@@ -116,12 +116,17 @@ func (r *Resource) checkAndSetKinds() error {
 }
 
 func (r *Resource) checkAndSetGroups() error {
-	r.FullGroup = strings.Split(r.APIVersion, "/")[0]
-	r.Group = strings.Split(r.FullGroup, ".")[0]
-
-	if len(r.Group) == 0 {
+	fg := strings.Split(r.APIVersion, "/")
+	if len(fg) < 2 || len(fg[0]) == 0 {
+		return errors.New("full group cannot be empty")
+	}
+	g := strings.Split(fg[0], ".")
+	if len(g) < 2 || len(g[0]) == 0 {
 		return errors.New("group cannot be empty")
 	}
+	r.FullGroup = fg[0]
+	r.Group = g[0]
+
 	if !ResourceGroupRegexp.MatchString(r.Group) {
 		return errors.New("group should consist of lowercase alphabetical characters")
 	}
@@ -130,7 +135,7 @@ func (r *Resource) checkAndSetGroups() error {
 
 func (r *Resource) checkAndSetVersion() error {
 	api := strings.Split(r.APIVersion, "/")
-	if len(api) < 2 {
+	if len(api) < 2 || len(api[1]) == 0 {
 		return errors.New("version cannot be empty")
 	}
 	r.Version = api[1]


### PR DESCRIPTION
**Description of the change:** bounds and length checking in resource version validators.

**Motivation for the change:** robust validation and to avoid panics.