### PR TITLE
pkg, example: Remove unnecessary declaration

### DIFF
--- a/example/memcached-operator/memcached_controller.go.tmpl
+++ b/example/memcached-operator/memcached_controller.go.tmpl
@@ -68,8 +68,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	return nil
 }
 
-var _ reconcile.Reconciler = &ReconcileMemcached{}
-
 // ReconcileMemcached reconciles a Memcached object
 type ReconcileMemcached struct {
 	// TODO: Clarify the split client

--- a/pkg/helm/controller/reconcile.go
+++ b/pkg/helm/controller/reconcile.go
@@ -31,8 +31,6 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/helm/release"
 )
 
-var _ reconcile.Reconciler = &HelmOperatorReconciler{}
-
 // ReleaseHookFunc defines a function signature for release hooks.
 type ReleaseHookFunc func(*rpb.Release) error
 

--- a/pkg/scaffold/controller_kind.go
+++ b/pkg/scaffold/controller_kind.go
@@ -106,8 +106,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	return nil
 }
 
-var _ reconcile.Reconciler = &Reconcile{{ .Resource.Kind }}{}
-
 // Reconcile{{ .Resource.Kind }} reconciles a {{ .Resource.Kind }} object
 type Reconcile{{ .Resource.Kind }} struct {
 	// This client, initialized using mgr.Client() above, is a split client

--- a/pkg/scaffold/controller_kind_test.go
+++ b/pkg/scaffold/controller_kind_test.go
@@ -104,8 +104,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	return nil
 }
 
-var _ reconcile.Reconciler = &ReconcileAppService{}
-
 // ReconcileAppService reconciles a AppService object
 type ReconcileAppService struct {
 	// This client, initialized using mgr.Client() above, is a split client


### PR DESCRIPTION
**Description of the change:**
Removal of "var _ reconcile.Reconciler" declarations from `helm/controller/reconcile.go`, `pkg/scaffold/controller_kind.go` and `example/memcached-operator/memcached_controller.go.tmpl`.

**Motivation for the change:**
Declaration with a blank identifier seems meaningless.


P.S: I am new to operator SDK and Go, so it's entirely possible that these declarations have a meaningful purpose, and if so, I would like to kindly ask you to explain it. Thank you.