### PR TITLE
commands: make build podman compatible

### DIFF
--- a/commands/operator-sdk/cmd/build.go
+++ b/commands/operator-sdk/cmd/build.go
@@ -172,7 +172,7 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 
 	log.Infof("Building Docker image %s", baseImageName)
 
-	dbArgs := []string{"build", ".", "-f", "build/Dockerfile", "-t", baseImageName}
+	dbArgs := []string{"build", "build/", "-t", baseImageName}
 
 	if dockerBuildArgs != "" {
 		splitArgs := strings.Fields(dockerBuildArgs)


### PR DESCRIPTION
**Description of the change:**

When running 'operator-sdk' build with podman-docker the build fails
with a path error. Removing -f and setting the PATH argument to ./build
allows podman to build the container.

Has been tested against podman 1.12 on fedora 29 and docker-ce  5:18.09.3~3-0~debian-stretch on debian stretch

**Motivation for the change:**

I want to be able to build the operator container with podman as I don't use docker


