### PR TITLE
hack/image/build-ansible-image.sh,Makefile,.travis.yml: fix ansible deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ x_base_steps:
     stage: deploy
     if: type != pull_request AND ( tag IS present OR branch = master OR commit_message =~ /\[travis deploy\]/ )
     <<: *go_before_install
-    install: skip
+    install: make install
     before_script:
       - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
       - git fetch --unshallow --tags

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ image: image/build image/push
 
 image/build: image/build/ansible image/build/helm
 
-image/build/ansible:
+image/build/ansible: build/operator-sdk-dev-x86_64-linux-gnu
 	./hack/image/build-ansible-image.sh $(ANSIBLE_BASE_IMAGE):dev
 
 image/build/helm:

--- a/hack/image/build-ansible-image.sh
+++ b/hack/image/build-ansible-image.sh
@@ -15,6 +15,6 @@ pushd "$BASEIMAGEDIR"
 go run "$ROOTDIR/hack/image/scaffold-ansible-image.go"
 
 mkdir -p build/_output/bin/
-cp $(which operator-sdk) build/_output/bin/ansible-operator
+cp $ROOTDIR/build/operator-sdk-dev-x86_64-linux-gnu build/_output/bin/ansible-operator
 operator-sdk build $1
 popd


### PR DESCRIPTION
**Description of the change:**
1. Ensure `operator-sdk` binary is available during deploy stages
2. Explicitly build and use `x86_64-linux` binary in base image

**Motivation for the change:**
Fixes the ansible deploy stage