### PR TITLE
commands/.../scorecard: set annotation example test max points to 1

### DIFF
--- a/commands/operator-sdk/cmd/scorecard/olm_tests.go
+++ b/commands/operator-sdk/cmd/scorecard/olm_tests.go
@@ -236,7 +236,7 @@ func getUsedResources(proxyPod *v1.Pod) ([]schema.GroupVersionKind, error) {
 
 // Run - implements Test interface
 func (t *AnnotationsContainExamplesTest) Run(ctx context.Context) *TestResult {
-	res := &TestResult{Test: t}
+	res := &TestResult{Test: t, MaximumPoints: 1}
 	if t.CSV.Annotations != nil && t.CSV.Annotations["alm-examples"] != "" {
 		res.EarnedPoints = 1
 	}

--- a/hack/tests/scorecard-subcommand.sh
+++ b/hack/tests/scorecard-subcommand.sh
@@ -19,11 +19,11 @@ commandoutput="$(operator-sdk scorecard \
   --proxy-image "$DEST_IMAGE" \
   --proxy-pull-policy Never \
   2>&1)"
-echo $commandoutput | grep "Total Score: 71%"
+echo $commandoutput | grep "Total Score: 80%"
 
 # test config file
 commandoutput2="$(operator-sdk scorecard \
   --proxy-image "$DEST_IMAGE" \
   --config "$CONFIG_PATH")"
-echo $commandoutput2 | grep "Total Score: 71%"
+echo $commandoutput2 | grep "Total Score: 80%"
 popd


### PR DESCRIPTION
**Description of the change:** Set maximum points for AnnotationsContiansExamples test to 1.


**Motivation for the change:** I forgot to set the maximum points for this test to 1 in the refactor, so now this was resulting in a score of 1/0 on pass instead of 1/1, and a fail was resulting in 0/0 instead of 0/1.