### PR TITLE
Remove invalid GPL license from test file

### DIFF
--- a/test/ansible-inventory/plugins/filter/test.py
+++ b/test/ansible-inventory/plugins/filter/test.py
@@ -1,20 +1,3 @@
-# (c) 2015, Filipe Niero Felisbino <filipenf@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 


### PR DESCRIPTION
**Description of the change:**
Remove GPL license from test filter plugin stub

**Motivation for the change:**
One of the files used for testing had a GPL license header that should not have been added, and the person named was not actually the author of the file.

I am the author of the test plugin stub in question.

closes #1213 
