### PR TITLE
pkg/ansible; Append current environment vars to runner

### DIFF
--- a/pkg/ansible/runner/runner.go
+++ b/pkg/ansible/runner/runner.go
@@ -249,9 +249,9 @@ func (r *runner) Run(ident string, u *unstructured.Unstructured, kubeconfig stri
 		} else {
 			dc = r.cmdFunc(ident, inputDir.Path)
 		}
-		dc.Env = append(dc.Env, fmt.Sprintf("K8S_AUTH_KUBECONFIG=%s", kubeconfig), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
 		// Append current environment since setting dc.Env to anything other than nil overwrites current env
 		dc.Env = append(dc.Env, os.Environ()...)
+		dc.Env = append(dc.Env, fmt.Sprintf("K8S_AUTH_KUBECONFIG=%s", kubeconfig), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
 
 		output, err := dc.CombinedOutput()
 		if err != nil {

--- a/pkg/ansible/runner/runner.go
+++ b/pkg/ansible/runner/runner.go
@@ -250,6 +250,8 @@ func (r *runner) Run(ident string, u *unstructured.Unstructured, kubeconfig stri
 			dc = r.cmdFunc(ident, inputDir.Path)
 		}
 		dc.Env = append(dc.Env, fmt.Sprintf("K8S_AUTH_KUBECONFIG=%s", kubeconfig), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+		// Append current environment since setting dc.Env to anything other than nil overwrites current env
+		dc.Env = append(dc.Env, os.Environ()...)
 
 		output, err := dc.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Append current environment vars to Ansible Runner invocation.

**Motivation for the change:**
Without doing this $PATH is completely screwed up and I cannot shell out to executables in my PATH.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
