### PR TITLE
fixes several ansible test failures and flaws

### DIFF
--- a/pkg/ansible/controller/reconcile.go
+++ b/pkg/ansible/controller/reconcile.go
@@ -186,9 +186,13 @@ func (r *AnsibleOperatorReconciler) Reconcile(request reconcile.Request) (reconc
 		if err != nil {
 			return reconcileResult, err
 		}
+		return reconcileResult, nil
 	}
 	if r.ManageStatus {
 		err = r.markDone(u, statusEvent, failureMessages)
+		if err != nil {
+			logger.Error(err, "failed to mark status done")
+		}
 	}
 	return reconcileResult, err
 }

--- a/pkg/ansible/controller/reconcile_test.go
+++ b/pkg/ansible/controller/reconcile_test.go
@@ -318,7 +318,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
-			Name:            "Finalizer successful reconcile",
+			Name:            "Finalizer successful deletion reconcile",
 			GVK:             gvk,
 			ReconcilePeriod: 5 * time.Second,
 			ManageStatus:    true,
@@ -344,6 +344,23 @@ func TestReconcile(t *testing.T) {
 					"apiVersion": "operator-sdk/v1beta1",
 					"kind":       "Testing",
 					"spec":       map[string]interface{}{},
+					"status": map[string]interface{}{
+						"conditions": []interface{}{
+							map[string]interface{}{
+								"status": "True",
+								"type":   "Running",
+								"ansibleResult": map[string]interface{}{
+									"changed":    int64(0),
+									"failures":   int64(0),
+									"ok":         int64(0),
+									"skipped":    int64(0),
+									"completion": eventTime.Format("2006-01-02T15:04:05.99999999"),
+								},
+								"message": "Awaiting next reconciliation",
+								"reason":  "Successful",
+							},
+						},
+					},
 				},
 			}),
 			Result: reconcile.Result{

--- a/pkg/ansible/events/log_events.go
+++ b/pkg/ansible/events/log_events.go
@@ -70,7 +70,7 @@ func (l loggingEventHandler) Handle(ident string, u *unstructured.Unstructured, 
 			return
 		}
 		if e.Event == eventapi.EventRunnerOnOk && debugAction {
-			logger.V(1).Info("[playbook debug]", "EventData.TaskArgs", e.EventData["task_args"])
+			logger.Info("[playbook debug]", "EventData.TaskArgs", e.EventData["task_args"])
 			return
 		}
 		if e.Event == eventapi.EventRunnerOnFailed {

--- a/pkg/ansible/proxy/proxy.go
+++ b/pkg/ansible/proxy/proxy.go
@@ -93,7 +93,7 @@ func CacheResponseHandler(h http.Handler, informerCache cache.Cache, restMapper 
 			if err != nil {
 				// break here in case resource doesn't exist in cache but exists on APIserver
 				// This is very unlikely but provides user with expected 404
-				log.Error(err, "didn't find object in cache")
+				log.Info(fmt.Sprintf("cache miss: %v, %v", k, obj))
 				break
 			}
 

--- a/test/ansible-memcached/memfin/tasks/main.yml
+++ b/test/ansible-memcached/memfin/tasks/main.yml
@@ -1,2 +1,7 @@
-- debug:
-    msg: "this is a finalizer"
+- name: delete configmap for test
+  k8s:
+    kind: ConfigMap
+    api_version: v1
+    name: deleteme
+    namespace: default
+    state: absent

--- a/test/ansible-operator/cmd/ansible-operator/main.go
+++ b/test/ansible-operator/cmd/ansible-operator/main.go
@@ -39,7 +39,7 @@ func printVersion() {
 func main() {
 	flag.Parse()
 
-	logf.SetLogger(logf.ZapLogger(true))
+	logf.SetLogger(logf.ZapLogger(false))
 
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {


### PR DESCRIPTION
- Fixes bug where reconcile attempted to update status after running finalizer
- Stops depending on grepping for a log statement for a test to pass
- Disables debug log mode by default
- logs cache miss at INFO instead of ERROR
- adds commented-out check for errors in logs in e2e tests, which will be enabled after #818 gets fixed