### PR TITLE
pkg/scaffold,version: bump to track v0.6.x branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Bug Fixes
+
 ## v0.6.0
 
 ### Added

--- a/pkg/scaffold/ansible/gopkgtoml.go
+++ b/pkg/scaffold/ansible/gopkgtoml.go
@@ -35,8 +35,8 @@ func (s *GopkgToml) GetInput() (input.Input, error) {
 const gopkgTomlTmpl = `[[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
-  version = "=v0.6.0" #osdk_version_annotation
+  branch = "v0.6.x" #osdk_branch_annotation
+  # version = "=v0.6.0" #osdk_version_annotation
 
 [[override]]
   name = "k8s.io/api"

--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -102,8 +102,8 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
-  version = "=v0.6.0" #osdk_version_annotation
+  branch = "v0.6.x" #osdk_branch_annotation
+  # version = "=v0.6.0" #osdk_version_annotation
 
 [prune]
   go-tests = true

--- a/pkg/scaffold/gopkgtoml_test.go
+++ b/pkg/scaffold/gopkgtoml_test.go
@@ -94,8 +94,8 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
-  version = "=v0.6.0" #osdk_version_annotation
+  branch = "v0.6.x" #osdk_branch_annotation
+  # version = "=v0.6.0" #osdk_version_annotation
 
 [prune]
   go-tests = true

--- a/pkg/scaffold/helm/gopkgtoml.go
+++ b/pkg/scaffold/helm/gopkgtoml.go
@@ -35,8 +35,8 @@ func (s *GopkgToml) GetInput() (input.Input, error) {
 const gopkgTomlTmpl = `[[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
-  version = "=v0.6.0" #osdk_version_annotation
+  branch = "v0.6.x" #osdk_branch_annotation
+  # version = "=v0.6.0" #osdk_version_annotation
 
 [[override]]
   name = "k8s.io/api"

--- a/version/version.go
+++ b/version/version.go
@@ -15,5 +15,5 @@
 package version
 
 var (
-	Version = "v0.6.0"
+	Version = "v0.6.0+git"
 )


### PR DESCRIPTION
**Description of the change:** Bump v0.6.x branch to track the branch instead of v0.6.0 tag


**Motivation for the change:** Version bump for release branch