### PR TITLE
pkg/test: remove dependence on ctx.t

### DIFF
--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -67,26 +67,19 @@ func (ctx *TestCtx) GetID() string {
 }
 
 func (ctx *TestCtx) Cleanup() {
-	for i := len(ctx.cleanupFns) - 1; i >= 0; i-- {
-		err := ctx.cleanupFns[i]()
-		if err != nil {
-			ctx.t.Errorf("A cleanup function failed with error: (%v)\n", err)
-		}
-	}
-}
-
-// cleanupNoT is a modified version of Cleanup; does not use t for logging, instead uses log
-// intended for use by MainEntry, which does not have a testing.T
-func (ctx *TestCtx) cleanupNoT() {
 	failed := false
 	for i := len(ctx.cleanupFns) - 1; i >= 0; i-- {
 		err := ctx.cleanupFns[i]()
 		if err != nil {
 			failed = true
-			log.Errorf("A cleanup function failed with error: (%v)", err)
+			if ctx.t != nil {
+				ctx.t.Errorf("A cleanup function failed with error: (%v)\n", err)
+			} else {
+				log.Errorf("A cleanup function failed with error: (%v)", err)
+			}
 		}
 	}
-	if failed {
+	if ctx.t == nil && failed {
 		log.Fatal("A cleanup function failed")
 	}
 }

--- a/pkg/test/main_entry.go
+++ b/pkg/test/main_entry.go
@@ -117,7 +117,7 @@ func MainEntry(m *testing.M) {
 			log.Infof("Local operator stdout: %s", string(localCmdOutBuf.Bytes()))
 			log.Infof("Local operator stderr: %s", string(localCmdErrBuf.Bytes()))
 		}
-		ctx.cleanupNoT()
+		ctx.Cleanup()
 		os.Exit(exitCode)
 	}()
 	// create crd


### PR DESCRIPTION
**Description of the change:** This commit removes `Cleanup`'s dependence on `t`.


**Motivation for the change:** The test library has functions that are useful outside of `go test`, such as `createFromYAML`, `ctx` resource deletion, and auto setting of resource cleanup when using the framework's client. The only function that required `t` and would fail if it did not exist was `Cleanup`, as other function could handle if it was nil.