### PR TITLE
pkg/ansible/controller; Check if GVK is already registered

### DIFF
--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -32,8 +32,11 @@ cp "$ROOTDIR/test/ansible-memcached/defaults.yml" memcached-operator/roles/memca
 cp "$ROOTDIR/test/ansible-memcached/asserts.yml"  memcached-operator/molecule/default/asserts.yml
 cp "$ROOTDIR/test/ansible-memcached/molecule.yml"  memcached-operator/molecule/test-local/molecule.yml
 cp -a "$ROOTDIR/test/ansible-memcached/memfin" memcached-operator/roles/
+cp -a "$ROOTDIR/test/ansible-memcached/secret" memcached-operator/roles/
 cat "$ROOTDIR/test/ansible-memcached/watches-finalizer.yaml" >> memcached-operator/watches.yaml
 cat "$ROOTDIR/test/ansible-memcached/prepare-test-image.yml" >> memcached-operator/molecule/test-local/prepare.yml
+# Append v1 kind to watches to test watching already registered GVK
+cat "$ROOTDIR/test/ansible-memcached/watches-v1-kind.yaml" >> memcached-operator/watches.yaml
 
 
 # Test local

--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -93,6 +93,7 @@ cp "$ROOTDIR/test/ansible-memcached/tasks.yml" memcached-operator/roles/memcache
 cp "$ROOTDIR/test/ansible-memcached/defaults.yml" memcached-operator/roles/memcached/defaults/main.yml
 cp -a "$ROOTDIR/test/ansible-memcached/memfin" memcached-operator/roles/
 cat "$ROOTDIR/test/ansible-memcached/watches-finalizer.yaml" >> memcached-operator/watches.yaml
+# Append Foo kind to watches to test watching multiple Kinds
 cat "$ROOTDIR/test/ansible-memcached/watches-foo-kind.yaml" >> memcached-operator/watches.yaml
 
 pushd memcached-operator

--- a/pkg/ansible/controller/controller.go
+++ b/pkg/ansible/controller/controller.go
@@ -64,12 +64,16 @@ func Add(mgr manager.Manager, options Options) *controller.Controller {
 		ManageStatus:    options.ManageStatus,
 	}
 
-	// Register the GVK with the schema
-	mgr.GetScheme().AddKnownTypeWithName(options.GVK, &unstructured.Unstructured{})
-	metav1.AddToGroupVersion(mgr.GetScheme(), schema.GroupVersion{
-		Group:   options.GVK.Group,
-		Version: options.GVK.Version,
-	})
+	scheme := mgr.GetScheme()
+	_, err := scheme.New(options.GVK)
+	if err != nil {
+		// Register the GVK with the schema
+		scheme.AddKnownTypeWithName(options.GVK, &unstructured.Unstructured{})
+		metav1.AddToGroupVersion(mgr.GetScheme(), schema.GroupVersion{
+			Group:   options.GVK.Group,
+			Version: options.GVK.Version,
+		})
+	}
 
 	//Create new controller runtime controller and set the controller to watch GVK.
 	c, err := controller.New(fmt.Sprintf("%v-controller", strings.ToLower(options.GVK.Kind)), mgr, controller.Options{

--- a/pkg/ansible/controller/controller.go
+++ b/pkg/ansible/controller/controller.go
@@ -26,6 +26,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	crthandler "sigs.k8s.io/controller-runtime/pkg/handler"
@@ -66,13 +67,16 @@ func Add(mgr manager.Manager, options Options) *controller.Controller {
 
 	scheme := mgr.GetScheme()
 	_, err := scheme.New(options.GVK)
-	if err != nil {
+	if runtime.IsNotRegisteredError(err) {
 		// Register the GVK with the schema
 		scheme.AddKnownTypeWithName(options.GVK, &unstructured.Unstructured{})
 		metav1.AddToGroupVersion(mgr.GetScheme(), schema.GroupVersion{
 			Group:   options.GVK.Group,
 			Version: options.GVK.Version,
 		})
+	} else if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
 	}
 
 	//Create new controller runtime controller and set the controller to watch GVK.

--- a/test/ansible-memcached/asserts.yml
+++ b/test/ansible-memcached/asserts.yml
@@ -56,6 +56,10 @@
             resource_name=custom_resource.metadata.name
           )}}'
 
+      - name: Verify that test-service was created
+        assert:
+          that: lookup('k8s', kind='Service', api_version='v1', namespace=namespace, resource_name='test-service')
+
       - name: Delete the custom resource
         k8s:
           state: absent
@@ -74,15 +78,15 @@
         until: not cr.resources
         failed_when: cr.resources
 
-      - name: Verify the ConfigMap was deleted
-        assert:
-          that: not lookup('k8s', kind='ConfigMap', api_version='v1', namespace=namespace, resource_name='deleteme')
-
       - name: Verify the Deployment was deleted (wait 30s)
         assert:
           that: not lookup('k8s', kind='Deployment', api_version='apps/v1', namespace=namespace, label_selector='app=memcached')
         retries: 10
         delay: 3
+
+      - name: Verify that test-service was deleted
+        assert:
+          that: not lookup('k8s', kind='Service', api_version='v1', namespace=namespace, resource_name='test-service')
 
       rescue:
       - name: debug cr

--- a/test/ansible-memcached/asserts.yml
+++ b/test/ansible-memcached/asserts.yml
@@ -56,6 +56,7 @@
             resource_name=custom_resource.metadata.name
           )}}'
 
+      # This will verify that the `secret` role was executed
       - name: Verify that test-service was created
         assert:
           that: lookup('k8s', kind='Service', api_version='v1', namespace=namespace, resource_name='test-service')
@@ -83,10 +84,6 @@
           that: not lookup('k8s', kind='Deployment', api_version='apps/v1', namespace=namespace, label_selector='app=memcached')
         retries: 10
         delay: 3
-
-      - name: Verify that test-service was deleted
-        assert:
-          that: not lookup('k8s', kind='Service', api_version='v1', namespace=namespace, resource_name='test-service')
 
       rescue:
       - name: debug cr

--- a/test/ansible-memcached/secret/tasks/main.yml
+++ b/test/ansible-memcached/secret/tasks/main.yml
@@ -3,6 +3,13 @@
     definition:
       kind: Service
       api_version: v1
-      name: test-service
-      namespace: default
+      metadata:
+        name: test-service
+        namespace: default
+      spec:
+        ports:
+        - protocol: TCP
+          port: 8332
+          targetPort: 8332
+          name: rpc
       state: present

--- a/test/ansible-memcached/secret/tasks/main.yml
+++ b/test/ansible-memcached/secret/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: Create test service
+  k8s:
+    definition:
+      kind: Service
+      api_version: v1
+      name: test-service
+      namespace: default
+      state: present

--- a/test/ansible-memcached/secret/tasks/main.yml
+++ b/test/ansible-memcached/secret/tasks/main.yml
@@ -12,4 +12,3 @@
           port: 8332
           targetPort: 8332
           name: rpc
-      state: present

--- a/test/ansible-memcached/tasks.yml
+++ b/test/ansible-memcached/tasks.yml
@@ -43,3 +43,13 @@
     namespace: "{{ meta.namespace }}"
     status:
       test: "hello world"
+
+- k8s:
+    definition:
+      kind: Secret
+      apiVersion: v1
+      metadata:
+        name: test-secret
+        namespace: "{{ meta.namespace }}"
+      data:
+        test: "hello" | b64encode

--- a/test/ansible-memcached/tasks.yml
+++ b/test/ansible-memcached/tasks.yml
@@ -52,4 +52,4 @@
         name: test-secret
         namespace: "{{ meta.namespace }}"
       data:
-        test: "hello" | b64encode
+        test: aGVsbG8K

--- a/test/ansible-memcached/watches-v1-kind.yaml
+++ b/test/ansible-memcached/watches-v1-kind.yaml
@@ -1,4 +1,4 @@
 - version: v1
   group:
-  kind: Pod
+  kind: Secret
   role: /opt/ansible/roles/secret

--- a/test/ansible-memcached/watches-v1-kind.yaml
+++ b/test/ansible-memcached/watches-v1-kind.yaml
@@ -1,0 +1,4 @@
+- version: v1
+  group:
+  kind: Pod
+  role: /opt/ansible/roles/secret

--- a/test/ansible-memcached/watches-v1-kind.yaml
+++ b/test/ansible-memcached/watches-v1-kind.yaml
@@ -2,3 +2,4 @@
   group:
   kind: Secret
   role: /opt/ansible/roles/secret
+  manageStatus: false


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Fixes controller.Add so that we aren't double-registering GVKs. We check if the GVK is already registered before we attempt to register it again.

**Motivation for the change:**
Currently Ansible Operator is unable to watch any resources that exist in the core API groups.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
