### PR TITLE
Remove hyphen from controller generated code

### DIFF
--- a/pkg/scaffold/addtoscheme.go
+++ b/pkg/scaffold/addtoscheme.go
@@ -33,7 +33,7 @@ type AddToScheme struct {
 func (s *AddToScheme) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		fileName := fmt.Sprintf("addtoscheme_%s_%s.go",
-			GoImportGroup(s.Resource.Group),
+			strings.ToLower(s.Resource.GoImportGroup),
 			strings.ToLower(s.Resource.Version))
 		s.Path = filepath.Join(ApisDir, fileName)
 	}
@@ -44,7 +44,7 @@ func (s *AddToScheme) GetInput() (input.Input, error) {
 const addToSchemeTemplate = `package apis
 
 import (
-	"{{ .Repo }}/pkg/apis/{{ (goimport .Resource.Group)}}/{{ .Resource.Version }}"
+	"{{ .Repo }}/pkg/apis/{{ .Resource.GoImportGroup}}/{{ .Resource.Version }}"
 )
 
 func init() {

--- a/pkg/scaffold/addtoscheme.go
+++ b/pkg/scaffold/addtoscheme.go
@@ -33,7 +33,7 @@ type AddToScheme struct {
 func (s *AddToScheme) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		fileName := fmt.Sprintf("addtoscheme_%s_%s.go",
-			strings.ToLower(s.Resource.Group),
+			GoImportGroup(s.Resource.Group),
 			strings.ToLower(s.Resource.Version))
 		s.Path = filepath.Join(ApisDir, fileName)
 	}
@@ -44,7 +44,7 @@ func (s *AddToScheme) GetInput() (input.Input, error) {
 const addToSchemeTemplate = `package apis
 
 import (
-	"{{ .Repo }}/pkg/apis/{{ .Resource.Group }}/{{ .Resource.Version }}"
+	"{{ .Repo }}/pkg/apis/{{ (goimport .Resource.Group)}}/{{ .Resource.Version }}"
 )
 
 func init() {

--- a/pkg/scaffold/addtoscheme.go
+++ b/pkg/scaffold/addtoscheme.go
@@ -33,7 +33,7 @@ type AddToScheme struct {
 func (s *AddToScheme) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		fileName := fmt.Sprintf("addtoscheme_%s_%s.go",
-			strings.ToLower(s.Resource.GoImportGroup),
+			s.Resource.GoImportGroup,
 			strings.ToLower(s.Resource.Version))
 		s.Path = filepath.Join(ApisDir, fileName)
 	}

--- a/pkg/scaffold/controller_kind.go
+++ b/pkg/scaffold/controller_kind.go
@@ -44,7 +44,7 @@ const controllerKindTemplate = `package {{ .Resource.LowerKind }}
 import (
 	"context"
 
-	{{ (underscore .Resource.Group)}}{{ .Resource.Version }} "{{ .Repo }}/pkg/apis/{{ .Resource.Group}}/{{ .Resource.Version }}"
+	{{ (rmhyphen .Resource.Group)}}{{ .Resource.Version }} "{{ .Repo }}/pkg/apis/{{ .Resource.Group}}/{{ .Resource.Version }}"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -88,7 +88,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource {{ .Resource.Kind }}
-	err = c.Watch(&source.Kind{Type: &{{ (underscore .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &{{ (rmhyphen .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Watch for changes to secondary resource Pods and requeue the owner {{ .Resource.Kind }}
 	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
-		OwnerType:    &{{ (underscore .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{},
+		OwnerType:    &{{ (rmhyphen .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{},
 	})
 	if err != nil {
 		return err
@@ -128,7 +128,7 @@ func (r *Reconcile{{ .Resource.Kind }}) Reconcile(request reconcile.Request) (re
 	reqLogger.Info("Reconciling {{ .Resource.Kind }}")
 
 	// Fetch the {{ .Resource.Kind }} instance
-	instance := &{{ (underscore .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}
+	instance := &{{ (rmhyphen .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -171,7 +171,7 @@ func (r *Reconcile{{ .Resource.Kind }}) Reconcile(request reconcile.Request) (re
 }
 
 // newPodForCR returns a busybox pod with the same name/namespace as the cr
-func newPodForCR(cr *{{ (underscore .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}) *corev1.Pod {
+func newPodForCR(cr *{{ (rmhyphen .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}) *corev1.Pod {
 	labels := map[string]string{
 		"app": cr.Name,
 	}

--- a/pkg/scaffold/controller_kind.go
+++ b/pkg/scaffold/controller_kind.go
@@ -44,7 +44,7 @@ const controllerKindTemplate = `package {{ .Resource.LowerKind }}
 import (
 	"context"
 
-	{{ (goimport .Resource.Group)}}{{ .Resource.Version }} "{{ .Repo }}/pkg/apis/{{ (goimport .Resource.Group)}}/{{ .Resource.Version }}"
+	{{ .Resource.GoImportGroup}}{{ .Resource.Version }} "{{ .Repo }}/pkg/apis/{{ .Resource.GoImportGroup}}/{{ .Resource.Version }}"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -88,7 +88,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource {{ .Resource.Kind }}
-	err = c.Watch(&source.Kind{Type: &{{ (goimport .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &{{ .Resource.GoImportGroup}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Watch for changes to secondary resource Pods and requeue the owner {{ .Resource.Kind }}
 	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
-		OwnerType:    &{{ (goimport .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{},
+		OwnerType:    &{{ .Resource.GoImportGroup}}{{ .Resource.Version }}.{{ .Resource.Kind }}{},
 	})
 	if err != nil {
 		return err
@@ -128,7 +128,7 @@ func (r *Reconcile{{ .Resource.Kind }}) Reconcile(request reconcile.Request) (re
 	reqLogger.Info("Reconciling {{ .Resource.Kind }}")
 
 	// Fetch the {{ .Resource.Kind }} instance
-	instance := &{{ (goimport .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}
+	instance := &{{ .Resource.GoImportGroup}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -171,7 +171,7 @@ func (r *Reconcile{{ .Resource.Kind }}) Reconcile(request reconcile.Request) (re
 }
 
 // newPodForCR returns a busybox pod with the same name/namespace as the cr
-func newPodForCR(cr *{{ (goimport .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}) *corev1.Pod {
+func newPodForCR(cr *{{ .Resource.GoImportGroup}}{{ .Resource.Version }}.{{ .Resource.Kind }}) *corev1.Pod {
 	labels := map[string]string{
 		"app": cr.Name,
 	}

--- a/pkg/scaffold/controller_kind.go
+++ b/pkg/scaffold/controller_kind.go
@@ -44,7 +44,7 @@ const controllerKindTemplate = `package {{ .Resource.LowerKind }}
 import (
 	"context"
 
-	{{ (rmhyphen .Resource.Group)}}{{ .Resource.Version }} "{{ .Repo }}/pkg/apis/{{ .Resource.Group}}/{{ .Resource.Version }}"
+	{{ (goimport .Resource.Group)}}{{ .Resource.Version }} "{{ .Repo }}/pkg/apis/{{ (goimport .Resource.Group)}}/{{ .Resource.Version }}"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -88,7 +88,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource {{ .Resource.Kind }}
-	err = c.Watch(&source.Kind{Type: &{{ (rmhyphen .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &{{ (goimport .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Watch for changes to secondary resource Pods and requeue the owner {{ .Resource.Kind }}
 	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
-		OwnerType:    &{{ (rmhyphen .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{},
+		OwnerType:    &{{ (goimport .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{},
 	})
 	if err != nil {
 		return err
@@ -128,7 +128,7 @@ func (r *Reconcile{{ .Resource.Kind }}) Reconcile(request reconcile.Request) (re
 	reqLogger.Info("Reconciling {{ .Resource.Kind }}")
 
 	// Fetch the {{ .Resource.Kind }} instance
-	instance := &{{ (rmhyphen .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}
+	instance := &{{ (goimport .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -171,7 +171,7 @@ func (r *Reconcile{{ .Resource.Kind }}) Reconcile(request reconcile.Request) (re
 }
 
 // newPodForCR returns a busybox pod with the same name/namespace as the cr
-func newPodForCR(cr *{{ (rmhyphen .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}) *corev1.Pod {
+func newPodForCR(cr *{{ (goimport .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}) *corev1.Pod {
 	labels := map[string]string{
 		"app": cr.Name,
 	}

--- a/pkg/scaffold/controller_kind.go
+++ b/pkg/scaffold/controller_kind.go
@@ -44,7 +44,7 @@ const controllerKindTemplate = `package {{ .Resource.LowerKind }}
 import (
 	"context"
 
-	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .Repo }}/pkg/apis/{{ .Resource.Group}}/{{ .Resource.Version }}"
+	{{ (underscore .Resource.Group)}}{{ .Resource.Version }} "{{ .Repo }}/pkg/apis/{{ .Resource.Group}}/{{ .Resource.Version }}"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -88,7 +88,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource {{ .Resource.Kind }}
-	err = c.Watch(&source.Kind{Type: &{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &{{ (underscore .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Watch for changes to secondary resource Pods and requeue the owner {{ .Resource.Kind }}
 	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
-		OwnerType:    &{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}{},
+		OwnerType:    &{{ (underscore .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{},
 	})
 	if err != nil {
 		return err
@@ -128,7 +128,7 @@ func (r *Reconcile{{ .Resource.Kind }}) Reconcile(request reconcile.Request) (re
 	reqLogger.Info("Reconciling {{ .Resource.Kind }}")
 
 	// Fetch the {{ .Resource.Kind }} instance
-	instance := &{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}
+	instance := &{{ (underscore .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -171,7 +171,7 @@ func (r *Reconcile{{ .Resource.Kind }}) Reconcile(request reconcile.Request) (re
 }
 
 // newPodForCR returns a busybox pod with the same name/namespace as the cr
-func newPodForCR(cr *{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}) *corev1.Pod {
+func newPodForCR(cr *{{ (underscore .Resource.Group)}}{{ .Resource.Version }}.{{ .Resource.Kind }}) *corev1.Pod {
 	labels := map[string]string{
 		"app": cr.Name,
 	}

--- a/pkg/scaffold/doc.go
+++ b/pkg/scaffold/doc.go
@@ -34,7 +34,7 @@ type Doc struct {
 func (s *Doc) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		s.Path = filepath.Join(ApisDir,
-			GoImportGroup(s.Resource.Group),
+			s.Resource.GoImportGroup,
 			strings.ToLower(s.Resource.Version),
 			DocFile)
 	}

--- a/pkg/scaffold/doc.go
+++ b/pkg/scaffold/doc.go
@@ -34,7 +34,7 @@ type Doc struct {
 func (s *Doc) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		s.Path = filepath.Join(ApisDir,
-			strings.ToLower(s.Resource.Group),
+			GoImportGroup(s.Resource.Group),
 			strings.ToLower(s.Resource.Version),
 			DocFile)
 	}

--- a/pkg/scaffold/register.go
+++ b/pkg/scaffold/register.go
@@ -34,7 +34,7 @@ type Register struct {
 func (s *Register) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		s.Path = filepath.Join(ApisDir,
-			GoImportGroup(s.Resource.Group),
+			s.Resource.GoImportGroup,
 			strings.ToLower(s.Resource.Version),
 			RegisterFile)
 	}

--- a/pkg/scaffold/register.go
+++ b/pkg/scaffold/register.go
@@ -34,7 +34,7 @@ type Register struct {
 func (s *Register) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		s.Path = filepath.Join(ApisDir,
-			strings.ToLower(s.Resource.Group),
+			GoImportGroup(s.Resource.Group),
 			strings.ToLower(s.Resource.Version),
 			RegisterFile)
 	}

--- a/pkg/scaffold/resource.go
+++ b/pkg/scaffold/resource.go
@@ -61,6 +61,9 @@ type Resource struct {
 	// LowerKind is lowercased(Kind) e.g appservice
 	LowerKind string
 
+	// GoImportGroup is the non-hyphenated go import group for this resource
+	GoImportGroup string
+
 	// TODO: allow user to specify list of short names for Resource e.g app, myapp
 }
 
@@ -95,6 +98,8 @@ func (r *Resource) Validate() error {
 	if len(r.Resource) == 0 {
 		r.Resource = rs.Pluralize(strings.ToLower(r.Kind))
 	}
+
+	r.setImportGroup()
 
 	return nil
 }
@@ -144,4 +149,9 @@ func (r *Resource) checkAndSetVersion() error {
 		return errors.New("version is not in the correct Kubernetes version format, ex. v1alpha1")
 	}
 	return nil
+}
+
+func (r *Resource) setImportGroup() {
+	s := strings.ToLower(r.Group)
+	r.GoImportGroup = strings.Replace(s, "-", "", -1)
 }

--- a/pkg/scaffold/resource.go
+++ b/pkg/scaffold/resource.go
@@ -51,6 +51,9 @@ type Resource struct {
 	// Parsed from APIVersion
 	Group string
 
+	// GoImportGroup is the non-hyphenated go import group for this resource
+	GoImportGroup string
+
 	// Version is the API version - e.g. v1alpha1
 	// Parsed from APIVersion
 	Version string
@@ -60,9 +63,6 @@ type Resource struct {
 
 	// LowerKind is lowercased(Kind) e.g appservice
 	LowerKind string
-
-	// GoImportGroup is the non-hyphenated go import group for this resource
-	GoImportGroup string
 
 	// TODO: allow user to specify list of short names for Resource e.g app, myapp
 }
@@ -99,8 +99,6 @@ func (r *Resource) Validate() error {
 		r.Resource = rs.Pluralize(strings.ToLower(r.Kind))
 	}
 
-	r.setImportGroup()
-
 	return nil
 }
 
@@ -132,6 +130,9 @@ func (r *Resource) checkAndSetGroups() error {
 	r.FullGroup = fg[0]
 	r.Group = g[0]
 
+	s := strings.ToLower(r.Group)
+	r.GoImportGroup = strings.Replace(s, "-", "", -1)
+
 	if err := validation.IsDNS1123Subdomain(r.Group); err != nil {
 		return fmt.Errorf("group name is invalid: %v", err)
 	}
@@ -149,9 +150,4 @@ func (r *Resource) checkAndSetVersion() error {
 		return errors.New("version is not in the correct Kubernetes version format, ex. v1alpha1")
 	}
 	return nil
-}
-
-func (r *Resource) setImportGroup() {
-	s := strings.ToLower(r.Group)
-	r.GoImportGroup = strings.Replace(s, "-", "", -1)
 }

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -191,10 +191,16 @@ func newTemplate(i input.Input) (*template.Template, error) {
 	t := template.New(i.Path).Funcs(template.FuncMap{
 		"title":    strings.Title,
 		"lower":    strings.ToLower,
-		"rmhyphen": func(a string) string { return strings.Replace(a, "-", "", -1) },
+		"goimport": GoImportGroup,
 	})
 	if len(i.TemplateFuncs) > 0 {
 		t.Funcs(i.TemplateFuncs)
 	}
 	return t.Parse(i.TemplateBody)
+}
+
+// GoImportGroup returns a copy of the string s with package naming convention.
+func GoImportGroup(s string) string {
+	s = strings.ToLower(s)
+	return strings.Replace(s, "-", "", -1)
 }

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -189,18 +189,11 @@ func (s *Scaffold) doRender(i input.Input, e input.File, absPath string) error {
 // the input's TemplateFuncs.
 func newTemplate(i input.Input) (*template.Template, error) {
 	t := template.New(i.Path).Funcs(template.FuncMap{
-		"title":    strings.Title,
-		"lower":    strings.ToLower,
-		"goimport": GoImportGroup,
+		"title": strings.Title,
+		"lower": strings.ToLower,
 	})
 	if len(i.TemplateFuncs) > 0 {
 		t.Funcs(i.TemplateFuncs)
 	}
 	return t.Parse(i.TemplateBody)
-}
-
-// GoImportGroup returns a copy of the string s with package naming convention.
-func GoImportGroup(s string) string {
-	s = strings.ToLower(s)
-	return strings.Replace(s, "-", "", -1)
 }

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -189,8 +189,9 @@ func (s *Scaffold) doRender(i input.Input, e input.File, absPath string) error {
 // the input's TemplateFuncs.
 func newTemplate(i input.Input) (*template.Template, error) {
 	t := template.New(i.Path).Funcs(template.FuncMap{
-		"title": strings.Title,
-		"lower": strings.ToLower,
+		"title":      strings.Title,
+		"lower":      strings.ToLower,
+		"underscore": func(a string) string { return strings.Replace(a, "-", "_", -1) },
 	})
 	if len(i.TemplateFuncs) > 0 {
 		t.Funcs(i.TemplateFuncs)

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -189,9 +189,9 @@ func (s *Scaffold) doRender(i input.Input, e input.File, absPath string) error {
 // the input's TemplateFuncs.
 func newTemplate(i input.Input) (*template.Template, error) {
 	t := template.New(i.Path).Funcs(template.FuncMap{
-		"title":      strings.Title,
-		"lower":      strings.ToLower,
-		"underscore": func(a string) string { return strings.Replace(a, "-", "_", -1) },
+		"title":    strings.Title,
+		"lower":    strings.ToLower,
+		"rmhyphen": func(a string) string { return strings.Replace(a, "-", "", -1) },
 	})
 	if len(i.TemplateFuncs) > 0 {
 		t.Funcs(i.TemplateFuncs)

--- a/pkg/scaffold/types.go
+++ b/pkg/scaffold/types.go
@@ -32,7 +32,7 @@ type Types struct {
 func (s *Types) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		s.Path = filepath.Join(ApisDir,
-			strings.ToLower(s.Resource.Group),
+			GoImportGroup(s.Resource.Group),
 			strings.ToLower(s.Resource.Version),
 			s.Resource.LowerKind+"_types.go")
 	}

--- a/pkg/scaffold/types.go
+++ b/pkg/scaffold/types.go
@@ -32,7 +32,7 @@ type Types struct {
 func (s *Types) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		s.Path = filepath.Join(ApisDir,
-			GoImportGroup(s.Resource.Group),
+			s.Resource.GoImportGroup,
 			strings.ToLower(s.Resource.Version),
 			s.Resource.LowerKind+"_types.go")
 	}


### PR DESCRIPTION
**Description of the change:**

Currently, if API group contains hyphen(`-`), `operator-sdk add controller` 
fails to execute because Go does not allow us to use
hyphone for import package alias.

Since API group accepts hyphen in Kubernetes, openshift-sdk should
handle hyphen in API group as well.

This patch replaces `-` with `_` in generated code.


**Motivation for the change:**

Fixes https://github.com/operator-framework/operator-sdk/issues/997
