### PR TITLE
doc/ansible/dev/*: add documentation for dependent watches option

### DIFF
--- a/doc/ansible/dev/advanced_options.md
+++ b/doc/ansible/dev/advanced_options.md
@@ -13,7 +13,7 @@ Some features can be overridden per resource via an annotation on that CR. The o
 |---------|----------|------------|-------------------------|---------|---------------|
 | Reconcile Period | `reconcilePeriod`  | time between reconcile runs for a particular CR  | ansbile.operator-sdk/reconcile-period  | 1m | |
 | Manage Status | `manageStatus` | Allows the ansible operator to manage the conditions section of each resource's status section. | | true | |
-| Watching Dependent Resources | `watchDependentResources` | Allows the ansible operator to dynamically watch resources that are created by ansible | | true | |
+| Watching Dependent Resources | `watchDependentResources` | Allows the ansible operator to dynamically watch resources that are created by ansible | | true | [dependent_watches.md](dependent_watches.md) |
 | Watching Cluster-Scoped Resources | `watchClusterScopedResources` | Allows the ansible operator to watch cluster-scoped resources that are created by ansible | | false | |
 | Max Runner Artifacts | `maxRunnerArtifacts` | Manages the number of [artifact directories](https://ansible-runner.readthedocs.io/en/latest/intro.html#runner-artifacts-directory-hierarchy) that ansible runner will keep in the operator container for each individual resource. | ansible.operator-sdk/max-runner-artifacts | 20 | |
 | Finalizer | `finalizer`  | Sets a finalizer on the CR and maps a deletion event to a playbook or role | | | [finalizers.md](finalizers.md)|

--- a/doc/ansible/dev/dependent_watches.md
+++ b/doc/ansible/dev/dependent_watches.md
@@ -1,0 +1,33 @@
+# Dependent Watches
+This document describes the `watchDependentResources` option in [`watches.yaml`](https://github.com/operator-framework/operator-sdk/blob/0136d0ec3f916364a4f005895ef12aa80ab8f2de/doc/ansible/dev/advanced_options.md#watches-file-options) file. It delves into what dependent resources are, why the option is required, how it is achieved and finally gives an example.
+
+### What are dependent resources?
+In most cases, an operator creates a bunch of Kubernetes resources in the cluster, that helps deploy and manage the application. For instance, the [etcd-operator](https://github.com/coreos/etcd-operator/blob/master/doc/gif/demo.gif) creates two services and a number of pods for a single `EtcdCluster` CR. In this case, all the Kubernetes resources created by the operator for a CR is defined as dependent resources.
+
+### Why the `watchDependentResources` option?
+Often, an operator needs to watch dependent resources. To achieve this, a developer would set the field, `watchDependentResources` to `True` in the `watches.yaml` file. If enabled, a change in a dependent resource will trigger the reconciliation loop causing Ansible code to run.
+
+For example, since the _etcd-operator_ needs to ensure that all the pods are up and running, it needs to know when a pod changes. Enabling the dependent watches option would trigger the reconciliation loop to run. The Ansible logic needs to handle these cases and make sure that all the dependent resources are in the desired state as declared by the `CR spec`
+
+`Note: By default it is enabled when using ansible-operator`
+
+### How is this achieved?
+The `ansible-operator` base image achieves this by leveraging the concept of [owner-references](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/). Whenever a Kubernetes resource is created by Ansible code, the `ansible-operator`'s `proxy` module injects `owner-references` into the resource being created. The `owner-references` means the resource is owned by the CR for which reconciliation is taking place.
+
+Whenever the `watchDependentResources` field is enabled, the `ansible-operator` will watch all the resources owned by the CR, registering callbacks to their change events. Upon a change, the callback will enqueue a `ReconcileRequest` for the CR. The enqueued reconciliation request will trigger the `Reconcile` function of the controller which will execute the ansible logic for reconciliation.
+
+### Example
+
+This is an example of a watches file with the `watchDependentResources` field set to `True`
+```yaml
+
+- version: v1alpha1
+  group: app.example.com
+  kind: AppService
+  playbook: /opt/ansible/playbook.yml
+  maxRunnerArtifacts: 30
+  reconcilePeriod: 5s
+  manageStatus: False
+  watchDependentResources: True
+
+```

--- a/doc/ansible/dev/dependent_watches.md
+++ b/doc/ansible/dev/dependent_watches.md
@@ -1,5 +1,5 @@
 # Dependent Watches
-This document describes the `watchDependentResources` option in [`watches.yaml`](https://github.com/operator-framework/operator-sdk/blob/0136d0ec3f916364a4f005895ef12aa80ab8f2de/doc/ansible/dev/advanced_options.md#watches-file-options) file. It delves into what dependent resources are, why the option is required, how it is achieved and finally gives an example.
+This document describes the `watchDependentResources` option in [`watches.yaml`](#Example) file. It delves into what dependent resources are, why the option is required, how it is achieved and finally gives an example.
 
 ### What are dependent resources?
 In most cases, an operator creates a bunch of Kubernetes resources in the cluster, that helps deploy and manage the application. For instance, the [etcd-operator](https://github.com/coreos/etcd-operator/blob/master/doc/gif/demo.gif) creates two services and a number of pods for a single `EtcdCluster` CR. In this case, all the Kubernetes resources created by the operator for a CR is defined as dependent resources.


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Add documentation for watching dependent resources.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
