### PR TITLE
fix(helm dockerfile): reduce extraneous layers

### DIFF
--- a/pkg/scaffold/ansible/build_dockerfile.go
+++ b/pkg/scaffold/ansible/build_dockerfile.go
@@ -45,8 +45,9 @@ func (b *BuildDockerfile) GetInput() (input.Input, error) {
 
 const buildDockerfileAnsibleTmpl = `FROM quay.io/operator-framework/ansible-operator:{{.ImageTag}}
 
-COPY {{.RolesDir}}/ ${HOME}/{{.RolesDir}}/
 COPY watches.yaml ${HOME}/watches.yaml
+
+COPY {{.RolesDir}}/ ${HOME}/{{.RolesDir}}/
 {{- if .GeneratePlaybook }}
 COPY playbook.yml ${HOME}/playbook.yml
 {{- end }}

--- a/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -64,6 +64,9 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
     USER_NAME=ansible-operator\
     HOME=/opt/ansible
 
+{{- if .Watches }}
+COPY watches.yaml ${HOME}/watches.yaml{{ end }}
+
 # install operator binary
 COPY build/_output/bin/{{.ProjectName}} ${OPERATOR}
 # install k8s_status Ansible Module
@@ -76,8 +79,6 @@ RUN  /usr/local/bin/user_setup
 COPY roles/ ${HOME}/roles/{{ end }}
 {{- if .Playbook }}
 COPY playbook.yml ${HOME}/playbook.yml{{ end }}
-{{- if .Watches }}
-COPY watches.yaml ${HOME}/watches.yaml{{ end }}
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 

--- a/pkg/scaffold/helm/dockerfile.go
+++ b/pkg/scaffold/helm/dockerfile.go
@@ -44,6 +44,6 @@ func (d *Dockerfile) GetInput() (input.Input, error) {
 
 const dockerFileHelmTmpl = `FROM quay.io/operator-framework/helm-operator:{{.ImageTag}}
 
-COPY {{.HelmChartsDir}}/ ${HOME}/{{.HelmChartsDir}}/
 COPY watches.yaml ${HOME}/watches.yaml
+COPY {{.HelmChartsDir}}/ ${HOME}/{{.HelmChartsDir}}/
 `

--- a/pkg/scaffold/helm/dockerfilehybrid.go
+++ b/pkg/scaffold/helm/dockerfilehybrid.go
@@ -48,6 +48,9 @@ ENV OPERATOR=/usr/local/bin/helm-operator \
     USER_NAME=helm \
     HOME=/opt/helm
 
+{{- if .Watches }}
+COPY watches.yaml ${HOME}/watches.yaml{{ end }}
+
 # install operator binary
 COPY build/_output/bin/{{.ProjectName}} ${OPERATOR}
 
@@ -56,8 +59,6 @@ RUN  /usr/local/bin/user_setup
 
 {{- if .HelmCharts }}
 COPY helm-charts/ ${HOME}/helm-charts/{{ end }}
-{{- if .Watches }}
-COPY watches.yaml ${HOME}/watches.yaml{{ end }}
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Minor change to reorder the Helm operator Dockerfile template to copy the `watches.yaml` file _before_ the `helm-charts` directory.

**Motivation for the change:**

It is very unlikely that you will make a change to watches.yaml and create a new Docker image without a corresponding change to the helm-charts directory. However, it's very plausible that you may make a change to the helm-charts directory to modify an existing template without touching the watches file. Previously, this would cause the creation of additional layer for the watches file, since the file addition layer happens after the helm-charts directory is added. With this change, the watches.yaml image layer can be reused for multiple operator images until the file itself actually changes.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
