### PR TITLE
pkg/ansible; Fix implementation of watching dependent resources

### DIFF
--- a/pkg/ansible/operator/operator.go
+++ b/pkg/ansible/operator/operator.go
@@ -49,6 +49,9 @@ func Run(done chan error, mgr manager.Manager, f *flags.AnsibleOperatorFlags, cM
 			ManageStatus: runner.GetManageStatus(),
 		}
 		applyFlagsToControllerOptions(f, &o)
+		if d, ok := runner.GetReconcilePeriod(); ok {
+			o.ReconcilePeriod = d
+		}
 		ctr := controller.Add(mgr, o)
 		if ctr == nil {
 			done <- errors.New("failed to add controller")

--- a/pkg/ansible/proxy/proxy.go
+++ b/pkg/ansible/proxy/proxy.go
@@ -160,6 +160,7 @@ func InjectOwnerReferenceHandler(h http.Handler, cMap *ControllerMap, restMapper
 			}
 			owner := metav1.OwnerReference{}
 			json.Unmarshal(authString, &owner)
+			log.Info(fmt.Sprintf("Owner: %#v", owner))
 
 			body, err := ioutil.ReadAll(req.Body)
 			if err != nil {
@@ -215,6 +216,7 @@ func InjectOwnerReferenceHandler(h http.Handler, cMap *ControllerMap, restMapper
 					m := "could not add watch to controller"
 					log.Error(err, m)
 					http.Error(w, m, http.StatusInternalServerError)
+					return
 				}
 			}
 		}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Prior to this the `watchDependentResources` field in watches.yaml was not being passed along to the runner. We were also setting the wrong values when re-queuing for the owner.

**Motivation for the change:**
Fixes watching of dependent resources for Ansible Operator
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->

In a follow-up PR I will address the corner-case of a namespaced operator trying to watch cluster-scoped resources.
