### PR TITLE
Do not let operator-sdk add crd overwrite exsiting file

### DIFF
--- a/pkg/scaffold/cr.go
+++ b/pkg/scaffold/cr.go
@@ -38,6 +38,7 @@ func (s *Cr) GetInput() (input.Input, error) {
 			s.Resource.LowerKind)
 		s.Path = filepath.Join(CrdsDir, fileName)
 	}
+	s.IfExistsAction = input.Skip
 	s.TemplateBody = crTemplate
 	return s.Input, nil
 }

--- a/pkg/scaffold/crd.go
+++ b/pkg/scaffold/crd.go
@@ -38,6 +38,7 @@ func (s *Crd) GetInput() (input.Input, error) {
 			s.Resource.LowerKind)
 		s.Path = filepath.Join(CrdsDir, fileName)
 	}
+	s.IfExistsAction = input.Skip
 	s.TemplateBody = crdTemplate
 	return s.Input, nil
 }


### PR DESCRIPTION
**Description of the change:**

`operator-sdk add crd` commands overwrites
`deploy/crds/app_v1alpha1_example_{crd,cr}.yaml` even if files exist.

This patch changes to skip overwrites if the file exists.


**Motivation for the change:**

Fixes https://github.com/operator-framework/operator-sdk/issues/1006
