### PR TITLE
pkg/scaffold,version: bump to track v0.5.x branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Bug Fixes
+
 ## v0.5.0
 
 ### Added

--- a/doc/dev/developer_guide.md
+++ b/doc/dev/developer_guide.md
@@ -47,7 +47,7 @@ See the project [README][sdk_readme] for more details.
 [git_tool]:https://git-scm.com/downloads
 [go_tool]:https://golang.org/dl/
 [repo_sdk]:https://github.com/operator-framework/operator-sdk
-[fork_guide]:https://help.github.com/articles/fork-a-repo/
+[fork_guide]:https://help.github.com/en/articles/fork-a-repo
 [docker_tool]:https://docs.docker.com/install/
 [kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [sdk_readme]:../../README.md

--- a/doc/dev/release.md
+++ b/doc/dev/release.md
@@ -253,7 +253,7 @@ You've now fully released a new version of the Operator SDK. Good work!
 
 [doc-maintainers]:../../MAINTAINERS
 [doc-readme-prereqs]:https://github.com/operator-framework/operator-sdk#prerequisites
-[doc-git-default-key]:https://help.github.com/articles/telling-git-about-your-signing-key/
+[doc-git-default-key]:https://help.github.com/en/articles/telling-git-about-your-signing-key
 [doc-gpg-default-key]:https://lists.gnupg.org/pipermail/gnupg-users/2001-September/010163.html
 [link-github-gpg-key-upload]:https://github.com/settings/keys
 [link-git-config-gpg-key]:https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work

--- a/doc/versioning.md
+++ b/doc/versioning.md
@@ -25,4 +25,4 @@ Minor version changes will not break compatibility between the previous minor ve
 Patch versions changes are meant only for bug fixes, and will not break compatibility of the current minor version. A patch release will contain a collection of minor bug fixes, or individual major and security bug fixes, depending on severity.
 
 [link-semver]:https://semver.org/
-[link-github-milestones]: https://help.github.com/articles/about-milestones/
+[link-github-milestones]: https://help.github.com/en/articles/about-milestones

--- a/pkg/scaffold/ansible/gopkgtoml.go
+++ b/pkg/scaffold/ansible/gopkgtoml.go
@@ -35,8 +35,8 @@ func (s *GopkgToml) GetInput() (input.Input, error) {
 const gopkgTomlTmpl = `[[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
-  version = "=v0.5.0" #osdk_version_annotation
+  branch = "v0.5.x" #osdk_branch_annotation
+  # version = "=v0.5.0" #osdk_version_annotation
 
 [[override]]
   name = "k8s.io/api"

--- a/pkg/scaffold/ansible/molecule_default_molecule.go
+++ b/pkg/scaffold/ansible/molecule_default_molecule.go
@@ -50,6 +50,7 @@ platforms:
   - k8s
   image: bsycorp/kind:latest-1.12
   privileged: True
+  override_command: no
   exposed_ports:
     - 8443/tcp
     - 10080/tcp

--- a/pkg/scaffold/ansible/molecule_test_local_molecule.go
+++ b/pkg/scaffold/ansible/molecule_test_local_molecule.go
@@ -50,6 +50,7 @@ platforms:
   - k8s
   image: bsycorp/kind:latest-1.12
   privileged: True
+  override_command: no
   exposed_ports:
     - 8443/tcp
     - 10080/tcp

--- a/pkg/scaffold/gopkgtoml.go
+++ b/pkg/scaffold/gopkgtoml.go
@@ -102,8 +102,8 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
-  version = "=v0.5.0" #osdk_version_annotation
+  branch = "v0.5.x" #osdk_branch_annotation
+  # version = "=v0.5.0" #osdk_version_annotation
 
 [prune]
   go-tests = true

--- a/pkg/scaffold/gopkgtoml_test.go
+++ b/pkg/scaffold/gopkgtoml_test.go
@@ -94,8 +94,8 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
-  version = "=v0.5.0" #osdk_version_annotation
+  branch = "v0.5.x" #osdk_branch_annotation
+  # version = "=v0.5.0" #osdk_version_annotation
 
 [prune]
   go-tests = true

--- a/pkg/scaffold/helm/gopkgtoml.go
+++ b/pkg/scaffold/helm/gopkgtoml.go
@@ -35,8 +35,8 @@ func (s *GopkgToml) GetInput() (input.Input, error) {
 const gopkgTomlTmpl = `[[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
-  version = "=v0.5.0" #osdk_version_annotation
+  branch = "v0.5.x" #osdk_branch_annotation
+  # version = "=v0.5.0" #osdk_version_annotation
 
 [[override]]
   name = "k8s.io/kubernetes"

--- a/test/ansible-inventory/molecule/test-local/molecule.yml
+++ b/test/ansible-inventory/molecule/test-local/molecule.yml
@@ -12,6 +12,7 @@ platforms:
   - k8s
   image: bsycorp/kind:latest-1.12
   privileged: True
+  override_command: no
   exposed_ports:
     - 8443/tcp
     - 10080/tcp

--- a/test/ansible-memcached/molecule.yml
+++ b/test/ansible-memcached/molecule.yml
@@ -12,6 +12,7 @@ platforms:
   - k8s
   image: bsycorp/kind:latest-1.12
   privileged: True
+  override_command: no
   exposed_ports:
     - 8443/tcp
     - 10080/tcp

--- a/version/version.go
+++ b/version/version.go
@@ -15,5 +15,5 @@
 package version
 
 var (
-	Version = "v0.5.0"
+	Version = "v0.5.0+git"
 )


### PR DESCRIPTION
**Description of the change:** Bump v0.5.x branch to track the branch instead of v0.5.0 tag


**Motivation for the change:** Version bump for release branch