### PR TITLE
hack/test,test: Use the :dev image as the base for testing Ansible Operator

### DIFF
--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -33,16 +33,17 @@ cp "$ROOTDIR/test/ansible-memcached/asserts.yml"  memcached-operator/molecule/de
 cp "$ROOTDIR/test/ansible-memcached/molecule.yml"  memcached-operator/molecule/test-local/molecule.yml
 cp -a "$ROOTDIR/test/ansible-memcached/memfin" memcached-operator/roles/
 cat "$ROOTDIR/test/ansible-memcached/watches-finalizer.yaml" >> memcached-operator/watches.yaml
+cat "$ROOTDIR/test/ansible-memcached/prepare-test-image.yml" >> memcached-operator/molecule/test-local/prepare.yml
 
 
 # Test local
 pushd memcached-operator
+sed -i 's|\(FROM quay.io/operator-framework/ansible-operator\)\(:.*\)\?|\1:dev|g' build/Dockerfile
 OPERATORDIR="$(pwd)"
 TEST_CLUSTER_PORT=24443 operator-sdk test local --namespace default
 
 # Test cluster
 DEST_IMAGE="quay.io/example/memcached-operator:v0.0.2-test"
-sed -i 's|\(FROM quay.io/operator-framework/ansible-operator\)\(:.*\)\?|\1:dev|g' build/Dockerfile
 operator-sdk build --enable-tests "$DEST_IMAGE"
 trap_add 'remove_prereqs' EXIT
 deploy_prereqs

--- a/test/ansible-memcached/prepare-test-image.yml
+++ b/test/ansible-memcached/prepare-test-image.yml
@@ -1,0 +1,21 @@
+  - name: Dump the dev image
+    command: docker save -o /tmp/dev-operator.tar quay.io/operator-framework/ansible-operator:dev
+  - name: Copy the image to the kind container
+    command: docker cp /tmp/dev-operator.tar kind-test-local:/dev-operator.tar
+
+- name: Make dev operator image available
+  hosts: k8s
+  gather_facts: no
+  tasks:
+  - name: Make dev operator available
+    command: docker load -i /dev-operator.tar
+
+- name: Clean up
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - name: remove dev-operator.tar
+    file:
+      path: /tmp/dev-operator.tar
+      state: absent


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

Fixes #958 
Unblocks #946 

**Description of the change:**
Copies the :dev image into the Kubernetes-in-Docker container and uses that as the base instead of the versioned base image that is generated by default.

**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
