### PR TITLE
commands/operator-sdk/cmd/up/local.go: build and run binary directly

### DIFF
--- a/commands/operator-sdk/cmd/up/local.go
+++ b/commands/operator-sdk/cmd/up/local.go
@@ -178,7 +178,7 @@ func upLocalHelm() error {
 func buildLocal(outputBinName string) error {
 	args := []string{"build", "-o", outputBinName}
 	if ldFlags != "" {
-		args = append(args, []string{"-ldflags", ldFlags}...)
+		args = append(args, "-ldflags", ldFlags)
 	}
 	args = append(args, filepath.Join(scaffold.ManagerDir, scaffold.CmdFile))
 

--- a/commands/operator-sdk/cmd/up/local.go
+++ b/commands/operator-sdk/cmd/up/local.go
@@ -89,7 +89,6 @@ func upLocalFunc(cmd *cobra.Command, args []string) error {
 	t := projutil.GetOperatorType()
 	switch t {
 	case projutil.OperatorTypeGo:
-		projutil.MustInProjectRoot()
 		return upLocal()
 	case projutil.OperatorTypeAnsible:
 		return upLocalAnsible()
@@ -100,16 +99,20 @@ func upLocalFunc(cmd *cobra.Command, args []string) error {
 }
 
 func upLocal() error {
-	args := []string{"run"}
-	if ldFlags != "" {
-		args = append(args, []string{"-ldflags", ldFlags}...)
+	projutil.MustInProjectRoot()
+	absProjectPath := projutil.MustGetwd()
+	projectName := filepath.Base(absProjectPath)
+	outputBinName := filepath.Join(scaffold.BuildBinDir, projectName+"-local")
+	if err := buildLocal(outputBinName); err != nil {
+		return fmt.Errorf("failed to build operator to run locally: (%v)", err)
 	}
-	args = append(args, filepath.Join(scaffold.ManagerDir, scaffold.CmdFile))
+
+	args := []string{}
 	if operatorFlags != "" {
 		extraArgs := strings.Split(operatorFlags, " ")
 		args = append(args, extraArgs...)
 	}
-	dc := exec.Command("go", args...)
+	dc := exec.Command(outputBinName, args...)
 	c := make(chan os.Signal)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
@@ -120,8 +123,6 @@ func upLocal() error {
 		}
 		os.Exit(0)
 	}()
-	dc.Stdout = os.Stdout
-	dc.Stderr = os.Stderr
 	dc.Env = os.Environ()
 	// only set env var if user explicitly specified a kubeconfig path
 	if kubeConfig != "" {
@@ -172,6 +173,20 @@ func upLocalHelm() error {
 	}
 
 	return helm.Run(helmOperatorFlags)
+}
+
+func buildLocal(outputBinName string) error {
+	args := []string{"build", "-o", outputBinName}
+	if ldFlags != "" {
+		args = append(args, []string{"-ldflags", ldFlags}...)
+	}
+	args = append(args, filepath.Join(scaffold.ManagerDir, scaffold.CmdFile))
+
+	bc := exec.Command("go", args...)
+	if err := projutil.ExecCmd(bc); err != nil {
+		return err
+	}
+	return nil
 }
 
 func printVersion() {


### PR DESCRIPTION
**Description of the change:**
Changes `operator-sdk up local` for Go projects to stop using `go run` and instead use `go build` followed by executing the binary directly.

**Motivation for the change:**
e2e tests that use `operator-sdk up local` are not properly cleaned up because [`go run` does not forward signals to its child process](https://github.com/golang/go/issues/15553#issuecomment-217162874).

As a result, there is a leftover process listening on port `8383` (for metrics exporting) that causes future runs of the e2e test to fail due to not being able to listen on port `8383`
