### PR TITLE
Add clear error message when kubeconfig is missing for `operator-sdk scorecard`

### DIFF
--- a/commands/operator-sdk/cmd/scorecard/scorecard.go
+++ b/commands/operator-sdk/cmd/scorecard/scorecard.go
@@ -142,7 +142,7 @@ func ScorecardTests(cmd *cobra.Command, args []string) error {
 	var err error
 	kubeconfig, SCConf.Namespace, err = k8sInternal.GetKubeconfigAndNamespace(SCConf.KubeconfigPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to build the kubeconfig: %v", err)
 	}
 	scheme := runtime.NewScheme()
 	// scheme for client go


### PR DESCRIPTION
**Motivation for the change:**

Executing `operator-sdk scorecard` without setting `kubeconfig` fails with
following error:

BEFORE:
```
$ operator-sdk scorecard --cr-manifest deploy/crds/app_v1alpha1_appservice_cr.yaml --olm-tests=false
Error: invalid configuration: no configuration has been provided
```

It is difficult to realize what config file was invalid by reading the message
`Error: invalid configuration: no configuration has been provided`.

This patch adds clear message when kubeconfig is missing or failed to
parse.

AFTER:
```
$ operator-sdk scorecard --cr-manifest deploy/crds/cache_v1alpha1_memcached_cr.yaml --olm-tests=false
Error: failed to build the kubeconfig: invalid configuration: no configuration has been provided
```