### PR TITLE
docs: add instructions to install via Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ $ make dep
 $ make install
 ```
 
+Alternatively, if you are using [Homebrew][homebrew_tool], you can install the SDK CLI tool with the following command:
+
+```sh
+$ brew install operator-sdk
+```
+
 Create and deploy an app-operator using the SDK CLI:
 
 ```sh
@@ -167,6 +173,7 @@ Operator SDK is under Apache 2.0 license. See the [LICENSE][license_file] file f
 [contrib]: ./CONTRIBUTING.MD
 [bug_guide]:./doc/dev/reporting_bugs.md
 [license_file]:./LICENSE
+[homebrew_tool]:https://brew.sh/
 [dep_tool]:https://golang.github.io/dep/docs/installation.html
 [git_tool]:https://git-scm.com/downloads
 [go_tool]:https://golang.org/dl/

--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -37,6 +37,12 @@ $ make install
 
 This installs the CLI binary `operator-sdk` at `$GOPATH/bin`.
 
+Alternatively, if you are using [Homebrew][homebrew_tool], you can install the SDK CLI tool with the following command:
+
+```sh
+$ brew install operator-sdk
+```
+
 ## Create a new project
 
 Use the CLI to create a new Ansible-based memcached-operator project:
@@ -178,7 +184,7 @@ Ansible Operator will simply pass all key value pairs listed in the Custom
 Resource spec field along to Ansible as
 [variables](https://docs.ansible.com/ansible/2.5/user_guide/playbooks_variables.html#passing-variables-on-the-command-line).
 The names of all variables in the spec field are converted to snake_case
-by the operator before running ansible. For example, `serviceAccount` in 
+by the operator before running ansible. For example, `serviceAccount` in
 the spec becomes `service_account` in ansible.
 It is recommended that you perform some type validation in Ansible on the
 variables to ensure that your application is receiving expected input.
@@ -380,7 +386,7 @@ kubectl logs deployment/memcached-operator -c ansible
 kubectl logs deployment/memcached-operator -c operator
 ```
 
-The `ansible` logs contain all of the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks, 
+The `ansible` logs contain all of the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks,
 whereas the `operator` logs will contain much more detailed information about the Ansible Operator's internals and interface with Kubernetes.
 
 ### Update the size
@@ -422,6 +428,7 @@ $ kubectl delete -f deploy/crds/cache_v1alpha1_memcached_cr.yaml
 ```
 
 [layout_doc]:./project_layout.md
+[homebrew_tool]:https://brew.sh/
 [dep_tool]:https://golang.github.io/dep/docs/installation.html
 [git_tool]:https://git-scm.com/downloads
 [go_tool]:https://golang.org/dl/

--- a/doc/helm/user-guide.md
+++ b/doc/helm/user-guide.md
@@ -34,6 +34,12 @@ make install
 
 This installs the CLI binary `operator-sdk` at `$GOPATH/bin`.
 
+Alternatively, if you are using [Homebrew][homebrew_tool], you can install the SDK CLI tool with the following command:
+
+```sh
+$ brew install operator-sdk
+```
+
 ## Create a new project
 
 Use the CLI to create a new Helm-based nginx-operator project:
@@ -354,6 +360,7 @@ kubectl delete -f deploy/crds/example_v1alpha1_nginx_crd.yaml
 ```
 
 [layout_doc]:./project_layout.md
+[homebrew_tool]:https://brew.sh/
 [dep_tool]:https://golang.github.io/dep/docs/installation.html
 [git_tool]:https://git-scm.com/downloads
 [go_tool]:https://golang.org/dl/

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -34,6 +34,12 @@ $ make install
 
 This installs the CLI binary `operator-sdk` at `$GOPATH/bin`.
 
+Alternatively, if you are using [Homebrew][homebrew_tool], you can install the SDK CLI tool with the following command:
+
+```sh
+$ brew install operator-sdk
+```
+
 ## Create a new project
 
 Use the CLI to create a new memcached-operator project:
@@ -405,7 +411,7 @@ After adding new import paths to your operator project, run `dep ensure` in the 
 ### Handle Cleanup on Deletion
 
 To implement complex deletion logic, you can add a finalizer to your Custom Resource. This will prevent your Custom Resource from being
-deleted until you remove the finalizer (ie, after your cleanup logic has successfully run). For more information, see the 
+deleted until you remove the finalizer (ie, after your cleanup logic has successfully run). For more information, see the
 [official Kubernetes documentation on finalizers](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#finalizers).
 
 ### Metrics
@@ -484,6 +490,7 @@ When the operator is not running in a cluster, the Manager will return an error 
 [layout_doc]:./project_layout.md
 [ansible_user_guide]:./ansible/user-guide.md
 [helm_user_guide]:./helm/user-guide.md
+[homebrew_tool]:https://brew.sh/
 [dep_tool]:https://golang.github.io/dep/docs/installation.html
 [git_tool]:https://git-scm.com/downloads
 [go_tool]:https://golang.org/dl/


### PR DESCRIPTION
**Description of the change:**
Adds details to the README and user-guide about installing the `operator-sdk` tool via the Homebrew formula.

**Motivation for the change:**
This adds instructions to install the operator-sdk tool via a Homebrew formula. This is a common package manager for those running macOS, and ensures that the tool (and `go`/`dep`) are installed properly in one step.

ref https://github.com/Homebrew/homebrew-core/pull/37826