### PR TITLE
Use RHEL UBI for go, helm, and scorecard base images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Changed the Go, Helm, and Scorecard base images to `registry.access.redhat.com/ubi7/ubi-minimal:7.6` ([#1139](https://github.com/operator-framework/operator-sdk/pull/1139))
+
 ### Deprecated
 
 ### Removed

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -36,7 +36,7 @@ building example-operator...
 
 building container quay.io/example/operator:v0.0.1...
 Sending build context to Docker daemon  163.9MB
-Step 1/4 : FROM alpine:3.6
+Step 1/4 : FROM registry.access.redhat.com/ubi7/ubi-minimal:7.6
  ---> 77144d8c6bdc
 Step 2/4 : ADD tmp/_output/bin/example-operator /usr/local/bin/example-operator
  ---> 2ada0d6ca93c

--- a/images/scorecard-proxy/Dockerfile
+++ b/images/scorecard-proxy/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM alpine:3.8
+FROM registry.access.redhat.com/ubi7/ubi-minimal:7.6
 
 ENV PROXY=/usr/local/bin/scorecard-proxy \
     USER_UID=1001 \

--- a/pkg/scaffold/build_dockerfile.go
+++ b/pkg/scaffold/build_dockerfile.go
@@ -34,7 +34,7 @@ func (s *Dockerfile) GetInput() (input.Input, error) {
 	return s.Input, nil
 }
 
-const dockerfileTmpl = `FROM alpine:3.8
+const dockerfileTmpl = `FROM registry.access.redhat.com/ubi7/ubi-minimal:7.6
 
 ENV OPERATOR=/usr/local/bin/{{.ProjectName}} \
     USER_UID=1001 \

--- a/pkg/scaffold/build_dockerfile_test.go
+++ b/pkg/scaffold/build_dockerfile_test.go
@@ -33,7 +33,7 @@ func TestDockerfile(t *testing.T) {
 	}
 }
 
-const dockerfileExp = `FROM alpine:3.8
+const dockerfileExp = `FROM registry.access.redhat.com/ubi7/ubi-minimal:7.6
 
 ENV OPERATOR=/usr/local/bin/app-operator \
     USER_UID=1001 \

--- a/pkg/scaffold/helm/dockerfilehybrid.go
+++ b/pkg/scaffold/helm/dockerfilehybrid.go
@@ -41,7 +41,7 @@ func (d *DockerfileHybrid) GetInput() (input.Input, error) {
 	return d.Input, nil
 }
 
-const dockerFileHybridHelmTmpl = `FROM alpine:3.6
+const dockerFileHybridHelmTmpl = `FROM registry.access.redhat.com/ubi7/ubi-minimal:7.6
 
 ENV OPERATOR=/usr/local/bin/helm-operator \
     USER_UID=1001 \


### PR DESCRIPTION
**Description of the change:**
Update Go, Helm, and Scorecard base images to use `registry.access.redhat.com/ubi7/ubi-minimal:7.6`

**Motivation for the change:**
To make simplify the process for making operators available in OCP.

Question: should we make this configurable via a flag or force this change on all users? Note that even if we force it on all users, they can always change their Dockerfile to use whatever base image they want.

/cc @dmesser @robszumski 