### PR TITLE
add crd: only skip overwriting CRD's/CR's when explicitly adding them

### DIFF
--- a/commands/operator-sdk/cmd/add/crd.go
+++ b/commands/operator-sdk/cmd/add/crd.go
@@ -78,8 +78,14 @@ func crdFunc(cmd *cobra.Command, args []string) error {
 
 	s := scaffold.Scaffold{}
 	err = s.Execute(cfg,
-		&scaffold.Crd{Resource: resource},
-		&scaffold.Cr{Resource: resource},
+		&scaffold.Crd{
+			Input:    input.Input{IfExistsAction: input.Skip},
+			Resource: resource,
+		},
+		&scaffold.Cr{
+			Input:    input.Input{IfExistsAction: input.Skip},
+			Resource: resource,
+		},
 	)
 	if err != nil {
 		return fmt.Errorf("crd scaffold failed: (%v)", err)

--- a/pkg/scaffold/cr.go
+++ b/pkg/scaffold/cr.go
@@ -38,7 +38,6 @@ func (s *Cr) GetInput() (input.Input, error) {
 			s.Resource.LowerKind)
 		s.Path = filepath.Join(CrdsDir, fileName)
 	}
-	s.IfExistsAction = input.Skip
 	s.TemplateBody = crTemplate
 	return s.Input, nil
 }

--- a/pkg/scaffold/crd.go
+++ b/pkg/scaffold/crd.go
@@ -38,7 +38,6 @@ func (s *Crd) GetInput() (input.Input, error) {
 			s.Resource.LowerKind)
 		s.Path = filepath.Join(CrdsDir, fileName)
 	}
-	s.IfExistsAction = input.Skip
 	s.TemplateBody = crdTemplate
 	return s.Input, nil
 }


### PR DESCRIPTION
**Description of the change:** see #1007, but moved to `CRD` and `CR` instantiations.

**Motivation for the change:** some commands need to overwrite CRD manifests.