### PR TITLE
commands/.../scorecard: disable inconsistent test

### DIFF
--- a/commands/operator-sdk/cmd/scorecard/scorecard.go
+++ b/commands/operator-sdk/cmd/scorecard/scorecard.go
@@ -195,11 +195,15 @@ func ScorecardTests(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println("Checking that operator actions are reflected in status")
-		err = checkStatusUpdate(runtimeClient, obj)
-		if err != nil {
-			return err
-		}
+		// This test is far too inconsistent and unreliable to be meaningful,
+		// so it has been disabled
+		/*
+			fmt.Println("Checking that operator actions are reflected in status")
+			err = checkStatusUpdate(runtimeClient, obj)
+			if err != nil {
+				return err
+			}
+		*/
 		fmt.Println("Checking that writing into CRs has an effect")
 		logs, err := writingIntoCRsHasEffect(obj)
 		if err != nil {

--- a/doc/test-framework/scorecard.md
+++ b/doc/test-framework/scorecard.md
@@ -52,14 +52,6 @@ has a maximum score of 1.
 This test checks the Custom Resource that is created in the cluster to make sure that it has a status block. This
 test has a maximum score of 1.
 
-#### Operator Action Are Reflected In Status
-
-This test makes modifications to each field in the Custom Resources spec block, waits, then verifies that the
-operator updates the status block. This test has a maximum score of 1.
-
-Note: This test is somewhat prone to breakage as it can potentially change a spec field to an
-invalid value. We plan to partially replace this test with user defined tests in the future.
-
 #### Writing Into CRs Has An Effect
 
 This test reads the scorecard proxy's logs to verify that the operator is making `PUT` and/or `POST` requests to the

--- a/hack/tests/scorecard-subcommand.sh
+++ b/hack/tests/scorecard-subcommand.sh
@@ -10,8 +10,8 @@ set -ex
 # the test framework directory has all the manifests needed to run the cluster
 pushd test/test-framework
 commandoutput="$(operator-sdk scorecard --cr-manifest deploy/crds/cache_v1alpha1_memcached_cr.yaml --init-timeout 60 --csv-path deploy/memcachedoperator.0.0.2.csv.yaml --verbose --proxy-image $DEST_IMAGE --proxy-pull-policy Never 2>&1)"
-echo $commandoutput | grep "Total Score: 6/8 points"
+echo $commandoutput | grep "Total Score: 5/7 points"
 # test config file
 commandoutput2="$(operator-sdk scorecard --proxy-image $DEST_IMAGE)"
-echo $commandoutput2 | grep "Total Score: 6/8 points"
+echo $commandoutput2 | grep "Total Score: 5/7 points"
 popd


### PR DESCRIPTION
**Description of the change:** Disable "Operator actions are reflected in status" test


**Motivation for the change:** This test is quite poor and very likely to fail on more complicated operators. It is too unreliable for the score to be meaningful, so it should be disabled and eventually replaced by more operator specific, user configured tests.