### PR TITLE
hack/ci/check-doc-only-update: don't set -x

### DIFF
--- a/hack/ci/check-doc-only-update.sh
+++ b/hack/ci/check-doc-only-update.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 # Make sure the TRAVIS_COMMIT_RANGE is valid, by catching any errors and exiting.
 if [ -z "$TRAVIS_COMMIT_RANGE" ] || ! git rev-list --quiet $TRAVIS_COMMIT_RANGE; then


### PR DESCRIPTION
**Description of the change:** Removes `-x` set option in check-doc-only-update


**Motivation for the change:** The `set -x` option was persisting throughout the entire test since we were sourcing the script, and this was causing the travis logs to become much more difficult to understand. We don't need the `-x` option for this script, so we can remove it to improve the travis logs.