### PR TITLE
doc/helm/*: fix helm docs links

### DIFF
--- a/doc/helm/dev/developer_guide.md
+++ b/doc/helm/dev/developer_guide.md
@@ -450,7 +450,7 @@ message: "Hello world 2"
 newParameter: "newParam"
 ```
 
-[helm_charts]:https://docs.helm.sh/developing_charts
-[helm_values]:https://docs.helm.sh/using_helm/#customizing-the-chart-before-installing
-[helm_install]:https://docs.helm.sh/using_helm/
+[helm_charts]:https://helm.sh/docs/developing_charts/
+[helm_values]:https://helm.sh/docs/using_helm/#customizing-the-chart-before-installing
+[helm_install]:https://helm.sh/docs/using_helm/
 [helm_operator_user_guide]:../user-guide.md

--- a/doc/helm/project_layout.md
+++ b/doc/helm/project_layout.md
@@ -7,6 +7,8 @@ table describes a basic rundown of each generated file/directory.
 | File/Folders | Purpose |
 | :---         | :---    |
 | deploy | Contains a generic set of Kubernetes manifests for deploying this operator on a Kubernetes cluster. |
-| helm-charts/\<kind> | Contains a Helm chart initialized using the equivalent of [`helm create`](https://docs.helm.sh/helm/#helm-create) |
+| helm-charts/\<kind> | Contains a Helm chart initialized using the equivalent of [`helm create`][docs_helm_create] |
 | build | Contains scripts that the operator-sdk uses for build and initialization. |
 | watches.yaml | Contains Group, Version, Kind, and Helm chart location. |
+
+[docs_helm_create]:https://helm.sh/docs/helm/#helm-create

--- a/doc/helm/user-guide.md
+++ b/doc/helm/user-guide.md
@@ -47,7 +47,7 @@ This creates the nginx-operator project specifically for watching the
 Nginx resource with APIVersion `example.com/v1apha1` and Kind
 `Nginx`.
 
-To learn more about the project directory structure, see the 
+To learn more about the project directory structure, see the
 [project layout][layout_doc] doc.
 
 ### Operator scope
@@ -334,5 +334,5 @@ kubectl delete -f deploy/crds/example_v1alpha1_nginx_cr.yaml
 [docker_tool]:https://docs.docker.com/install/
 [kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [minikube_tool]:https://github.com/kubernetes/minikube#installation
-[helm_charts]:https://docs.helm.sh/developing_charts/
-[helm_values]:https://docs.helm.sh/using_helm/#customizing-the-chart-before-installing
+[helm_charts]:https://helm.sh/docs/developing_charts/
+[helm_values]:https://helm.sh/docs/using_helm/#customizing-the-chart-before-installing


### PR DESCRIPTION
More link issues, this time with helm docs. Not sure why `marker` isn't catching the redirect like my browser is.