### PR TITLE
pkg/scaffold/*: allow Inputs to specify template functions

### DIFF
--- a/pkg/scaffold/input/input.go
+++ b/pkg/scaffold/input/input.go
@@ -16,6 +16,8 @@
 
 package input
 
+import "text/template"
+
 // IfExistsAction determines what to do if the scaffold file already exists
 type IfExistsAction int
 
@@ -45,6 +47,10 @@ type Input struct {
 
 	// TemplateBody is the template body to execute
 	TemplateBody string
+
+	// TemplateFuncs are any funcs used in the template. These funcs must be
+	// registered before execution.
+	TemplateFuncs template.FuncMap
 
 	// Repo is the go project package
 	Repo string

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -147,7 +147,7 @@ func (s *Scaffold) doRender(i input.Input, e input.File, absPath string) error {
 		}
 	} else {
 		// All other files are rendered via their templates.
-		temp, err := newTemplate(e).Parse(i.TemplateBody)
+		temp, err := newTemplate(i)
 		if err != nil {
 			return err
 		}
@@ -172,10 +172,15 @@ func (s *Scaffold) doRender(i input.Input, e input.File, absPath string) error {
 	return err
 }
 
-// newTemplate a new template with common functions
-func newTemplate(t input.File) *template.Template {
-	return template.New(fmt.Sprintf("%T", t)).Funcs(template.FuncMap{
+// newTemplate returns a new template named by i.Path with common functions and
+// the input's TemplateFuncs.
+func newTemplate(i input.Input) (*template.Template, error) {
+	t := template.New(i.Path).Funcs(template.FuncMap{
 		"title": strings.Title,
 		"lower": strings.ToLower,
 	})
+	if len(i.TemplateFuncs) > 0 {
+		t.Funcs(i.TemplateFuncs)
+	}
+	return t.Parse(i.TemplateBody)
 }


### PR DESCRIPTION
**Description of the change:** add a `TemplateFuncs` field to `input.Input` for functions to be applied to a scaffold template, and add these funcs to the template in `newTemplate`.


**Motivation for the change:** complex templates may require Go functions defined in a scaffold source file.
