### PR TITLE
pkg,test: Add deployments/finalizers to roles

### DIFF
--- a/pkg/scaffold/olm-catalog/testdata/deploy/olm-catalog/app-operator/0.1.0/app-operator.v0.1.0.clusterserviceversion.yaml
+++ b/pkg/scaffold/olm-catalog/testdata/deploy/olm-catalog/app-operator/0.1.0/app-operator.v0.1.0.clusterserviceversion.yaml
@@ -86,6 +86,14 @@ spec:
           - '*'
           verbs:
           - '*'
+        - apiGroups:
+          - apps
+          resourceNames:
+          - app-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
         serviceAccountName: app-operator
     strategy: deployment
   installModes:

--- a/pkg/scaffold/olm-catalog/testdata/deploy/role.yaml
+++ b/pkg/scaffold/olm-catalog/testdata/deploy/role.yaml
@@ -31,4 +31,12 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  resourceNames:
+  - app-operator
+  verbs:
+  - "update"
 serviceAccountName: app-operator

--- a/pkg/scaffold/role.go
+++ b/pkg/scaffold/role.go
@@ -191,4 +191,12 @@ rules:
   verbs:
   - "get"
   - "create"
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  resourceNames:
+  - {{ .ProjectName }}
+  verbs:
+  - "update"
 `

--- a/pkg/scaffold/role_test.go
+++ b/pkg/scaffold/role_test.go
@@ -85,6 +85,14 @@ rules:
   verbs:
   - "get"
   - "create"
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  resourceNames:
+  - app-operator
+  verbs:
+  - "update"
 `
 
 const clusterroleExp = `kind: ClusterRole
@@ -126,4 +134,12 @@ rules:
   verbs:
   - "get"
   - "create"
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  resourceNames:
+  - app-operator
+  verbs:
+  - "update"
 `

--- a/test/test-framework/deploy/namespace-init.yaml
+++ b/test/test-framework/deploy/namespace-init.yaml
@@ -38,6 +38,14 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  resourceNames:
+  - memcached-operator
+  verbs:
+  - "update"
 
 ---
 

--- a/test/test-framework/deploy/olm-catalog/memcached-operator/0.0.2/memcached-operator.v0.0.2.clusterserviceversion.yaml
+++ b/test/test-framework/deploy/olm-catalog/memcached-operator/0.0.2/memcached-operator.v0.0.2.clusterserviceversion.yaml
@@ -53,6 +53,14 @@ spec:
           - '*'
           verbs:
           - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          resourceNames:
+          - memcached-operator
+          verbs:
+          - "update"
       deployments:
       - name: memcached-operator
         spec:

--- a/test/test-framework/deploy/role.yaml
+++ b/test/test-framework/deploy/role.yaml
@@ -31,3 +31,11 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  resourceNames:
+  - memcached-operator
+  verbs:
+  - "update"


### PR DESCRIPTION

**Description of the change:**
Because the Service now adds an OwnerReference wherever
OwnerReferencesPermissionEnforcement is enabled this role is needed
to be able to create an OwnerReference in the Service that points to the
Deployment.

Because we determine the owner of the Service dynamically, this role
would need to be adjusted by the user to fit whatever type of deployment
resource they use.

