### PR TITLE
Makefile: add build/operator-sdk to install target requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean:
 
 .PHONY: all test format dep clean
 
-install:
+install: build/operator-sdk
 	$(Q)go install -gcflags "all=-trimpath=${GOPATH}" -asmflags "all=-trimpath=${GOPATH}" $(BUILD_PATH)
 
 release_x86_64 := \


### PR DESCRIPTION
**Description of the change:**

Improve the Makefile install target.


**Motivation for the change:**

To fix documentation.