### PR TITLE
doc/user-guide: show how to enable both leader election options

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -407,7 +407,7 @@ For improved reliability and quick failover it may be necessary to run multiple 
 There are two different leader election implementations to choose from, each with its own tradeoff.
 
 - [Leader-for-life][leader_for_life]: The leader pod only gives up leadership (via garbage collection) when it is deleted. Avoids the possibility of 2 instances mistakenly running as leaders(split brain). However this method can be slow to elect a new leader when the leader pod is on an unresponsive node(partioned) where it takes a long time for the leader pod to be deleted.
-- [Leader-with-lease][leader_with_lease]: The leader pod periodically renews the leader lease and gives up leadership when it can't renew the lease. This method allows for a faster transistion to a new leader when the existing leader is isolated, but there is a possibility of split brain in [certain situations][lease_split_brain].
+- [Leader-with-lease][leader_with_lease]: The leader pod periodically renews the leader lease and gives up leadership when it can't renew the lease. This method allows for a faster transition to a new leader when the existing leader is isolated, but there is a possibility of split brain in [certain situations][lease_split_brain].
 
 By deafult the SDK enables the leader-for-life implementation. However you should consult the docs above for both approaches to consider the tradeoffs that make sense for your use case.
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -409,7 +409,7 @@ There are two different leader election implementations to choose from, each wit
 - [Leader-for-life][leader_for_life]: The leader pod only gives up leadership (via garbage collection) when it is deleted. Avoids the possibility of 2 instances mistakenly running as leaders(split brain). However, this method can be slow to elect a new leader when the leader pod is on an unresponsive node(partitioned) where it takes a long time for the leader pod to be deleted.
 - [Leader-with-lease][leader_with_lease]: The leader pod periodically renews the leader lease and gives up leadership when it can't renew the lease. This method allows for a faster transition to a new leader when the existing leader is isolated, but there is a possibility of split brain in [certain situations][lease_split_brain].
 
-By deafult the SDK enables the leader-for-life implementation. However you should consult the docs above for both approaches to consider the tradeoffs that make sense for your use case.
+By default the SDK enables the leader-for-life implementation. However you should consult the docs above for both approaches to consider the tradeoffs that make sense for your use case.
 
 The following examples illustrate how to use the two options:
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -407,7 +407,7 @@ For improved reliability and quick failover it may be necessary to run multiple 
 There are two different leader election implementations to choose from, each with its own tradeoff.
 
 - [Leader-for-life][leader_for_life]: The leader pod only gives up leadership (via garbage collection) when it is deleted. This implementation precludes the possibility of 2 instances mistakenly running as leaders (split brain). However, this method can be slow to elect a new leader when the leader pod is on an unresponsive node (partitioned), as it takes a long time for the leader pod to be deleted.
-- [Leader-with-lease][leader_with_lease]: The leader pod periodically renews the leader lease and gives up leadership when it can't renew the lease. This method allows for a faster transition to a new leader when the existing leader is isolated, but there is a possibility of split brain in [certain situations][lease_split_brain].
+- [Leader-with-lease][leader_with_lease]: The leader pod periodically renews the leader lease and gives up leadership when it can't renew the lease. This implementation allows for a faster transition to a new leader when the existing leader is isolated, but there is a possibility of split brain in [certain situations][lease_split_brain].
 
 By default the SDK enables the leader-for-life implementation. However you should consult the docs above for both approaches to consider the tradeoffs that make sense for your use case.
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -437,7 +437,7 @@ If the operator is not running inside a cluster `leader.Become()` will simply re
 
 ### Leader with lease
 
-The leader with leases approach can be enabled via the [Manager Options][manager_options] for leader election.
+The leader-with-lease approach can be enabled via the [Manager Options][manager_options] for leader election.
 
 ```Go
 import (

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -406,7 +406,7 @@ For improved reliability and quick failover it may be necessary to run multiple 
 
 There are two different leader election implementations to choose from, each with its own tradeoff.
 
-- [Leader-for-life][leader_for_life]: The leader pod only gives up leadership (via garbage collection) when it is deleted. Avoids the possibility of 2 instances mistakenly running as leaders(split brain). However, this method can be slow to elect a new leader when the leader pod is on an unresponsive node(partitioned) where it takes a long time for the leader pod to be deleted.
+- [Leader-for-life][leader_for_life]: The leader pod only gives up leadership (via garbage collection) when it is deleted. This implementation precludes the possibility of 2 instances mistakenly running as leaders (split brain). However, this method can be slow to elect a new leader when the leader pod is on an unresponsive node (partitioned), as it takes a long time for the leader pod to be deleted.
 - [Leader-with-lease][leader_with_lease]: The leader pod periodically renews the leader lease and gives up leadership when it can't renew the lease. This method allows for a faster transition to a new leader when the existing leader is isolated, but there is a possibility of split brain in [certain situations][lease_split_brain].
 
 By default the SDK enables the leader-for-life implementation. However you should consult the docs above for both approaches to consider the tradeoffs that make sense for your use case.

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -406,7 +406,7 @@ For improved reliability and quick failover it may be necessary to run multiple 
 
 There are two different leader election implementations to choose from, each with its own tradeoff.
 
-- [Leader-for-life][leader_for_life]: The leader pod only gives up leadership (via garbage collection) when it is deleted. Avoids the possibility of 2 instances mistakenly running as leaders(split brain). However this method can be slow to elect a new leader when the leader pod is on an unresponsive node(partioned) where it takes a long time for the leader pod to be deleted.
+- [Leader-for-life][leader_for_life]: The leader pod only gives up leadership (via garbage collection) when it is deleted. Avoids the possibility of 2 instances mistakenly running as leaders(split brain). However, this method can be slow to elect a new leader when the leader pod is on an unresponsive node(partitioned) where it takes a long time for the leader pod to be deleted.
 - [Leader-with-lease][leader_with_lease]: The leader pod periodically renews the leader lease and gives up leadership when it can't renew the lease. This method allows for a faster transition to a new leader when the existing leader is isolated, but there is a possibility of split brain in [certain situations][lease_split_brain].
 
 By deafult the SDK enables the leader-for-life implementation. However you should consult the docs above for both approaches to consider the tradeoffs that make sense for your use case.


### PR DESCRIPTION
**Description of the change:**
Added a brief overview of the two leader election implementations that can be used along with their respective tradeoffs and example code snippets on how to use them. 

**Motivation for the change:**

Fixes #665 #784 

I'm aiming to keep the explanations as concise as possible without being too vague and referring to the pkg godocs for more details on the implementations themselves.

I also need a second opinion on whether this is bloating the user-guide, and if we would rather keep this in a separate doc and just link it from the user-guide.