### PR TITLE
log: allow different log levels

### DIFF
--- a/doc/user/logging.md
+++ b/doc/user/logging.md
@@ -38,10 +38,9 @@ In the above example, we add the zap flagset to the operator's command line flag
 By default, `zap.Logger()` will return a logger that is ready for production use. It uses a JSON encoder, logs starting at the `info` level, and has [sampling][zap_sampling] enabled. To customize the default behavior, users can use the zap flagset and specify flags on the command line. The zap flagset includes the following flags that can be used to configure the logger:
 * `--zap-devel` - Enables the zap development config (changes defaults to console encoder, debug log level, and disables sampling) (default: `false`)
 * `--zap-encoder` string - Sets the zap log encoding (`json` or `console`)
-* `--zap-level` string - Sets the zap log level (`debug`, `info`, or `error`)
-* `--zap-sample` - Enables zap's sampling mode
+* `--zap-level` string or integer - Sets the zap log level (`debug`, `info`, `error`, or an integer value greater than 0)
+* `--zap-sample` - Enables zap's sampling mode. Sampling will be disabled for integer log levels > 1.
 
-**NOTE:** Although the `logr` interface supports multiple debug levels (e.g. `log.V(1).Info()`, `log.V(2).Info()`, etc.), zap supports only a single debug level with `log.V(1).Info()`. Log statements with higher debug levels will not be printed with the zap's `logr` backend.
 
 ## Creating a structured log statement
 

--- a/doc/user/logging.md
+++ b/doc/user/logging.md
@@ -39,7 +39,7 @@ By default, `zap.Logger()` will return a logger that is ready for production use
 * `--zap-devel` - Enables the zap development config (changes defaults to console encoder, debug log level, and disables sampling) (default: `false`)
 * `--zap-encoder` string - Sets the zap log encoding (`json` or `console`)
 * `--zap-level` string or integer - Sets the zap log level (`debug`, `info`, `error`, or an integer value greater than 0)
-* `--zap-sample` - Enables zap's sampling mode. Sampling will be disabled for integer log levels > 1.
+* `--zap-sample` - Enables zap's sampling mode. Sampling will be disabled for integer log levels greater than 1.
 
 
 ## Creating a structured log statement

--- a/pkg/log/zap/flags.go
+++ b/pkg/log/zap/flags.go
@@ -91,11 +91,28 @@ type levelValue struct {
 func (v *levelValue) Set(l string) error {
 	v.set = true
 	lower := strings.ToLower(l)
+	var lvl int
 	switch lower {
-	case "debug", "info", "error":
-		return v.level.Set(l)
+	case "debug":
+		lvl = -1
+	case "info":
+		lvl = 0
+	case "error":
+		lvl = 1
+	default:
+		i, err := strconv.Atoi(lower)
+		if err != nil {
+			return fmt.Errorf("invalid log level \"%s\"", l)
+		}
+
+		if i > 0 {
+			lvl = -1 * i
+		} else {
+			lvl = i
+		}
 	}
-	return fmt.Errorf("invalid log level \"%s\"", l)
+	v.level = zapcore.Level(int8(lvl))
+	return nil
 }
 
 func (v levelValue) String() string {

--- a/pkg/log/zap/flags.go
+++ b/pkg/log/zap/flags.go
@@ -37,8 +37,8 @@ func init() {
 	zapFlagSet = pflag.NewFlagSet("zap", pflag.ExitOnError)
 	zapFlagSet.BoolVar(&development, "zap-devel", false, "Enable zap development mode (changes defaults to console encoder, debug log level, and disables sampling)")
 	zapFlagSet.Var(&encoderVal, "zap-encoder", "Zap log encoding ('json' or 'console')")
-	zapFlagSet.Var(&levelVal, "zap-level", "Zap log level (one of 'debug', 'info', 'error')")
-	zapFlagSet.Var(&sampleVal, "zap-sample", "Enable zap log sampling")
+	zapFlagSet.Var(&levelVal, "zap-level", "Zap log level (one of 'debug', 'info', 'error' or any integer value > 0)")
+	zapFlagSet.Var(&sampleVal, "zap-sample", "Enable zap log sampling. Sampling will be disabled for integer log levels > 1")
 }
 
 func FlagSet() *pflag.FlagSet {
@@ -108,7 +108,7 @@ func (v *levelValue) Set(l string) error {
 		if i > 0 {
 			lvl = -1 * i
 		} else {
-			lvl = i
+			return fmt.Errorf("invalid log level \"%s\"", l)
 		}
 	}
 	v.level = zapcore.Level(int8(lvl))

--- a/pkg/log/zap/flags.go
+++ b/pkg/log/zap/flags.go
@@ -98,7 +98,7 @@ func (v *levelValue) Set(l string) error {
 	case "info":
 		lvl = 0
 	case "error":
-		lvl = 1
+		lvl = 2
 	default:
 		i, err := strconv.Atoi(lower)
 		if err != nil {

--- a/pkg/log/zap/flags_test.go
+++ b/pkg/log/zap/flags_test.go
@@ -53,11 +53,10 @@ func TestLevel(t *testing.T) {
 			expLevel: zapcore.ErrorLevel,
 		},
 		{
-			name:     "negative number level set",
-			input:    "-10",
-			expStr:   "Level(-10)",
-			expSet:   true,
-			expLevel: zapcore.Level(int8(-10)),
+			name:      "negative number should error",
+			input:     "-10",
+			shouldErr: true,
+			expSet:    false,
 		},
 		{
 			name:     "positive number level results in negative level set",
@@ -79,7 +78,7 @@ func TestLevel(t *testing.T) {
 			lvl := levelValue{}
 			err := lvl.Set(tc.input)
 			if err != nil && !tc.shouldErr {
-				t.Fatalf("unknown error - %v", err)
+				t.Fatalf("Unknown error - %v", err)
 			}
 			if err != nil && tc.shouldErr {
 				return
@@ -141,7 +140,7 @@ func TestSample(t *testing.T) {
 			sample := sampleValue{}
 			err := sample.Set(tc.input)
 			if err != nil && !tc.shouldErr {
-				t.Fatalf("unknown error - %v", err)
+				t.Fatalf("Unknown error - %v", err)
 			}
 			if err != nil && tc.shouldErr {
 				return
@@ -189,7 +188,7 @@ func TestEncoder(t *testing.T) {
 			encoder := encoderValue{}
 			err := encoder.Set(tc.input)
 			if err != nil && !tc.shouldErr {
-				t.Fatalf("unknown error - %v", err)
+				t.Fatalf("Unknown error - %v", err)
 			}
 			if err != nil && tc.shouldErr {
 				return

--- a/pkg/log/zap/flags_test.go
+++ b/pkg/log/zap/flags_test.go
@@ -1,0 +1,203 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.uber.org/zap/zapcore"
+)
+
+func TestLevel(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		shouldErr bool
+		expStr    string
+		expSet    bool
+		expLevel  zapcore.Level
+	}{
+		{
+			name:     "debug level set",
+			input:    "debug",
+			expStr:   "debug",
+			expSet:   true,
+			expLevel: zapcore.DebugLevel,
+		},
+		{
+			name:     "info level set",
+			input:    "info",
+			expStr:   "info",
+			expSet:   true,
+			expLevel: zapcore.InfoLevel,
+		},
+		{
+			name:     "error level set",
+			input:    "error",
+			expStr:   "error",
+			expSet:   true,
+			expLevel: zapcore.ErrorLevel,
+		},
+		{
+			name:     "negative number level set",
+			input:    "-10",
+			expStr:   "Level(-10)",
+			expSet:   true,
+			expLevel: zapcore.Level(int8(-10)),
+		},
+		{
+			name:     "positive number level results in negative level set",
+			input:    "8",
+			expStr:   "Level(-8)",
+			expSet:   true,
+			expLevel: zapcore.Level(int8(-8)),
+		},
+		{
+			name:      "non-integer should cause error",
+			input:     "invalid",
+			shouldErr: true,
+			expSet:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			lvl := levelValue{}
+			err := lvl.Set(tc.input)
+			if err != nil && !tc.shouldErr {
+				t.Fatalf("unknown error - %v", err)
+			}
+			if err != nil && tc.shouldErr {
+				return
+			}
+			assert.Equal(t, tc.expSet, lvl.set)
+			assert.Equal(t, tc.expLevel, lvl.level)
+			assert.Equal(t, "level", lvl.Type())
+			assert.Equal(t, tc.expStr, lvl.String())
+		})
+	}
+}
+
+func TestSample(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		shouldErr bool
+		expStr    string
+		expSet    bool
+		expValue  bool
+	}{
+		{
+			name:     "enable sampling",
+			input:    "true",
+			expStr:   "true",
+			expSet:   true,
+			expValue: true,
+		},
+		{
+			name:     "disable sampling",
+			input:    "false",
+			expStr:   "false",
+			expSet:   true,
+			expValue: false,
+		},
+		{
+			name:      "invalid input",
+			input:     "notaboolean",
+			shouldErr: true,
+			expSet:    false,
+		},
+		{
+			name:     "UPPERCASE true input",
+			input:    "true",
+			expStr:   "true",
+			expSet:   true,
+			expValue: true,
+		},
+		{
+			name:      "MiXeDCase true input",
+			input:     "tRuE",
+			shouldErr: true,
+			expSet:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sample := sampleValue{}
+			err := sample.Set(tc.input)
+			if err != nil && !tc.shouldErr {
+				t.Fatalf("unknown error - %v", err)
+			}
+			if err != nil && tc.shouldErr {
+				return
+			}
+			assert.Equal(t, tc.expSet, sample.set)
+			assert.Equal(t, tc.expValue, sample.sample)
+			assert.Equal(t, "sample", sample.Type())
+			assert.Equal(t, tc.expStr, sample.String())
+			assert.True(t, sample.IsBoolFlag())
+		})
+	}
+}
+func TestEncoder(t *testing.T) {
+	testCases := []struct {
+		name       string
+		input      string
+		shouldErr  bool
+		expStr     string
+		expSet     bool
+		expEncoder zapcore.Encoder
+	}{
+		{
+			name:       "json encoder",
+			input:      "json",
+			expStr:     "json",
+			expSet:     true,
+			expEncoder: jsonEncoder(),
+		},
+		{
+			name:       "console encoder",
+			input:      "console",
+			expStr:     "console",
+			expSet:     true,
+			expEncoder: consoleEncoder(),
+		},
+		{
+			name:       "unknown encoder",
+			input:      "unknown",
+			shouldErr:  true,
+			expEncoder: nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoder := encoderValue{}
+			err := encoder.Set(tc.input)
+			if err != nil && !tc.shouldErr {
+				t.Fatalf("unknown error - %v", err)
+			}
+			if err != nil && tc.shouldErr {
+				return
+			}
+			assert.Equal(t, tc.expSet, encoder.set)
+			assert.Equal(t, "encoder", encoder.Type())
+			assert.Equal(t, tc.expStr, encoder.String())
+			assert.ObjectsAreEqual(tc.expEncoder, encoder.encoder)
+		})
+	}
+}

--- a/pkg/log/zap/logger.go
+++ b/pkg/log/zap/logger.go
@@ -75,6 +75,13 @@ func getConfig(destWriter io.Writer) config {
 	}
 	if levelVal.set {
 		c.level = zap.NewAtomicLevelAt(levelVal.level)
+
+		// Disable sampling when we are in debug mode. Otherwise, this will
+		// cause index out of bounds errors in the sampling code.
+		if levelVal.level < -1 {
+			sampleVal.set = false
+			c.sample = false
+		}
 	}
 	if sampleVal.set {
 		c.sample = sampleVal.sample

--- a/pkg/log/zap/logger_test.go
+++ b/pkg/log/zap/logger_test.go
@@ -1,0 +1,192 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zap
+
+import (
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetConfig(t *testing.T) {
+	var opts []zap.Option
+
+	testCases := []struct {
+		name      string
+		inDevel   bool
+		inEncoder encoderValue
+		inLevel   levelValue
+		inSample  sampleValue
+		expected  config
+	}{
+		{
+			name:    "development on",
+			inDevel: true,
+			inEncoder: encoderValue{
+				set: false,
+			},
+			inLevel: levelValue{
+				set: false,
+			},
+			inSample: sampleValue{
+				set: false,
+			},
+			expected: config{
+				encoder: consoleEncoder(),
+				level:   zap.NewAtomicLevelAt(zap.DebugLevel),
+				opts:    append(opts, zap.Development(), zap.AddStacktrace(zap.ErrorLevel)),
+				sample:  false,
+			},
+		},
+		{
+			name:    "development off",
+			inDevel: false,
+			inEncoder: encoderValue{
+				set: false,
+			},
+			inLevel: levelValue{
+				set: false,
+			},
+			inSample: sampleValue{
+				set: false,
+			},
+			expected: config{
+				encoder: jsonEncoder(),
+				level:   zap.NewAtomicLevelAt(zap.InfoLevel),
+				opts:    append(opts, zap.AddStacktrace(zap.WarnLevel)),
+				sample:  true,
+			},
+		},
+		{
+			name:    "set encoder",
+			inDevel: false,
+			inEncoder: encoderValue{
+				set:     true,
+				encoder: consoleEncoder(),
+			},
+			inLevel: levelValue{
+				set: false,
+			},
+			inSample: sampleValue{
+				set: false,
+			},
+			expected: config{
+				encoder: jsonEncoder(),
+				level:   zap.NewAtomicLevelAt(zap.InfoLevel),
+				opts:    append(opts, zap.AddStacktrace(zap.WarnLevel)),
+				sample:  true,
+			},
+		},
+		{
+			name:    "set level using level constant",
+			inDevel: false,
+			inEncoder: encoderValue{
+				set: false,
+			},
+			inLevel: levelValue{
+				set:   true,
+				level: zapcore.ErrorLevel,
+			},
+			inSample: sampleValue{
+				set: false,
+			},
+			expected: config{
+				encoder: jsonEncoder(),
+				level:   zap.NewAtomicLevelAt(zap.ErrorLevel),
+				opts:    append(opts, zap.AddStacktrace(zap.WarnLevel)),
+				sample:  true,
+			},
+		},
+		{
+			name:    "set level using custom level",
+			inDevel: false,
+			inEncoder: encoderValue{
+				set: false,
+			},
+			inLevel: levelValue{
+				set:   true,
+				level: zapcore.Level(-10),
+			},
+			inSample: sampleValue{
+				set: false,
+			},
+			expected: config{
+				encoder: jsonEncoder(),
+				level:   zap.NewAtomicLevelAt(zapcore.Level(-10)),
+				opts:    append(opts, zap.AddStacktrace(zap.WarnLevel)),
+				sample:  false,
+			},
+		},
+		{
+			name:    "set level using custom level, sample override not possible",
+			inDevel: false,
+			inEncoder: encoderValue{
+				set: false,
+			},
+			inLevel: levelValue{
+				set:   true,
+				level: zapcore.Level(-10),
+			},
+			inSample: sampleValue{
+				set:    true,
+				sample: true,
+			},
+			expected: config{
+				encoder: jsonEncoder(),
+				level:   zap.NewAtomicLevelAt(zapcore.Level(-10)),
+				opts:    append(opts, zap.AddStacktrace(zap.WarnLevel)),
+				sample:  false,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			development = tc.inDevel
+			encoderVal = tc.inEncoder
+			levelVal = tc.inLevel
+			sampleVal = tc.inSample
+
+			cfg := getConfig()
+			assert.Equal(t, tc.expected.level, cfg.level)
+			assert.Equal(t, len(tc.expected.opts), len(cfg.opts))
+			assert.Equal(t, tc.expected.sample, cfg.sample)
+
+			dalog := createLogger(cfg, os.Stderr)
+			dalog.V(10).Info("This should not panic")
+		})
+	}
+}
+
+func createLogger(cfg config, dest io.Writer) logr.Logger {
+	syncer := zapcore.AddSync(dest)
+	if cfg.sample {
+		cfg.opts = append(cfg.opts, zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+			return zapcore.NewSampler(core, time.Second, 100, 100)
+		}))
+	}
+	cfg.opts = append(cfg.opts, zap.AddCallerSkip(1), zap.ErrorOutput(syncer))
+	log := zap.New(zapcore.NewCore(cfg.encoder, syncer, cfg.level))
+	log = log.WithOptions(cfg.opts...)
+	return zapr.NewLogger(log)
+}


### PR DESCRIPTION
With this feature we can use --zap-level 10 and this will allow
log.V(10).Info("hello world") to be seen in the logs. Prior to this
change debug (log.V(1)) was the lowest value attainable.

We also disable sampling when using an integer less than -1
(i.e. beyond debug). The zap sampling code assumes the lowest number for
sampling is DebugLevel (-1) which isn't the case in this scenario.
Disabling sampling makes sense at this point because sampling is used
for better performing logs which isn't required for trace level type
logs.

We also handle negative values being passed in.