### PR TITLE
Makefile: trim gopath from panic logs (#1042)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean:
 .PHONY: all test format dep clean
 
 install:
-	$(Q)go install $(BUILD_PATH)
+	$(Q)go install -gcflags "all=-trimpath=${GOPATH}" -asmflags "all=-trimpath=${GOPATH}" $(BUILD_PATH)
 
 release_x86_64 := \
 	build/operator-sdk-$(VERSION)-x86_64-linux-gnu \
@@ -53,7 +53,7 @@ build/operator-sdk-%-x86_64-linux-gnu: GOARGS = GOOS=linux GOARCH=amd64
 build/operator-sdk-%-x86_64-apple-darwin: GOARGS = GOOS=darwin GOARCH=amd64
 
 build/%:
-	$(Q)$(GOARGS) go build -o $@ $(BUILD_PATH)
+	$(Q)$(GOARGS) go build -gcflags "all=-trimpath=${GOPATH}" -asmflags "all=-trimpath=${GOPATH}" -o $@ $(BUILD_PATH)
 	
 build/%.asc:
 	$(Q){ \

--- a/commands/operator-sdk/cmd/build.go
+++ b/commands/operator-sdk/cmd/build.go
@@ -144,13 +144,16 @@ func buildFunc(cmd *cobra.Command, args []string) {
 
 	projutil.MustInProjectRoot()
 	goBuildEnv := append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0")
+	goTrimFlags := []string{"-gcflags", "all=-trimpath=${GOPATH}", "-asmflags", "all=-trimpath=${GOPATH}"}
 	absProjectPath := projutil.MustGetwd()
+	projectName := filepath.Base(absProjectPath)
 
 	// Don't need to build go code if Ansible Operator
 	if mainExists() {
 		managerDir := filepath.Join(projutil.CheckAndGetProjectGoPkg(), scaffold.ManagerDir)
-		outputBinName := filepath.Join(absProjectPath, scaffold.BuildBinDir, filepath.Base(absProjectPath))
-		buildCmd := exec.Command("go", "build", "-o", outputBinName, managerDir)
+		outputBinName := filepath.Join(absProjectPath, scaffold.BuildBinDir, projectName)
+		goBuildArgs := append(append([]string{"build"}, goTrimFlags...), "-o", outputBinName, managerDir)
+		buildCmd := exec.Command("go", goBuildArgs...)
 		buildCmd.Env = goBuildEnv
 		buildCmd.Stdout = os.Stdout
 		buildCmd.Stderr = os.Stderr
@@ -181,9 +184,10 @@ func buildFunc(cmd *cobra.Command, args []string) {
 	}
 
 	if enableTests {
-		if mainExists() {
-			testBinary := filepath.Join(absProjectPath, scaffold.BuildBinDir, filepath.Base(absProjectPath)+"-test")
-			buildTestCmd := exec.Command("go", "test", "-c", "-o", testBinary, testLocationBuild+"/...")
+		if projutil.GetOperatorType() == projutil.OperatorTypeGo {
+			testBinary := filepath.Join(absProjectPath, scaffold.BuildBinDir, projectName+"-test")
+			goTestBuildArgs := append(append([]string{"test"}, goTrimFlags...), "-c", "-o", testBinary, testLocationBuild+"/...")
+			buildTestCmd := exec.Command("go", goTestBuildArgs...)
 			buildTestCmd.Env = goBuildEnv
 			buildTestCmd.Stdout = os.Stdout
 			buildTestCmd.Stderr = os.Stderr

--- a/hack/image/build-scorecard-proxy-image.sh
+++ b/hack/image/build-scorecard-proxy-image.sh
@@ -3,7 +3,7 @@
 set -eux
 
 # build operator binary and base image
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o images/scorecard-proxy/scorecard-proxy images/scorecard-proxy/cmd/proxy/main.go
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -gcflags "all=-trimpath=${GOPATH}" -asmflags "all=-trimpath=${GOPATH}" -o images/scorecard-proxy/scorecard-proxy images/scorecard-proxy/cmd/proxy/main.go
 pushd images/scorecard-proxy
 docker build -t "$1" .
 popd


### PR DESCRIPTION
**Description of the change:** Trim the GOPATH from binaries built with `install` or `build`.

**Motivation for the change:** Remove the home directory of the builder from the panic path.