### PR TITLE
pkg/helm/run.go: fix logging when WATCH_NAMESPACE=""

### DIFF
--- a/pkg/helm/run.go
+++ b/pkg/helm/run.go
@@ -53,9 +53,13 @@ func Run(flags *hoflags.HelmOperatorFlags) error {
 	namespace, found := os.LookupEnv(k8sutil.WatchNamespaceEnvVar)
 	log = log.WithValues("Namespace", namespace)
 	if found {
-		log.Info("Watching single namespace.")
+		if namespace == metav1.NamespaceAll {
+			log.Info("Watching all namespaces.")
+		} else {
+			log.Info("Watching single namespace.")
+		}
 	} else {
-		log.Info(fmt.Sprintf("%v environment variable not set. This operator is watching all namespaces.",
+		log.Info(fmt.Sprintf("%v environment variable not set. Watching all namespaces.",
 			k8sutil.WatchNamespaceEnvVar))
 		namespace = metav1.NamespaceAll
 	}


### PR DESCRIPTION
**Description of the change:**
Fixes logging about which namespaces are watched.

**Motivation for the change:**
Addressing [this comment](https://github.com/operator-framework/operator-sdk/pull/917#discussion_r252010384) since #917 will likely be closed in favor of #1102.