### PR TITLE
pkg/ansible/proxy; Do not inject owner references on subresource requests

### DIFF
--- a/pkg/ansible/proxy/proxy.go
+++ b/pkg/ansible/proxy/proxy.go
@@ -66,8 +66,6 @@ func CacheResponseHandler(h http.Handler, informerCache cache.Cache, restMapper 
 				log.Error(err, "Failed to convert request")
 				break
 			}
-			// Set Content-Type header
-			w.Header().Set("Content-Type", "application/json")
 
 			// check if resource is present on request
 			if !r.IsResourceRequest {
@@ -128,6 +126,8 @@ func CacheResponseHandler(h http.Handler, informerCache cache.Cache, restMapper 
 				return
 			}
 
+			// Set Content-Type header
+			w.Header().Set("Content-Type", "application/json")
 			// Set X-Cache header to signal that response is served from Cache
 			w.Header().Set("X-Cache", "HIT")
 			json.Indent(&i, resp, "", "  ")


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
* Adds a `Content-Type` header to our cache.
* Checks if a subresource is present on the request before injecting owner reference

**Motivation for the change:**
Kubectl exec now works from within Ansible Operator tasks
<!--

Note: If this PR is fixing an issue make sure to add a note saying:

-->
Closes #911 
