### PR TITLE
fixed #827

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ format:
 dep:
 	$(Q)dep ensure -v
 
+dep-update:
+	$(Q)dep ensure -update -v
+
 clean:
 	$(Q)rm -rf build
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Added `-update` flag to sync the `Gopkg.toml` to`Gopkg.lock`. 

**Motivation for the change:**
The `Gopkg.toml` does NOT sync to `Gopkg.lock` automatically. Correct me if I'm wrong.
But, it will take more time to run if we add this `-update` flag.
Any comments are welcome！

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<issue_number>

-->
Closes #827 