### PR TITLE
pkg/ansible/runner: Add ability to specify ANSIBLE_INVENTORY env variable

### DIFF
--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -50,9 +50,16 @@ DEST_IMAGE="quay.io/example/memcached-operator:v0.0.2-test"
 operator-sdk build --enable-tests "$DEST_IMAGE"
 trap_add 'remove_prereqs' EXIT
 deploy_prereqs
-TEST_CLUSTER_PORT=25443 operator-sdk test cluster --image-pull-policy Never --namespace default --service-account memcached-operator ${DEST_IMAGE}
+operator-sdk test cluster --image-pull-policy Never --namespace default --service-account memcached-operator ${DEST_IMAGE}
 
 remove_prereqs
 
 popd
+popd
+
+pushd "${ROOTDIR}/test/ansible-inventory"
+
+sed -i 's|\(FROM quay.io/operator-framework/ansible-operator\)\(:.*\)\?|\1:dev|g' build/Dockerfile
+TEST_CLUSTER_PORT=24443 operator-sdk test local --namespace default
+
 popd

--- a/pkg/ansible/runner/internal/inputdir/inputdir.go
+++ b/pkg/ansible/runner/internal/inputdir/inputdir.go
@@ -20,8 +20,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
+	"github.com/spf13/afero"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
@@ -58,6 +60,38 @@ func (i *InputDir) addFile(path string, content []byte) error {
 		log.Error(err, "Unable to write file", "Path", fullPath)
 	}
 	return err
+}
+
+// copyInventory copies a file or directory from src to dst
+func (i *InputDir) copyInventory(src string, dst string) error {
+	fs := afero.NewOsFs()
+	return afero.Walk(fs, src,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			fullDst := strings.Replace(path, src, dst, 1)
+			if info.IsDir() {
+				if err = fs.MkdirAll(fullDst, info.Mode()); err != nil {
+					return err
+				}
+				if err = fs.Chmod(fullDst, info.Mode()); err != nil {
+					return err
+				}
+			} else {
+				f, err := fs.Open(path)
+				if err != nil {
+					return err
+				}
+				if err = afero.WriteReader(fs, fullDst, f); err != nil {
+					return err
+				}
+				if err = fs.Chmod(fullDst, info.Mode()); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 }
 
 // Stdout reads the stdout from the ansible artifact that corresponds to the
@@ -103,14 +137,34 @@ func (i *InputDir) Write() error {
 
 	// If ansible-runner is running in a python virtual environment, propagate
 	// that to ansible.
-	venv := os.Getenv("VIRTUAL_ENV")
-	hosts := "localhost ansible_connection=local"
-	if venv != "" {
-		hosts = fmt.Sprintf("%s ansible_python_interpreter=%s", hosts, filepath.Join(venv, "bin/python"))
-	}
-	err = i.addFile("inventory/hosts", []byte(hosts))
-	if err != nil {
-		return err
+	ansible_inventory := os.Getenv("ANSIBLE_INVENTORY")
+	if ansible_inventory == "" {
+		venv := os.Getenv("VIRTUAL_ENV")
+		hosts := "localhost ansible_connection=local"
+		if venv != "" {
+			hosts = fmt.Sprintf("%s ansible_python_interpreter=%s", hosts, filepath.Join(venv, "bin/python"))
+		}
+		err = i.addFile("inventory/hosts", []byte(hosts))
+		if err != nil {
+			return err
+		}
+	} else {
+		fi, err := os.Stat(ansible_inventory)
+		if err != nil {
+			return err
+		}
+		switch mode := fi.Mode(); {
+		case mode.IsDir():
+			err = i.copyInventory(ansible_inventory, filepath.Join(i.Path, "inventory"))
+			if err != nil {
+				return err
+			}
+		case mode.IsRegular():
+			err = i.copyInventory(ansible_inventory, filepath.Join(i.Path, "inventory/hosts"))
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	if i.PlaybookPath != "" {

--- a/pkg/ansible/runner/internal/inputdir/inputdir.go
+++ b/pkg/ansible/runner/internal/inputdir/inputdir.go
@@ -75,9 +75,6 @@ func (i *InputDir) copyInventory(src string, dst string) error {
 				if err = fs.MkdirAll(fullDst, info.Mode()); err != nil {
 					return err
 				}
-				if err = fs.Chmod(fullDst, info.Mode()); err != nil {
-					return err
-				}
 			} else {
 				f, err := fs.Open(path)
 				if err != nil {
@@ -135,10 +132,13 @@ func (i *InputDir) Write() error {
 		return err
 	}
 
-	// If ansible-runner is running in a python virtual environment, propagate
-	// that to ansible.
+	// ANSIBLE_INVENTORY takes precendence over our generated hosts file
+	// so if the envvar is set we don't bother making it, we just copy
+	// the inventory into our runner directory
 	ansible_inventory := os.Getenv("ANSIBLE_INVENTORY")
 	if ansible_inventory == "" {
+		// If ansible-runner is running in a python virtual environment, propagate
+		// that to ansible.
 		venv := os.Getenv("VIRTUAL_ENV")
 		hosts := "localhost ansible_connection=local"
 		if venv != "" {

--- a/test/ansible-inventory/ansible.cfg
+++ b/test/ansible-inventory/ansible.cfg
@@ -1,0 +1,10 @@
+[defaults]
+inventory_plugins = /opt/ansible/plugins/inventory
+stdout_callback = yaml
+callback_whitelist = profile_tasks,timer
+module_utils = /opt/ansible/module_utils
+roles_path = /opt/ansible/roles
+library = /opt/ansible/library
+inventory = /opt/ansible/inventory
+filter_plugins = /opt/ansible/plugins/filter
+remote_tmp = /tmp/ansible

--- a/test/ansible-inventory/build/Dockerfile
+++ b/test/ansible-inventory/build/Dockerfile
@@ -1,0 +1,4 @@
+FROM quay.io/operator-framework/ansible-operator:dev
+
+COPY ansible.cfg /etc/ansible/ansible.cfg
+COPY . ${HOME}/

--- a/test/ansible-inventory/deploy/crds/inventory_v1alpha1_inventory_cr.yaml
+++ b/test/ansible-inventory/deploy/crds/inventory_v1alpha1_inventory_cr.yaml
@@ -1,0 +1,7 @@
+apiVersion: inventory.apps.fabianism.us/v1alpha1
+kind: Inventory
+metadata:
+  name: example-inventory
+spec:
+  # Add fields here
+  size: 3

--- a/test/ansible-inventory/deploy/crds/inventory_v1alpha1_inventory_crd.yaml
+++ b/test/ansible-inventory/deploy/crds/inventory_v1alpha1_inventory_crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: inventorys.inventory.apps.fabianism.us
+spec:
+  group: inventory.apps.fabianism.us
+  names:
+    kind: Inventory
+    listKind: InventoryList
+    plural: inventorys
+    singular: inventory
+  scope: Namespaced
+  version: v1alpha1
+  subresources:
+    status: {}

--- a/test/ansible-inventory/deploy/operator.yaml
+++ b/test/ansible-inventory/deploy/operator.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: inventory
+  template:
+    metadata:
+      labels:
+        name: inventory
+    spec:
+      serviceAccountName: inventory
+      containers:
+        - name: inventory
+          # Replace this with the built image name
+          image: "{{ REPLACE_IMAGE }}"
+          ports:
+          - containerPort: 60000
+            name: metrics
+          imagePullPolicy: "{{ pull_policy|default('Always') }}"
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "inventory"
+            - name: ANSIBLE_INVENTORY
+              value: /opt/ansible/inventory

--- a/test/ansible-inventory/deploy/role.yaml
+++ b/test/ansible-inventory/deploy/role.yaml
@@ -1,0 +1,46 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: inventory
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - inventory.apps.fabianism.us
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/test/ansible-inventory/deploy/role_binding.yaml
+++ b/test/ansible-inventory/deploy/role_binding.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: inventory
+subjects:
+- kind: ServiceAccount
+  name: inventory
+roleRef:
+  kind: Role
+  name: inventory
+  apiGroup: rbac.authorization.k8s.io

--- a/test/ansible-inventory/deploy/service_account.yaml
+++ b/test/ansible-inventory/deploy/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: inventory

--- a/test/ansible-inventory/inventory/group_vars/test.yml
+++ b/test/ansible-inventory/inventory/group_vars/test.yml
@@ -1,0 +1,3 @@
+---
+
+sentinel: test

--- a/test/ansible-inventory/inventory/hosts
+++ b/test/ansible-inventory/inventory/hosts
@@ -1,0 +1,2 @@
+[test]
+127.0.0.1 ansible_connection=local

--- a/test/ansible-inventory/molecule/test-local/asserts.yml
+++ b/test/ansible-inventory/molecule/test-local/asserts.yml
@@ -1,0 +1,12 @@
+---
+- hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+    cm: '{{ lookup("k8s", api_version="v1", kind="ConfigMap", namespace=namespace, resource_name="inventory-cm") }}'
+  tasks:
+  - name: Assert sentinel ConfigMap has been created
+    assert:
+      that: cm.data.sentinel == 'test'
+  - name: output cm
+    debug: var=cm

--- a/test/ansible-inventory/molecule/test-local/molecule.yml
+++ b/test/ansible-inventory/molecule/test-local/molecule.yml
@@ -1,0 +1,54 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  enabled: False
+platforms:
+- name: kind-test-local
+  groups:
+  - k8s
+  image: bsycorp/kind:latest-1.12
+  privileged: True
+  exposed_ports:
+    - 8443/tcp
+    - 10080/tcp
+  published_ports:
+    - 0.0.0.0:${TEST_CLUSTER_PORT:-10443}:8443/tcp
+  pre_build_image: yes
+  volumes:
+    - ${MOLECULE_PROJECT_DIRECTORY}:/build:Z
+provisioner:
+  name: ansible
+  log: True
+  lint:
+    name: ansible-lint
+    enabled: False
+  inventory:
+    group_vars:
+      all:
+        namespace: ${TEST_NAMESPACE:-osdk-test}
+  env:
+    K8S_AUTH_KUBECONFIG: /tmp/molecule/kind-test-local/kubeconfig
+    KUBECONFIG: /tmp/molecule/kind-test-local/kubeconfig
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/roles
+    KIND_PORT: '${TEST_CLUSTER_PORT:-10443}'
+scenario:
+  name: test-local
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - side_effect
+    - verify
+    - destroy
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/test/ansible-inventory/molecule/test-local/playbook.yml
+++ b/test/ansible-inventory/molecule/test-local/playbook.yml
@@ -1,0 +1,74 @@
+---
+
+- name: Build Operator in Kubernetes docker container
+  hosts: k8s
+  vars:
+    image_name: inventory.apps.fabianism.us/inventory:testing
+  tasks:
+  # using command so we don't need to install any dependencies
+  - name: Get existing image hash
+    command: docker images -q {{image_name}}
+    register: prev_hash
+    changed_when: false
+
+  - name: Build Operator Image
+    command: docker build -f /build/build/Dockerfile -t {{ image_name }} /build
+    register: build_cmd
+    changed_when: not prev_hash.stdout or (prev_hash.stdout and prev_hash.stdout not in ''.join(build_cmd.stdout_lines[-2:]))
+
+- name: Converge
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+    deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+    pull_policy: Never
+    REPLACE_IMAGE: inventory.apps.fabianism.us/inventory:testing
+    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'crds/inventory_v1alpha1_inventory_cr.yaml'])) | from_yaml }}"
+  tasks:
+  - name: Delete the Operator Deployment
+    k8s:
+      state: absent
+      namespace: '{{ namespace }}'
+      definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) }}"
+    register: delete_deployment
+    when: hostvars[groups.k8s.0].build_cmd.changed
+
+  - name: Wait 30s for Operator Deployment to terminate
+    k8s_facts:
+      api_version: '{{ definition.apiVersion }}'
+      kind: '{{ definition.kind }}'
+      namespace: '{{ namespace }}'
+      name: '{{ definition.metadata.name }}'
+    vars:
+      definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
+    register: deployment
+    until: not deployment.resources
+    delay: 3
+    retries: 10
+    when: delete_deployment.changed
+
+  - name: Create the Operator Deployment
+    k8s:
+      namespace: '{{ namespace }}'
+      definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) }}"
+
+  - name: Create the inventory.apps.fabianism.us/v1alpha1.Inventory
+    k8s:
+      state: present
+      namespace: '{{ namespace }}'
+      definition: "{{ custom_resource }}"
+
+  - name: Wait 30s for reconcilation to run
+    k8s_facts:
+      api_version: '{{ custom_resource.apiVersion }}'
+      kind: '{{ custom_resource.kind }}'
+      namespace: '{{ namespace }}'
+      name: '{{ custom_resource.metadata.name }}'
+    register: cr
+    until:
+    - "'Successful' in (cr | json_query('resources[].status.conditions[].reason'))"
+    delay: 3
+    retries: 10
+
+- import_playbook: asserts.yml

--- a/test/ansible-inventory/molecule/test-local/prepare.yml
+++ b/test/ansible-inventory/molecule/test-local/prepare.yml
@@ -1,0 +1,84 @@
+---
+- name: Prepare
+  hosts: k8s
+  gather_facts: no
+  vars:
+    kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
+  tasks:
+    - name: delete the kubeconfig if present
+      file:
+        path: '{{ kubeconfig }}'
+        state: absent
+      delegate_to: localhost
+
+    - name: Fetch the kubeconfig
+      fetch:
+        dest: '{{ kubeconfig }}'
+        flat: yes
+        src: /root/.kube/config
+
+    - name: Change the kubeconfig port to the proper value
+      replace:
+        regexp: 8443
+        replace: "{{ lookup('env', 'KIND_PORT') }}"
+        path: '{{ kubeconfig }}'
+      delegate_to: localhost
+
+    - name: Wait for the Kubernetes API to become available (this could take a minute)
+      uri:
+        url: "https://localhost:8443/apis"
+        status_code: 200
+        validate_certs: no
+      register: result
+      until: (result.status|default(-1)) == 200
+      retries: 60
+      delay: 5
+
+- name: Prepare operator resources
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+    deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+  tasks:
+  - name: Create Custom Resource Definition
+    k8s:
+      definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/inventory_v1alpha1_inventory_crd.yaml'])) }}"
+
+  - name: Ensure specified namespace is present
+    k8s:
+      api_version: v1
+      kind: Namespace
+      name: '{{ namespace }}'
+
+  - name: Create RBAC resources
+    k8s:
+      definition: "{{ lookup('template', '/'.join([deploy_dir, item])) }}"
+      namespace: '{{ namespace }}'
+    with_items:
+      - role.yaml
+      - role_binding.yaml
+      - service_account.yaml
+
+  - name: Dump the dev image
+    command: docker save -o /tmp/dev-operator.tar quay.io/operator-framework/ansible-operator:dev
+
+  - name: Copy the image to the kind container
+    command: docker cp /tmp/dev-operator.tar kind-test-local:/dev-operator.tar
+
+- name: Make dev operator image available
+  hosts: k8s
+  gather_facts: no
+  tasks:
+  - name: Make dev operator available
+    command: docker load -i /dev-operator.tar
+
+- name: Clean up
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - name: remove dev-operator.tar
+    file:
+      path: /tmp/dev-operator.tar
+      state: absent

--- a/test/ansible-inventory/playbooks/playbook.yml
+++ b/test/ansible-inventory/playbooks/playbook.yml
@@ -1,0 +1,13 @@
+---
+
+- hosts: test
+  gather_facts: no
+  tasks:
+  - import_role:
+      name: inventory
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - command: echo hello
+  - debug: msg='{{ "hello" | test }}'

--- a/test/ansible-inventory/plugins/filter/test.py
+++ b/test/ansible-inventory/plugins/filter/test.py
@@ -1,0 +1,32 @@
+# (c) 2015, Filipe Niero Felisbino <filipenf@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+def test(sentinel):
+    return sentinel == 'test'
+
+
+class FilterModule(object):
+    ''' Fake test plugin for ansible-operator '''
+
+    def filters(self):
+        return {
+            'test': test
+        }

--- a/test/ansible-inventory/roles/inventory/tasks/main.yml
+++ b/test/ansible-inventory/roles/inventory/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- when: sentinel | test
+  block:
+  - k8s:
+      definition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: inventory-cm
+          namespace: '{{ meta.namespace }}'
+        data:
+          sentinel: '{{ sentinel }}'
+          groups: '{{ groups | to_nice_yaml }}'

--- a/test/ansible-inventory/watches.yaml
+++ b/test/ansible-inventory/watches.yaml
@@ -1,0 +1,6 @@
+---
+- version: v1alpha1
+  group: inventory.apps.fabianism.us
+  kind: Inventory
+  playbook: /opt/ansible/playbooks/playbook.yml
+  inventory: /opt/ansible/inventory


### PR DESCRIPTION
**Description of the change:**
If the `ANSIBLE_INVENTORY` environment variable is set, the Ansible Operator will copy it into the runner artifacts directory. This is a placeholder until the `--inventory` option to runner supports directories, or until it respects the `ansible.cfg`.

**Motivation for the change:**
Allows users to specify more complex inventories, should at least partially unblock #954
