### PR TITLE
commands/.../test/local: move an error check to correct location

### DIFF
--- a/commands/operator-sdk/cmd/test/local.go
+++ b/commands/operator-sdk/cmd/test/local.go
@@ -130,19 +130,19 @@ func testLocalGoFunc(cmd *cobra.Command, args []string) error {
 			tlConfig.namespacedManPath = file.Name()
 		} else {
 			file, err := ioutil.TempFile("", "empty.yaml")
+			if err != nil {
+				return fmt.Errorf("could not create empty manifest file: (%v)", err)
+			}
 			tlConfig.namespacedManPath = file.Name()
 			emptyBytes := []byte{}
 			if err := file.Chmod(os.FileMode(fileutil.DefaultFileMode)); err != nil {
 				return fmt.Errorf("could not chown temporary namespaced manifest file: (%v)", err)
 			}
 			if _, err := file.Write(emptyBytes); err != nil {
-				return fmt.Errorf("could not create temporary namespaced manifest file: (%v)", err)
+				return fmt.Errorf("could not write temporary namespaced manifest file: (%v)", err)
 			}
 			if err := file.Close(); err != nil {
 				return err
-			}
-			if err != nil {
-				return fmt.Errorf("could not create empty manifest file: (%v)", err)
 			}
 		}
 		defer func() {


### PR DESCRIPTION
**Description of the change:** Move error check to correct location


**Motivation for the change:** Check error correctly

/cc @hasbro17 