### PR TITLE
pkg/scaffold/helm/operator.go: Remove metrics port

### DIFF
--- a/pkg/scaffold/helm/operator.go
+++ b/pkg/scaffold/helm/operator.go
@@ -56,9 +56,6 @@ spec:
         - name: {{.ProjectName}}
           # Replace this with the built image name
           image: REPLACE_IMAGE
-          ports:
-          - containerPort: 60000
-            name: metrics
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
This port is deprecated.

