### PR TITLE
Added version command

### DIFF
--- a/commands/operator-sdk/cmd/root.go
+++ b/commands/operator-sdk/cmd/root.go
@@ -39,6 +39,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(NewMigrateCmd())
 	cmd.AddCommand(NewRunCmd())
 	cmd.AddCommand(NewOLMCatalogCmd())
+	cmd.AddCommand(NewVersionCmd())
 
 	return cmd
 }

--- a/commands/operator-sdk/cmd/version.go
+++ b/commands/operator-sdk/cmd/version.go
@@ -1,0 +1,35 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	sdkVersion "github.com/operator-framework/operator-sdk/version"
+	"github.com/spf13/cobra"
+)
+
+func NewVersionCmd() *cobra.Command {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Prints the version",
+		Long:  `The version command prints the version of the operator-sdk.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("operator-sdk version: %v\n", sdkVersion.Version)
+		},
+	}
+
+	return versionCmd
+}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adding version command.
Note: Leaves intact --version behavior in case that would affect somebody.

**Motivation for the change:**
Bringing operator-sdk into sync with other k8s binaries in look and feel
Closes #1165 

