### PR TITLE
updated description when using cluster-scoped flag (ansible & helm)

### DIFF
--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -67,6 +67,7 @@ Using `--cluster-scoped` will scaffold the new operator with the following modif
 * `deploy/role.yaml` - Use `ClusterRole` instead of `Role`
 * `deploy/role_binding.yaml`:
   * Use `ClusterRoleBinding` instead of `RoleBinding`
+  * Use `ClusterRole` instead of `Role` for roleRef
   * Set the subject namespace to `REPLACE_NAMESPACE`. This must be changed to the namespace in which the operator is deployed.
 
 ### Watches file

--- a/doc/helm/user-guide.md
+++ b/doc/helm/user-guide.md
@@ -90,6 +90,7 @@ Using `--cluster-scoped` will scaffold the new operator with the following modif
 * `deploy/role.yaml` - Use `ClusterRole` instead of `Role`
 * `deploy/role_binding.yaml`:
   * Use `ClusterRoleBinding` instead of `RoleBinding`
+  * Use `ClusterRole` instead of `Role` for roleRef
   * Set the subject namespace to `REPLACE_NAMESPACE`. This must be changed to the namespace in which the operator is deployed.
 
 ## Customize the operator logic


### PR DESCRIPTION
**Description of the change:**
When using cluster-scoped flag, in the file deploy/role_binding.yaml CluserRole is used instead of Role. Keeping in sync ansible and helm cause of pull request #1190

**Motivation for the change:**
Making the docs more accurate