### PR TITLE
docs: Make first ref to quay.io link to https://quay.io

### DIFF
--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -16,7 +16,7 @@ powered by Ansible using tools and libraries provided by the Operator SDK.
 - Access to a Kubernetes v.1.9.0+ cluster.
 
 **Note**: This guide uses [minikube][minikube_tool] version v0.25.0+ as the
-local Kubernetes cluster and quay.io for the public registry.
+local Kubernetes cluster and [quay.io](https://quay.io) for the public registry.
 
 ## Install the Operator SDK CLI
 

--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -16,7 +16,7 @@ powered by Ansible using tools and libraries provided by the Operator SDK.
 - Access to a Kubernetes v.1.9.0+ cluster.
 
 **Note**: This guide uses [minikube][minikube_tool] version v0.25.0+ as the
-local Kubernetes cluster and [quay.io](https://quay.io) for the public registry.
+local Kubernetes cluster and [quay.io][quay_link] for the public registry.
 
 ## Install the Operator SDK CLI
 
@@ -431,3 +431,4 @@ $ kubectl delete -f deploy/crds/cache_v1alpha1_memcached_cr.yaml
 [ansible_tool]:https://docs.ansible.com/ansible/latest/index.html
 [ansible_runner_tool]:https://ansible-runner.readthedocs.io/en/latest/install.html
 [ansible_runner_http_plugin]:https://github.com/ansible/ansible-runner-http
+[quay_link]:https://quay.io

--- a/doc/helm/user-guide.md
+++ b/doc/helm/user-guide.md
@@ -13,7 +13,7 @@ powered by Helm using tools and libraries provided by the Operator SDK.
 - Access to a Kubernetes v.1.11.3+ cluster.
 
 **Note**: This guide uses [minikube][minikube_tool] version v0.25.0+ as the
-local Kubernetes cluster and [quay.io](https://quay.io) for the public registry.
+local Kubernetes cluster and [quay.io][quay_link] for the public registry.
 
 ## Install the Operator SDK CLI
 
@@ -362,3 +362,4 @@ kubectl delete -f deploy/crds/example_v1alpha1_nginx_crd.yaml
 [minikube_tool]:https://github.com/kubernetes/minikube#installation
 [helm_charts]:https://helm.sh/docs/developing_charts/
 [helm_values]:https://helm.sh/docs/using_helm/#customizing-the-chart-before-installing
+[quay_link]:https://quay.io

--- a/doc/helm/user-guide.md
+++ b/doc/helm/user-guide.md
@@ -13,7 +13,7 @@ powered by Helm using tools and libraries provided by the Operator SDK.
 - Access to a Kubernetes v.1.11.3+ cluster.
 
 **Note**: This guide uses [minikube][minikube_tool] version v0.25.0+ as the
-local Kubernetes cluster and quay.io for the public registry.
+local Kubernetes cluster and [quay.io](https://quay.io) for the public registry.
 
 ## Install the Operator SDK CLI
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -14,7 +14,7 @@ Guide][helm_user_guide]. The rest of this document will show how to program an o
 - [kubectl][kubectl_tool] version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.
 
-**Note**: This guide uses [minikube][minikube_tool] version v0.25.0+ as the local Kubernetes cluster and [quay.io](https://quay.io) for the public registry.
+**Note**: This guide uses [minikube][minikube_tool] version v0.25.0+ as the local Kubernetes cluster and [quay.io][quay_link] for the public registry.
 
 ## Install the Operator SDK CLI
 
@@ -499,3 +499,4 @@ When the operator is not running in a cluster, the Manager will return an error 
 [request-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Request
 [result_go_doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Result
 [metrics_doc]: ./user/metrics/README.md
+[quay_link]: https://quay.io

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -14,7 +14,7 @@ Guide][helm_user_guide]. The rest of this document will show how to program an o
 - [kubectl][kubectl_tool] version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.
 
-**Note**: This guide uses [minikube][minikube_tool] version v0.25.0+ as the local Kubernetes cluster and quay.io for the public registry.
+**Note**: This guide uses [minikube][minikube_tool] version v0.25.0+ as the local Kubernetes cluster and [quay.io](https://quay.io) for the public registry.
 
 ## Install the Operator SDK CLI
 


### PR DESCRIPTION
**Description of the change:**

This change modifies the user guides (Go, Helm, and Ansible) first meaningful reference to quay.io so that the text links to the quay.io website.

**Motivation for the change:**

In the off chance that someone hasn't has only heard of a single
container registry (eg Docker Hub), provide a hyperlink to quay.io on
its first mention. Plus, having the link provides for a little less
typing for people to get to the site.