### PR TITLE
pkg/ansible,pkg/scaffold/ansible; enables leader election for ansible operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - New commands [`operator-sdk run ansible`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#ansible) and [`operator-sdk run helm`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#helm) which run the SDK as ansible  and helm operator processes, respectively. These are intended to be used when running in a Pod inside a cluster. Developers wanting to run their operator locally should continue to use `up local`. ([#887](https://github.com/operator-framework/operator-sdk/pull/887) and [#897](https://github.com/operator-framework/operator-sdk/pull/897))
 - Ansible operator proxy added the cache handler which allows the get requests to use the operators cache. [#760](https://github.com/operator-framework/operator-sdk/pull/760)
 - Ansible operator proxy added ability to dynamically watch dependent resource that were created by ansible operator. [#857](https://github.com/operator-framework/operator-sdk/pull/857)
+- Ansible-based operators have leader election turned on by default. When upgrading, add environment variable `POD_NAME` to your operator's Deployment using the Kubernetes downward API. To see an example, run `operator-sdk new --type=ansible ...` and see file `deploy/operator.yaml`.
+
 ### Changed
 
 - The official images for the Ansible and Helm operators have moved! Travis now builds, tags, and pushes operator base images during CI ([#832](https://github.com/operator-framework/operator-sdk/pull/832)).

--- a/commands/operator-sdk/cmd/test/cluster.go
+++ b/commands/operator-sdk/cmd/test/cluster.go
@@ -22,6 +22,8 @@ import (
 
 	k8sInternal "github.com/operator-framework/operator-sdk/internal/util/k8sutil"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/ansible"
 	"github.com/operator-framework/operator-sdk/pkg/test"
@@ -108,6 +110,12 @@ func testClusterFunc(cmd *cobra.Command, args []string) error {
 				Env: []v1.EnvVar{{
 					Name:      test.TestNamespaceEnv,
 					ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
+				}, {
+					Name:  k8sutil.OperatorNameEnvVar,
+					Value: "test-operator",
+				}, {
+					Name:      leader.PodNameEnv,
+					ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"}},
 				}},
 			}},
 		},

--- a/pkg/ansible/run.go
+++ b/pkg/ansible/run.go
@@ -24,7 +24,6 @@ import (
 	proxy "github.com/operator-framework/operator-sdk/pkg/ansible/proxy"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
-	"github.com/operator-framework/operator-sdk/pkg/ready"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -73,20 +72,6 @@ func Run(flags *aoflags.AnsibleOperatorFlags) {
 		log.Error(err, "")
 		os.Exit(1)
 	}
-
-	// Set ready
-	r := ready.NewFileReady()
-	err = r.Set()
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-	defer func() {
-		if err = r.Unset(); err != nil {
-			log.Error(err, "")
-			os.Exit(1)
-		}
-	}()
 
 	done := make(chan error)
 	cMap := proxy.NewControllerMap()

--- a/pkg/ansible/run.go
+++ b/pkg/ansible/run.go
@@ -15,6 +15,7 @@
 package ansible
 
 import (
+	"context"
 	"os"
 	"runtime"
 
@@ -22,6 +23,8 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/ansible/operator"
 	proxy "github.com/operator-framework/operator-sdk/pkg/ansible/proxy"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"github.com/operator-framework/operator-sdk/pkg/leader"
+	"github.com/operator-framework/operator-sdk/pkg/ready"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -42,6 +45,8 @@ func printVersion() {
 func Run(flags *aoflags.AnsibleOperatorFlags) {
 	logf.SetLogger(logf.ZapLogger(false))
 
+	printVersion()
+
 	namespace, found := os.LookupEnv(k8sutil.WatchNamespaceEnvVar)
 	if found {
 		log.Infof("Watching %v namespace.", namespace)
@@ -58,7 +63,31 @@ func Run(flags *aoflags.AnsibleOperatorFlags) {
 		log.Fatal(err)
 	}
 
-	printVersion()
+	name, found := os.LookupEnv(k8sutil.OperatorNameEnvVar)
+	if !found {
+		log.Fatal("OPERATOR_NAME environment variable not set")
+	}
+	// Become the leader before proceeding
+	err = leader.Become(context.TODO(), name+"-lock")
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	// Set ready
+	r := ready.NewFileReady()
+	err = r.Set()
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+	defer func() {
+		if err = r.Unset(); err != nil {
+			log.Error(err, "")
+			os.Exit(1)
+		}
+	}()
+
 	done := make(chan error)
 	cMap := proxy.NewControllerMap()
 

--- a/pkg/scaffold/ansible/build_test_framework_ansible_test_script.go
+++ b/pkg/scaffold/ansible/build_test_framework_ansible_test_script.go
@@ -39,7 +39,7 @@ func (b *BuildTestFrameworkAnsibleTestScript) GetInput() (input.Input, error) {
 
 const buildTestFrameworkAnsibleTestScriptAnsibleTmpl = `#!/bin/sh
 export WATCH_NAMESPACE=${TEST_NAMESPACE}
-(/usr/local/bin/entrypoint > /tmp/operator.log 2>&1)&
+(/usr/local/bin/entrypoint)&
 trap "kill $!" SIGINT SIGTERM EXIT
 
 cd ${HOME}/project

--- a/pkg/scaffold/ansible/deploy_operator.go
+++ b/pkg/scaffold/ansible/deploy_operator.go
@@ -70,6 +70,10 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
               {{- end}}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "{{.ProjectName}}"
 `

--- a/test/ansible-memcached/asserts.yml
+++ b/test/ansible-memcached/asserts.yml
@@ -22,7 +22,7 @@
 
     - name: Wait 2 minutes for memcached deployment
       debug:
-        msg: Waiting for memcached deployment...
+        var: deploy
       until: deploy and deploy.status and deploy.status.replicas == deploy.status.get("availableReplicas", 0)
       retries: 12
       delay: 10


### PR DESCRIPTION
Leader election has been enabled for a while for go-based operators. This uses the same approach and very similar code.