### PR TITLE
Gopkg.toml,pkg/scaffold/helm/gopkgtoml.go: bump to helm 2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Bug Fixes
 
+- Fixed an issue that caused `operator-sdk new --type=helm` to fail for charts that have template files in nested template directories. ([#1235](https://github.com/operator-framework/operator-sdk/pull/1235))
+
 ## v0.6.0
 
 ### Added

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1431,7 +1431,7 @@
   revision = "b90029ef6cd877cb3f422d75b3a07707e3aac6b7"
 
 [[projects]]
-  digest = "1:c31467fbb43cc1fda0459314ca9f182c6c9779645b171d4883ee5d3684744c2b"
+  digest = "1:eb6da42f08a1a53b7375b7ee8188d70df15767691f66e030308b759b8a685141"
   name = "k8s.io/helm"
   packages = [
     "pkg/chartutil",
@@ -1468,8 +1468,8 @@
     "pkg/version",
   ]
   pruneopts = "NUT"
-  revision = "79d07943b03aea2b76c12644b4b54733bc5958d6"
-  version = "v2.13.0"
+  revision = "618447cbf203d147601b4b9bd7f8c37a5d39fbb4"
+  version = "v2.13.1"
 
 [[projects]]
   digest = "1:c263611800c3a97991dbcf9d3bc4de390f6224aaa8ca0a7226a9d734f65a416a"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,7 +46,7 @@
 
 [[constraint]]
   name = "k8s.io/helm"
-  version = "=v2.13.0"
+  version = "=v2.13.1"
 
 [[constraint]]
   name = "github.com/operator-framework/operator-lifecycle-manager"
@@ -67,7 +67,7 @@
 
 # We need overrides for the following imports because dep can't resolve them
 # correctly. The easiest way to get this right is to use the versions that
-# k8s.io/helm uses. See https://github.com/helm/helm/blob/v2.13.0/glide.lock
+# k8s.io/helm uses. See https://github.com/helm/helm/blob/v2.13.1/glide.lock
 [[override]]
   name = "k8s.io/kubernetes"
   revision = "c6d339953bd4fd8c021a6b5fb46d7952b30be9f9"

--- a/pkg/scaffold/helm/gopkgtoml.go
+++ b/pkg/scaffold/helm/gopkgtoml.go
@@ -64,7 +64,7 @@ const gopkgTomlTmpl = `[[constraint]]
 
 # We need overrides for the following imports because dep can't resolve them
 # correctly. The easiest way to get this right is to use the versions that
-# k8s.io/helm uses. See https://github.com/helm/helm/blob/v2.13.0/glide.lock
+# k8s.io/helm uses. See https://github.com/helm/helm/blob/v2.13.1/glide.lock
 [[override]]
   name = "k8s.io/kubernetes"
   revision = "c6d339953bd4fd8c021a6b5fb46d7952b30be9f9"

--- a/vendor/k8s.io/helm/pkg/chartutil/save.go
+++ b/vendor/k8s.io/helm/pkg/chartutil/save.go
@@ -63,6 +63,12 @@ func SaveDir(c *chart.Chart, dest string) error {
 	// Save templates
 	for _, f := range c.Templates {
 		n := filepath.Join(outdir, f.Name)
+
+		d := filepath.Dir(n)
+		if err := os.MkdirAll(d, 0755); err != nil {
+			return err
+		}
+
 		if err := ioutil.WriteFile(n, f.Data, 0644); err != nil {
 			return err
 		}


### PR DESCRIPTION
**Description of the change:**
Bumps helm version to 2.13.1

**Motivation for the change:**
Helm 2.13.1 fixes an issue in `chartutil.SaveDir()` that causes `operator-sdk new mychart-operator --type=helm --helm-chart=./my-chart` to fail if `./mychart` contains files in subdirectories of `./mychart/templates` (e.g. `./mychart/templates/hooks/myhook.yaml`)
