### PR TITLE
test local: fix reconcile 'cannot find RESTMapping' error

### DIFF
--- a/commands/operator-sdk/cmd/test/local.go
+++ b/commands/operator-sdk/cmd/test/local.go
@@ -186,7 +186,9 @@ func testLocalFunc(cmd *cobra.Command, args []string) {
 		}
 	}
 	testArgs := []string{"test", args[0] + "/..."}
-	testArgs = append(testArgs, "-"+test.KubeConfigFlag, tlConfig.kubeconfig)
+	if tlConfig.kubeconfig != "" {
+		testArgs = append(testArgs, "-"+test.KubeConfigFlag, tlConfig.kubeconfig)
+	}
 	testArgs = append(testArgs, "-"+test.NamespacedManPathFlag, tlConfig.namespacedManPath)
 	testArgs = append(testArgs, "-"+test.GlobalManPathFlag, tlConfig.globalManPath)
 	testArgs = append(testArgs, "-"+test.ProjRootFlag, projutil.MustGetwd())

--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -80,7 +80,7 @@ required = [
 
 [[override]]
   name = "sigs.k8s.io/controller-runtime"
-  version = "v0.1.4"
+  version = "=v0.1.4"
 
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"

--- a/pkg/scaffold/gopkgtoml_test.go
+++ b/pkg/scaffold/gopkgtoml_test.go
@@ -72,7 +72,7 @@ required = [
 
 [[override]]
   name = "sigs.k8s.io/controller-runtime"
-  version = "v0.1.4"
+  version = "=v0.1.4"
 
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"

--- a/pkg/test/framework.go
+++ b/pkg/test/framework.go
@@ -144,8 +144,11 @@ func AddToFrameworkScheme(addToScheme addToSchemeFunc, obj runtime.Object) error
 	if err != nil {
 		return err
 	}
-	dynClient, err := dynclient.New(Global.KubeConfig, dynclient.Options{Scheme: Global.Scheme, Mapper: restMapper})
 	restMapper.Reset()
+	dynClient, err := dynclient.New(Global.KubeConfig, dynclient.Options{Scheme: Global.Scheme, Mapper: restMapper})
+	if err != nil {
+		return fmt.Errorf("failed to initialize new dynamic client: (%v)", err)
+	}
 	err = wait.PollImmediate(time.Second, time.Second*10, func() (done bool, err error) {
 		if *singleNamespace {
 			err = dynClient.List(goctx.TODO(), &dynclient.ListOptions{Namespace: Global.Namespace}, obj)

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -46,7 +46,7 @@ const (
 	retryInterval               = time.Second * 5
 	timeout                     = time.Second * 60
 	cleanupRetryInterval        = time.Second * 1
-	cleanupTimeout              = time.Second * 5
+	cleanupTimeout              = time.Second * 10
 )
 
 func TestMemcached(t *testing.T) {

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
@@ -41,13 +42,11 @@ import (
 )
 
 const (
-	filemode             os.FileMode = 0664
-	dirmode              os.FileMode = 0750
-	crYAML               string      = "apiVersion: \"cache.example.com/v1alpha1\"\nkind: \"Memcached\"\nmetadata:\n  name: \"example-memcached\"\nspec:\n  size: 3"
-	retryInterval                    = time.Second * 5
-	timeout                          = time.Second * 60
-	cleanupRetryInterval             = time.Second * 1
-	cleanupTimeout                   = time.Second * 5
+	crYAML               string = "apiVersion: \"cache.example.com/v1alpha1\"\nkind: \"Memcached\"\nmetadata:\n  name: \"example-memcached\"\nspec:\n  size: 3"
+	retryInterval               = time.Second * 5
+	timeout                     = time.Second * 60
+	cleanupRetryInterval        = time.Second * 1
+	cleanupTimeout              = time.Second * 5
 )
 
 func TestMemcached(t *testing.T) {
@@ -68,7 +67,7 @@ func TestMemcached(t *testing.T) {
 
 	// Setup
 	absProjectPath := filepath.Join(gopath, "src/github.com/example-inc")
-	if err := os.MkdirAll(absProjectPath, dirmode); err != nil {
+	if err := os.MkdirAll(absProjectPath, fileutil.DefaultDirFileMode); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Chdir(absProjectPath); err != nil {
@@ -112,7 +111,7 @@ func TestMemcached(t *testing.T) {
 			gopkgString := string(gopkg)
 			gopkgLoc := strings.LastIndex(gopkgString, "\n  name = \"github.com/operator-framework/operator-sdk\"\n")
 			gopkgString = gopkgString[:gopkgLoc] + "\n  source = \"https://github.com/" + prSlug + "\"\n  revision = \"" + prSha + "\"\n" + gopkgString[gopkgLoc+1:]
-			err = ioutil.WriteFile("Gopkg.toml", []byte(gopkgString), filemode)
+			err = ioutil.WriteFile("Gopkg.toml", []byte(gopkgString), fileutil.DefaultFileMode)
 			if err != nil {
 				t.Fatalf("failed to write updated Gopkg.toml: %v", err)
 			}
@@ -182,7 +181,7 @@ func TestMemcached(t *testing.T) {
 		}
 	}
 	os.Remove("pkg/apis/cache/v1alpha1/memcached_types.go")
-	err = ioutil.WriteFile("pkg/apis/cache/v1alpha1/memcached_types.go", bytes.Join(memcachedTypesFileLines, []byte("\n")), filemode)
+	err = ioutil.WriteFile("pkg/apis/cache/v1alpha1/memcached_types.go", bytes.Join(memcachedTypesFileLines, []byte("\n")), fileutil.DefaultFileMode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +193,7 @@ func TestMemcached(t *testing.T) {
 	}
 
 	t.Log("Copying test files to ./test")
-	if err = os.MkdirAll("./test", dirmode); err != nil {
+	if err = os.MkdirAll("./test", fileutil.DefaultDirFileMode); err != nil {
 		t.Fatalf("could not create test/e2e dir: %v", err)
 	}
 	cmdOut, err = exec.Command("cp", "-a", filepath.Join(gopath, "src/github.com/operator-framework/operator-sdk/test/e2e/incluster-test-code"), "./test/e2e").CombinedOutput()
@@ -324,7 +323,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 	filename := "deploy/cr.yaml"
 	err := ioutil.WriteFile(filename,
 		[]byte(crYAML),
-		filemode)
+		fileutil.DefaultFileMode)
 	if err != nil {
 		return err
 	}
@@ -431,7 +430,7 @@ func MemcachedCluster(t *testing.T) {
 			t.Fatal(err)
 		}
 		operatorYAML = bytes.Replace(operatorYAML, []byte("imagePullPolicy: Always"), []byte("imagePullPolicy: Never"), 1)
-		err = ioutil.WriteFile("deploy/operator.yaml", operatorYAML, filemode)
+		err = ioutil.WriteFile("deploy/operator.yaml", operatorYAML, fileutil.DefaultFileMode)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -41,9 +41,13 @@ import (
 )
 
 const (
-	filemode os.FileMode = 0664
-	dirmode  os.FileMode = 0750
-	crYAML   string      = "apiVersion: \"cache.example.com/v1alpha1\"\nkind: \"Memcached\"\nmetadata:\n  name: \"example-memcached\"\nspec:\n  size: 3"
+	filemode             os.FileMode = 0664
+	dirmode              os.FileMode = 0750
+	crYAML               string      = "apiVersion: \"cache.example.com/v1alpha1\"\nkind: \"Memcached\"\nmetadata:\n  name: \"example-memcached\"\nspec:\n  size: 3"
+	retryInterval                    = time.Second * 5
+	timeout                          = time.Second * 60
+	cleanupRetryInterval             = time.Second * 1
+	cleanupTimeout                   = time.Second * 5
 )
 
 func TestMemcached(t *testing.T) {
@@ -227,7 +231,7 @@ func TestMemcached(t *testing.T) {
 	// create crd
 	filename := file.Name()
 	framework.Global.NamespacedManPath = &filename
-	err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: time.Second * 10, RetryInterval: time.Second * 1})
+	err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -247,7 +251,7 @@ func memcachedLeaderTest(t *testing.T, f *framework.Framework, ctx *framework.Te
 		return err
 	}
 
-	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "memcached-operator", 1, time.Second*5, time.Second*30)
+	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "memcached-operator", 1, retryInterval, timeout)
 	if err != nil {
 		return err
 	}
@@ -263,7 +267,7 @@ func memcachedLeaderTest(t *testing.T, f *framework.Framework, ctx *framework.Te
 		return err
 	}
 
-	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "memcached-operator", 1, time.Second*5, time.Second*30)
+	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "memcached-operator", 1, retryInterval, timeout)
 	if err != nil {
 		return err
 	}
@@ -327,7 +331,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 
 	// create memcached custom resource
 	framework.Global.NamespacedManPath = &filename
-	err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: time.Second * 10, RetryInterval: time.Second * 1})
+	err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		return err
 	}
@@ -338,7 +342,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 		return err
 	}
 	// wait for example-memcached to reach 3 replicas
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-memcached", 3, time.Second*5, time.Second*30)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-memcached", 3, retryInterval, timeout)
 	if err != nil {
 		return err
 	}
@@ -367,7 +371,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 	}
 
 	// wait for example-memcached to reach 4 replicas
-	return e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-memcached", 4, time.Second*5, time.Second*30)
+	return e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-memcached", 4, retryInterval, timeout)
 }
 
 func MemcachedLocal(t *testing.T) {
@@ -461,7 +465,7 @@ func MemcachedCluster(t *testing.T) {
 	// create namespaced resources
 	filename := file.Name()
 	framework.Global.NamespacedManPath = &filename
-	err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: time.Second * 10, RetryInterval: time.Second * 1})
+	err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -472,7 +476,7 @@ func MemcachedCluster(t *testing.T) {
 		t.Fatal(err)
 	}
 	// wait for memcached-operator to be ready
-	err = e2eutil.WaitForOperatorDeployment(t, framework.Global.KubeClient, namespace, "memcached-operator", 1, time.Second*5, time.Second*30)
+	err = e2eutil.WaitForOperatorDeployment(t, framework.Global.KubeClient, namespace, "memcached-operator", 1, retryInterval, timeout)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -494,7 +498,7 @@ func MemcachedClusterTest(t *testing.T) {
 	// create sa
 	filename := "deploy/service_account.yaml"
 	framework.Global.NamespacedManPath = &filename
-	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: time.Second * 10, RetryInterval: time.Second * 1})
+	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -503,7 +507,7 @@ func MemcachedClusterTest(t *testing.T) {
 	// create rbac
 	filename = "deploy/role.yaml"
 	framework.Global.NamespacedManPath = &filename
-	err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: time.Second * 10, RetryInterval: time.Second * 1})
+	err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -511,7 +515,7 @@ func MemcachedClusterTest(t *testing.T) {
 
 	filename = "deploy/role_binding.yaml"
 	framework.Global.NamespacedManPath = &filename
-	err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: time.Second * 10, RetryInterval: time.Second * 1})
+	err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/test-framework/test/e2e/memcached_test.go
+++ b/test/test-framework/test/e2e/memcached_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var (
+const (
 	retryInterval        = time.Second * 5
 	timeout              = time.Second * 60
 	cleanupRetryInterval = time.Second * 1


### PR DESCRIPTION
**Description of the change:** clean up and fix tests.

**Motivation for the change:** the following error has been seen in several PR's with the CI command
```sh
$ operator-sdk test local ./test/e2e --up-local --namespace=test-memcached
```
```
{
  "level":"error",
  "ts":1543959163.0456057,
  "logger":"controller_memcached",
  "caller":"memcached/memcached_controller.go:127",
  "msg":"failed to create new Deployment.",
  "Request.Namespace":"test-memcached",
  "Request.Name":"example-memcached",
  "Deployment.Namespace":"test-memcached",
  "Deployment.Name":"example-memcached",
  "error":"deployments.apps \"example-memcached\" is forbidden: cannot set blockOwnerDeletion in this case because cannot find RESTMapping for APIVersion cache.example.com/v1alpha1 Kind Memcached: no matches for kind \"Memcached\" in version \"cache.example.com/v1alpha1\""
}
```
The issue is likely related to a race condition between cluster CRD registration and creating a Deployment with a CR owner reference.