### PR TITLE
Makefile: trim gopath from panic logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean:
 .PHONY: all test format dep clean
 
 install:
-	$(Q)go install $(BUILD_PATH)
+	$(Q)go install -gcflags "all=-trimpath=${GOPATH}" -asmflags "all=-trimpath=${GOPATH}" $(BUILD_PATH)
 
 release_x86_64 := \
 	build/operator-sdk-$(VERSION)-x86_64-linux-gnu \
@@ -53,7 +53,7 @@ build/operator-sdk-%-x86_64-linux-gnu: GOARGS = GOOS=linux GOARCH=amd64
 build/operator-sdk-%-x86_64-apple-darwin: GOARGS = GOOS=darwin GOARCH=amd64
 
 build/%:
-	$(Q)$(GOARGS) go build -o $@ $(BUILD_PATH)
+	$(Q)$(GOARGS) go build -gcflags "all=-trimpath=${GOPATH}" -asmflags "all=-trimpath=${GOPATH}" -o $@ $(BUILD_PATH)
 	
 build/%.asc:
 	$(Q){ \

--- a/commands/operator-sdk/cmd/build.go
+++ b/commands/operator-sdk/cmd/build.go
@@ -145,6 +145,7 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 
 	projutil.MustInProjectRoot()
 	goBuildEnv := append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0")
+	goTrimFlags := []string{"-gcflags", "all=-trimpath=${GOPATH}", "-asmflags", "all=-trimpath=${GOPATH}"}
 	absProjectPath := projutil.MustGetwd()
 	projectName := filepath.Base(absProjectPath)
 
@@ -152,7 +153,8 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 	if projutil.GetOperatorType() == projutil.OperatorTypeGo {
 		managerDir := filepath.Join(projutil.CheckAndGetProjectGoPkg(), scaffold.ManagerDir)
 		outputBinName := filepath.Join(absProjectPath, scaffold.BuildBinDir, projectName)
-		buildCmd := exec.Command("go", "build", "-o", outputBinName, managerDir)
+		goBuildArgs := append(append([]string{"build"}, goTrimFlags...), "-o", outputBinName, managerDir)
+		buildCmd := exec.Command("go", goBuildArgs...)
 		buildCmd.Env = goBuildEnv
 		if err := projutil.ExecCmd(buildCmd); err != nil {
 			return fmt.Errorf("failed to build operator binary: (%v)", err)
@@ -178,7 +180,8 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 	if enableTests {
 		if projutil.GetOperatorType() == projutil.OperatorTypeGo {
 			testBinary := filepath.Join(absProjectPath, scaffold.BuildBinDir, projectName+"-test")
-			buildTestCmd := exec.Command("go", "test", "-c", "-o", testBinary, testLocationBuild+"/...")
+			goTestBuildArgs := append(append([]string{"test"}, goTrimFlags...), "-c", "-o", testBinary, testLocationBuild+"/...")
+			buildTestCmd := exec.Command("go", goTestBuildArgs...)
 			buildTestCmd.Env = goBuildEnv
 			if err := projutil.ExecCmd(buildTestCmd); err != nil {
 				return fmt.Errorf("failed to build test binary: (%v)", err)

--- a/hack/image/build-scorecard-proxy-image.sh
+++ b/hack/image/build-scorecard-proxy-image.sh
@@ -3,7 +3,7 @@
 set -eux
 
 # build operator binary and base image
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o images/scorecard-proxy/scorecard-proxy images/scorecard-proxy/cmd/proxy/main.go
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -gcflags "all=-trimpath=${GOPATH}" -asmflags "all=-trimpath=${GOPATH}" -o images/scorecard-proxy/scorecard-proxy images/scorecard-proxy/cmd/proxy/main.go
 pushd images/scorecard-proxy
 docker build -t "$1" .
 popd


### PR DESCRIPTION
**Description of the change:** Trim the GOPATH from binaries built with `install` or `build`.


**Motivation for the change:** Remove the home directory of the builder from the panic path.

Example of current panic output:

```
/home/apavel/go/src/github.com/operator-framework/operator-sdk/vendor/github.com/spf13/cobra/command.go:852 +0x30a
github.com/operator-framework/operator-sdk/vendor/github.com/spf13/cobra.(*Command).Execute(0xc4200f1180, 0xc4207d5f78, 0xc4200b6058)
        /home/apavel/go/src/github.com/operator-framework/operator-sdk/vendor/github.com/spf13/cobra/command.go:800 +0x2b
main.main()
        /home/apavel/go/src/github.com/operator-framework/operator-sdk/commands/operator-sdk/main.go:24 +0x27
```

Example of new panic output:

```
...
 src/github.com/operator-framework/operator-sdk/vendor/github.com/spf13/cobra/command.go:852 +0x30a
github.com/operator-framework/operator-sdk/vendor/github.com/spf13/cobra.(*Command).Execute(0xc4200c9400, 0xc420877f78, 0xc42004c178)
        src/github.com/operator-framework/operator-sdk/vendor/github.com/spf13/cobra/command.go:800 +0x2b
main.main()
        src/github.com/operator-framework/operator-sdk/commands/operator-sdk/main.go:24 +0x27
```

When merged, this will be cherry-picked to the `v0.4.x` branch so that panics from the binary as well as the helm and ansible operators have the cleaner panic output.

Closes #1036 
