### PR TITLE
doc/*: fix broken links

### DIFF
--- a/doc/dev/developer_guide.md
+++ b/doc/dev/developer_guide.md
@@ -47,7 +47,7 @@ See the project [README][sdk_readme] for more details.
 [git_tool]:https://git-scm.com/downloads
 [go_tool]:https://golang.org/dl/
 [repo_sdk]:https://github.com/operator-framework/operator-sdk
-[fork_guide]:https://help.github.com/articles/fork-a-repo/
+[fork_guide]:https://help.github.com/en/articles/fork-a-repo
 [docker_tool]:https://docs.docker.com/install/
 [kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [sdk_readme]:../../README.md

--- a/doc/dev/release.md
+++ b/doc/dev/release.md
@@ -251,7 +251,7 @@ You've now fully released a new version of the Operator SDK. Good work!
 
 [doc-maintainers]:../../MAINTAINERS
 [doc-readme-prereqs]:../../README.md#prerequisites
-[doc-git-default-key]:https://help.github.com/articles/telling-git-about-your-signing-key/
+[doc-git-default-key]:https://help.github.com/en/articles/telling-git-about-your-signing-key
 [doc-gpg-default-key]:https://lists.gnupg.org/pipermail/gnupg-users/2001-September/010163.html
 [link-github-gpg-key-upload]:https://github.com/settings/keys
 [link-git-config-gpg-key]:https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work

--- a/doc/versioning.md
+++ b/doc/versioning.md
@@ -25,4 +25,4 @@ Minor version changes will not break compatibility between the previous minor ve
 Patch versions changes are meant only for bug fixes, and will not break compatibility of the current minor version. A patch release will contain a collection of minor bug fixes, or individual major and security bug fixes, depending on severity.
 
 [link-semver]:https://semver.org/
-[link-github-milestones]: https://help.github.com/articles/about-milestones/
+[link-github-milestones]: https://help.github.com/en/articles/about-milestones


### PR DESCRIPTION
Looks like github added a language path segment before `articles`.