### PR TITLE
pkg/scaffold/olm-catalog: add InstallModes to CSV's

### DIFF
--- a/pkg/scaffold/olm-catalog/testdata/deploy/olm-catalog/app-operator/0.1.0/app-operator.v0.1.0.clusterserviceversion.yaml
+++ b/pkg/scaffold/olm-catalog/testdata/deploy/olm-catalog/app-operator/0.1.0/app-operator.v0.1.0.clusterserviceversion.yaml
@@ -81,6 +81,15 @@ spec:
           - '*'
         serviceAccountName: app-operator
     strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespace
   maturity: Basic Install
   provider: {}
   version: 0.1.0


### PR DESCRIPTION
**Description of the change:** add `spec.installModes` to CSV's that don't have them.

**Motivation for the change:** SDK operators must specify that the `MultiNamespace` install mode is not supported.
