### PR TITLE
Fix gcp authentication for the test framework

### DIFF
--- a/commands/operator-sdk/cmd/test/cluster.go
+++ b/commands/operator-sdk/cmd/test/cluster.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 type testClusterConfig struct {

--- a/pkg/test/framework.go
+++ b/pkg/test/framework.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/kubernetes"
 	cgoscheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	dynclient "sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
Signed-off-by: Serge Catudal <serge.catudal@gmail.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Fix gcp authentication for the test frameworkd when running the commands:

*  `operator-sdk test local`
* `operator-sdk test cluster`

on a kubernetes cluster deployed on Google Cloud Platform.

> **NOTE:** tested successfully on a GKE cluster.

**Motivation for the change:**

Closes #865
