### PR TITLE
pkg/leader: Switch to controller-runtime config pkg

### DIFF
--- a/pkg/leader/leader.go
+++ b/pkg/leader/leader.go
@@ -26,8 +26,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/rest"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -58,7 +58,7 @@ func Become(ctx context.Context, lockName string) error {
 		return err
 	}
 
-	config, err := rest.InClusterConfig()
+	config, err := config.GetConfig()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

**Description of the change:**
Switch to using controller-runtime helper to get config.

**Motivation for the change:**
See -> https://github.com/operator-framework/operator-sdk/pull/1037#discussion_r252663270
