### PR TITLE
pkg/scaffold/crd*.go: support crd.Versions

### DIFF
--- a/pkg/scaffold/crd_test.go
+++ b/pkg/scaffold/crd_test.go
@@ -100,6 +100,10 @@ spec:
           - nodes
           type: object
   version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
 `
 
 func TestCRDNonGoProject(t *testing.T) {
@@ -135,4 +139,8 @@ spec:
   subresources:
     status: {}
   version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
 `


### PR DESCRIPTION
**Description of the change:** populate a CRD's `Versions` field. `Version` is kept for backwards compatibility.


**Motivation for the change:** `Version` is deprecated in newer k8s api versions.

Closes #1012 