### PR TITLE
commands/.../test/local.go: use default kubeconfig

### DIFF
--- a/commands/operator-sdk/cmd/test/local.go
+++ b/commands/operator-sdk/cmd/test/local.go
@@ -178,6 +178,12 @@ func testLocalGoFunc(cmd *cobra.Command, args []string) {
 	testArgs := []string{"test", args[0] + "/..."}
 	if tlConfig.kubeconfig != "" {
 		testArgs = append(testArgs, "-"+test.KubeConfigFlag, tlConfig.kubeconfig)
+	} else {
+		// Use the system default kubeconfig.
+		homedir, ok := os.LookupEnv("HOME")
+		if ok {
+			testArgs = append(testArgs, "-"+test.KubeConfigFlag, homedir+"/.kube/config")
+		}
 	}
 	testArgs = append(testArgs, "-"+test.NamespacedManPathFlag, tlConfig.namespacedManPath)
 	testArgs = append(testArgs, "-"+test.GlobalManPathFlag, tlConfig.globalManPath)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This change adds the system default kubeconfig to test local if one
is not specified through --kubeconfig flag.

**Motivation for the change:**
Default kubeconfig used to be in test local https://github.com/operator-framework/operator-sdk/pull/717/files#diff-b6a250dfb7ca3e246979976a0467cf97. This change adds that back.

Closes #943 