### PR TITLE
commands/.../generate/*: set generator header file if not supplied

### DIFF
--- a/commands/operator-sdk/cmd/add/api.go
+++ b/commands/operator-sdk/cmd/add/api.go
@@ -29,6 +29,7 @@ import (
 var (
 	apiVersion string
 	kind       string
+	headerFile string
 )
 
 func NewApiCmd() *cobra.Command {
@@ -76,6 +77,7 @@ Example:
 	if err := apiCmd.MarkFlagRequired("kind"); err != nil {
 		log.Fatalf("Failed to mark `kind` flag for `add api` subcommand as required")
 	}
+	apiCmd.Flags().StringVar(&headerFile, "header-file", "", "Path to file containing headers for generated files.")
 
 	return apiCmd
 }
@@ -122,12 +124,12 @@ func apiRun(cmd *cobra.Command, args []string) error {
 	}
 
 	// Run k8s codegen for deepcopy
-	if err := generate.K8sCodegen(); err != nil {
+	if err := generate.K8sCodegen(headerFile); err != nil {
 		return err
 	}
 
 	// Generate a validation spec for the new CRD.
-	if err := generate.OpenAPIGen(); err != nil {
+	if err := generate.OpenAPIGen(headerFile); err != nil {
 		return err
 	}
 

--- a/commands/operator-sdk/cmd/generate/internal/genutil.go
+++ b/commands/operator-sdk/cmd/generate/internal/genutil.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 	"github.com/operator-framework/operator-sdk/pkg/scaffold"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func BuildCodegenBinaries(genDirs []string, binDir, codegenSrcDir string) error {
@@ -103,4 +105,24 @@ func CreateFQApis(pkg string, gvs map[string][]string) string {
 		gn++
 	}
 	return fqb.String()
+}
+
+func GetHeaderFileIfEmpty(hf string) (string, func(), error) {
+	if hf == "" {
+		f, err := ioutil.TempFile("", "")
+		if err != nil {
+			return "", nil, err
+		}
+		if err = f.Close(); err != nil {
+			return "", nil, err
+		}
+		hf = f.Name()
+		rm := func() {
+			if err = os.RemoveAll(hf); err != nil {
+				log.Error(err)
+			}
+		}
+		return hf, rm, nil
+	}
+	return hf, nil, nil
 }

--- a/commands/operator-sdk/cmd/generate/k8s.go
+++ b/commands/operator-sdk/cmd/generate/k8s.go
@@ -75,8 +75,11 @@ func K8sCodegen(hf string) error {
 	projutil.MustInProjectRoot()
 
 	if hf == "" {
-		f, err := ioutil.TempFile(scaffold.BuildBinDir, "")
+		f, err := ioutil.TempFile("", "")
 		if err != nil {
+			return err
+		}
+		if err = f.Close(); err != nil {
 			return err
 		}
 		hf = f.Name()

--- a/commands/operator-sdk/cmd/generate/k8s.go
+++ b/commands/operator-sdk/cmd/generate/k8s.go
@@ -17,7 +17,6 @@ package generate
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -74,21 +73,14 @@ func k8sFunc(cmd *cobra.Command, args []string) error {
 func K8sCodegen(hf string) error {
 	projutil.MustInProjectRoot()
 
-	if hf == "" {
-		f, err := ioutil.TempFile("", "")
-		if err != nil {
-			return err
-		}
-		if err = f.Close(); err != nil {
-			return err
-		}
-		hf = f.Name()
-		defer func() {
-			if err = os.RemoveAll(hf); err != nil {
-				log.Error(err)
-			}
-		}()
+	hft, rm, err := genutil.GetHeaderFileIfEmpty(hf)
+	if err != nil {
+		return err
 	}
+	if rm != nil {
+		defer rm()
+	}
+	hf = hft
 
 	wd := projutil.MustGetwd()
 	repoPkg := projutil.CheckAndGetProjectGoPkg()

--- a/commands/operator-sdk/cmd/generate/openapi.go
+++ b/commands/operator-sdk/cmd/generate/openapi.go
@@ -68,6 +68,18 @@ func openAPIFunc(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return fmt.Errorf("command %s doesn't accept any arguments", cmd.CommandPath())
 	}
+	if headerFile == "" {
+		f, err := ioutil.TempFile(scaffold.BuildBinDir, "")
+		if err != nil {
+			return err
+		}
+		headerFile = f.Name()
+		defer func() {
+			if err = os.RemoveAll(headerFile); err != nil {
+				log.Error(err)
+			}
+		}()
+	}
 
 	return OpenAPIGen()
 }
@@ -144,18 +156,6 @@ func buildOpenAPIGenBinary(binDir, codegenSrcDir string) error {
 }
 
 func openAPIGen(binDir string, fqApis []string) (err error) {
-	if headerFile == "" {
-		f, err := ioutil.TempFile(scaffold.BuildBinDir, "")
-		if err != nil {
-			return err
-		}
-		headerFile = f.Name()
-		defer func() {
-			if err = os.RemoveAll(headerFile); err != nil {
-				log.Error(err)
-			}
-		}()
-	}
 	cgPath := filepath.Join(binDir, "openapi-gen")
 	for _, fqApi := range fqApis {
 		args := []string{

--- a/commands/operator-sdk/cmd/generate/openapi.go
+++ b/commands/operator-sdk/cmd/generate/openapi.go
@@ -76,15 +76,6 @@ func openAPIFunc(cmd *cobra.Command, args []string) error {
 func OpenAPIGen(hf string) error {
 	projutil.MustInProjectRoot()
 
-	hft, rm, err := genutil.GetHeaderFileIfEmpty(hf)
-	if err != nil {
-		return err
-	}
-	if rm != nil {
-		defer rm()
-	}
-	hf = hft
-
 	absProjectPath := projutil.MustGetwd()
 	repoPkg := projutil.CheckAndGetProjectGoPkg()
 	srcDir := filepath.Join(absProjectPath, "vendor", "k8s.io", "kube-openapi")
@@ -108,7 +99,8 @@ func OpenAPIGen(hf string) error {
 	apisPkg := filepath.Join(repoPkg, scaffold.ApisDir)
 	fqApiStr := genutil.CreateFQApis(apisPkg, gvMap)
 	fqApis := strings.Split(fqApiStr, ",")
-	if err := openAPIGen(binDir, hf, fqApis); err != nil {
+	f := func(a string) error { return openAPIGen(binDir, a, fqApis) }
+	if err = genutil.WithHeaderFile(hf, f); err != nil {
 		return err
 	}
 

--- a/commands/operator-sdk/cmd/generate/openapi.go
+++ b/commands/operator-sdk/cmd/generate/openapi.go
@@ -17,7 +17,6 @@ package generate
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -77,21 +76,14 @@ func openAPIFunc(cmd *cobra.Command, args []string) error {
 func OpenAPIGen(hf string) error {
 	projutil.MustInProjectRoot()
 
-	if hf == "" {
-		f, err := ioutil.TempFile("", "")
-		if err != nil {
-			return err
-		}
-		if err = f.Close(); err != nil {
-			return err
-		}
-		hf = f.Name()
-		defer func() {
-			if err = os.RemoveAll(hf); err != nil {
-				log.Error(err)
-			}
-		}()
+	hft, rm, err := genutil.GetHeaderFileIfEmpty(hf)
+	if err != nil {
+		return err
 	}
+	if rm != nil {
+		defer rm()
+	}
+	hf = hft
 
 	absProjectPath := projutil.MustGetwd()
 	repoPkg := projutil.CheckAndGetProjectGoPkg()

--- a/commands/operator-sdk/cmd/generate/openapi.go
+++ b/commands/operator-sdk/cmd/generate/openapi.go
@@ -78,8 +78,11 @@ func OpenAPIGen(hf string) error {
 	projutil.MustInProjectRoot()
 
 	if hf == "" {
-		f, err := ioutil.TempFile(scaffold.BuildBinDir, "")
+		f, err := ioutil.TempFile("", "")
 		if err != nil {
+			return err
+		}
+		if err = f.Close(); err != nil {
 			return err
 		}
 		hf = f.Name()


### PR DESCRIPTION
**Description of the change:** allow users to pass in a header file for `generate k8s`, or use a temp file if one is not supplied.


**Motivation for the change:** `deepcopy-gen` and `defaulter-gen` now require header files, and will fail if not provided. I noticed this when testing the SDK with go modules; `go mod vendor` removes default header files from the gengo repo.