### PR TITLE
test/e2e/memcached_test.go: make tests work on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
     # Build and test go
     - <<: *test
       name: Go on OpenShift
-      script: make test/ci-go
+      script: make test/ci-go ARGS="-v"
 
     # Build and test ansible
     - <<: *test

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -249,6 +249,7 @@ func TestMemcached(t *testing.T) {
 		t.Run("ClusterTest", MemcachedClusterTest)
 		t.Run("Local", MemcachedLocal)
 	})
+
 }
 
 func memcachedLeaderTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -93,10 +93,16 @@ func TestMemcached(t *testing.T) {
 	ctx.AddCleanupFn(func() error { return os.RemoveAll(absProjectPath) })
 
 	os.Chdir("memcached-operator")
-	prSlug, ok := os.LookupEnv("TRAVIS_PULL_REQUEST_SLUG")
-	if ok && prSlug != "" {
-		prSha, ok := os.LookupEnv("TRAVIS_PULL_REQUEST_SHA")
-		if ok && prSha != "" {
+	repo, ok := os.LookupEnv("TRAVIS_PULL_REQUEST_SLUG")
+	if repo == "" {
+		repo, ok = os.LookupEnv("TRAVIS_REPO_SLUG")
+	}
+	if ok && repo != "" && repo != "operator-framework/operator-sdk" {
+		commitSha, ok := os.LookupEnv("TRAVIS_PULL_REQUEST_SHA")
+		if commitSha == "" {
+			commitSha, ok = os.LookupEnv("TRAVIS_COMMIT")
+		}
+		if ok && commitSha != "" {
 			gopkg, err := ioutil.ReadFile("Gopkg.toml")
 			if err != nil {
 				t.Fatal(err)
@@ -111,7 +117,7 @@ func TestMemcached(t *testing.T) {
 			// correctly.
 			gopkgString := string(gopkg)
 			gopkgLoc := strings.LastIndex(gopkgString, "\n  name = \"github.com/operator-framework/operator-sdk\"\n")
-			gopkgString = gopkgString[:gopkgLoc] + "\n  source = \"https://github.com/" + prSlug + "\"\n  revision = \"" + prSha + "\"\n" + gopkgString[gopkgLoc+1:]
+			gopkgString = gopkgString[:gopkgLoc] + "\n  source = \"https://github.com/" + repo + "\"\n  revision = \"" + commitSha + "\"\n" + gopkgString[gopkgLoc+1:]
 			err = ioutil.WriteFile("Gopkg.toml", []byte(gopkgString), fileutil.DefaultFileMode)
 			if err != nil {
 				t.Fatalf("failed to write updated Gopkg.toml: %v", err)
@@ -124,7 +130,7 @@ func TestMemcached(t *testing.T) {
 	}
 	cmdOut, err = exec.Command("dep", "ensure").CombinedOutput()
 	if err != nil {
-		t.Fatalf("error: %v\nCommand Output: %s\n", err, string(cmdOut))
+		t.Fatalf("error after modifying Gopkg.toml: %v\nCommand Output: %s\n", err, string(cmdOut))
 	}
 
 	// Set replicas to 2 to test leader election. In production, this should
@@ -217,7 +223,7 @@ func TestMemcached(t *testing.T) {
 		t.Fatalf("dep ensure failed: %v\nCommand Output:\n%v", err, string(cmdOut))
 	}
 	// link local sdk to vendor if not in travis
-	if prSlug == "" {
+	if repo == "" {
 		os.RemoveAll("vendor/github.com/operator-framework/operator-sdk/pkg")
 		os.Symlink(filepath.Join(gopath, "src/github.com/operator-framework/operator-sdk/pkg"),
 			"vendor/github.com/operator-framework/operator-sdk/pkg")

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -249,7 +249,6 @@ func TestMemcached(t *testing.T) {
 		t.Run("ClusterTest", MemcachedClusterTest)
 		t.Run("Local", MemcachedLocal)
 	})
-
 }
 
 func memcachedLeaderTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {


### PR DESCRIPTION
**Description of the change:** This PR makes travis builds work correctly on forks of the sdk repo


**Motivation for the change:** This allows developers to test their changes in their own forks before making a PR. This was previously implemented in #766, but it caused the Gopkg.lock replacement to also occur on this repo's branches, which could mask typos in the generated Gopkg.lock. This PR includes a check to make sure it does not run for branches in this repo.

Closes #805 