### PR TITLE
Add support for "wait for pods" in e2eutils

### DIFF
--- a/pkg/test/e2eutil/wait_util.go
+++ b/pkg/test/e2eutil/wait_util.go
@@ -72,7 +72,7 @@ func WaitForDeployment(t *testing.T, kubeclient kubernetes.Interface, namespace,
 	return nil
 }
 
-func waitForPod(t *testing.T, runtimeClient test.FrameworkClient, namespace, name string, retryInterval, timeout time.Duration) error {
+func WaitForPod(t *testing.T, runtimeClient test.FrameworkClient, namespace, name string, retryInterval, timeout time.Duration) error {
 	pod := &corev1.Pod{}
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		err = runtimeClient.Get(context.TODO(), client.ObjectKey{Name: name, Namespace: namespace}, pod)

--- a/pkg/test/e2eutil/wait_util.go
+++ b/pkg/test/e2eutil/wait_util.go
@@ -73,7 +73,7 @@ func waitForDeployment(t *testing.T, kubeclient kubernetes.Interface, namespace,
 }
 
 func waitForPod(t *testing.T, runtimeClient test.FrameworkClient, namespace, name string, retryInterval, timeout time.Duration) error {
-	pod := &metav1.Pod{}
+	pod := &corev1.Pod{}
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		err = runtimeClient.Get(context.TODO(), client.ObjectKey{Name: name, Namespace: namespace}, pod)
 		if err != nil {
@@ -90,6 +90,7 @@ func waitForPod(t *testing.T, runtimeClient test.FrameworkClient, namespace, nam
 		t.Logf("Waiting for full availability of %s pod\n", name)
 		return false, nil
 	})
+
 	if err != nil {
 		return err
 	}

--- a/pkg/test/e2eutil/wait_util.go
+++ b/pkg/test/e2eutil/wait_util.go
@@ -44,7 +44,7 @@ func WaitForOperatorDeployment(t *testing.T, kubeclient kubernetes.Interface, na
 	return waitForDeployment(t, kubeclient, namespace, name, replicas, retryInterval, timeout, true)
 }
 
-func WaitForDeployment(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, replicas int, retryInterval, timeout time.Duration, isOperator bool) error {
+func waitForDeployment(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, replicas int, retryInterval, timeout time.Duration, isOperator bool) error {
 	if isOperator && test.Global.LocalOperator {
 		t.Log("Operator is running locally; skip waitForDeployment")
 		return nil
@@ -72,6 +72,8 @@ func WaitForDeployment(t *testing.T, kubeclient kubernetes.Interface, namespace,
 	return nil
 }
 
+// WaitForPod checks to see if a given pod is running after a specified amount of time.
+// If the deployment is not running after timeout * retries seconds, the function returns an error
 func WaitForPod(t *testing.T, runtimeClient test.FrameworkClient, namespace, name string, retryInterval, timeout time.Duration) error {
 	pod := &corev1.Pod{}
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {

--- a/pkg/test/e2eutil/wait_util.go
+++ b/pkg/test/e2eutil/wait_util.go
@@ -15,11 +15,14 @@
 package e2eutil
 
 import (
+	"context"
 	"testing"
 	"time"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/operator-framework/operator-sdk/pkg/test"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/test/e2eutil/wait_util.go
+++ b/pkg/test/e2eutil/wait_util.go
@@ -44,7 +44,7 @@ func WaitForOperatorDeployment(t *testing.T, kubeclient kubernetes.Interface, na
 	return waitForDeployment(t, kubeclient, namespace, name, replicas, retryInterval, timeout, true)
 }
 
-func waitForDeployment(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, replicas int, retryInterval, timeout time.Duration, isOperator bool) error {
+func WaitForDeployment(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, replicas int, retryInterval, timeout time.Duration, isOperator bool) error {
 	if isOperator && test.Global.LocalOperator {
 		t.Log("Operator is running locally; skip waitForDeployment")
 		return nil

--- a/pkg/test/e2eutil/wait_util.go
+++ b/pkg/test/e2eutil/wait_util.go
@@ -17,6 +17,7 @@ package e2eutil
 import (
 	"testing"
 	"time"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/operator-framework/operator-sdk/pkg/test"
 
@@ -65,5 +66,30 @@ func waitForDeployment(t *testing.T, kubeclient kubernetes.Interface, namespace,
 		return err
 	}
 	t.Logf("Deployment available (%d/%d)\n", replicas, replicas)
+	return nil
+}
+
+func waitForPod(t *testing.T, runtimeClient test.FrameworkClient, namespace, name string, retryInterval, timeout time.Duration) error {
+	pod := &metav1.Pod{}
+	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		err = runtimeClient.Get(context.TODO(), client.ObjectKey{Name: name, Namespace: namespace}, pod)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				t.Logf("Waiting for availability of %s pod\n", name)
+				return false, nil
+			}
+			return false, err
+		}
+
+		if pod.Status.Phase == corev1.PodRunning {
+			return true, nil
+		}
+		t.Logf("Waiting for full availability of %s pod\n", name)
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	t.Logf("%s Pod available\n", name)
 	return nil
 }


### PR DESCRIPTION
**Description of the change:**

Waiting for pods is useful for simple tests. 

Based on the feedback from 
https://github.com/operator-framework/operator-sdk/issues/1128#issuecomment-466549666

**Motivation for the change:**

Closes https://github.com/operator-framework/operator-sdk/issues/1128
