### PR TITLE
.travis.yml: enable caching for dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: go
 go_import_path: github.com/operator-framework/operator-sdk
 sudo: required
 
+cache:
+  directories:
+    - $GOPATH/pkg/dep
+
 go:
 - 1.10.3
 


### PR DESCRIPTION
**Description of the change:** Enables caching for dep. This should improve CI times, but can cause problems if dep's cache gets corrupted. See this PR for more info: https://github.com/golang/dep/pull/1293#issuecomment-342969292. We may manually have to reset the cache in the case of corruption.


**Motivation for the change:** Speed up CI. Closes #1062 