### PR TITLE
test/e2e,pkg/test/e2eutil: re-enable and fix leader election e2e test

### DIFF
--- a/pkg/test/e2eutil/wait_util.go
+++ b/pkg/test/e2eutil/wait_util.go
@@ -15,6 +15,7 @@
 package e2eutil
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -22,8 +23,10 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // WaitForDeployment checks to see if a given deployment has a certain number of available replicas after a specified amount of time
@@ -65,5 +68,32 @@ func waitForDeployment(t *testing.T, kubeclient kubernetes.Interface, namespace,
 		return err
 	}
 	t.Logf("Deployment available (%d/%d)\n", replicas, replicas)
+	return nil
+}
+
+func WaitForDeletion(t *testing.T, dynclient client.Client, obj runtime.Object, retryInterval, timeout time.Duration) error {
+	key, err := client.ObjectKeyFromObject(obj)
+	if err != nil {
+		return err
+	}
+
+	kind := obj.GetObjectKind().GroupVersionKind().Kind
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		err = dynclient.Get(ctx, key, obj)
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		t.Logf("Waiting for %s %s to be deleted\n", kind, key)
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	t.Logf("%s %s was deleted\n", kind, key)
 	return nil
 }

--- a/test/e2e/incluster-test-code/memcached_test.go.tmpl
+++ b/test/e2e/incluster-test-code/memcached_test.go.tmpl
@@ -114,7 +114,7 @@ func MemcachedCluster(t *testing.T) {
 	// get global framework variables
 	f := framework.Global
 	// wait for memcached-operator to be ready
-	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "memcached-operator", 1, retryInterval, timeout)
+	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "memcached-operator", 2, retryInterval, timeout)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -137,21 +137,18 @@ func TestMemcached(t *testing.T) {
 		t.Fatalf("Error after modifying Gopkg.toml: %v\nCommand Output: %s\n", err, string(cmdOut))
 	}
 
-	// Temporarily disabling the leader election test due to GitHub issue #920 and PR #932.
-	// TODO: Update this test so that it works with the changes from #932
-	//
-	// // Set replicas to 2 to test leader election. In production, this should
-	// // almost always be set to 1, because there isn't generally value in having
-	// // a hot spare operator process.
-	// opYaml, err := ioutil.ReadFile("deploy/operator.yaml")
-	// if err != nil {
-	// 	t.Fatalf("Could not read deploy/operator.yaml: %v", err)
-	// }
-	// newOpYaml := bytes.Replace(opYaml, []byte("replicas: 1"), []byte("replicas: 2"), 1)
-	// err = ioutil.WriteFile("deploy/operator.yaml", newOpYaml, 0644)
-	// if err != nil {
-	// 	t.Fatalf("Could not write deploy/operator.yaml: %v", err)
-	// }
+	// Set replicas to 2 to test leader election. In production, this should
+	// almost always be set to 1, because there isn't generally value in having
+	// a hot spare operator process.
+	opYaml, err := ioutil.ReadFile("deploy/operator.yaml")
+	if err != nil {
+		t.Fatalf("Could not read deploy/operator.yaml: %v", err)
+	}
+	newOpYaml := bytes.Replace(opYaml, []byte("replicas: 1"), []byte("replicas: 2"), 1)
+	err = ioutil.WriteFile("deploy/operator.yaml", newOpYaml, 0644)
+	if err != nil {
+		t.Fatalf("Could not write deploy/operator.yaml: %v", err)
+	}
 
 	cmdOut, err = exec.Command("operator-sdk",
 		"add",
@@ -273,7 +270,7 @@ func memcachedLeaderTest(t *testing.T, f *framework.Framework, ctx *framework.Te
 		return err
 	}
 
-	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "memcached-operator", 1, retryInterval, timeout)
+	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "memcached-operator", 2, retryInterval, timeout)
 	if err != nil {
 		return err
 	}
@@ -289,7 +286,12 @@ func memcachedLeaderTest(t *testing.T, f *framework.Framework, ctx *framework.Te
 		return err
 	}
 
-	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "memcached-operator", 1, retryInterval, timeout)
+	err = e2eutil.WaitForDeletion(t, f.Client.Client, leader, retryInterval, timeout)
+	if err != nil {
+		return err
+	}
+
+	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "memcached-operator", 2, retryInterval, timeout)
 	if err != nil {
 		return err
 	}
@@ -508,16 +510,14 @@ func MemcachedCluster(t *testing.T) {
 		t.Fatal(err)
 	}
 	// wait for memcached-operator to be ready
-	err = e2eutil.WaitForOperatorDeployment(t, framework.Global.KubeClient, namespace, "memcached-operator", 1, retryInterval, timeout)
+	err = e2eutil.WaitForOperatorDeployment(t, framework.Global.KubeClient, namespace, "memcached-operator", 2, retryInterval, timeout)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Temporarily disabling the leader election test due to GitHub issue #920 and PR #932.
-	// TODO: Update this test so that it works with the changes from #932
-	// if err = memcachedLeaderTest(t, framework.Global, ctx); err != nil {
-	// 	t.Fatal(err)
-	// }
+	if err = memcachedLeaderTest(t, framework.Global, ctx); err != nil {
+		t.Fatal(err)
+	}
 
 	if err = memcachedScaleTest(t, framework.Global, ctx); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
**Description of the change:**
* Re-enables and fixes leader election tests
* Adds `e2eutil.WaitForDeletion()` to help avoid test flakes 

**Motivation for the change:**
Closes #934 
