### PR TITLE
OWNERS,*/OWNERS: add fabianvf and jmrodri to OWNERS for ansible

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,8 +6,6 @@ approvers:
   - LiliC
   - joelanford
   - theishshah
-  - fabianvf
-  - dymurray
 reviewers:
   - hasbro17
   - AlexNPavel
@@ -16,5 +14,3 @@ reviewers:
   - LiliC
   - joelanford
   - theishshah
-  - fabianvf
-  - dymurray

--- a/doc/ansible/OWNERS
+++ b/doc/ansible/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - fabianvf
+  - jmrodri
+reviewers:
+  - fabianvf
+  - jmrodri

--- a/pkg/ansible/OWNERS
+++ b/pkg/ansible/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - fabianvf
+  - jmrodri
+reviewers:
+  - fabianvf
+  - jmrodri

--- a/pkg/scaffold/ansible/OWNERS
+++ b/pkg/scaffold/ansible/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - fabianvf
+  - jmrodri
+reviewers:
+  - fabianvf
+  - jmrodri

--- a/test/ansible-inventory/OWNERS
+++ b/test/ansible-inventory/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - fabianvf
+  - jmrodri
+reviewers:
+  - fabianvf
+  - jmrodri

--- a/test/ansible-memcached/OWNERS
+++ b/test/ansible-memcached/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - fabianvf
+  - jmrodri
+reviewers:
+  - fabianvf
+  - jmrodri


### PR DESCRIPTION
**Description of the change:** This commit adds fabianvf and jmrodri to OWNERS files for ansible related directories. This prevents them from automatically being added as reviewers by the ci-robot for non-ansible related SDK PRs.


**Motivation for the change:** Prevent the ci-robot from automatically requesting reviews from people working specifically on the ansible operator on non-ansible related PRs.

/cc @jmrodri @fabianvf @shawn-hurley 