### PR TITLE
Code cleanup for removing unused container port:60000

### DIFF
--- a/pkg/scaffold/olm-catalog/testdata/deploy/olm-catalog/app-operator/0.1.0/app-operator.v0.1.0.clusterserviceversion.yaml
+++ b/pkg/scaffold/olm-catalog/testdata/deploy/olm-catalog/app-operator/0.1.0/app-operator.v0.1.0.clusterserviceversion.yaml
@@ -45,9 +45,6 @@ spec:
                 image: quay.io/example-inc/operator:v0.1.0
                 imagePullPolicy: Always
                 name: app-operator
-                ports:
-                - containerPort: 60000
-                  name: metrics
                 resources: {}
               serviceAccountName: app-operator
       permissions:

--- a/pkg/scaffold/olm-catalog/testdata/deploy/operator.yaml
+++ b/pkg/scaffold/olm-catalog/testdata/deploy/operator.yaml
@@ -16,9 +16,6 @@ spec:
       containers:
         - name: app-operator
           image: quay.io/example-inc/operator:v0.1.0
-          ports:
-          - containerPort: 60000
-            name: metrics
           command:
           - app-operator
           imagePullPolicy: Always

--- a/test/ansible-inventory/deploy/operator.yaml
+++ b/test/ansible-inventory/deploy/operator.yaml
@@ -17,9 +17,6 @@ spec:
         - name: inventory
           # Replace this with the built image name
           image: "{{ REPLACE_IMAGE }}"
-          ports:
-          - containerPort: 60000
-            name: metrics
           imagePullPolicy: "{{ pull_policy|default('Always') }}"
           env:
             - name: WATCH_NAMESPACE

--- a/test/test-framework/deploy/namespace-init.yaml
+++ b/test/test-framework/deploy/namespace-init.yaml
@@ -85,9 +85,6 @@ spec:
         image: quay.io/coreos/operator-sdk-dev:test-framework-operator-runtime
         imagePullPolicy: Always
         name: memcached-operator
-        ports:
-        - containerPort: 60000
-          name: metrics
         resources: {}
       serviceAccountName: memcached-operator
 status: {}

--- a/test/test-framework/deploy/olm-catalog/memcached-operator/0.0.2/memcached-operator.v0.0.2.clusterserviceversion.yaml
+++ b/test/test-framework/deploy/olm-catalog/memcached-operator/0.0.2/memcached-operator.v0.0.2.clusterserviceversion.yaml
@@ -36,9 +36,6 @@ spec:
                 - name: memcached-operator
                   # Replace this with the built image name
                   image: quay.io/example/memcached-operator:v0.0.1
-                  ports:
-                  - containerPort: 60000
-                    name: metrics
                   command:
                   - memcached-operator
                   imagePullPolicy: Never

--- a/test/test-framework/deploy/operator.yaml
+++ b/test/test-framework/deploy/operator.yaml
@@ -17,9 +17,6 @@ spec:
         - name: memcached-operator
           # Replace this with the built image name
           image: quay.io/coreos/operator-sdk-dev:test-framework-operator
-          ports:
-          - containerPort: 60000
-            name: metrics
           command:
           - memcached-operator
           imagePullPolicy: Always


### PR DESCRIPTION
metrics: Cleanup unused container port

Code cleanup for removing containerPort:60000. It is deprecated.

Closes #1130 
