### PR TITLE
pkg/ansible/controller; Remove IsAlreadyRegistered() check in controller

### DIFF
--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -14,6 +14,7 @@ deploy_operator() {
     kubectl create -f "$OPERATORDIR/deploy/role.yaml"
     kubectl create -f "$OPERATORDIR/deploy/role_binding.yaml"
     kubectl create -f "$OPERATORDIR/deploy/crds/ansible_v1alpha1_memcached_crd.yaml"
+    kubectl create -f "$OPERATORDIR/deploy/crds/ansible_v1alpha1_foo_crd.yaml"
     kubectl create -f "$OPERATORDIR/deploy/operator.yaml"
 }
 
@@ -22,6 +23,7 @@ remove_operator() {
     kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/role.yaml"
     kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/role_binding.yaml"
     kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/crds/ansible_v1alpha1_memcached_crd.yaml"
+    kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/crds/ansible_v1alpha1_foo_crd.yaml"
     kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/operator.yaml"
 }
 
@@ -91,8 +93,11 @@ cp "$ROOTDIR/test/ansible-memcached/tasks.yml" memcached-operator/roles/memcache
 cp "$ROOTDIR/test/ansible-memcached/defaults.yml" memcached-operator/roles/memcached/defaults/main.yml
 cp -a "$ROOTDIR/test/ansible-memcached/memfin" memcached-operator/roles/
 cat "$ROOTDIR/test/ansible-memcached/watches-finalizer.yaml" >> memcached-operator/watches.yaml
+cat "$ROOTDIR/test/ansible-memcached/watches-foo-kind.yaml" >> memcached-operator/watches.yaml
 
 pushd memcached-operator
+# Add a second Kind to test watching multiple GVKs
+operator-sdk add crd --kind=Foo --api-version=ansible.example.com/v1alpha1
 sed -i 's|\(FROM quay.io/operator-framework/ansible-operator\)\(:.*\)\?|\1:dev|g' build/Dockerfile
 operator-sdk build "$DEST_IMAGE"
 sed -i "s|{{ REPLACE_IMAGE }}|$DEST_IMAGE|g" deploy/operator.yaml

--- a/pkg/ansible/controller/controller.go
+++ b/pkg/ansible/controller/controller.go
@@ -64,13 +64,6 @@ func Add(mgr manager.Manager, options Options) *controller.Controller {
 		ManageStatus:    options.ManageStatus,
 	}
 
-	if mgr.GetScheme().IsVersionRegistered(schema.GroupVersion{
-		Group:   options.GVK.Group,
-		Version: options.GVK.Version,
-	}) {
-		log.Info("Version already registered... skipping")
-		return nil
-	}
 	// Register the GVK with the schema
 	mgr.GetScheme().AddKnownTypeWithName(options.GVK, &unstructured.Unstructured{})
 	metav1.AddToGroupVersion(mgr.GetScheme(), schema.GroupVersion{

--- a/test/ansible-memcached/watches-foo-kind.yaml
+++ b/test/ansible-memcached/watches-foo-kind.yaml
@@ -1,0 +1,4 @@
+- version: v1alpha1
+  group: ansible.example.com
+  kind: Foo
+  role: /dev/null


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
There is no need to skip adding the controller if the version is already registered.

**Motivation for the change:**
This currently breaks the ability to watch multiple kinds in the same operator.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
Closes #962 