### PR TITLE
commands/.../up/local.go: set operator name env for ansible and helm

### DIFF
--- a/commands/operator-sdk/cmd/up/local.go
+++ b/commands/operator-sdk/cmd/up/local.go
@@ -137,27 +137,21 @@ func upLocal() error {
 
 func upLocalAnsible() error {
 	logf.SetLogger(logf.ZapLogger(false))
-
-	// Set the kubeconfig that the manager will be able to grab
-	// only set env var if user explicitly specified a kubeconfig path
-	if kubeConfig != "" {
-		if err := os.Setenv(k8sutil.KubeConfigEnvVar, kubeConfig); err != nil {
-			return fmt.Errorf("failed to set %s environment variable: (%v)", k8sutil.KubeConfigEnvVar, err)
-		}
+	if err := setupOperatorEnv(); err != nil {
+		return err
 	}
-	// Set the namespace that the manager will be able to grab
-	if namespace != "" {
-		if err := os.Setenv(k8sutil.WatchNamespaceEnvVar, namespace); err != nil {
-			return fmt.Errorf("failed to set %s environment variable: (%v)", k8sutil.WatchNamespaceEnvVar, err)
-		}
-	}
-
 	return ansible.Run(ansibleOperatorFlags)
 }
 
 func upLocalHelm() error {
 	logf.SetLogger(logf.ZapLogger(false))
+	if err := setupOperatorEnv(); err != nil {
+		return err
+	}
+	return helm.Run(helmOperatorFlags)
+}
 
+func setupOperatorEnv() error {
 	// Set the kubeconfig that the manager will be able to grab
 	// only set env var if user explicitly specified a kubeconfig path
 	if kubeConfig != "" {
@@ -171,8 +165,15 @@ func upLocalHelm() error {
 			return fmt.Errorf("failed to set %s environment variable: (%v)", k8sutil.WatchNamespaceEnvVar, err)
 		}
 	}
-
-	return helm.Run(helmOperatorFlags)
+	// Set the operator name, if not already set
+	projutil.MustInProjectRoot()
+	if _, err := k8sutil.GetOperatorName(); err != nil {
+		operatorName := filepath.Base(projutil.MustGetwd())
+		if err := os.Setenv(k8sutil.OperatorNameEnvVar, operatorName); err != nil {
+			return fmt.Errorf("failed to set %s environment variable: (%v)", k8sutil.OperatorNameEnvVar, err)
+		}
+	}
+	return nil
 }
 
 func buildLocal(outputBinName string) error {


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
1. Adds the `OPERATOR_NAME` environment variable to the environment for Ansible and Helm operators when running `up local`
2. Moves environment setup into a new function shared by the Ansible and Helm upLocal functions.

**Motivation for the change:**
1. The Ansible and Helm operators fail unless OPERATOR_NAME is set. The operator.yaml we scaffold sets this already, but we do not set it when running locally.
2. To reduce duplication

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
