### PR TITLE
.travis.yml: cache $HOME/.cache/go-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: go
 go_import_path: github.com/operator-framework/operator-sdk
 sudo: required
 
+cache:
+  directories:
+    - $HOME/.cache/go-build
+
 go:
 - 1.10.3
 


### PR DESCRIPTION
**Description of the change:** Cache the $HOME/.cache/go-build


**Motivation for the change:** Significantly improve build speed for CI. In tests on my branch, the go and ansible CI tests increased in performance by ~4 minutes

Initial Build (before cache was created): https://travis-ci.org/AlexNPavel/operator-sdk/builds/489678685
Cached Build: https://travis-ci.org/AlexNPavel/operator-sdk/builds/489690596

The way that cache works:
CI checks if the current PR has a cache. If yes, use that.
CI checks if target branch has cache. If yes, use that.
CI checks if default branch (master) has cache. If yes, use that.

This should improve build times for most builds, as all of our dependencies will now be precompiled and only sdk changes and linking will need to be done by CI.