### PR TITLE
pkg/test/main_entry.go: build local binary instead of `go run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bug Fixes
 
+- Fix issue where running `operator-sdk test local --up-local` would sometimes leave a running process in the background after exit ([#1089](https://github.com/operator-framework/operator-sdk/pull/1020))
+
 ## v0.5.0
 
 ### Added


### PR DESCRIPTION
**Description of the change:** Build the test local binary instead of using `go run`. Essentially runs `--up-local` in the same way that #1010 changed the `up local` subcommand to work.


**Motivation for the change:** This allows us to kill the process on exit correctly, which wouldn't always work correctly when using `go run`

Closes #1088