### PR TITLE
Use same validation with k8s's for API resource group

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1475,6 +1475,7 @@
     "k8s.io/apimachinery/pkg/util/net",
     "k8s.io/apimachinery/pkg/util/proxy",
     "k8s.io/apimachinery/pkg/util/sets",
+    "k8s.io/apimachinery/pkg/util/validation",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/util/yaml",
     "k8s.io/cli-runtime/pkg/genericclioptions/resource",

--- a/pkg/scaffold/resource.go
+++ b/pkg/scaffold/resource.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 
 	"github.com/markbates/inflect"
+
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 var (
@@ -31,8 +33,6 @@ var (
 	ResourceVersionRegexp = regexp.MustCompile("^v[1-9][0-9]*((alpha|beta)[1-9][0-9]*)?$")
 	// ResourceKindRegexp matches Kubernetes API Kind's.
 	ResourceKindRegexp = regexp.MustCompile("^[A-Z]{1}[a-zA-Z0-9]+$")
-	// ResourceGroupRegexp matches Kubernetes API Group's.
-	ResourceGroupRegexp = regexp.MustCompile("^[a-z0-9]+$")
 )
 
 // Resource contains the information required to scaffold files for a resource.
@@ -127,8 +127,8 @@ func (r *Resource) checkAndSetGroups() error {
 	r.FullGroup = fg[0]
 	r.Group = g[0]
 
-	if !ResourceGroupRegexp.MatchString(r.Group) {
-		return errors.New("group should consist of lowercase alphabetical characters")
+	if err := validation.IsDNS1123Subdomain(r.Group); err != nil {
+		return fmt.Errorf("group name is invalid: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Currently operator-sdk does not allow to use `-` for api groups as:

```
$ operator-sdk add api --api-version=node-problem-detector.operator.k8s.io/v1alpha1 --kind=NodeProblemDetector
INFO[0000] Generating api version node-problem-detector.operator.k8s.io/v1alpha1 for kind NodeProblemDetector.
FATA[0000] group should consist of lowercase alphabetical characters
```

This validation is different from upstream's validation, and
operator-sdk cannot work if api groups uses `-`.

This patch changes to calls `IsDNS1123Subdomain()` which is same
validation for api groups with kubernetes's.
