### PR TITLE
hack/ci: Add check for valid commit range

### DIFF
--- a/hack/ci/check-doc-only-update.sh
+++ b/hack/ci/check-doc-only-update.sh
@@ -4,7 +4,7 @@ set -ex
 
 # Make sure the TRAVIS_COMMIT_RANGE is valid, by catching any errors and exiting.
 if [ -z "$TRAVIS_COMMIT_RANGE" ] || ! git rev-list --quiet $TRAVIS_COMMIT_RANGE; then
-  echo "Failed to check the commit range is valid."
+  echo "Invalid commit range. Skipping check for doc only update"
   return 0
 fi
 

--- a/hack/ci/check-doc-only-update.sh
+++ b/hack/ci/check-doc-only-update.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 
-if [ "$TRAVIS_COMMIT_RANGE" != "" ] && ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md)|(\.MD)|(\.png)|(\.pdf)|^(doc/)|^(MAINTAINERS)|^(LICENSE)'; then
-  echo "Only doc files were updated, not running the CI."
-  exit
+set -ex
+
+# Make sure the TRAVIS_COMMIT_RANGE is valid, by catching any errors and exiting.
+if [ -z "$TRAVIS_COMMIT_RANGE" ] || ! git rev-list --quiet $TRAVIS_COMMIT_RANGE; then
+  echo "Failed to check the commit range is valid."
+  return 0
 fi
 
+if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md)|(\.MD)|(\.png)|(\.pdf)|^(doc/)|^(MAINTAINERS)|^(LICENSE)'; then
+  echo "Only doc files were updated, not running the CI."
+  exit 0
+fi


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
In cases when PRs were force pushed and the commit range was not
valid, the PR job would still pass as we did catch the error. This adds
a check and exits in case of an invalid commit range.

**Motivation for the change:**
Ran into a weird error when running tests, where the commit didn't exist anymore(I think), as it exited the `check-doc-only-update.sh` with `true` which in turn was passing my tests.

https://api.travis-ci.org/v3/job/479857827/log.txt
```bash
[0K$ source hack/ci/check-doc-only-update.sh
fatal: ambiguous argument '99b2197f26fa...3493d93a7547': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
Only doc files were updated, not running the CI.
```
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
