### PR TITLE
.github: don't ask for Gopkg.lock

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -25,7 +25,7 @@ A clear and concise description of what you expected to happen (or insert a code
 **Environment**
 * operator-sdk version:
 
-  Insert operator-sdk release or Git SHA here. If you have paste the Gopkg.lock operator-sdk information here. 
+  Insert operator-sdk release or Git SHA here.
 
 * Kubernetes version information:
 


### PR DESCRIPTION


**Description of the change:**

Don't ask for Gopkg.lock info in bug report template


**Motivation for the change:**

That info isn't useful in most cases and makes the issue message long enough to be unreadable.
