### PR TITLE
.travis.yml: make dep ensure verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ x_base_steps:
       # that it can properly exit the test early with success
       - source hack/ci/check-doc-only-update.sh
       - curl -Lo dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x dep && sudo mv dep /usr/local/bin/
-      - travis_retry dep ensure
+      - travis_retry dep ensure -v
 
   # Base go, ansbile, and helm job
   - &test


### PR DESCRIPTION
**Description of the change:** Make the `dep ensure` part of the `before_install` step verbose


**Motivation for the change:** `dep ensure` is currently stalling on many PRs, and it would be useful to see what's causing problems when situations like this arise.