### PR TITLE
OLM version update

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -559,7 +559,8 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:3dcc854b578714014e88a91805fd4f947713f3400ebb521095db97a5036eb89f"
+  branch = "master"
+  digest = "1:23e2e9001efb9eed6c89b080366f0a483dcc5edbb5b9ed89c0c838258467e6b1"
   name = "github.com/operator-framework/operator-lifecycle-manager"
   packages = [
     "pkg/api/apis/operators",
@@ -574,7 +575,7 @@
     "pkg/lib/ownerutil",
   ]
   pruneopts = "UT"
-  revision = "7ba3268c94bb247da0e5f3e1e625b5347ad9f1fb"
+  revision = "5eb7ae5bdb7ac36a26d6e34e5d0ec07be128927f"
 
 [[projects]]
   digest = "1:e5d0bd87abc2781d14e274807a470acd180f0499f8bf5bb18606e9ec22ad9de9"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -44,7 +44,7 @@
 
 [[constraint]]
   name = "github.com/operator-framework/operator-lifecycle-manager"
-  revision = "7ba3268c94bb247da0e5f3e1e625b5347ad9f1fb"
+  revision = "5eb7ae5bdb7ac36a26d6e34e5d0ec07be128927f"
 
 [[override]]
   name = "k8s.io/kube-aggregator"

--- a/commands/operator-sdk/cmd/scorecard/olm_tests.go
+++ b/commands/operator-sdk/cmd/scorecard/olm_tests.go
@@ -17,14 +17,14 @@ package scorecard
 import (
 	"context"
 
-	olmAPI "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	olmapiv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // crdsHaveResources checks to make sure that all owned CRDs have resources listed
-func crdsHaveResources(csv *olmAPI.ClusterServiceVersion) {
+func crdsHaveResources(csv *olmapiv1alpha1.ClusterServiceVersion) {
 	test := scorecardTest{testType: olmIntegration, name: "Owned CRDs have resources listed"}
 	for _, crd := range csv.Spec.CustomResourceDefinitions.Owned {
 		test.maximumPoints++
@@ -39,19 +39,19 @@ func crdsHaveResources(csv *olmAPI.ClusterServiceVersion) {
 }
 
 // annotationsContainExamples makes sure that the CSVs list at least 1 example for the CR
-func annotationsContainExamples(csv *olmAPI.ClusterServiceVersion) {
+func annotationsContainExamples(csv *olmapiv1alpha1.ClusterServiceVersion) {
 	test := scorecardTest{testType: olmIntegration, name: "CRs have at least 1 example", maximumPoints: 1}
 	if csv.Annotations != nil && csv.Annotations["alm-examples"] != "" {
 		test.earnedPoints = 1
 	}
 	scTests = append(scTests, test)
 	if test.earnedPoints == 0 {
-		scSuggestions = append(scSuggestions, "Add an alm-examples annotation to your CSV to pass the " + test.name + " test")
+		scSuggestions = append(scSuggestions, "Add an alm-examples annotation to your CSV to pass the "+test.name+" test")
 	}
 }
 
 // statusDescriptors makes sure that all status fields found in the created CR has a matching descriptor in the CSV
-func statusDescriptors(csv *olmAPI.ClusterServiceVersion, runtimeClient client.Client, obj *unstructured.Unstructured) error {
+func statusDescriptors(csv *olmapiv1alpha1.ClusterServiceVersion, runtimeClient client.Client, obj *unstructured.Unstructured) error {
 	test := scorecardTest{testType: olmIntegration, name: "Status fields with descriptors"}
 	err := runtimeClient.Get(context.TODO(), types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, obj)
 	if err != nil {
@@ -64,7 +64,7 @@ func statusDescriptors(csv *olmAPI.ClusterServiceVersion, runtimeClient client.C
 	}
 	statusBlock := obj.Object["status"].(map[string]interface{})
 	test.maximumPoints = len(statusBlock)
-	var crd *olmAPI.CRDDescription
+	var crd *olmapiv1alpha1.CRDDescription
 	for _, owned := range csv.Spec.CustomResourceDefinitions.Owned {
 		if owned.Kind == obj.GetKind() {
 			crd = &owned
@@ -92,7 +92,7 @@ func statusDescriptors(csv *olmAPI.ClusterServiceVersion, runtimeClient client.C
 }
 
 // specDescriptors makes sure that all spec fields found in the created CR has a matching descriptor in the CSV
-func specDescriptors(csv *olmAPI.ClusterServiceVersion, runtimeClient client.Client, obj *unstructured.Unstructured) error {
+func specDescriptors(csv *olmapiv1alpha1.ClusterServiceVersion, runtimeClient client.Client, obj *unstructured.Unstructured) error {
 	test := scorecardTest{testType: olmIntegration, name: "Spec fields with descriptors"}
 	err := runtimeClient.Get(context.TODO(), types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, obj)
 	if err != nil {
@@ -105,7 +105,7 @@ func specDescriptors(csv *olmAPI.ClusterServiceVersion, runtimeClient client.Cli
 	}
 	specBlock := obj.Object["spec"].(map[string]interface{})
 	test.maximumPoints = len(specBlock)
-	var crd *olmAPI.CRDDescription
+	var crd *olmapiv1alpha1.CRDDescription
 	for _, owned := range csv.Spec.CustomResourceDefinitions.Owned {
 		if owned.Kind == obj.GetKind() {
 			crd = &owned
@@ -127,7 +127,7 @@ func specDescriptors(csv *olmAPI.ClusterServiceVersion, runtimeClient client.Cli
 	}
 	scTests = append(scTests, test)
 	for key := range specBlock {
-		scSuggestions = append(scSuggestions, "Add a spec descriptor for " + key)
+		scSuggestions = append(scSuggestions, "Add a spec descriptor for "+key)
 	}
 	return nil
 }

--- a/commands/operator-sdk/cmd/scorecard/scorecard.go
+++ b/commands/operator-sdk/cmd/scorecard/scorecard.go
@@ -23,7 +23,7 @@ import (
 	k8sInternal "github.com/operator-framework/operator-sdk/internal/util/k8sutil"
 	"github.com/operator-framework/operator-sdk/internal/util/yamlutil"
 
-	olmApi "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	olmapiv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
@@ -154,7 +154,7 @@ func ScorecardTests(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to add failed to add extensions api scheme to client: (%v)", err)
 	}
 	// olm api (CS
-	if err := olmApi.AddToScheme(scheme); err != nil {
+	if err := olmapiv1alpha1.AddToScheme(scheme); err != nil {
 		return fmt.Errorf("failed to add failed to add oml api scheme (CSVs) to client: (%v)", err)
 	}
 	dynamicDecoder = serializer.NewCodecFactory(scheme).UniversalDeserializer()
@@ -215,9 +215,9 @@ func ScorecardTests(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		csv := &olmApi.ClusterServiceVersion{}
+		csv := &olmapiv1alpha1.ClusterServiceVersion{}
 		switch o := rawCSV.(type) {
-		case *olmApi.ClusterServiceVersion:
+		case *olmapiv1alpha1.ClusterServiceVersion:
 			csv = o
 		default:
 			return fmt.Errorf("provided yaml file not of ClusterServiceVersion type")

--- a/pkg/scaffold/olm-catalog/csv_test.go
+++ b/pkg/scaffold/olm-catalog/csv_test.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/ghodss/yaml"
-	olmApi "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	olmInstall "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
+	olmapiv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	olminstall "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install"
 )
 
 const testDataDir = "testdata"
@@ -77,7 +77,7 @@ func TestUpdateVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	csv := &olmApi.ClusterServiceVersion{}
+	csv := &olmapiv1alpha1.ClusterServiceVersion{}
 	if err := yaml.Unmarshal(csvExpBytes, csv); err != nil {
 		t.Fatal(err)
 	}
@@ -102,12 +102,12 @@ func TestUpdateVersion(t *testing.T) {
 		t.Errorf("Wanted csv name %s, got %s", wantedName, csv.ObjectMeta.Name)
 	}
 
-	var resolver *olmInstall.StrategyResolver
+	var resolver *olminstall.StrategyResolver
 	stratInterface, err := resolver.UnmarshalStrategy(csv.Spec.InstallStrategy)
 	if err != nil {
 		t.Fatal(err)
 	}
-	strat, ok := stratInterface.(*olmInstall.StrategyDetailsDeployment)
+	strat, ok := stratInterface.(*olminstall.StrategyDetailsDeployment)
 	if !ok {
 		t.Fatalf("Strategy of type %T was not StrategyDetailsDeployment", stratInterface)
 	}


### PR DESCRIPTION
**Description of the change:** update OLM version to latest non-breaking commit so the SDK has the newest CSV fields available. Also [standardized](https://golang.org/doc/effective_go.html#names) OLM import identifiers.


**Motivation for the change:** users should have access to the latest CSV fields. Updating OLM version is not a breaking change.