### PR TITLE
Output error message with command usage when `operator-sdk scorecard` failed with invalid options

### DIFF
--- a/commands/operator-sdk/cmd/scorecard/scorecard.go
+++ b/commands/operator-sdk/cmd/scorecard/scorecard.go
@@ -92,8 +92,6 @@ var (
 const scorecardPodName = "operator-scorecard-test"
 
 func ScorecardTests(cmd *cobra.Command, args []string) error {
-	// in main.go, we catch and print errors, so we don't want cobra to print the error itself
-	cmd.SilenceErrors = true
 	if !SCConf.BasicTests && !SCConf.OLMTests {
 		return errors.New("at least one test type is required")
 	}


### PR DESCRIPTION
Currently `operator-sdk scorecard` does not output any reason why the
command failed, when the usage was wrong. This patch outputs the error
message to make it user friendly.

**Motivation for the change:**
Fixes https://github.com/operator-framework/operator-sdk/issues/1003
