### PR TITLE
Molecule override cmd

### DIFF
--- a/pkg/scaffold/ansible/molecule_default_molecule.go
+++ b/pkg/scaffold/ansible/molecule_default_molecule.go
@@ -50,6 +50,7 @@ platforms:
   - k8s
   image: bsycorp/kind:latest-1.12
   privileged: True
+  override_command: no
   exposed_ports:
     - 8443/tcp
     - 10080/tcp

--- a/pkg/scaffold/ansible/molecule_test_local_molecule.go
+++ b/pkg/scaffold/ansible/molecule_test_local_molecule.go
@@ -50,6 +50,7 @@ platforms:
   - k8s
   image: bsycorp/kind:latest-1.12
   privileged: True
+  override_command: no
   exposed_ports:
     - 8443/tcp
     - 10080/tcp

--- a/test/ansible-inventory/molecule/test-local/molecule.yml
+++ b/test/ansible-inventory/molecule/test-local/molecule.yml
@@ -12,6 +12,7 @@ platforms:
   - k8s
   image: bsycorp/kind:latest-1.12
   privileged: True
+  override_command: no
   exposed_ports:
     - 8443/tcp
     - 10080/tcp

--- a/test/ansible-memcached/molecule.yml
+++ b/test/ansible-memcached/molecule.yml
@@ -12,6 +12,7 @@ platforms:
   - k8s
   image: bsycorp/kind:latest-1.12
   privileged: True
+  override_command: no
   exposed_ports:
     - 8443/tcp
     - 10080/tcp


### PR DESCRIPTION
**Description of the change:**
Molecule now requires you to set the `override_command` option to `false` in order to prevent it from overriding the `CMD` directive on a docker image you're using. This PR brings the generated molecule.yml files up to date. See https://github.com/ansible/molecule/pull/1771

**Motivation for the change:**
We're going to break without it.

