### PR TITLE
pkg/metrics: Add Deployment ownerReference to metrics Service object

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1581,6 +1581,7 @@
     "golang.org/x/tools/imports",
     "gopkg.in/yaml.v2",
     "k8s.io/api/apps/v1",
+    "k8s.io/api/batch/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1581,7 +1581,6 @@
     "golang.org/x/tools/imports",
     "gopkg.in/yaml.v2",
     "k8s.io/api/apps/v1",
-    "k8s.io/api/batch/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",

--- a/commands/operator-sdk/cmd/test/cluster.go
+++ b/commands/operator-sdk/cmd/test/cluster.go
@@ -24,7 +24,6 @@ import (
 	k8sInternal "github.com/operator-framework/operator-sdk/internal/util/k8sutil"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/ansible"
 	"github.com/operator-framework/operator-sdk/pkg/test"
@@ -113,7 +112,7 @@ func testClusterFunc(cmd *cobra.Command, args []string) error {
 					Name:  k8sutil.OperatorNameEnvVar,
 					Value: "test-operator",
 				}, {
-					Name:      leader.PodNameEnv,
+					Name:      k8sutil.PodNameEnvVar,
 					ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"}},
 				}},
 			}},

--- a/pkg/k8sutil/constants.go
+++ b/pkg/k8sutil/constants.go
@@ -25,6 +25,10 @@ const (
 	WatchNamespaceEnvVar = "WATCH_NAMESPACE"
 
 	// OperatorNameEnvVar is the constant for env variable OPERATOR_NAME
-	// wich is the name of the current operator
+	// which is the name of the current operator
 	OperatorNameEnvVar = "OPERATOR_NAME"
+
+	// PodNameEnvVar is the contast for env variable POD_NAME
+	// which is the name of the current pod.
+	PodNameEnvVar = "POD_NAME"
 )

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -108,7 +108,7 @@ func GetPod(ctx context.Context, client crclient.Client, ns string) (*corev1.Pod
 	key := crclient.ObjectKey{Namespace: ns, Name: podName}
 	err := client.Get(ctx, key, pod)
 	if err != nil {
-		log.Error(err, "Failed to get Pod currently running in", "Pod.Namespace", ns, "Pod.Name", podName)
+		log.Error(err, "Failed to get Pod", "Pod.Namespace", ns, "Pod.Name", podName)
 		return nil, err
 	}
 

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -112,7 +112,7 @@ func GetPod(ctx context.Context, client crclient.Client, ns string) (*corev1.Pod
 		return nil, err
 	}
 
-	log.V(1).Info("Found Pod currently running in", "Pod.Name", pod.Name)
+	log.V(1).Info("Found Pod", "Pod.Namespace", ns, "Pod.Name", pod.Name)
 
 	return pod, nil
 }

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -15,12 +15,16 @@
 package k8sutil
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	discovery "k8s.io/client-go/discovery"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -82,4 +86,33 @@ func ResourceExists(dc discovery.DiscoveryInterface, apiGroupVersion, kind strin
 		}
 	}
 	return false, nil
+}
+
+// GetPod returns a Pod object that corresponds to the pod in which the code
+// is currently running.
+// It expects the environment variable POD_NAME to be set by the downwards API.
+func GetPod(ctx context.Context, client crclient.Client, ns string) (*corev1.Pod, error) {
+	podName := os.Getenv(PodNameEnvVar)
+	if podName == "" {
+		return nil, fmt.Errorf("required env %s not set, please configure downward API", PodNameEnvVar)
+	}
+
+	log.V(1).Info("Found podname", "Pod.Name", podName)
+
+	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+	}
+	key := crclient.ObjectKey{Namespace: ns, Name: podName}
+	err := client.Get(ctx, key, pod)
+	if err != nil {
+		log.Error(err, "Failed to get Pod currently running in", "Pod.Namespace", ns, "Pod.Name", podName)
+		return nil, err
+	}
+
+	log.V(1).Info("Found Pod currently running in", "Pod.Name", pod.Name)
+
+	return pod, nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -26,8 +26,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/rest"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -182,7 +182,7 @@ func getPodDeployment(ctx context.Context, client crclient.Client, ns string) (*
 }
 
 func createClient() (crclient.Client, error) {
-	config, err := rest.InClusterConfig()
+	config, err := config.GetConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -147,14 +147,7 @@ func getPodOwnerRef(ctx context.Context, client crclient.Client, ns string) (*me
 	if err != nil {
 		return nil, err
 	}
-	podOwnerRefs := &metav1.OwnerReference{
-		APIVersion: "core/v1",
-		Kind:       "Pod",
-		Name:       pod.Name,
-		UID:        pod.UID,
-		Controller: &trueVar,
-	}
-
+	podOwnerRefs := metav1.NewControllerRef(pod, pod.GroupVersionKind())
 	// Get Owner that the Pod belongs to
 	ownerRef := metav1.GetControllerOf(pod)
 	finalOwnerRef, err := findFinalOwnerRef(ctx, client, ns, ownerRef)


### PR DESCRIPTION

**Description of the change:**
Add Deployment ownerReference to metrics Service object, by getting the Pod the operator is currently running in and via ReplicaSet getting the Deployment Object.

**Motivation for the change:**
When operator Deployment is deleted currently the metrics Service operator creates was not deleted.

Closes https://github.com/operator-framework/operator-sdk/issues/459
