### PR TITLE
commands/.../scorecard: move getCRDs to k8sutil

### DIFF
--- a/commands/operator-sdk/cmd/olm-catalog/gen-csv.go
+++ b/commands/operator-sdk/cmd/olm-catalog/gen-csv.go
@@ -67,7 +67,7 @@ func genCSVFunc(cmd *cobra.Command, args []string) error {
 		AbsProjectPath: absProjectPath,
 		ProjectName:    filepath.Base(absProjectPath),
 	}
-	if projutil.GetOperatorType() == projutil.OperatorTypeGo {
+	if projutil.IsOperatorGo() {
 		cfg.Repo = projutil.CheckAndGetProjectGoPkg()
 	}
 

--- a/commands/operator-sdk/cmd/scorecard/resource_handler.go
+++ b/commands/operator-sdk/cmd/scorecard/resource_handler.go
@@ -31,7 +31,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -224,24 +223,6 @@ func addProxyContainer(dep *appsv1.Deployment) {
 			ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
 		}},
 	})
-}
-
-// unstructuredToCRD converts an unstructured object to a CRD
-func unstructuredToCRD(obj *unstructured.Unstructured) (*apiextv1beta1.CustomResourceDefinition, error) {
-	jsonByte, err := obj.MarshalJSON()
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert CRD to json: %v", err)
-	}
-	crdObj, _, err := dynamicDecoder.Decode(jsonByte, nil, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode CRD object: %v", err)
-	}
-	switch o := crdObj.(type) {
-	case *apiextv1beta1.CustomResourceDefinition:
-		return o, nil
-	default:
-		return nil, fmt.Errorf("conversion of runtime object to CRD failed (resulting runtime object not CRD type)")
-	}
 }
 
 // unstructuredToDeployment converts an unstructured object to a deployment

--- a/internal/util/k8sutil/crd.go
+++ b/internal/util/k8sutil/crd.go
@@ -1,0 +1,46 @@
+package k8sutil
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	yaml "github.com/ghodss/yaml"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+)
+
+func GetCRDs(crdsDir string) ([]*apiextv1beta1.CustomResourceDefinition, error) {
+	manifests, err := GetCRDManifestPaths(crdsDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CRD's from %s: (%v)", crdsDir, err)
+	}
+	crds := make([]*apiextv1beta1.CustomResourceDefinition, len(manifests))
+	for i, m := range manifests {
+		b, err := ioutil.ReadFile(m)
+		if err != nil {
+			return nil, err
+		}
+		if err = yaml.Unmarshal(b, crds[i]); err != nil {
+			return nil, err
+		}
+	}
+	return crds, nil
+}
+
+func GetCRDManifestPaths(crdsDir string) (crdPaths []string, err error) {
+	err = filepath.Walk(crdsDir, func(path string, info os.FileInfo, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if info == nil {
+			return nil
+		}
+		if !info.IsDir() && strings.HasSuffix(info.Name(), "_crd.yaml") {
+			crdPaths = append(crdPaths, filepath.Join(crdsDir, info.Name()))
+		}
+		return nil
+	})
+	return crdPaths, err
+}

--- a/internal/util/k8sutil/crd.go
+++ b/internal/util/k8sutil/crd.go
@@ -39,8 +39,8 @@ func GetCRDManifestPaths(crdsDir string) (crdPaths []string, err error) {
 		if info == nil {
 			return nil
 		}
-		if !info.IsDir() && strings.HasSuffix(info.Name(), "_crd.yaml") {
-			crdPaths = append(crdPaths, filepath.Join(crdsDir, info.Name()))
+		if !info.IsDir() && strings.HasSuffix(path, "_crd.yaml") {
+			crdPaths = append(crdPaths, path)
 		}
 		return nil
 	})

--- a/internal/util/k8sutil/crd.go
+++ b/internal/util/k8sutil/crd.go
@@ -16,15 +16,17 @@ func GetCRDs(crdsDir string) ([]*apiextv1beta1.CustomResourceDefinition, error) 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get CRD's from %s: (%v)", crdsDir, err)
 	}
-	crds := make([]*apiextv1beta1.CustomResourceDefinition, len(manifests))
-	for i, m := range manifests {
+	var crds []*apiextv1beta1.CustomResourceDefinition
+	for _, m := range manifests {
 		b, err := ioutil.ReadFile(m)
 		if err != nil {
 			return nil, err
 		}
-		if err = yaml.Unmarshal(b, crds[i]); err != nil {
+		crd := &apiextv1beta1.CustomResourceDefinition{}
+		if err = yaml.Unmarshal(b, crd); err != nil {
 			return nil, err
 		}
+		crds = append(crds, crd)
 	}
 	return crds, nil
 }


### PR DESCRIPTION
**Description of the change:** move getCRDs to `internal/util/k8sutil/crd.go` as an exported function, and add a helper to get CRD files.

**Motivation for the change:** getting CRD's or their manifests occurs in at least one other place in the SDK. These two helpers will be useful in `generate openapi` and other commands. For example, PR #1016 will use them.