### PR TITLE
pkg,version: bump to use v0.4.x branch

### DIFF
--- a/pkg/scaffold/ansible/gopkgtoml.go
+++ b/pkg/scaffold/ansible/gopkgtoml.go
@@ -35,8 +35,8 @@ func (s *GopkgToml) GetInput() (input.Input, error) {
 const gopkgTomlTmpl = `[[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
-  version = "=v0.4.0" #osdk_version_annotation
+  branch = "v0.4.x" #osdk_branch_annotation
+  # version = "=v0.4.0" #osdk_version_annotation
 
 [[override]]
   name = "k8s.io/api"

--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -89,8 +89,8 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
-  version = "=v0.4.0" #osdk_version_annotation
+  branch = "v0.4.x" #osdk_branch_annotation
+  # version = "=v0.4.0" #osdk_version_annotation
 
 [prune]
   go-tests = true

--- a/pkg/scaffold/gopkgtoml_test.go
+++ b/pkg/scaffold/gopkgtoml_test.go
@@ -81,8 +81,8 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
-  version = "=v0.4.0" #osdk_version_annotation
+  branch = "v0.4.x" #osdk_branch_annotation
+  # version = "=v0.4.0" #osdk_version_annotation
 
 [prune]
   go-tests = true

--- a/pkg/scaffold/helm/gopkgtoml.go
+++ b/pkg/scaffold/helm/gopkgtoml.go
@@ -35,8 +35,8 @@ func (s *GopkgToml) GetInput() (input.Input, error) {
 const gopkgTomlTmpl = `[[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
-  version = "=v0.4.0" #osdk_version_annotation
+  branch = "v0.4.x" #osdk_branch_annotation
+  # version = "=v0.4.0" #osdk_version_annotation
 
 [[override]]
   name = "k8s.io/kubernetes"

--- a/version/version.go
+++ b/version/version.go
@@ -15,5 +15,5 @@
 package version
 
 var (
-	Version = "v0.4.0"
+	Version = "v0.4.0+git"
 )


### PR DESCRIPTION
**Description of the change:** Update version and gopkg files to use v0.4.x branch instead of v0.4.0 tag


**Motivation for the change:** This ensures that cherry-picked commits pushed to the branch are tested correctly instead of using the old v0.4.0 tag