### PR TITLE
[pkg/ansible/runner] link latest artifacts directory to 'latest'  ident

### DIFF
--- a/pkg/ansible/runner/runner.go
+++ b/pkg/ansible/runner/runner.go
@@ -297,7 +297,21 @@ func (r *runner) Run(ident string, u *unstructured.Unstructured, kubeconfig stri
 		if err != nil && err != http.ErrServerClosed {
 			logger.Error(err, "Error from event API")
 		}
+
+		// link the current run to the `latest` directory under artifacts
+		currentRun := filepath.Join(inputDir.Path, "artifacts", ident)
+		latestArtifacts := filepath.Join(inputDir.Path, "artifacts", "latest")
+		if _, err = os.Lstat(latestArtifacts); err == nil {
+			if err = os.Remove(latestArtifacts); err != nil {
+				logger.Error(err, "Error removing the latest artifacts symlink")
+			}
+		}
+		if err = os.Symlink(currentRun, latestArtifacts); err != nil {
+			logger.Error(err, "Error symlinking latest artifacts")
+		}
+
 	}()
+
 	return &runResult{
 		events:   receiver.Events,
 		inputDir: &inputDir,

--- a/test/ansible-memcached/asserts.yml
+++ b/test/ansible-memcached/asserts.yml
@@ -139,6 +139,16 @@
         retries: 10
         delay: 3
 
+      - name: Add operator pod to inventory
+        add_host:
+          name: '{{ pod.metadata.name }}'
+          groups: operator
+          ansible_connection: kubectl
+          ansible_remote_tmp: /tmp/ansible
+          kubectl_namespace: '{{ namespace }}'
+        when: molecule_yml.scenario.name == "test-local"
+        vars:
+          pod: '{{ q("k8s", api_version="v1", kind="Pod", namespace=namespace, label_selector="name=memcached-operator").0 }}'
       rescue:
       - name: debug cr
         ignore_errors: yes
@@ -178,3 +188,12 @@
 
       - fail:
           msg: "Failed in asserts.yml"
+
+- hosts: operator
+  gather_facts: no
+  become: false
+  tasks:
+  - name: Output latest log
+    command: cat /tmp/ansible-operator/runner/ansible.example.com/v1alpha1/Memcached/{{ namespace }}/example-memcached/artifacts/latest/stdout
+    register: ansible_log
+  - debug: var=ansible_log.stdout_lines


### PR DESCRIPTION
**Description of the change:**
Creates a directory called "latest" in the artifacts directory, which is linked to the most recent ansible run

**Motivation for the change:**
This will greatly ease the debugging experience, as there will be a single copy-pasteable command that can be run to view a human readable log.

