### PR TITLE
test/test-framework/deploy/operator.yaml: update image

### DIFF
--- a/test/test-framework/deploy/crds/cache_v1alpha1_memcached_crd.yaml
+++ b/test/test-framework/deploy/crds/cache_v1alpha1_memcached_crd.yaml
@@ -1,6 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  creationTimestamp: null
   name: memcacheds.cache.example.com
 spec:
   group: cache.example.com
@@ -10,4 +11,34 @@ spec:
     plural: memcacheds
     singular: memcached
   scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            size:
+              format: int32
+              type: integer
+            test:
+              type: string
+          required:
+          - size
+          type: object
+        status:
+          properties:
+            nodes:
+              items:
+                type: string
+              type: array
+          required:
+          - nodes
+          type: object
   version: v1alpha1
+  subresources:
+    status: {}

--- a/test/test-framework/deploy/operator.yaml
+++ b/test/test-framework/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: memcached-operator
           # Replace this with the built image name
-          image: quay.io/coreos/operator-sdk-dev:test-framework-operator-runtime
+          image: quay.io/coreos/operator-sdk-dev:test-framework-operator
           ports:
           - containerPort: 60000
             name: metrics
@@ -28,5 +28,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "memcached-operator"


### PR DESCRIPTION
**Description of the change:** The sdk's subcommand tests rely on a very old memcached example that has not been updated in 4 months. I've pushed up a new memcached operator image based on sdk `v0.4.0`. The old operator image did not support the status resource, so the new operator and manifests have been updated to work with subresources. This also adds validation for the CRD, which will be useful for #979.

**Motivation for the change:** Make tests work with subresources.
