### PR TITLE
CustomRenderer interface for non-templated scaffolds

### DIFF
--- a/pkg/scaffold/customrender.go
+++ b/pkg/scaffold/customrender.go
@@ -1,0 +1,21 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scaffold
+
+// CustomRenderer is the interface for writing any scaffold file that does
+// not use a template.
+type CustomRenderer interface {
+	CustomRender() ([]byte, error)
+}

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -117,18 +117,12 @@ func (s *Scaffold) doFile(e input.File) error {
 		}
 	}
 
-	return s.doTemplate(i, e, absFilePath)
+	return s.doRender(i, e, absFilePath)
 }
 
 const goFileExt = ".go"
 
-// doTemplate executes the template at absPath for a file using the input
-func (s *Scaffold) doTemplate(i input.Input, e input.File, absPath string) error {
-	temp, err := newTemplate(e).Parse(i.TemplateBody)
-	if err != nil {
-		return err
-	}
-
+func (s *Scaffold) doRender(i input.Input, e input.File, absPath string) error {
 	var mode os.FileMode = fileutil.DefaultFileMode
 	if i.IsExec {
 		mode = fileutil.DefaultExecFileMode
@@ -145,18 +139,30 @@ func (s *Scaffold) doTemplate(i input.Input, e input.File, absPath string) error
 		}()
 	}
 
-	out := &bytes.Buffer{}
-	err = temp.Execute(out, e)
-	if err != nil {
-		return err
+	var b []byte
+	if c, ok := e.(CustomRenderer); ok {
+		// CustomRenderers have a non-template method of file rendering.
+		if b, err = c.CustomRender(); err != nil {
+			return err
+		}
+	} else {
+		// All other files are rendered via their templates.
+		temp, err := newTemplate(e).Parse(i.TemplateBody)
+		if err != nil {
+			return err
+		}
+
+		out := &bytes.Buffer{}
+		if err = temp.Execute(out, e); err != nil {
+			return err
+		}
+		b = out.Bytes()
 	}
-	b := out.Bytes()
 
 	// gofmt the imports
 	if filepath.Ext(absPath) == goFileExt {
 		b, err = imports.Process(absPath, b, nil)
 		if err != nil {
-			fmt.Printf("%s\n", out.Bytes())
 			return err
 		}
 	}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:** added the `CustomRenderer` interface. `scaffold.Execute()` will execute `CustomRender()` if an `input.File` implements the interface, otherwise defaulting to `template.Execute()`.


**Motivation for the change:** complex scaffold files that might not want use a template, ex. CSV's, and should be able to write arbitrary bytes to a scaffold file.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
