### PR TITLE
Set KUBECONFIG and K8S_AUTH_KUBECONFIG environment variables for ansible-runner

### DIFF
--- a/pkg/ansible/runner/runner.go
+++ b/pkg/ansible/runner/runner.go
@@ -216,6 +216,7 @@ func (r *runner) Run(ident string, u *unstructured.Unstructured, kubeconfig stri
 		Parameters: r.makeParameters(u),
 		EnvVars: map[string]string{
 			"K8S_AUTH_KUBECONFIG": kubeconfig,
+			"KUBECONFIG":          kubeconfig,
 		},
 		Settings: map[string]string{
 			"runner_http_url":  receiver.SocketPath,
@@ -244,6 +245,7 @@ func (r *runner) Run(ident string, u *unstructured.Unstructured, kubeconfig stri
 		} else {
 			dc = r.cmdFunc(ident, inputDir.Path)
 		}
+		dc.Env = append(dc.Env, fmt.Sprintf("K8S_AUTH_KUBECONFIG=%s", kubeconfig), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
 
 		output, err := dc.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
**Description of the change:**
This change ensures that the `K8S_AUTH_KUBECONFIG` and `KUBECONFIG` variables are set for both the outer ansible-runner context (for lookup plugins) and the context that runner sets when executing tasks (for modules etc). This should make the `k8s` lookup plugin respect the kubeconfig created by the operator.

**Motivation for the change:**
the Ansible `k8s` lookup plugin was connecting directly to the cluster instead of using the Operator's proxy.