### PR TITLE
doc/dev/testing: Update documentation

### DIFF
--- a/doc/dev/testing/end-to-end.md
+++ b/doc/dev/testing/end-to-end.md
@@ -14,7 +14,7 @@ local minikube instance running on the machine.
 ### Remote Kubernetes Instance
 
 To run the tests on a remote cluster, the tests need access to a remote kubernetes cluster
-running kubernetes 1.10 as well as a docker image repo to push the operator image to,
+running kubernetes 1.11 as well as a docker image repo to push the operator image to,
 such as quay.io. To run the test, use this command:
 
 ```sh

--- a/doc/dev/testing/travis-build.md
+++ b/doc/dev/testing/travis-build.md
@@ -1,11 +1,10 @@
 # TravisCI Build Information
 
-Travis is set to run once every 24hrs against the master branch. The results of the builds can be found [here](https://travis-ci.org/operator-framework/operator-sdk/builds).
+Travis is set to run once every 24hrs against the master branch. The results of the builds can be found [here][builds].
 
-## Tool Versions
-* Kubernetes: 1.10.0
-* Minikube: 0.25.2
-* Go: 1.10.1
+## Test setup
+
+For Travis test setup see the [following CI script][script].
 
 ## Test Workflow
 1. Build the operator-sdk binary
@@ -18,3 +17,6 @@ Travis is set to run once every 24hrs against the master branch. The results of 
 4. Ensure proper formatting
 5. Ensure all go files contain a license header
 6. Ensure all error messages have consistent capitalization
+
+[builds]: https://travis-ci.org/operator-framework/operator-sdk/builds
+[script]: ../../../hack/ci/setup-openshift.sh 


### PR DESCRIPTION

**Description of the change:**
Our requirements in the testing docs were no longer up to date, instead of having to keep it up to date I think linking to the CI script might be a better option.
