### PR TITLE
dependencies: using latest revision of controller-tools

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1680,6 +1680,7 @@
   ]
   pruneopts = "NUT"
   revision = "b8adde9bc6d7f3fba449d306613a9daed23676c8"
+  version = "v0.1.10"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1668,7 +1668,7 @@
   version = "v0.1.10"
 
 [[projects]]
-  digest = "1:f164325288ca5707c0fb20c70a8e54dba5142d5f9b852aca675c97244a2ca39e"
+  digest = "1:d9b023a1f03e70736cedd89f6a0d700a298c73cedc1ad20c55275abcdc71fc50"
   name = "sigs.k8s.io/controller-tools"
   packages = [
     "pkg/crd/generator",
@@ -1679,8 +1679,7 @@
     "pkg/util",
   ]
   pruneopts = "NUT"
-  revision = "fbf141159251d035089e7acdd5a343f8cec91b94"
-  version = "v0.1.9"
+  revision = "b8adde9bc6d7f3fba449d306613a9daed23676c8"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -74,13 +74,6 @@
   name = "github.com/docker/docker"
   revision = "a9fbbdc8dd8794b20af358382ab780559bca589d"
 
-# This override enables to use quantity.Resource as type during generation of OpenAPI specs
-# (https://github.com/kubernetes-sigs/controller-tools/pull/174)
-# TODO: avoid revision once a release containing this feature has been rolled out
-[[override]]
-  name = "sigs.k8s.io/controller-tools"
-  revision = "b8adde9bc6d7f3fba449d306613a9daed23676c8"
-
 [prune]
   unused-packages = true
   go-tests = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -74,6 +74,13 @@
   name = "github.com/docker/docker"
   revision = "a9fbbdc8dd8794b20af358382ab780559bca589d"
 
+# This override enables to use quantity.Resource as type during generation of OpenAPI specs
+# (https://github.com/kubernetes-sigs/controller-tools/pull/174)
+# TODO: avoid revision once a release containing this feature has been rolled out
+[[override]]
+  name = "sigs.k8s.io/controller-tools"
+  revision = "b8adde9bc6d7f3fba449d306613a9daed23676c8"
+
 [prune]
   unused-packages = true
   go-tests = true

--- a/vendor/sigs.k8s.io/controller-tools/pkg/internal/codegen/parse/index.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/internal/codegen/parse/index.go
@@ -71,7 +71,8 @@ func (b *APIs) parseIndex() {
 
 		// TODO: revisit the part...
 		if r.Resource == "" {
-			r.Resource = strings.ToLower(inflect.Pluralize(r.Kind))
+			rs := inflect.NewDefaultRuleset()
+			r.Resource = rs.Pluralize(strings.ToLower(r.Kind))
 		}
 		rt, err := parseResourceAnnotation(c)
 		if err != nil {

--- a/vendor/sigs.k8s.io/controller-tools/pkg/internal/codegen/parse/util.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/internal/codegen/parse/util.go
@@ -217,6 +217,20 @@ func HasDocAnnotation(t *types.Type) bool {
 	return false
 }
 
+// hasSingular returns true if t is an APIResource annotated with
+// +kubebuilder:singular
+func hasSingular(t *types.Type) bool {
+	if !IsAPIResource(t) {
+		return false
+	}
+	for _, c := range t.CommentLines{
+		if strings.Contains(c, "+kubebuilder:singular"){
+			return true
+		}
+	}
+	return false
+}
+
 // IsUnversioned returns true if t is in given group, and not in versioned path.
 func IsUnversioned(t *types.Type, group string) bool {
 	return IsApisDir(filepath.Base(filepath.Dir(t.Name.Package))) && GetGroup(t) == group
@@ -309,6 +323,16 @@ func getCategoriesTag(c *types.Type) string {
 		panic(errors.Errorf("Must specify +kubebuilder:categories comment for type %v", c.Name))
 	}
 	return resource
+}
+
+// getSingularName returns the value of the +kubebuilder:singular tag
+func getSingularName(c *types.Type) string {
+	comments := Comments(c.CommentLines)
+	singular := comments.getTag("kubebuilder:singular", "=")
+	if len(singular) == 0 {
+		panic(errors.Errorf("Must specify a value to use with +kubebuilder:singular comment for type %v", c.Name))
+	}
+	return singular
 }
 
 // getDocAnnotation parse annotations of "+kubebuilder:doc:" with tags of "warning" or "doc" for control generating doc config.


### PR DESCRIPTION
Allowing use of `quantity.Resource` during OpenAPI generation in order to avoid declaration of `string` and parse at implementation level ([PR](https://github.com/kubernetes-sigs/controller-tools/pull/174) on `controller-tools` repo)

**Description of the change:**

Just updating the `Gopkg.tml` and ensuring dependencies

**Motivation for the change:**

I know that progbably it's better to wait a new `controller-tools` release but since this fix is really useful, why not to implement it?

Tight now, for my CRD that implements a `quantity.Resource` specs, I have to declare them as `string` and add a `+kubebuilder:validation:Pattern` annotation in order to ensure that client passes the right values and, in the end, execute a `Parse` at implementation level.

With this latest revision we can avoid all of this getting more cleaner code.