### PR TITLE
pkg/schaffold: Add missing errors handeling in main.go

### DIFF
--- a/pkg/scaffold/cmd.go
+++ b/pkg/scaffold/cmd.go
@@ -90,7 +90,11 @@ func main() {
 	}
 
 	// Become the leader before proceeding
-	leader.Become(context.TODO(), "{{ .ProjectName }}-lock")
+	err = leader.Become(context.TODO(), "{{ .ProjectName }}-lock")
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
 
 	r := ready.NewFileReady()
 	err = r.Set()
@@ -98,7 +102,12 @@ func main() {
 		log.Error(err, "")
 		os.Exit(1)
 	}
-	defer r.Unset()
+	defer func() {
+		if err = r.Unset(); err != nil {
+			log.Error(err, "")
+			os.Exit(1)
+		}
+	}()
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})

--- a/pkg/scaffold/cmd_test.go
+++ b/pkg/scaffold/cmd_test.go
@@ -88,7 +88,11 @@ func main() {
 	}
 
 	// Become the leader before proceeding
-	leader.Become(context.TODO(), "app-operator-lock")
+	err = leader.Become(context.TODO(), "app-operator-lock")
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
 
 	r := ready.NewFileReady()
 	err = r.Set()
@@ -96,7 +100,12 @@ func main() {
 		log.Error(err, "")
 		os.Exit(1)
 	}
-	defer r.Unset()
+	defer func() {
+		if err = r.Unset(); err != nil {
+			log.Error(err, "")
+			os.Exit(1)
+		}
+	}()
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})


### PR DESCRIPTION
**Description of the change:**

This PR is adding missings errors handling in the operator generated code from `pkg/scaffold`.

**Motivation for the change:**

"errcheck" tool detects 2 errors on the operator generated code:
- cmd/manager/main.go:70:15:warning: error return value not checked
(leader.Become(context.TODO(), "memcached-operator-lock")) (errcheck)
- cmd/manager/main.go:78:9:warning: error return value not checked (r.Unset())
(errcheck)

Closes #893

