### PR TITLE
pkg/scaffold/ansible; Use yml as playbook extension

### DIFF
--- a/pkg/scaffold/ansible/playbook.go
+++ b/pkg/scaffold/ansible/playbook.go
@@ -40,5 +40,5 @@ const playbookTmpl = `- hosts: localhost
   gather_facts: no
   tasks:
   - import_role:
-      name: "{{.Resource.Kind}}"
+      name: "{{.Resource.LowerKind}}"
 `

--- a/pkg/scaffold/ansible/playbook.go
+++ b/pkg/scaffold/ansible/playbook.go
@@ -19,7 +19,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 )
 
-const PlaybookYamlFile = "playbook.yaml"
+const PlaybookYamlFile = "playbook.yml"
 
 // Playbook - the playbook tmpl wrapper
 type Playbook struct {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Use `.yml` for playbook scaffolding

**Motivation for the change:**
Breaks scaffolding currently.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
Closes #933 