### PR TITLE
Make migrate command look for playbook.yml instead of .yaml

### DIFF
--- a/commands/operator-sdk/cmd/migrate.go
+++ b/commands/operator-sdk/cmd/migrate.go
@@ -69,14 +69,14 @@ func migrateAnsible() {
 		Watches: true,
 		Roles:   true,
 	}
-	_, err := os.Stat("playbook.yaml")
+	_, err := os.Stat("playbook.yml")
 	switch {
 	case err == nil:
 		dockerfile.Playbook = true
 	case os.IsNotExist(err):
 		log.Info("No playbook was found, so not including it in the new Dockerfile")
 	default:
-		log.Fatalf("Error trying to stat playbook.yaml: (%v)", err)
+		log.Fatalf("Error trying to stat playbook.yml: (%v)", err)
 	}
 
 	renameDockerfile()

--- a/doc/ansible/dev/developer_guide.md
+++ b/doc/ansible/dev/developer_guide.md
@@ -76,7 +76,7 @@ Modify `roles/Foo/defaults/main.yml` to set `state` to `present` by default.
 state: present
 ```
 
-Create an Ansible playbook `playbook.yaml` in the top-level directory which
+Create an Ansible playbook `playbook.yml` in the top-level directory which
 includes role `Foo`:
 ```yaml
 ---
@@ -87,7 +87,7 @@ includes role `Foo`:
 
 Run the playbook:
 ```bash
-$ ansible-playbook playbook.yaml
+$ ansible-playbook playbook.yml
  [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
 
 

--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -106,14 +106,14 @@ An example Watches file:
 - version: v1alpha1
   group: bar.example.com
   kind: Bar
-  playbook: /opt/ansible/playbook.yaml
+  playbook: /opt/ansible/playbook.yml
 
 # More complex example for our Baz kind
 # Here we will disable requeuing and be managing the CR status in the playbook
 - version: v1alpha1
   group: baz.example.com
   kind: Baz
-  playbook: /opt/ansible/baz.yaml
+  playbook: /opt/ansible/baz.yml
   reconcilePeriod: 0
   manageStatus: false
 ```
@@ -149,7 +149,7 @@ should go.
 - version: v1alpha1
   group: cache.example.com
   kind: Memcached
-  role: /opt/ansible/roles/Memcached
+  role: /opt/ansible/roles/memcached
 ```
 
 **Playbook**
@@ -167,7 +167,7 @@ Playbook
 ## Building the Memcached Ansible Role
 
 The first thing to do is to modify the generated Ansible role under
-`roles/Memcached`. This Ansible Role controls the logic that is executed when a
+`roles/memcached`. This Ansible Role controls the logic that is executed when a
 resource is modified.
 
 ### Define the Memcached spec
@@ -183,7 +183,7 @@ It is recommended that you perform some type validation in Ansible on the
 variables to ensure that your application is receiving expected input.
 
 First, set a default in case the user doesn't set the `spec` field by modifying
-`roles/Memcached/defaults/main.yml`:
+`roles/memcached/defaults/main.yml`:
 ```yaml
 size: 1
 ```
@@ -192,13 +192,13 @@ size: 1
 
 Now that we have the spec defined, we can define what Ansible is actually
 executed on resource changes. Since this is an Ansible Role, the default
-behavior will be to execute the tasks in `roles/Memcached/tasks/main.yml`. We
+behavior will be to execute the tasks in `roles/memcached/tasks/main.yml`. We
 want Ansible to create a deployment if it does not exist which runs the
 `memcached:1.4.36-alpine` image. Ansible 2.5+ supports the [k8s Ansible
 Module](https://docs.ansible.com/ansible/2.6/modules/k8s_module.html) which we
 will leverage to control the deployment definition.
 
-Modify `roles/Memcached/tasks/main.yml` to look like the following:
+Modify `roles/memcached/tasks/main.yml` to look like the following:
 ```yaml
 ---
 - name: start memcached

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -167,6 +167,9 @@ Generating CSV manifest version 0.1.1
 Adds a main.go source file and any associated source files for an operator that
 is not of the "go" type.
 
+**Note**: This command will look for playbook.yml in the project root, if you use the .yaml extension
+you will need to rename it before running migrate or manually add it to your Dockerfile.
+
 ### Example
 
 ```console

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -26,7 +26,7 @@ remove_prereqs() {
 }
 
 pushd "$GOTMP"
-operator-sdk new memcached-operator --api-version=ansible.example.com/v1alpha1 --kind=Memcached --type=ansible
+operator-sdk new memcached-operator --api-version=ansible.example.com/v1alpha1 --kind=Memcached --type=ansible --generate-playbook
 cp "$ROOTDIR/test/ansible-memcached/tasks.yml" memcached-operator/roles/memcached/tasks/main.yml
 cp "$ROOTDIR/test/ansible-memcached/defaults.yml" memcached-operator/roles/memcached/defaults/main.yml
 cp "$ROOTDIR/test/ansible-memcached/asserts.yml"  memcached-operator/molecule/default/asserts.yml

--- a/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -72,7 +72,7 @@ RUN  /usr/local/bin/user_setup
 {{- if .Roles }}
 COPY roles/ ${HOME}/roles/{{ end }}
 {{- if .Playbook }}
-COPY playbook.yml ${HOME}/playbook.yaml{{ end }}
+COPY playbook.yml ${HOME}/playbook.yml{{ end }}
 {{- if .Watches }}
 COPY watches.yaml ${HOME}/watches.yaml{{ end }}
 

--- a/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -25,7 +25,7 @@ import (
 type DockerfileHybrid struct {
 	input.Input
 
-	// Playbook - if true, include a COPY statement for playbook.yaml
+	// Playbook - if true, include a COPY statement for playbook.yml
 	Playbook bool
 
 	// Roles - if true, include a COPY statement for the roles directory
@@ -72,7 +72,7 @@ RUN  /usr/local/bin/user_setup
 {{- if .Roles }}
 COPY roles/ ${HOME}/roles/{{ end }}
 {{- if .Playbook }}
-COPY playbook.yaml ${HOME}/playbook.yaml{{ end }}
+COPY playbook.yml ${HOME}/playbook.yaml{{ end }}
 {{- if .Watches }}
 COPY watches.yaml ${HOME}/watches.yaml{{ end }}
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
