### PR TITLE
pkg/helm/release/manager.go: only apply patch if resources change

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1425,6 +1425,7 @@
     "github.com/go-logr/logr",
     "github.com/markbates/inflect",
     "github.com/martinlindhe/base36",
+    "github.com/mattbaird/jsonpatch",
     "github.com/pborman/uuid",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/sergi/go-diff/diffmatchpatch",

--- a/pkg/helm/release/manager.go
+++ b/pkg/helm/release/manager.go
@@ -348,23 +348,23 @@ func reconcileRelease(ctx context.Context, tillerKubeClient *kube.Client, namesp
 	})
 }
 
-func generatePatch(orig, new runtime.Object) ([]byte, error) {
-	origJSON, err := json.Marshal(orig)
+func generatePatch(existing, expected runtime.Object) ([]byte, error) {
+	existingJSON, err := json.Marshal(existing)
 	if err != nil {
 		return nil, err
 	}
-	newJSON, err := json.Marshal(new)
+	expectedJSON, err := json.Marshal(expected)
 	if err != nil {
 		return nil, err
 	}
 
-	ops, err := jsonpatch.CreatePatch(origJSON, newJSON)
+	ops, err := jsonpatch.CreatePatch(existingJSON, expectedJSON)
 	if err != nil {
 		return nil, err
 	}
 
 	// We ignore the "remove" operations from the full patch because they are
-	// fields added by Kubernetes or by the user after the original release
+	// fields added by Kubernetes or by the user after the existing release
 	// resource has been applied. The goal for this patch is to make sure that
 	// the fields managed by the Helm chart are applied.
 	patchOps := make([]jsonpatch.JsonPatchOperation, 0)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Updates the Helm reconciler to only apply patches when there are changes to be made to dependent resources


**Motivation for the change:**
The Helm reconciler currently patches every dependent resource of a Helm chart during reconciliation even when the dependent resource does not require any changes, which results in unnecessary chatter with the API server.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
