### PR TITLE
ServiceMonitors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -98,12 +98,17 @@
   revision = "bf70f2a70fb1b1f36d90d671a72795984eab0fcb"
 
 [[projects]]
-  digest = "1:83222dd265299f065a2ae969c7780b6c6a225c770975051955320a95b0526239"
+  digest = "1:8c0d543ff6b636f293a99ae8479fbdb4b3adc89dc4cedf5af9f29bf06ef61d90"
   name = "github.com/coreos/prometheus-operator"
-  packages = ["pkg/client/monitoring/v1"]
+  packages = [
+    "pkg/apis/monitoring",
+    "pkg/apis/monitoring/v1",
+    "pkg/client/versioned/scheme",
+    "pkg/client/versioned/typed/monitoring/v1",
+  ]
   pruneopts = ""
-  revision = "4a7fea51ab3f10329472c07028354617fb6635fe"
-  version = "v0.24.0"
+  revision = "72ec4b9b16ef11700724dc71fec77112536eed40"
+  version = "v0.26.0"
 
 [[projects]]
   digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
@@ -560,14 +565,6 @@
   pruneopts = ""
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
-
-[[projects]]
-  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
-  name = "github.com/pkg/errors"
-  packages = ["."]
-  pruneopts = ""
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
 
 [[projects]]
   digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
@@ -1081,7 +1078,6 @@
   digest = "1:7c2cc0050e1fb85b8f900d1f8debb02bd4b3985b6dc18d0137ed8db8cca84dd7"
   name = "k8s.io/client-go"
   packages = [
-    "deprecated-dynamic",
     "discovery",
     "discovery/cached",
     "dynamic",
@@ -1201,8 +1197,7 @@
   version = "v2.12.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:27b5d6ad25d086dda2c482099d4b918a2c3e947f80e0671fa366732daf59afed"
+  digest = "1:a2f78b8fd86be41f2aa77404245aed4f4f410ac3aabc5f3bd9bd1fcc09076c53"
   name = "k8s.io/kube-openapi"
   packages = [
     "pkg/common",
@@ -1210,7 +1205,7 @@
     "pkg/util/proto/validation",
   ]
   pruneopts = ""
-  revision = "e494cc58111187acad93e64529228a2fc0153e39"
+  revision = "0cf8f7e6ed1d2e3d47d02e3b6e559369af24d803"
 
 [[projects]]
   digest = "1:49553260d1b581e741aac6f8ba6a898921538cf40d3809bdf938692d3fa6dd6a"
@@ -1424,7 +1419,8 @@
   analyzer-version = 1
   input-imports = [
     "github.com/BurntSushi/toml",
-    "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1",
+    "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1",
+    "github.com/coreos/prometheus-operator/pkg/client/versioned/typed/monitoring/v1",
     "github.com/ghodss/yaml",
     "github.com/go-logr/logr",
     "github.com/markbates/inflect",

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -21,6 +21,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
+	discovery "k8s.io/client-go/discovery"
 )
 
 // GetWatchNamespace returns the namespace the operator should be watching for changes
@@ -80,4 +81,23 @@ func InitOperatorService() (*v1.Service, error) {
 		},
 	}
 	return service, nil
+}
+
+// ResourceExists returns true if the given resource kind exists
+// in the given api groupversion
+func ResourceExists(dc discovery.DiscoveryInterface, apiGroupVersion, kind string) (bool, error) {
+	apiLists, err := dc.ServerResources()
+	if err != nil {
+		return false, err
+	}
+	for _, apiList := range apiLists {
+		if apiList.GroupVersion == apiGroupVersion {
+			for _, r := range apiList.APIResources {
+				if r.Kind == kind {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
 }

--- a/pkg/metrics/service-monitor.go
+++ b/pkg/metrics/service-monitor.go
@@ -15,12 +15,44 @@
 package metrics
 
 import (
-	monitoringv1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	monclientv1 "github.com/coreos/prometheus-operator/pkg/client/versioned/typed/monitoring/v1"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 )
 
-// GenereateServiceMonitor generates a prometheus-operator ServiceMonitor object
+// CreateServiceMonitors creates ServiceMonitors objects based on an array of Service objects.
+// If CR ServiceMonitor is not registered in the Cluster it will not attempt at creating resources.
+func CreateServiceMonitors(config *rest.Config, ns string, services []*v1.Service) ([]*monitoringv1.ServiceMonitor, error) {
+	// check if we can even create ServiceMonitors
+	exists, err := hasServiceMonitor(config)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		// ServiceMonitor was not registered, but we don't want to produce more errors just return.
+		return nil, nil
+	}
+
+	var serviceMonitors []*monitoringv1.ServiceMonitor
+	mclient := monclientv1.NewForConfigOrDie(config)
+
+	for _, s := range services {
+		sm := GenerateServiceMonitor(s)
+		smc, err := mclient.ServiceMonitors(ns).Create(sm)
+		if err != nil {
+			return serviceMonitors, err
+		}
+		serviceMonitors = append(serviceMonitors, smc)
+	}
+
+	return serviceMonitors, nil
+}
+
+// GenerateServiceMonitor generates a prometheus-operator ServiceMonitor object
 // based on the passed Service object.
 func GenerateServiceMonitor(s *v1.Service) *monitoringv1.ServiceMonitor {
 	labels := make(map[string]string)
@@ -49,4 +81,13 @@ func GenerateServiceMonitor(s *v1.Service) *monitoringv1.ServiceMonitor {
 			},
 		},
 	}
+}
+
+// hasServiceMonitor checks if ServiceMonitor is registered in the cluster.
+func hasServiceMonitor(config *rest.Config) (bool, error) {
+	dc := discovery.NewDiscoveryClientForConfigOrDie(config)
+	apiVersion := "monitoring.coreos.com/v1"
+	kind := "ServiceMonitor"
+
+	return k8sutil.ResourceExists(dc, apiVersion, kind)
 }

--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -79,6 +79,10 @@ required = [
   revision = "d082d5923d3cc0bfbb066ee5fbdea3d0ca79acf8"
 
 [[override]]
+  name = "github.com/coreos/prometheus-operator"
+  version = "=v0.26.0"
+
+[[override]]
   name = "sigs.k8s.io/controller-runtime"
   version = "=v0.1.8"
 

--- a/pkg/scaffold/gopkgtoml_test.go
+++ b/pkg/scaffold/gopkgtoml_test.go
@@ -71,6 +71,10 @@ required = [
   revision = "d082d5923d3cc0bfbb066ee5fbdea3d0ca79acf8"
 
 [[override]]
+  name = "github.com/coreos/prometheus-operator"
+  version = "=v0.26.0"
+
+[[override]]
   name = "sigs.k8s.io/controller-runtime"
   version = "=v0.1.8"
 


### PR DESCRIPTION
**Description of the change:**
This PR adds a helper function to create [ServiceMonitor](https://github.com/coreos/prometheus-operator/blob/3288dbd9cf9a9b667d16e48d7c113753635654ef/Documentation/design.md#servicemonitor) objects by passing a metrics Service objects that already exist. The function does a check to makes sure the ServiceMonitor is registered within the cluster before creating the ServiceMonitor object. 

*Note:* As this is just a helper function, I am not sure if we should add an end-to-end test as for that we need to deploy prometheus-operator as well. Let me know your thoughts.

**Motivation for the change:**

Closes https://github.com/operator-framework/operator-sdk/issues/789
