### PR TITLE
OWNERS: add file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,20 @@
+approvers:
+  - hasbro17
+  - AlexNPavel
+  - estroz
+  - shawn-hurley
+  - LiliC
+  - joelanford
+  - theishshah
+  - fabianvf
+  - dymurray
+reviewers:
+  - hasbro17
+  - AlexNPavel
+  - estroz
+  - shawn-hurley
+  - LiliC
+  - joelanford
+  - theishshah
+  - fabianvf
+  - dymurray


### PR DESCRIPTION
**Description of the change:** Add OWNERS file. Currently, all reviewers are also approvers.


**Motivation for the change:** To start integrating with Openshift Prow automation, we need an OWNERS file. For now, this won't change the way we approve of merge PRs, but we may start to use prow for those features in the future.