### PR TITLE
Adding max workers to the string of the message instead of a logr field

### DIFF
--- a/pkg/ansible/operator/operator.go
+++ b/pkg/ansible/operator/operator.go
@@ -89,7 +89,7 @@ func getMaxWorkers(gvk schema.GroupVersionKind, defvalue int) int {
 	if err != nil {
 		// we don't care why we couldn't parse it just use one.
 		// maybe we should log that we are defaulting to 1.
-		logf.Log.WithName("manager").V(0).Info("Using default value for workers %d", defvalue)
+		logf.Log.WithName("manager").V(0).Info(fmt.Sprintf("Using default value for workers %d", defvalue))
 		return defvalue
 	}
 


### PR DESCRIPTION

**Description of the change:**
add default workers value to the string of the message

**Motivation for the change:**
remove log panic logs from ansible operators when setting this option

Thanks @matihost for the report