### PR TITLE
Fix typo in user guide

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -79,7 +79,7 @@ mgr, err := manager.New(cfg, manager.Options{Namespace: ""})
 
 ## Add a new Custom Resource Definition
 
-Add a new Custom Resource Definition(CRD) API called Memcached, with APIVersion `cache.example.com/v1apha1` and Kind `Memcached`.
+Add a new Custom Resource Definition(CRD) API called Memcached, with APIVersion `cache.example.com/v1alpha1` and Kind `Memcached`.
 
 ```sh
 $ operator-sdk add api --api-version=cache.example.com/v1alpha1 --kind=Memcached


### PR DESCRIPTION
**Description of the change:** `v1apha1` -> `v1alpha1`

**Motivation for the change:** Typos are bad
