### PR TITLE
pkg/scaffold: use afero.Fs instead of os package directly

### DIFF
--- a/internal/util/fileutil/file_util.go
+++ b/internal/util/fileutil/file_util.go
@@ -42,10 +42,6 @@ type FileWriter struct {
 	once sync.Once
 }
 
-func NewFileWriter() *FileWriter {
-	return NewFileWriterFS(afero.NewOsFs())
-}
-
 func NewFileWriterFS(fs afero.Fs) *FileWriter {
 	fw := &FileWriter{}
 	fw.once.Do(func() {

--- a/pkg/scaffold/ansible/k8s_status.go
+++ b/pkg/scaffold/ansible/k8s_status.go
@@ -31,7 +31,6 @@ func (k *K8sStatus) GetInput() (input.Input, error) {
 	if k.Path == "" {
 		k.Path = K8sStatusPythonFile
 	}
-	k.TemplateBody = k8sStatusTmpl
 	return k.Input, nil
 }
 

--- a/pkg/scaffold/ansible/k8s_status.go
+++ b/pkg/scaffold/ansible/k8s_status.go
@@ -16,6 +16,7 @@ package ansible
 
 import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
+	"github.com/spf13/afero"
 )
 
 const K8sStatusPythonFile = "library/k8s_status.py"
@@ -33,6 +34,8 @@ func (k *K8sStatus) GetInput() (input.Input, error) {
 	k.TemplateBody = k8sStatusTmpl
 	return k.Input, nil
 }
+
+func (s K8sStatus) SetFS(_ afero.Fs) {}
 
 func (k K8sStatus) CustomRender() ([]byte, error) {
 	return []byte(k8sStatusTmpl), nil

--- a/pkg/scaffold/crd.go
+++ b/pkg/scaffold/crd.go
@@ -76,6 +76,8 @@ func initCache() {
 	})
 }
 
+func (s *CRD) SetFS(_ afero.Fs) {}
+
 func (s *CRD) CustomRender() ([]byte, error) {
 	i, _ := s.GetInput()
 	// controller-tools generates crd file names with no _crd.yaml suffix:

--- a/pkg/scaffold/customrender.go
+++ b/pkg/scaffold/customrender.go
@@ -14,8 +14,16 @@
 
 package scaffold
 
+import "github.com/spf13/afero"
+
 // CustomRenderer is the interface for writing any scaffold file that does
 // not use a template.
 type CustomRenderer interface {
+	// SetFS sets the fs in the CustomRenderer's underlying type if it exists.
+	// SetFS is used to inject the callers' fs into a CustomRenderer, which may
+	// want to write/read from the same fs.
+	SetFS(afero.Fs)
+	// CustomRender performs arbitrary rendering of file data and returns
+	// bytes to write to a file.
 	CustomRender() ([]byte, error)
 }

--- a/pkg/scaffold/olm-catalog/concat_crd.go
+++ b/pkg/scaffold/olm-catalog/concat_crd.go
@@ -21,6 +21,8 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/util/yamlutil"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
+
+	"github.com/spf13/afero"
 )
 
 const ConcatCRDYamlFile = "_generated.concat_crd.yaml"
@@ -45,6 +47,8 @@ func (s *ConcatCRD) GetInput() (input.Input, error) {
 	}
 	return s.Input, nil
 }
+
+func (s *ConcatCRD) SetFS(_ afero.Fs) {}
 
 // CustomRender returns the bytes of all CRD manifests concatenated into one file.
 func (s *ConcatCRD) CustomRender() ([]byte, error) {

--- a/pkg/scaffold/olm-catalog/csv.go
+++ b/pkg/scaffold/olm-catalog/csv.go
@@ -82,6 +82,8 @@ func (s *CSV) GetInput() (input.Input, error) {
 	return s.Input, nil
 }
 
+func (s *CSV) SetFS(fs afero.Fs) { s.initFS(fs) }
+
 // CustomRender allows a CSV to be written by marshalling
 // olmapiv1alpha1.ClusterServiceVersion instead of writing to a template.
 func (s *CSV) CustomRender() ([]byte, error) {

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -145,6 +145,7 @@ func (s *Scaffold) doRender(i input.Input, e input.File, absPath string) error {
 
 	var b []byte
 	if c, ok := e.(CustomRenderer); ok {
+		c.SetFS(s.Fs)
 		// CustomRenderers have a non-template method of file rendering.
 		if b, err = c.CustomRender(); err != nil {
 			return err

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -29,6 +29,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/scaffold/input"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 	"golang.org/x/tools/imports"
 )
 
@@ -36,13 +37,13 @@ import (
 type Scaffold struct {
 	// Repo is the go project package
 	Repo string
-
 	// AbsProjectPath is the absolute path to the project root, including the project directory.
 	AbsProjectPath string
-
 	// ProjectName is the operator's name, ex. app-operator
 	ProjectName string
-
+	// Fs is the filesystem GetWriter uses to write scaffold files.
+	Fs afero.Fs
+	// GetWriter returns a writer for writing scaffold files.
 	GetWriter func(path string, mode os.FileMode) (io.Writer, error)
 }
 
@@ -74,8 +75,11 @@ func (s *Scaffold) configure(cfg *input.Config) {
 
 // Execute executes scaffolding the Files
 func (s *Scaffold) Execute(cfg *input.Config, files ...input.File) error {
+	if s.Fs == nil {
+		s.Fs = afero.NewOsFs()
+	}
 	if s.GetWriter == nil {
-		s.GetWriter = fileutil.NewFileWriter().WriteCloser
+		s.GetWriter = fileutil.NewFileWriterFS(s.Fs).WriteCloser
 	}
 
 	// Configure s using common fields from cfg.
@@ -107,7 +111,7 @@ func (s *Scaffold) doFile(e input.File) error {
 	absFilePath := filepath.Join(s.AbsProjectPath, i.Path)
 
 	// Check if the file to write already exists
-	if _, err := os.Stat(absFilePath); err == nil || os.IsExist(err) {
+	if _, err := s.Fs.Stat(absFilePath); err == nil || os.IsExist(err) {
 		switch i.IfExistsAction {
 		case input.Overwrite:
 		case input.Skip:
@@ -168,9 +172,11 @@ func (s *Scaffold) doRender(i input.Input, e input.File, absPath string) error {
 	}
 
 	// Files being overwritten must be trucated to len 0 so no old bytes remain.
-	if _, err = os.Stat(absPath); err == nil && i.IfExistsAction == input.Overwrite {
-		if err = os.Truncate(absPath, 0); err != nil {
-			return err
+	if _, err = s.Fs.Stat(absPath); err == nil && i.IfExistsAction == input.Overwrite {
+		if file, ok := f.(afero.File); ok {
+			if err = file.Truncate(0); err != nil {
+				return err
+			}
 		}
 	}
 	_, err = f.Write(b)


### PR DESCRIPTION
**Description of the change:** add an `afero.Fs` field to Scaffold and use it in place of directly calling functions from the `os` package. `CustomRenderer`s must now implement `SetFS()`.


**Motivation for the change:** more versatile, enhances our ability to test complex scaffolds. `SetFS()` injects a `Scaffold`'s fs at runtime so we don't have unnecessarily disconnected fs'.