### PR TITLE
pkg/scaffold/olm-catalog: remove required CRDDescription updater

### DIFF
--- a/pkg/scaffold/olm-catalog/csv_updaters.go
+++ b/pkg/scaffold/olm-catalog/csv_updaters.go
@@ -193,59 +193,34 @@ type CSVCustomResourceDefinitionsUpdate struct {
 }
 
 func (store *updaterStore) AddOwnedCRD(yamlDoc []byte) error {
-	crdDesc, err := parseCRDDescriptionFromYAML(yamlDoc)
-	if err == nil {
-		store.crdUpdate.Owned = append(store.crdUpdate.Owned, *crdDesc)
-	}
-	return err
-}
-
-func (store *updaterStore) AddRequiredCRD(yamlDoc []byte) error {
-	crdDesc, err := parseCRDDescriptionFromYAML(yamlDoc)
-	if err == nil {
-		store.crdUpdate.Required = append(store.crdUpdate.Required, *crdDesc)
-	}
-	return err
-}
-
-func parseCRDDescriptionFromYAML(yamlDoc []byte) (*olmapiv1alpha1.CRDDescription, error) {
 	crd := &apiextv1beta1.CustomResourceDefinition{}
 	if err := yaml.Unmarshal(yamlDoc, crd); err != nil {
-		return nil, err
+		return err
 	}
-	return &olmapiv1alpha1.CRDDescription{
+	store.crdUpdate.Owned = append(store.crdUpdate.Owned, olmapiv1alpha1.CRDDescription{
 		Name:    crd.ObjectMeta.Name,
 		Version: crd.Spec.Version,
 		Kind:    crd.Spec.Names.Kind,
-	}, nil
+	})
+	return nil
 }
 
-// Apply updates all CRDDescriptions with any user-defined data in csv's
-// CRDDescriptions.
+// Apply updates csv's "owned" CRDDescriptions. "required" CRDDescriptions are
+// left as-is, since they are user-defined values.
 func (u *CSVCustomResourceDefinitionsUpdate) Apply(csv *olmapiv1alpha1.ClusterServiceVersion) error {
-	set := make(map[string]*olmapiv1alpha1.CRDDescription)
-	for _, csvDesc := range csv.GetAllCRDDescriptions() {
-		set[csvDesc.Name] = &csvDesc
+	set := make(map[string]olmapiv1alpha1.CRDDescription)
+	for _, csvDesc := range csv.Spec.CustomResourceDefinitions.Owned {
+		set[csvDesc.Name] = csvDesc
 	}
 	du := u.DeepCopy()
-	for i, uDesc := range du.Owned {
+	for i, uDesc := range u.Owned {
 		if csvDesc, ok := set[uDesc.Name]; ok {
-			d := csvDesc.DeepCopy()
-			d.Name = uDesc.Name
-			d.Version = uDesc.Version
-			d.Kind = uDesc.Kind
-			du.Owned[i] = *d
+			csvDesc.Name = uDesc.Name
+			csvDesc.Version = uDesc.Version
+			csvDesc.Kind = uDesc.Kind
+			du.Owned[i] = csvDesc
 		}
 	}
-	for i, uDesc := range du.Required {
-		if csvDesc, ok := set[uDesc.Name]; ok {
-			d := csvDesc.DeepCopy()
-			d.Name = uDesc.Name
-			d.Version = uDesc.Version
-			d.Kind = uDesc.Kind
-			du.Required[i] = *d
-		}
-	}
-	csv.Spec.CustomResourceDefinitions = *du
+	csv.Spec.CustomResourceDefinitions.Owned = du.Owned
 	return nil
 }

--- a/pkg/scaffold/olm-catalog/csv_updaters.go
+++ b/pkg/scaffold/olm-catalog/csv_updaters.go
@@ -84,7 +84,7 @@ func (s *updaterStore) AddToUpdater(yamlSpec []byte) error {
 	case "Deployment":
 		return s.AddDeploymentSpec(yamlSpec)
 	case "CustomResourceDefinition":
-		// TODO: determine whether 'owned' or 'required'
+		// All CRD's present will be 'owned'.
 		return s.AddOwnedCRD(yamlSpec)
 	}
 	return nil

--- a/pkg/scaffold/olm-catalog/testdata/deploy/crds/app_v1alpha1_app_crd.yaml
+++ b/pkg/scaffold/olm-catalog/testdata/deploy/crds/app_v1alpha1_app_crd.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: apps.example.com
+  name: apps1.example.com
 spec:
   group: app.example.com
   names:

--- a/pkg/scaffold/olm-catalog/testdata/deploy/crds/app_v1alpha2_app_crd.yaml
+++ b/pkg/scaffold/olm-catalog/testdata/deploy/crds/app_v1alpha2_app_crd.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: apps.example.com
+  name: apps2.example.com
 spec:
   group: app.example.com
   names:

--- a/pkg/scaffold/olm-catalog/testdata/deploy/olm-catalog/app-operator/0.1.0/app-operator.v0.1.0.clusterserviceversion.yaml
+++ b/pkg/scaffold/olm-catalog/testdata/deploy/olm-catalog/app-operator/0.1.0/app-operator.v0.1.0.clusterserviceversion.yaml
@@ -8,12 +8,20 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - kind: App
-      name: apps.example.com
+    - displayName: some display name
+      kind: App
+      name: apps1.example.com
       version: v1alpha1
-    - kind: App
-      name: apps.example.com
+    - description: some description
+      kind: App
+      name: apps2.example.com
       version: v1alpha2
+    required:
+    - description: Represents a cluster of etcd nodes.
+      displayName: etcd Cluster
+      kind: EtcdCluster
+      name: etcdclusters.etcd.database.coreos.com
+      version: v1beta2
   description: Placeholder description
   displayName: App Operator
   install:


### PR DESCRIPTION
**Description of the change:** 
* pkg/scaffold/olm-catalog: remove required `CRDDescription` update and test preservation of required `CRDDescription`s

**Motivation for the change:** [required `CRDDescription`s](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md#required-crds) are user-defined fields since their CRD manifests will not be present in an operator package or project.
