### PR TITLE
Symlink internal dir in e2e

### DIFF
--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/operator-framework/operator-sdk/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/ansible"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/helm"
 
@@ -29,14 +30,11 @@ import (
 )
 
 const (
-	SrcDir          = "src"
-	mainFile        = "./cmd/manager/main.go"
-	buildDockerfile = "./build/Dockerfile"
+	GopathEnv = "GOPATH"
+	SrcDir    = "src"
 )
 
-const (
-	GopathEnv = "GOPATH"
-)
+var mainFile = filepath.Join(scaffold.ManagerDir, scaffold.CmdFile)
 
 // OperatorType - the type of operator
 type OperatorType = string
@@ -57,7 +55,7 @@ const (
 func MustInProjectRoot() {
 	// if the current directory has the "./build/dockerfile" file, then it is safe to say
 	// we are at the project root.
-	_, err := os.Stat(buildDockerfile)
+	_, err := os.Stat(filepath.Join(scaffold.BuildDir, scaffold.DockerfileFile))
 	if err != nil {
 		if os.IsNotExist(err) {
 			log.Fatal("must run command in project root dir: project structure requires ./build/Dockerfile")

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -224,9 +224,12 @@ func TestMemcached(t *testing.T) {
 	}
 	// link local sdk to vendor if not in travis
 	if repo == "" {
-		os.RemoveAll("vendor/github.com/operator-framework/operator-sdk/pkg")
-		os.Symlink(filepath.Join(gopath, "src/github.com/operator-framework/operator-sdk/pkg"),
-			"vendor/github.com/operator-framework/operator-sdk/pkg")
+		for _, dir := range []string{"pkg", "internal"} {
+			repoDir := filepath.Join("github.com/operator-framework/operator-sdk", dir)
+			vendorDir := filepath.Join("vendor", repoDir)
+			os.RemoveAll(vendorDir)
+			os.Symlink(filepath.Join(gopath, "src", repoDir), vendorDir)
+		}
 	}
 
 	file, err := yamlutil.GenerateCombinedGlobalManifest()

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -228,7 +228,7 @@ func TestMemcached(t *testing.T) {
 			repoDir := filepath.Join("github.com/operator-framework/operator-sdk", dir)
 			vendorDir := filepath.Join("vendor", repoDir)
 			os.RemoveAll(vendorDir)
-			os.Symlink(filepath.Join(gopath, "src", repoDir), vendorDir)
+			os.Symlink(filepath.Join(gopath, projutil.SrcDir, repoDir), vendorDir)
 		}
 	}
 


### PR DESCRIPTION
**Description of the change:** symlink both `pkg` and `internal` dirs to the test project's `vendor` when running e2e tests locally, and some cleanup.

**Motivation for the change:** the e2e tests symlink `internal` so any future changes are picked up by local e2e tests.