### PR TITLE
pkg/kube-metrics: Add initial operator specific metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - New option for [`operator-sdk up local --enable-delve`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#up), which can be used to start the operator in remote debug mode with the [delve](https://github.com/go-delve/delve) debugger listening on port 2345. ([#1422](https://github.com/operator-framework/operator-sdk/pull/1422))
 - Enables controller-runtime metrics in Helm operator projects. ([#1482](https://github.com/operator-framework/operator-sdk/pull/1482))
 - New flags `--vendor` and `--skip-validation` for [`operator-sdk new`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#new) that direct the SDK to initialize a new project with a `vendor/` directory, and without validating project dependencies. `vendor/` is not written by default. ([#1519](https://github.com/operator-framework/operator-sdk/pull/1519))
+- Generating and serving info metrics about each custom resource. By default these metrics are exposed on port 8686. ([#1277](https://github.com/operator-framework/operator-sdk/pull/1277))
 
 ### Changed
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1559,8 +1559,8 @@
     "pkg/metrics_store",
   ]
   pruneopts = "NUT"
-  revision = "d7b8a74b2ba1cbabb26a7dfdd7bd0d65f2724a9e"
-  version = "v1.6.0-rc.0"
+  revision = "de19ed4f12d471fccc79f9a9fee73f7c107ecd33"
+  version = "v1.6.0"
 
 [[projects]]
   digest = "1:a2ca0c9095f3fd4160abcb64ebc3d99d3e2439da9c350705db7ab65dc98ee21d"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1854,6 +1854,7 @@
     "k8s.io/helm/pkg/tiller/environment",
     "k8s.io/klog",
     "k8s.io/kube-openapi/cmd/openapi-gen/args",
+    "k8s.io/kube-openapi/pkg/generators",
     "k8s.io/kube-state-metrics/pkg/collector",
     "k8s.io/kube-state-metrics/pkg/metric",
     "k8s.io/kube-state-metrics/pkg/metrics_store",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1551,6 +1551,18 @@
   revision = "0cf8f7e6ed1d2e3d47d02e3b6e559369af24d803"
 
 [[projects]]
+  digest = "1:584e35289f5869d56bea9469d4de6f96758a3276125bb3e7b2c41bd65cb5a226"
+  name = "k8s.io/kube-state-metrics"
+  packages = [
+    "pkg/collector",
+    "pkg/metric",
+    "pkg/metrics_store",
+  ]
+  pruneopts = "NUT"
+  revision = "d7b8a74b2ba1cbabb26a7dfdd7bd0d65f2724a9e"
+  version = "v1.6.0-rc.0"
+
+[[projects]]
   digest = "1:a2ca0c9095f3fd4160abcb64ebc3d99d3e2439da9c350705db7ab65dc98ee21d"
   name = "k8s.io/kubernetes"
   packages = [
@@ -1762,6 +1774,8 @@
     "github.com/pborman/uuid",
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_model/go",
+    "github.com/prometheus/common/expfmt",
     "github.com/prometheus/prometheus/util/promlint",
     "github.com/rogpeppe/go-internal/modfile",
     "github.com/sergi/go-diff/diffmatchpatch",
@@ -1801,15 +1815,18 @@
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/util/yaml",
     "k8s.io/apimachinery/pkg/version",
+    "k8s.io/apimachinery/pkg/watch",
     "k8s.io/cli-runtime/pkg/genericclioptions/resource",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/cached",
+    "k8s.io/client-go/dynamic",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/plugin/pkg/client/auth",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/restmapper",
+    "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api",
     "k8s.io/client-go/transport",
@@ -1837,7 +1854,9 @@
     "k8s.io/helm/pkg/tiller/environment",
     "k8s.io/klog",
     "k8s.io/kube-openapi/cmd/openapi-gen/args",
-    "k8s.io/kube-openapi/pkg/generators",
+    "k8s.io/kube-state-metrics/pkg/collector",
+    "k8s.io/kube-state-metrics/pkg/metric",
+    "k8s.io/kube-state-metrics/pkg/metrics_store",
     "k8s.io/kubernetes/pkg/kubectl/util",
     "sigs.k8s.io/controller-runtime/pkg/cache",
     "sigs.k8s.io/controller-runtime/pkg/client",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -65,9 +65,9 @@
   name = "github.com/spf13/cobra"
   version = "0.0.3"
 
-[[constraint]]
+[[override]]
   name = "k8s.io/kube-state-metrics"
-  version = "v1.6.0-rc.0"
+  version = "v1.6.0"
 
 # We need overrides for the following imports because dep can't resolve them
 # correctly. The easiest way to get this right is to use the versions that

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -65,6 +65,10 @@
   name = "github.com/spf13/cobra"
   version = "0.0.3"
 
+[[constraint]]
+  name = "k8s.io/kube-state-metrics"
+  version = "v1.6.0-rc.0"
+
 # We need overrides for the following imports because dep can't resolve them
 # correctly. The easiest way to get this right is to use the versions that
 # k8s.io/helm uses. See https://github.com/helm/helm/blob/v2.13.1/glide.lock

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -166,7 +166,7 @@ func main() {
 
 // serveCRMetrics gets the Operator/CustomResource GVKs
 // and generates metrics based on those types.
-// It serves those metrics on "metricsHost/operatorMetricsPort".
+// It serves those metrics on "http://metricsHost:operatorMetricsPort".
 func serveCRMetrics(cfg *rest.Config) {
 	// Below returns filterted operator/CustomResource specific GVKs.
 	// For more control create below GVK list with your own custom logic.

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -58,7 +58,6 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
-	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -165,13 +164,20 @@ func main() {
 	}
 }
 
+// serveCRMetrics gets the Operator/CustomResource GVKs
+// and generates metrics based on those types.
+// It serves those metrics on "metricsHost/operatorMetricsPort".
 func serveCRMetrics(cfg *rest.Config) {
-	operatorSpecificScheme := kuberuntime.NewScheme()
-	apis.AddToScheme(operatorSpecificScheme)
-	filteredScheme := kubemetrics.FilterOutMetaTypes(operatorSpecificScheme)
-	err := kubemetrics.ServeCRMetrics(cfg, []string{}, filteredScheme, metricsHost, operatorMetricsPort)
+	// Below returns filterted operator/CustomResource specific GVKs.
+	// For more control create below GVK list with your own custom logic.
+	filteredGVK, err := kubemetrics.GetGVKsFromAddToScheme(apis.AddToScheme())
 	if err != nil {
-		log.Error(err, "Could not serve Custom Resource metrics")
+		log.Error(err, "Could not generate or serve Custom Resource metrics")
+		return
+	}
+	err := kubemetrics.ServeCRMetrics(cfg, []string{}, filteredGVK, metricsHost, operatorMetricsPort)
+	if err != nil {
+		log.Error(err, "Could not generate or serve Custom Resource metrics")
 	}
 }
 `

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -183,7 +183,7 @@ func serveCRMetrics(cfg *rest.Config) error {
 	// To generate metrics in other namespaces, add the values below.
 	ns := []string{operatorNs}
 	// Generate and serve custom resource specific metrics.
-	err = kubemetrics.ServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
+	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
 	if err != nil {
 	    return err
 	}

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -170,7 +170,7 @@ func main() {
 func serveCRMetrics(cfg *rest.Config) {
 	// Below returns filterted operator/CustomResource specific GVKs.
 	// For more control create below GVK list with your own custom logic.
-	filteredGVK, err := kubemetrics.GetGVKsFromAddToScheme(apis.AddToScheme)
+	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
 	if err != nil {
 		log.Error(err, "Could not generate or serve Custom Resource metrics")
 		return

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -164,8 +164,7 @@ func main() {
 	}
 }
 
-// serveCRMetrics gets the Operator/CustomResource GVKs
-// and generates metrics based on those types.
+// serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
 // It serves those metrics on "http://metricsHost:operatorMetricsPort".
 func serveCRMetrics(cfg *rest.Config) {
 	// Below returns filterted operator/CustomResource specific GVKs.

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -170,12 +170,12 @@ func main() {
 func serveCRMetrics(cfg *rest.Config) {
 	// Below returns filterted operator/CustomResource specific GVKs.
 	// For more control create below GVK list with your own custom logic.
-	filteredGVK, err := kubemetrics.GetGVKsFromAddToScheme(apis.AddToScheme())
+	filteredGVK, err := kubemetrics.GetGVKsFromAddToScheme(apis.AddToScheme)
 	if err != nil {
 		log.Error(err, "Could not generate or serve Custom Resource metrics")
 		return
 	}
-	err := kubemetrics.ServeCRMetrics(cfg, []string{}, filteredGVK, metricsHost, operatorMetricsPort)
+	err = kubemetrics.ServeCRMetrics(cfg, []string{}, filteredGVK, metricsHost, operatorMetricsPort)
 	if err != nil {
 		log.Error(err, "Could not generate or serve Custom Resource metrics")
 	}

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -169,7 +169,7 @@ func main() {
 // serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
 // It serves those metrics on "http://metricsHost:operatorMetricsPort".
 func serveCRMetrics(cfg *rest.Config) error {
-	// Below function returns filterted operator/CustomResource specific GVKs.
+	// Below function returns filtered operator/CustomResource specific GVKs.
 	// For more control override the below GVK list with your own custom logic.
 	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
 	if err != nil {

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -168,7 +168,7 @@ func main() {
 // serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
 // It serves those metrics on "http://metricsHost:operatorMetricsPort".
 func serveCRMetrics(cfg *rest.Config) error {
-	// Below function returns filterted operator/CustomResource specific GVKs.
+	// Below function returns filtered operator/CustomResource specific GVKs.
 	// For more control override the below GVK list with your own custom logic.
 	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
 	if err != nil {

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -44,17 +44,20 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
 
 	"github.com/example-inc/app-operator/pkg/apis"
 	"github.com/example-inc/app-operator/pkg/controller"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
+	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -63,8 +66,9 @@ import (
 
 // Change below variables to serve metrics on different host or port.
 var (
-	metricsHost       = "0.0.0.0"
-	metricsPort int32 = 8383
+	metricsHost               = "0.0.0.0"
+	metricsPort         int32 = 8383
+	operatorMetricsPort int32 = 8686
 )
 var log = logf.Log.WithName("cmd")
 
@@ -111,7 +115,6 @@ func main() {
 	}
 
 	ctx := context.TODO()
-
 	// Become the leader before proceeding
 	err = leader.Become(ctx, "app-operator-lock")
 	if err != nil {
@@ -144,6 +147,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	serveCRMetrics(cfg)
+
 	// Create Service object to expose the metrics port.
 	_, err = metrics.ExposeMetricsPort(ctx, metricsPort)
 	if err != nil {
@@ -156,6 +161,16 @@ func main() {
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
 		log.Error(err, "Manager exited non-zero")
 		os.Exit(1)
+	}
+}
+
+func serveCRMetrics(cfg *rest.Config) {
+	operatorSpecificScheme := kuberuntime.NewScheme()
+	apis.AddToScheme(operatorSpecificScheme)
+	filteredScheme := kubemetrics.FilterOutMetaTypes(operatorSpecificScheme)
+	err := kubemetrics.ServeCRMetrics(cfg, []string{}, filteredScheme, metricsHost, operatorMetricsPort)
+	if err != nil {
+		log.Error(err, "Could not serve Custom Resource metrics")
 	}
 }
 `

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -163,8 +163,7 @@ func main() {
 	}
 }
 
-// serveCRMetrics gets the Operator/CustomResource GVKs
-// and generates metrics based on those types.
+// serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
 // It serves those metrics on "http://metricsHost:operatorMetricsPort".
 func serveCRMetrics(cfg *rest.Config) {
 	// Below returns filterted operator/CustomResource specific GVKs.

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -182,7 +182,7 @@ func serveCRMetrics(cfg *rest.Config) error {
 	// To generate metrics in other namespaces, add the values below.
 	ns := []string{operatorNs}
 	// Generate and serve custom resource specific metrics.
-	err = kubemetrics.ServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
+	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -146,7 +146,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	serveCRMetrics(cfg)
+	if err = serveCRMetrics(cfg); err != nil {
+		log.Info("Could not generate and serve custom resource metrics: ", err.Error())
+	}
 
 	// Create Service object to expose the metrics port.
 	_, err = metrics.ExposeMetricsPort(ctx, metricsPort)
@@ -165,17 +167,25 @@ func main() {
 
 // serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
 // It serves those metrics on "http://metricsHost:operatorMetricsPort".
-func serveCRMetrics(cfg *rest.Config) {
-	// Below returns filterted operator/CustomResource specific GVKs.
-	// For more control create below GVK list with your own custom logic.
+func serveCRMetrics(cfg *rest.Config) error {
+	// Below function returns filterted operator/CustomResource specific GVKs.
+	// For more control override the below GVK list with your own custom logic.
 	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
 	if err != nil {
-		log.Error(err, "Could not generate or serve Custom Resource metrics")
-		return
+		return err
 	}
-	err = kubemetrics.ServeCRMetrics(cfg, []string{}, filteredGVK, metricsHost, operatorMetricsPort)
+	// Get the namespace the operator is currently deployed in.
+	operatorNs, err := k8sutil.GetOperatorNamespace()
 	if err != nil {
-		log.Error(err, "Could not generate or serve Custom Resource metrics")
+		return err
 	}
+	// To generate metrics in other namespaces, add the values below.
+	ns := []string{operatorNs}
+	// Generate and serve custom resource specific metrics.
+	err = kubemetrics.ServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 `

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -165,11 +165,11 @@ func main() {
 
 // serveCRMetrics gets the Operator/CustomResource GVKs
 // and generates metrics based on those types.
-// It serves those metrics on "metricsHost/operatorMetricsPort".
+// It serves those metrics on "http://metricsHost:operatorMetricsPort".
 func serveCRMetrics(cfg *rest.Config) {
 	// Below returns filterted operator/CustomResource specific GVKs.
 	// For more control create below GVK list with your own custom logic.
-	filteredGVK, err := kubemetrics.GetGVKsFromAddToScheme(apis.AddToScheme)
+	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
 	if err != nil {
 		log.Error(err, "Could not generate or serve Custom Resource metrics")
 		return

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -169,12 +169,12 @@ func main() {
 func serveCRMetrics(cfg *rest.Config) {
 	// Below returns filterted operator/CustomResource specific GVKs.
 	// For more control create below GVK list with your own custom logic.
-	filteredGVK, err := kubemetrics.GetGVKsFromAddToScheme(apis.AddToScheme())
+	filteredGVK, err := kubemetrics.GetGVKsFromAddToScheme(apis.AddToScheme)
 	if err != nil {
 		log.Error(err, "Could not generate or serve Custom Resource metrics")
 		return
 	}
-	err := kubemetrics.ServeCRMetrics(cfg, []string{}, filteredGVK, metricsHost, operatorMetricsPort)
+	err = kubemetrics.ServeCRMetrics(cfg, []string{}, filteredGVK, metricsHost, operatorMetricsPort)
 	if err != nil {
 		log.Error(err, "Could not generate or serve Custom Resource metrics")
 	}

--- a/internal/pkg/scaffold/go_mod.go
+++ b/internal/pkg/scaffold/go_mod.go
@@ -86,6 +86,7 @@ replace (
 	github.com/coreos/prometheus-operator => github.com/coreos/prometheus-operator v0.29.0
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.1.10
 	sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.1.11-0.20190411181648-9d55346c2bde
+	k8s.io/kube-state-metrics => k8s.io/kube-state-metrics v1.6.0
 )
 `
 

--- a/internal/pkg/scaffold/go_mod.go
+++ b/internal/pkg/scaffold/go_mod.go
@@ -68,6 +68,7 @@ require (
 	k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
 	k8s.io/client-go v2.0.0-alpha.0.0.20181126152608-d082d5923d3c+incompatible
 	k8s.io/kube-openapi v0.0.0-20190603182131-db7b694dc208 // indirect
+	k8s.io/kube-state-metrics v1.6.0 // indirect
 	sigs.k8s.io/controller-runtime v0.1.10
 	sigs.k8s.io/controller-tools v0.1.10
 	sigs.k8s.io/testing_frameworks v0.1.0 // indirect

--- a/internal/pkg/scaffold/go_mod_test.go
+++ b/internal/pkg/scaffold/go_mod_test.go
@@ -69,6 +69,7 @@ require (
 	k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
 	k8s.io/client-go v2.0.0-alpha.0.0.20181126152608-d082d5923d3c+incompatible
 	k8s.io/kube-openapi v0.0.0-20190603182131-db7b694dc208 // indirect
+	k8s.io/kube-state-metrics v1.6.0 // indirect
 	sigs.k8s.io/controller-runtime v0.1.10
 	sigs.k8s.io/controller-tools v0.1.10
 	sigs.k8s.io/testing_frameworks v0.1.0 // indirect

--- a/internal/pkg/scaffold/go_mod_test.go
+++ b/internal/pkg/scaffold/go_mod_test.go
@@ -87,5 +87,6 @@ replace (
 	github.com/coreos/prometheus-operator => github.com/coreos/prometheus-operator v0.29.0
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.1.10
 	sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.1.11-0.20190411181648-9d55346c2bde
+	k8s.io/kube-state-metrics => k8s.io/kube-state-metrics v1.6.0
 )
 `

--- a/internal/pkg/scaffold/gopkgtoml.go
+++ b/internal/pkg/scaffold/gopkgtoml.go
@@ -72,9 +72,9 @@ required = [
   name = "github.com/coreos/prometheus-operator"
   version = "=v0.29.0"
 
-[[constraint]]
+[[override]]
   name = "k8s.io/kube-state-metrics"
-  version = "v1.6.0-rc.0"
+  version = "v1.6.0"
 
 [[override]]
   name = "sigs.k8s.io/controller-runtime"

--- a/internal/pkg/scaffold/gopkgtoml.go
+++ b/internal/pkg/scaffold/gopkgtoml.go
@@ -72,6 +72,10 @@ required = [
   name = "github.com/coreos/prometheus-operator"
   version = "=v0.29.0"
 
+[[constraint]]
+  name = "k8s.io/kube-state-metrics"
+  version = "v1.6.0-rc.0"
+
 [[override]]
   name = "sigs.k8s.io/controller-runtime"
   version = "=v0.1.10"
@@ -85,6 +89,11 @@ required = [
 [prune]
   go-tests = true
   non-go = true
+
+  [[prune.project]]
+    name = "k8s.io/kube-state-metrics"
+    unused-packages = true
+  
 `
 
 func PrintDepGopkgTOML(asFile bool) error {

--- a/internal/pkg/scaffold/gopkgtoml_test.go
+++ b/internal/pkg/scaffold/gopkgtoml_test.go
@@ -70,6 +70,10 @@ required = [
   name = "github.com/coreos/prometheus-operator"
   version = "=v0.29.0"
 
+[[constraint]]
+  name = "k8s.io/kube-state-metrics"
+  version = "v1.6.0-rc.0"
+
 [[override]]
   name = "sigs.k8s.io/controller-runtime"
   version = "=v0.1.10"
@@ -83,4 +87,9 @@ required = [
 [prune]
   go-tests = true
   non-go = true
+
+  [[prune.project]]
+    name = "k8s.io/kube-state-metrics"
+    unused-packages = true
+  
 `

--- a/internal/pkg/scaffold/gopkgtoml_test.go
+++ b/internal/pkg/scaffold/gopkgtoml_test.go
@@ -70,9 +70,9 @@ required = [
   name = "github.com/coreos/prometheus-operator"
   version = "=v0.29.0"
 
-[[constraint]]
+[[override]]
   name = "k8s.io/kube-state-metrics"
-  version = "v1.6.0-rc.0"
+  version = "v1.6.0"
 
 [[override]]
   name = "sigs.k8s.io/controller-runtime"

--- a/pkg/kube-metrics/collector.go
+++ b/pkg/kube-metrics/collector.go
@@ -17,7 +17,6 @@ package kubemetrics
 import (
 	"context"
 
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,14 +30,7 @@ import (
 
 // NewCollectors returns collections of metrics in the namespaces provided, per the api/kind resource.
 // The metrics are registered in the custom generateStore function that needs to be defined.
-// Current operators namespace will be added to the passed namespaces if it is not present.
 func NewCollectors(uc *Client, namespaces []string, api string, kind string, metricFamily []metric.FamilyGenerator) ([]kcollector.Collector, error) {
-	// Detect in which namespace the operator is deployed in.
-	operatorNamespace, err := k8sutil.GetOperatorNamespace()
-	if err != nil {
-		return nil, err
-	}
-	namespaces = append(namespaces, operatorNamespace)
 	namespaces = deduplicateNamespaces(namespaces)
 	var collectors []kcollector.Collector
 	// Generate collector per namespace.

--- a/pkg/kube-metrics/collector.go
+++ b/pkg/kube-metrics/collector.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	kcollector "k8s.io/kube-state-metrics/pkg/collector"
 	"k8s.io/kube-state-metrics/pkg/metric"
@@ -30,12 +31,12 @@ import (
 
 // NewCollectors returns collections of metrics in the namespaces provided, per the api/kind resource.
 // The metrics are registered in the custom generateStore function that needs to be defined.
-func NewCollectors(uc *Client, namespaces []string, api string, kind string, metricFamily []metric.FamilyGenerator) ([]kcollector.Collector, error) {
+func NewCollectors(cfg *rest.Config, namespaces []string, api string, kind string, metricFamily []metric.FamilyGenerator) ([]kcollector.Collector, error) {
 	namespaces = deduplicateNamespaces(namespaces)
 	var collectors []kcollector.Collector
 	// Generate collector per namespace.
 	for _, ns := range namespaces {
-		dclient, err := uc.ClientFor(api, kind, ns)
+		dclient, err := newClientForGVK(cfg, api, kind)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kube-metrics/collector.go
+++ b/pkg/kube-metrics/collector.go
@@ -1,0 +1,93 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubemetrics
+
+import (
+	"context"
+
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+	kcollector "k8s.io/kube-state-metrics/pkg/collector"
+	"k8s.io/kube-state-metrics/pkg/metric"
+	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
+)
+
+// NewCollectors returns collections of metrics in the namespaces provided, per the api/kind resource.
+// The metrics are registered in the custom generateStore function that needs to be defined.
+// Current operators namespace will be added to the passed namespaces if it is not present.
+func NewCollectors(uc *Client, namespaces []string, api string, kind string, metricFamily []metric.FamilyGenerator) ([]*kcollector.Collector, error) {
+	// Detect in which namespace the operator is deployed in.
+	operatorNamespace, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		return nil, err
+	}
+	namespaces = append(namespaces, operatorNamespace)
+	namespaces = deduplicateNamespaces(namespaces)
+	var collectors []*kcollector.Collector
+	// Generate collector per namespace.
+	for _, ns := range namespaces {
+		dclient, err := uc.ClientFor(api, kind, ns)
+		if err != nil {
+			return nil, err
+		}
+		composedMetricGenFuncs := metric.ComposeMetricGenFuncs(metricFamily)
+		headers := metric.ExtractMetricFamilyHeaders(metricFamily)
+		store := metricsstore.NewMetricsStore(headers, composedMetricGenFuncs)
+		reflectorPerNamespace(context.TODO(), dclient, &unstructured.Unstructured{}, store, ns)
+		collector := kcollector.NewCollector(store)
+		collectors = append(collectors, collector)
+	}
+	return collectors, nil
+}
+
+func deduplicateNamespaces(ns []string) []string {
+	keys := make(map[string]bool)
+	list := []string{}
+	for _, entry := range ns {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	return list
+}
+
+func reflectorPerNamespace(
+	ctx context.Context,
+	dynamicInterface dynamic.NamespaceableResourceInterface,
+	expectedType interface{},
+	store cache.Store,
+	ns string,
+) {
+	lw := listWatchFunc(dynamicInterface, ns)
+	reflector := cache.NewReflector(&lw, expectedType, store, 0)
+	go reflector.Run(ctx.Done())
+}
+
+func listWatchFunc(dynamicInterface dynamic.NamespaceableResourceInterface, namespace string) cache.ListWatch {
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return dynamicInterface.Namespace(namespace).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return dynamicInterface.Namespace(namespace).Watch(opts)
+		},
+	}
+}

--- a/pkg/kube-metrics/collector.go
+++ b/pkg/kube-metrics/collector.go
@@ -32,7 +32,7 @@ import (
 // NewCollectors returns collections of metrics in the namespaces provided, per the api/kind resource.
 // The metrics are registered in the custom generateStore function that needs to be defined.
 // Current operators namespace will be added to the passed namespaces if it is not present.
-func NewCollectors(uc *Client, namespaces []string, api string, kind string, metricFamily []metric.FamilyGenerator) ([]*kcollector.Collector, error) {
+func NewCollectors(uc *Client, namespaces []string, api string, kind string, metricFamily []metric.FamilyGenerator) ([]kcollector.Collector, error) {
 	// Detect in which namespace the operator is deployed in.
 	operatorNamespace, err := k8sutil.GetOperatorNamespace()
 	if err != nil {
@@ -40,7 +40,7 @@ func NewCollectors(uc *Client, namespaces []string, api string, kind string, met
 	}
 	namespaces = append(namespaces, operatorNamespace)
 	namespaces = deduplicateNamespaces(namespaces)
-	var collectors []*kcollector.Collector
+	var collectors []kcollector.Collector
 	// Generate collector per namespace.
 	for _, ns := range namespaces {
 		dclient, err := uc.ClientFor(api, kind, ns)
@@ -52,7 +52,7 @@ func NewCollectors(uc *Client, namespaces []string, api string, kind string, met
 		store := metricsstore.NewMetricsStore(headers, composedMetricGenFuncs)
 		reflectorPerNamespace(context.TODO(), dclient, &unstructured.Unstructured{}, store, ns)
 		collector := kcollector.NewCollector(store)
-		collectors = append(collectors, collector)
+		collectors = append(collectors, *collector)
 	}
 	return collectors, nil
 }

--- a/pkg/kube-metrics/collector.go
+++ b/pkg/kube-metrics/collector.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	kcollector "k8s.io/kube-state-metrics/pkg/collector"
 	"k8s.io/kube-state-metrics/pkg/metric"
@@ -31,15 +30,11 @@ import (
 
 // NewCollectors returns collections of metrics in the namespaces provided, per the api/kind resource.
 // The metrics are registered in the custom generateStore function that needs to be defined.
-func NewCollectors(cfg *rest.Config, namespaces []string, api string, kind string, metricFamily []metric.FamilyGenerator) ([]kcollector.Collector, error) {
+func NewCollectors(dclient dynamic.NamespaceableResourceInterface, namespaces []string, api string, kind string, metricFamily []metric.FamilyGenerator) []kcollector.Collector {
 	namespaces = deduplicateNamespaces(namespaces)
 	var collectors []kcollector.Collector
 	// Generate collector per namespace.
 	for _, ns := range namespaces {
-		dclient, err := newClientForGVK(cfg, api, kind)
-		if err != nil {
-			return nil, err
-		}
 		composedMetricGenFuncs := metric.ComposeMetricGenFuncs(metricFamily)
 		headers := metric.ExtractMetricFamilyHeaders(metricFamily)
 		store := metricsstore.NewMetricsStore(headers, composedMetricGenFuncs)
@@ -47,7 +42,7 @@ func NewCollectors(cfg *rest.Config, namespaces []string, api string, kind strin
 		collector := kcollector.NewCollector(store)
 		collectors = append(collectors, *collector)
 	}
-	return collectors, nil
+	return collectors
 }
 
 func deduplicateNamespaces(ns []string) (list []string) {

--- a/pkg/kube-metrics/collector.go
+++ b/pkg/kube-metrics/collector.go
@@ -57,12 +57,11 @@ func NewCollectors(uc *Client, namespaces []string, api string, kind string, met
 	return collectors, nil
 }
 
-func deduplicateNamespaces(ns []string) []string {
-	keys := make(map[string]bool)
-	list := []string{}
+func deduplicateNamespaces(ns []string) (list []string) {
+	keys := make(map[string]struct{})
 	for _, entry := range ns {
-		if _, value := keys[entry]; !value {
-			keys[entry] = true
+		if _, ok := keys[entry]; !ok {
+			keys[entry] = struct{}{}
 			list = append(list, entry)
 		}
 	}

--- a/pkg/kube-metrics/metrics.go
+++ b/pkg/kube-metrics/metrics.go
@@ -47,17 +47,17 @@ func ServeCRMetrics(cfg *rest.Config,
 	log.V(1).Info("Starting collecting operator types")
 	// Loop through all the possible operator/custom resource specific types.
 	for _, gvk := range operatorGVKs {
-		api := gvk.GroupVersion().String()
+		apiVersion := gvk.GroupVersion().String()
 		kind := gvk.Kind
 		// Generate metric based on the kind.
 		metricFamilies := generateMetricFamilies(gvk.Kind)
-		log.V(1).Info("Generating metric families", "apiVersion", api, "kind", kind)
-		dclient, err := newClientForGVK(cfg, api, kind)
+		log.V(1).Info("Generating metric families", "apiVersion", apiVersion, "kind", kind)
+		dclient, err := newClientForGVK(cfg, apiVersion, kind)
 		if err != nil {
 			return err
 		}
 		// Generate collector based on the group/version, kind and the metric families.
-		c := NewCollectors(dclient, ns, api, kind, metricFamilies)
+		c := NewCollectors(dclient, ns, apiVersion, kind, metricFamilies)
 		collectors = append(collectors, c)
 	}
 	// Start serving metrics.

--- a/pkg/kube-metrics/metrics.go
+++ b/pkg/kube-metrics/metrics.go
@@ -68,7 +68,7 @@ func ServeCRMetrics(cfg *rest.Config,
 }
 
 func generateMetricFamilies(kind string) []ksmetric.FamilyGenerator {
-	helpText := fmt.Sprintf("Information about the %s custom resource .", kind)
+	helpText := fmt.Sprintf("Information about the %s custom resource.", kind)
 	kindName := fmt.Sprintf("%s", strings.ToLower(kind))
 	metricName := fmt.Sprintf("%s_info", strings.ToLower(kind))
 

--- a/pkg/kube-metrics/metrics.go
+++ b/pkg/kube-metrics/metrics.go
@@ -65,7 +65,7 @@ func ServeCRMetrics(cfg *rest.Config, ns []string, operatorTypes map[schema.Grou
 
 func generateMetricFamilies(kind string) []ksmetric.FamilyGenerator {
 	helpText := fmt.Sprintf("Information about the %s operator replica.", kind)
-	kindName := fmt.Sprintf("%s", kind)
+	kindName := fmt.Sprintf("%s", strings.ToLower(kind))
 	metricName := fmt.Sprintf("%s_info", strings.ToLower(kind))
 
 	return []ksmetric.FamilyGenerator{

--- a/pkg/kube-metrics/metrics.go
+++ b/pkg/kube-metrics/metrics.go
@@ -68,7 +68,7 @@ func ServeCRMetrics(cfg *rest.Config,
 }
 
 func generateMetricFamilies(kind string) []ksmetric.FamilyGenerator {
-	helpText := fmt.Sprintf("Information about the %s operator custom resource replica.", kind)
+	helpText := fmt.Sprintf("Information about the %s custom resource .", kind)
 	kindName := fmt.Sprintf("%s", strings.ToLower(kind))
 	metricName := fmt.Sprintf("%s_info", strings.ToLower(kind))
 

--- a/pkg/kube-metrics/metrics.go
+++ b/pkg/kube-metrics/metrics.go
@@ -69,7 +69,7 @@ func GenerateAndServeCRMetrics(cfg *rest.Config,
 func generateMetricFamilies(kind string) []ksmetric.FamilyGenerator {
 	helpText := fmt.Sprintf("Information about the %s custom resource.", kind)
 	kindName := strings.ToLower(kind)
-	metricName := fmt.Sprintf("%s_info", strings.ToLower(kind))
+	metricName := fmt.Sprintf("%s_info", kindName)
 
 	return []ksmetric.FamilyGenerator{
 		ksmetric.FamilyGenerator{

--- a/pkg/kube-metrics/metrics.go
+++ b/pkg/kube-metrics/metrics.go
@@ -44,7 +44,6 @@ func ServeCRMetrics(cfg *rest.Config,
 		return errors.New("namespaces were empty; pass at least one namespace to generate custom resource metrics")
 	}
 	// Create new unstructured client.
-	uc := NewClientForConfig(cfg)
 	var collectors [][]kcollector.Collector
 	log.V(1).Info("Starting collecting operator types")
 	// Loop through all the possible operator/custom resource specific types.
@@ -53,7 +52,7 @@ func ServeCRMetrics(cfg *rest.Config,
 		metricFamilies := generateMetricFamilies(gvk.Kind)
 		log.V(1).Info("Generating metric families", "apiVersion", gvk.GroupVersion().String(), "kind", gvk.Kind)
 		// Generate collector based on the group/version, kind and the metric families.
-		c, err := NewCollectors(uc, ns, gvk.GroupVersion().String(), gvk.Kind, metricFamilies)
+		c, err := NewCollectors(cfg, ns, gvk.GroupVersion().String(), gvk.Kind, metricFamilies)
 		if err != nil {
 			if err == k8sutil.ErrNoNamespace {
 				log.Info("Skipping operator specific metrics; not running in a cluster.")

--- a/pkg/kube-metrics/metrics.go
+++ b/pkg/kube-metrics/metrics.go
@@ -68,7 +68,7 @@ func GenerateAndServeCRMetrics(cfg *rest.Config,
 
 func generateMetricFamilies(kind string) []ksmetric.FamilyGenerator {
 	helpText := fmt.Sprintf("Information about the %s custom resource.", kind)
-	kindName := fmt.Sprintf("%s", strings.ToLower(kind))
+	kindName := strings.ToLower(kind)
 	metricName := fmt.Sprintf("%s_info", strings.ToLower(kind))
 
 	return []ksmetric.FamilyGenerator{

--- a/pkg/kube-metrics/metrics.go
+++ b/pkg/kube-metrics/metrics.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"

--- a/pkg/kube-metrics/metrics.go
+++ b/pkg/kube-metrics/metrics.go
@@ -29,7 +29,7 @@ import (
 
 var log = logf.Log.WithName("kubemetrics")
 
-// ServeCRMetrics generates CustomResource specific metrics based on the inputted custom resource GVK.
+// ServeCRMetrics generates CustomResource specific metrics for each custom resource GVK in operatorGVKs.
 // A list of namespaces, ns, can be passed to ServeCRMetrics to scope the generated metrics. Passing nil or
 // an empty list of namespaces will result in an error.
 // The function also starts serving the generated collections of the metrics on given host and port.

--- a/pkg/kube-metrics/metrics.go
+++ b/pkg/kube-metrics/metrics.go
@@ -29,11 +29,11 @@ import (
 
 var log = logf.Log.WithName("kubemetrics")
 
-// ServeCRMetrics generates CustomResource specific metrics for each custom resource GVK in operatorGVKs.
+// GenerateAndServeCRMetrics generates CustomResource specific metrics for each custom resource GVK in operatorGVKs.
 // A list of namespaces, ns, can be passed to ServeCRMetrics to scope the generated metrics. Passing nil or
 // an empty list of namespaces will result in an error.
 // The function also starts serving the generated collections of the metrics on given host and port.
-func ServeCRMetrics(cfg *rest.Config,
+func GenerateAndServeCRMetrics(cfg *rest.Config,
 	ns []string,
 	operatorGVKs []schema.GroupVersionKind,
 	host string, port int32) error {

--- a/pkg/kube-metrics/metrics.go
+++ b/pkg/kube-metrics/metrics.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"github.com/pkg/errors"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -32,12 +33,16 @@ var log = logf.Log.WithName("kubemetrics")
 
 // ServeCRMetrics generates CustomResource specific metrics based on the inputted custom resource GVK.
 // A list of namespaces, ns, can be passed to ServeCRMetrics to scope the generated metrics. Passing nil or
-// an empty list of namespaces will result in using just the namespace the operator is deployed in.
+// an empty list of namespaces will result in an error.
 // The function also starts serving the generated collections of the metrics on given host and port.
 func ServeCRMetrics(cfg *rest.Config,
 	ns []string,
 	operatorGVKs []schema.GroupVersionKind,
 	host string, port int32) error {
+	// We have to have at least one namespace.
+	if len(ns) < 1 {
+		return errors.New("namespaces were empty; pass at least one namespace to generate custom resource metrics")
+	}
 	// Create new unstructured client.
 	uc := NewClientForConfig(cfg)
 	var collectors [][]kcollector.Collector

--- a/pkg/kube-metrics/metrics.go
+++ b/pkg/kube-metrics/metrics.go
@@ -85,7 +85,7 @@ func ServeCRMetrics(cfg *rest.Config,
 	for _, gvk := range operatorGVKs {
 		// Generate metric based on the kind.
 		metricFamilies := generateMetricFamilies(gvk.Kind)
-		log.V(1).Info("Generating metric families for kind ", gvk.Kind, "and group/version", gvk.GroupVersion().String())
+		log.V(1).Info("Generating metric families", "apiVersion", gvk.GroupVersion().String(), "kind", gvk.Kind)
 		// Generate collector based on the group/version, kind and the metric families.
 		c, err := NewCollectors(uc, ns, gvk.GroupVersion().String(), gvk.Kind, metricFamilies)
 		if err != nil {

--- a/pkg/kube-metrics/metrics.go
+++ b/pkg/kube-metrics/metrics.go
@@ -1,0 +1,116 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubemetrics
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	kcollector "k8s.io/kube-state-metrics/pkg/collector"
+	ksmetric "k8s.io/kube-state-metrics/pkg/metric"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("kubemetrics")
+
+// ServeCRMetrics generates CR specific metrics based on the operator GVK.
+// It starts serving collections of those metrics on given host and port.
+func ServeCRMetrics(cfg *rest.Config, ns []string, operatorTypes map[schema.GroupVersionKind]reflect.Type, host string, port int32) error {
+	// Create new unstructured client.
+	uc := NewClientForConfig(cfg)
+	var collectors [][]*kcollector.Collector
+	log.V(1).Info("Starting collecting operator types")
+
+	// Loop through all the possible operator specific types.
+	for gvk, _ := range operatorTypes {
+		// Generate metric based on the kind.
+		metricFamilies := generateMetricFamilies(gvk.Kind)
+		log.V(1).Info("Generating metric families for kind ", gvk.Kind, "and group/version", gvk.GroupVersion().String())
+		// Generate collector based on the resource, kind and the metric families.
+		c, err := NewCollectors(uc, ns, gvk.GroupVersion().String(), gvk.Kind, metricFamilies)
+		if err != nil {
+			if err == k8sutil.ErrNoNamespace {
+				log.Info("Skipping operator specific metrics; not running in a cluster.")
+				return nil
+			}
+			return err
+		}
+		collectors = append(collectors, c)
+	}
+	// Start serving metrics.
+	log.V(1).Info("Starting serving metric families")
+	go ServeMetrics(collectors, host, port)
+
+	return nil
+}
+
+func generateMetricFamilies(kind string) []ksmetric.FamilyGenerator {
+	helpText := fmt.Sprintf("Information about the %s operator replica.", kind)
+	kindName := fmt.Sprintf("%s", kind)
+	metricName := fmt.Sprintf("%s_info", strings.ToLower(kind))
+
+	return []ksmetric.FamilyGenerator{
+		ksmetric.FamilyGenerator{
+			Name: metricName,
+			Type: ksmetric.Gauge,
+			Help: helpText,
+			GenerateFunc: func(obj interface{}) *ksmetric.Family {
+				crd := obj.(*unstructured.Unstructured)
+				return &ksmetric.Family{
+					Metrics: []*ksmetric.Metric{
+						{
+							Value:       1,
+							LabelKeys:   []string{"namespace", kindName},
+							LabelValues: []string{crd.GetNamespace(), crd.GetName()},
+						},
+					},
+				}
+			},
+		},
+	}
+}
+
+// FilterOut takes in the operator specific scheme and filters out all generic apimachinery meta types.
+// It returns the GVK specific to this operator.
+func FilterOutMetaTypes(operatorSpecificScheme *runtime.Scheme) map[schema.GroupVersionKind]reflect.Type {
+	allOperatorKnownTypes := operatorSpecificScheme.AllKnownTypes()
+	for gvk, _ := range allOperatorKnownTypes {
+		kind := gvk.Kind
+		if strings.HasSuffix(kind, "List") ||
+			kind == "GetOptions" ||
+			kind == "DeleteOptions" ||
+			kind == "ExportOptions" ||
+			kind == "APIVersions" ||
+			kind == "APIGroupList" ||
+			kind == "APIResourceList" ||
+			kind == "UpdateOptions" ||
+			kind == "CreateOptions" ||
+			kind == "Status" ||
+			kind == "WatchEvent" ||
+			kind == "ListOptions" ||
+			kind == "APIGroup" {
+			delete(allOperatorKnownTypes, gvk)
+		}
+	}
+
+	return allOperatorKnownTypes
+}

--- a/pkg/kube-metrics/metrics.go
+++ b/pkg/kube-metrics/metrics.go
@@ -34,9 +34,12 @@ var log = logf.Log.WithName("kubemetrics")
 
 // GetGVKsFromAddToScheme takes in the operator specific scheme and
 // filters out all generic apimachinery meta types. It returns the GVK specific to this operator.
-func GetGVKsFromAddToScheme(addToSchemeFunc func(*runtime.Scheme)) ([]schema.GroupVersionKind, error) {
+func GetGVKsFromAddToScheme(addToSchemeFunc func(*runtime.Scheme) error) ([]schema.GroupVersionKind, error) {
 	s := kuberuntime.NewScheme()
-	addToSchemeFunc(s)
+	err := addToSchemeFunc(s)
+	if err != nil {
+		return nil, err
+	}
 	operatorKnownTypes := s.AllKnownTypes()
 	operatorGVKs := []schema.GroupVersionKind{}
 	for gvk, _ := range operatorKnownTypes {

--- a/pkg/kube-metrics/server.go
+++ b/pkg/kube-metrics/server.go
@@ -28,7 +28,7 @@ const (
 	healthzPath = "/healthz"
 )
 
-func ServeMetrics(collectors [][]*kcollector.Collector, host string, port int32) {
+func ServeMetrics(collectors [][]kcollector.Collector, host string, port int32) {
 	listenAddress := net.JoinHostPort(host, fmt.Sprint(port))
 	mux := http.NewServeMux()
 	// Add metricsPath
@@ -55,7 +55,7 @@ func ServeMetrics(collectors [][]*kcollector.Collector, host string, port int32)
 }
 
 type metricHandler struct {
-	collectors [][]*kcollector.Collector
+	collectors [][]kcollector.Collector
 }
 
 func (m *metricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/pkg/kube-metrics/server.go
+++ b/pkg/kube-metrics/server.go
@@ -1,0 +1,71 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubemetrics
+
+import (
+	"fmt"
+	logg "log"
+	"net"
+	"net/http"
+
+	kcollector "k8s.io/kube-state-metrics/pkg/collector"
+)
+
+const (
+	metricsPath = "/metrics"
+	healthzPath = "/healthz"
+)
+
+func ServeMetrics(collectors [][]*kcollector.Collector, host string, port int32) {
+	listenAddress := net.JoinHostPort(host, fmt.Sprint(port))
+	mux := http.NewServeMux()
+	// Add metricsPath
+	mux.Handle(metricsPath, &metricHandler{collectors})
+	// Add healthzPath
+	mux.HandleFunc(healthzPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	})
+	// Add index
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>
+             <head><title>Operator SDK Metrics</title></head>
+             <body>
+             <h1>kube-metrics</h1>
+			 <ul>
+             <li><a href='` + metricsPath + `'>metrics</a></li>
+             <li><a href='` + healthzPath + `'>healthz</a></li>
+			 </ul>
+             </body>
+             </html>`))
+	})
+	logg.Fatal(http.ListenAndServe(listenAddress, mux))
+}
+
+type metricHandler struct {
+	collectors [][]*kcollector.Collector
+}
+
+func (m *metricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	resHeader := w.Header()
+	// 0.0.4 is the exposition format version of prometheus
+	// https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
+	resHeader.Set("Content-Type", `text/plain; version=`+"0.0.4")
+	for _, collectors := range m.collectors {
+		for _, c := range collectors {
+			c.Collect(w)
+		}
+	}
+}

--- a/pkg/kube-metrics/server.go
+++ b/pkg/kube-metrics/server.go
@@ -16,7 +16,6 @@ package kubemetrics
 
 import (
 	"fmt"
-	logg "log"
 	"net"
 	"net/http"
 
@@ -51,7 +50,8 @@ func ServeMetrics(collectors [][]kcollector.Collector, host string, port int32) 
              </body>
              </html>`))
 	})
-	logg.Fatal(http.ListenAndServe(listenAddress, mux))
+	err := http.ListenAndServe(listenAddress, mux)
+	log.Error(err, "Failed to serve custom metrics")
 }
 
 type metricHandler struct {

--- a/pkg/kube-metrics/uclient.go
+++ b/pkg/kube-metrics/uclient.go
@@ -1,0 +1,114 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubemetrics
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+type Client struct {
+	cfg *rest.Config
+}
+
+func NewClientForConfig(cfg *rest.Config) *Client {
+	c := &Client{
+		cfg: cfg,
+	}
+
+	return c
+}
+
+func (c *Client) ClientFor(apiVersion, kind, namespace string) (dynamic.NamespaceableResourceInterface, error) {
+	apiResourceList, apiResource, err := c.getAPIResource(apiVersion, kind)
+	if err != nil {
+		return nil, errors.Wrapf(err, "discovering resource information failed for %s in %s", kind, apiVersion)
+	}
+
+	dc, err := newForConfig(apiResourceList.GroupVersion, c.cfg)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating dynamic client failed for %s", apiResourceList.GroupVersion)
+	}
+
+	gv, err := schema.ParseGroupVersion(apiResourceList.GroupVersion)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parsing GroupVersion %s failed", apiResourceList.GroupVersion)
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    gv.Group,
+		Version:  gv.Version,
+		Resource: apiResource.Name,
+	}
+
+	return dc.Resource(gvr), nil
+}
+
+func (c *Client) getAPIResource(apiVersion, kind string) (*metav1.APIResourceList, *metav1.APIResource, error) {
+	kclient, err := kubernetes.NewForConfig(c.cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	apiResourceLists, err := kclient.Discovery().ServerResources()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, apiResourceList := range apiResourceLists {
+		if apiResourceList.GroupVersion == apiVersion {
+			for _, r := range apiResourceList.APIResources {
+				if r.Kind == kind {
+					return apiResourceList, &r, nil
+				}
+			}
+		}
+	}
+
+	return nil, nil, fmt.Errorf("apiVersion %s and kind %s not found available in Kubernetes cluster", apiVersion, kind)
+}
+
+func newForConfig(groupVersion string, c *rest.Config) (dynamic.Interface, error) {
+	config := rest.CopyConfig(c)
+
+	err := setConfigDefaults(groupVersion, config)
+	if err != nil {
+		return nil, err
+	}
+
+	return dynamic.NewForConfig(config)
+}
+
+func setConfigDefaults(groupVersion string, config *rest.Config) error {
+	gv, err := schema.ParseGroupVersion(groupVersion)
+	if err != nil {
+		return err
+	}
+	config.GroupVersion = &gv
+	config.APIPath = "/apis"
+	if config.GroupVersion.Group == "" && config.GroupVersion.Version == "v1" {
+		config.APIPath = "/api"
+	}
+	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	return nil
+}

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -36,6 +37,8 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 
 	"github.com/ghodss/yaml"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/prometheus/util/promlint"
 	"github.com/rogpeppe/go-internal/modfile"
 	v1 "k8s.io/api/core/v1"
@@ -466,6 +469,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 	if err != nil {
 		return err
 	}
+
 	// wait for example-memcached to reach 3 replicas
 	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-memcached", 3, retryInterval, timeout)
 	if err != nil {
@@ -622,6 +626,10 @@ func MemcachedCluster(t *testing.T) {
 	if err = memcachedMetricsTest(t, framework.Global, ctx); err != nil {
 		t.Fatal(err)
 	}
+
+	if err = memcachedOperatorMetricsTest(t, framework.Global, ctx); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func memcachedMetricsTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
@@ -636,55 +644,14 @@ func memcachedMetricsTest(t *testing.T, f *framework.Framework, ctx *framework.T
 	if err != nil {
 		return fmt.Errorf("could not get metrics Service: (%v)", err)
 	}
-
-	// Get operator pod
-	pods := v1.PodList{}
-	opts := client.InNamespace(namespace)
 	if len(s.Spec.Selector) == 0 {
 		return fmt.Errorf("no labels found in metrics Service")
 	}
 
-	for k, v := range s.Spec.Selector {
-		if err := opts.SetLabelSelector(fmt.Sprintf("%s=%s", k, v)); err != nil {
-			return fmt.Errorf("failed to set list label selector: (%v)", err)
-		}
-	}
-
-	if err := opts.SetFieldSelector("status.phase=Running"); err != nil {
-		return fmt.Errorf("failed to set list field selector: (%v)", err)
-	}
-	err = f.Client.List(context.TODO(), opts, &pods)
+	response, err := getMetrics(t, f, s.Spec.Selector, namespace, "8383")
 	if err != nil {
-		return fmt.Errorf("failed to get pods: (%v)", err)
+		return fmt.Errorf("failed to lint metrics: %v", err)
 	}
-
-	podName := ""
-	numPods := len(pods.Items)
-	// TODO(lili): Remove below logic when we enable exposing metrics in all pods.
-	if numPods == 0 {
-		podName = pods.Items[0].Name
-	} else if numPods > 1 {
-		// If we got more than one pod, get leader pod name.
-		leader, err := verifyLeader(t, namespace, f, s.Spec.Selector)
-		if err != nil {
-			return err
-		}
-		podName = leader.Name
-	} else {
-		return fmt.Errorf("failed to get operator pod: could not select any pods with Service selector %v", s.Spec.Selector)
-	}
-	// Pod name must be there, otherwise we cannot read metrics data via pod proxy.
-	if podName == "" {
-		return fmt.Errorf("failed to get pod name")
-	}
-
-	// Get metrics data
-	request := proxyViaPod(f.KubeClient, namespace, podName, "8383", "/metrics")
-	response, err := request.DoRaw()
-	if err != nil {
-		return fmt.Errorf("failed to get response from metrics: %v", err)
-	}
-
 	// Make sure metrics are present
 	if len(response) == 0 {
 		return fmt.Errorf("metrics body is empty")
@@ -705,6 +672,126 @@ func memcachedMetricsTest(t *testing.T, f *framework.Framework, ctx *framework.T
 	}
 
 	return nil
+}
+
+func memcachedOperatorMetricsTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		return err
+	}
+
+	response, err := getMetrics(t, f, map[string]string{"name": operatorName}, namespace, "8686")
+	if err != nil {
+		return fmt.Errorf("failed to lint metrics: %v", err)
+	}
+	// Make sure metrics are present
+	if len(response) == 0 {
+		return fmt.Errorf("metrics body is empty")
+	}
+
+	// Perform prometheus metrics lint checks
+	l := promlint.New(bytes.NewReader(response))
+	problems, err := l.Lint()
+	if err != nil {
+		return fmt.Errorf("failed to lint metrics: %v", err)
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("found problems with metrics: %#+v", problems)
+	}
+
+	// Make sure the metrics are the way we expect them.
+	d := expfmt.NewDecoder(bytes.NewReader(response), expfmt.FmtText)
+	var mf dto.MetricFamily
+	for {
+		if err := d.Decode(&mf); err != nil {
+			if err == io.EOF {
+				break
+			}
+
+			return err
+		}
+
+		/*
+			Metric:
+			# HELP memcached_info Information about the Memcached operator replica.
+			# TYPE memcached_info gauge
+			memcached_info{namespace="memcached-memcached-group-cluster-1553683239",memcached="example-memcached"} 1
+		*/
+		if mf.GetName() != "memcached_info" {
+			return fmt.Errorf("metric name was incorrect: expected %s, got %s", "memcached_info", mf.GetName())
+		}
+		if mf.GetType() != dto.MetricType_GAUGE {
+			return fmt.Errorf("metric type was incorrect: expected %v, got %v", dto.MetricType_GAUGE, mf.GetType())
+		}
+
+		mlabels := mf.Metric[0].GetLabel()
+		if mlabels[0].GetName() != "namespace" {
+			return fmt.Errorf("metric label name was incorrect: expected %s, got %s", "namespace", mlabels[0].GetName())
+		}
+		if mlabels[0].GetValue() != namespace {
+			return fmt.Errorf("metric label value was incorrect: expected %s, got %s", namespace, mlabels[0].GetValue())
+		}
+		if mlabels[1].GetName() != "memcached" {
+			return fmt.Errorf("metric label name was incorrect: expected %s, got %s", "memcached", mlabels[1].GetName())
+		}
+		if mlabels[1].GetValue() != "example-memcached" {
+			return fmt.Errorf("metric label value was incorrect: expected %s, got %s", "example-memcached", mlabels[1].GetValue())
+		}
+
+		if mf.Metric[0].GetGauge().GetValue() != float64(1) {
+			return fmt.Errorf("metric counter was incorrect: expected %f, got %f", float64(1), mf.Metric[0].GetGauge().GetValue())
+		}
+	}
+
+	return nil
+}
+
+func getMetrics(t *testing.T, f *framework.Framework, label map[string]string, ns, port string) ([]byte, error) {
+	// Get operator pod
+	pods := v1.PodList{}
+	opts := client.InNamespace(ns)
+	for k, v := range label {
+		if err := opts.SetLabelSelector(fmt.Sprintf("%s=%s", k, v)); err != nil {
+			return nil, fmt.Errorf("failed to set list label selector: (%v)", err)
+		}
+	}
+	if err := opts.SetFieldSelector("status.phase=Running"); err != nil {
+		return nil, fmt.Errorf("failed to set list field selector: (%v)", err)
+	}
+	err := f.Client.List(context.TODO(), opts, &pods)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pods: (%v)", err)
+	}
+
+	podName := ""
+	numPods := len(pods.Items)
+	// TODO(lili): Remove below logic when we enable exposing metrics in all pods.
+	if numPods == 0 {
+		podName = pods.Items[0].Name
+	} else if numPods > 1 {
+		// If we got more than one pod, get leader pod name.
+		leader, err := verifyLeader(t, ns, f, label)
+		if err != nil {
+			return nil, err
+		}
+		podName = leader.Name
+	} else {
+		return nil, fmt.Errorf("failed to get operator pod: could not select any pods with selector %v", label)
+	}
+	// Pod name must be there, otherwise we cannot read metrics data via pod proxy.
+	if podName == "" {
+		return nil, fmt.Errorf("failed to get pod name")
+	}
+
+	// Get metrics data
+	request := proxyViaPod(f.KubeClient, ns, podName, port, "/metrics")
+	response, err := request.DoRaw()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get response from metrics: %v", err)
+	}
+
+	return response, nil
+
 }
 
 func proxyViaPod(kubeClient kubernetes.Interface, namespace, podName, podPortName, path string) *rest.Request {

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -650,7 +650,7 @@ func memcachedMetricsTest(t *testing.T, f *framework.Framework, ctx *framework.T
 
 	response, err := getMetrics(t, f, s.Spec.Selector, namespace, "8383")
 	if err != nil {
-		return fmt.Errorf("failed to lint metrics: %v", err)
+		return fmt.Errorf("failed to get metrics: %v", err)
 	}
 	// Make sure metrics are present
 	if len(response) == 0 {

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -648,6 +648,7 @@ func memcachedMetricsTest(t *testing.T, f *framework.Framework, ctx *framework.T
 		return fmt.Errorf("no labels found in metrics Service")
 	}
 
+	// TODO(lili): Make port a constant in internal/scaffold/cmd.go.
 	response, err := getMetrics(t, f, s.Spec.Selector, namespace, "8383")
 	if err != nil {
 		return fmt.Errorf("failed to get metrics: %v", err)
@@ -680,6 +681,7 @@ func memcachedOperatorMetricsTest(t *testing.T, f *framework.Framework, ctx *fra
 		return err
 	}
 
+	// TODO(lili): Make port a constant in internal/scaffold/cmd.go.
 	response, err := getMetrics(t, f, map[string]string{"name": operatorName}, namespace, "8686")
 	if err != nil {
 		return fmt.Errorf("failed to lint metrics: %v", err)

--- a/vendor/k8s.io/kube-state-metrics/LICENSE
+++ b/vendor/k8s.io/kube-state-metrics/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/k8s.io/kube-state-metrics/pkg/collector/collector.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/collector/collector.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"io"
+)
+
+// Store represents a metrics store e.g.
+// k8s.io/kube-state-metrics/pkg/metrics_store.
+type Store interface {
+	WriteAll(io.Writer)
+}
+
+// Collector represents a kube-state-metrics metric collector. It is a stripped
+// down version of the Prometheus client_golang collector.
+type Collector struct {
+	Store Store
+}
+
+// NewCollector constructs a collector with the given Store.
+func NewCollector(s Store) *Collector {
+	return &Collector{s}
+}
+
+// Collect returns all metrics of the underlying store of the collector.
+func (c *Collector) Collect(w io.Writer) {
+	c.Store.WriteAll(w)
+}

--- a/vendor/k8s.io/kube-state-metrics/pkg/metric/family.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/metric/family.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"strings"
+)
+
+// Family represents a set of metrics with the same name and help text.
+type Family struct {
+	Name    string
+	Metrics []*Metric
+}
+
+// ByteSlice returns the given Family in its string representation.
+func (f Family) ByteSlice() []byte {
+	b := strings.Builder{}
+	for _, m := range f.Metrics {
+		b.WriteString(f.Name)
+		m.Write(&b)
+	}
+
+	return []byte(b.String())
+}

--- a/vendor/k8s.io/kube-state-metrics/pkg/metric/generator.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/metric/generator.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"strings"
+
+	metricsstore "k8s.io/kube-state-metrics/pkg/metrics_store"
+)
+
+// FamilyGenerator provides everything needed to generate a metric family with a
+// Kubernetes object.
+type FamilyGenerator struct {
+	Name         string
+	Help         string
+	Type         Type
+	GenerateFunc func(obj interface{}) *Family
+}
+
+// Generate calls the FamilyGenerator.GenerateFunc and gives the family its
+// name. The reasoning behind injecting the name at such a late point in time is
+// deduplication in the code, preventing typos made by developers as
+// well as saving memory.
+func (g *FamilyGenerator) Generate(obj interface{}) *Family {
+	family := g.GenerateFunc(obj)
+	family.Name = g.Name
+	return family
+}
+
+func (g *FamilyGenerator) generateHeader() string {
+	header := strings.Builder{}
+	header.WriteString("# HELP ")
+	header.WriteString(g.Name)
+	header.WriteByte(' ')
+	header.WriteString(g.Help)
+	header.WriteByte('\n')
+	header.WriteString("# TYPE ")
+	header.WriteString(g.Name)
+	header.WriteByte(' ')
+	header.WriteString(string(g.Type))
+
+	return header.String()
+}
+
+// ExtractMetricFamilyHeaders takes in a slice of FamilyGenerator metrics and
+// returns the extracted headers.
+func ExtractMetricFamilyHeaders(families []FamilyGenerator) []string {
+	headers := make([]string, len(families))
+
+	for i, f := range families {
+		headers[i] = f.generateHeader()
+	}
+
+	return headers
+}
+
+// ComposeMetricGenFuncs takes a slice of metric families and returns a function
+// that composes their metric generation functions into a single one.
+func ComposeMetricGenFuncs(familyGens []FamilyGenerator) func(obj interface{}) []metricsstore.FamilyByteSlicer {
+	return func(obj interface{}) []metricsstore.FamilyByteSlicer {
+		families := make([]metricsstore.FamilyByteSlicer, len(familyGens))
+
+		for i, gen := range familyGens {
+			families[i] = gen.Generate(obj)
+		}
+
+		return families
+	}
+}
+
+type whiteBlackLister interface {
+	IsIncluded(string) bool
+	IsExcluded(string) bool
+}
+
+// FilterMetricFamilies takes a white- and a blacklist and a slice of metric
+// families and returns a filtered slice.
+func FilterMetricFamilies(l whiteBlackLister, families []FamilyGenerator) []FamilyGenerator {
+	filtered := []FamilyGenerator{}
+
+	for _, f := range families {
+		if l.IsIncluded(f.Name) {
+			filtered = append(filtered, f)
+		}
+	}
+
+	return filtered
+}

--- a/vendor/k8s.io/kube-state-metrics/pkg/metric/metric.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/metric/metric.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metric
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	initialNumBufSize = 24
+)
+
+var (
+	numBufPool = sync.Pool{
+		New: func() interface{} {
+			b := make([]byte, 0, initialNumBufSize)
+			return &b
+		},
+	}
+)
+
+// Type represents the type of a metric e.g. a counter. See
+// https://prometheus.io/docs/concepts/metric_types/.
+type Type string
+
+// Gauge defines a Prometheus gauge.
+var Gauge Type = "gauge"
+
+// Counter defines a Prometheus counter.
+var Counter Type = "counter"
+
+// Metric represents a single time series.
+type Metric struct {
+	// The name of a metric is injected by its family to reduce duplication.
+	LabelKeys   []string
+	LabelValues []string
+	Value       float64
+}
+
+func (m *Metric) Write(s *strings.Builder) {
+	if len(m.LabelKeys) != len(m.LabelValues) {
+		panic(fmt.Sprintf(
+			"expected labelKeys %q to be of same length as labelValues %q",
+			m.LabelKeys, m.LabelValues,
+		))
+	}
+
+	labelsToString(s, m.LabelKeys, m.LabelValues)
+	s.WriteByte(' ')
+	writeFloat(s, m.Value)
+	s.WriteByte('\n')
+}
+
+func labelsToString(m *strings.Builder, keys, values []string) {
+	if len(keys) > 0 {
+		var separator byte = '{'
+
+		for i := 0; i < len(keys); i++ {
+			m.WriteByte(separator)
+			m.WriteString(keys[i])
+			m.WriteString("=\"")
+			escapeString(m, values[i])
+			m.WriteByte('"')
+			separator = ','
+		}
+
+		m.WriteByte('}')
+	}
+}
+
+var (
+	escapeWithDoubleQuote = strings.NewReplacer("\\", `\\`, "\n", `\n`, "\"", `\"`)
+)
+
+// escapeString replaces '\' by '\\', new line character by '\n', and '"' by
+// '\"'.
+// Taken from github.com/prometheus/common/expfmt/text_create.go.
+func escapeString(m *strings.Builder, v string) {
+	escapeWithDoubleQuote.WriteString(m, v)
+}
+
+// writeFloat is equivalent to fmt.Fprint with a float64 argument but hardcodes
+// a few common cases for increased efficiency. For non-hardcoded cases, it uses
+// strconv.AppendFloat to avoid allocations, similar to writeInt.
+// Taken from github.com/prometheus/common/expfmt/text_create.go.
+func writeFloat(w *strings.Builder, f float64) {
+	switch {
+	case f == 1:
+		w.WriteByte('1')
+	case f == 0:
+		w.WriteByte('0')
+	case f == -1:
+		w.WriteString("-1")
+	case math.IsNaN(f):
+		w.WriteString("NaN")
+	case math.IsInf(f, +1):
+		w.WriteString("+Inf")
+	case math.IsInf(f, -1):
+		w.WriteString("-Inf")
+	default:
+		bp := numBufPool.Get().(*[]byte)
+		*bp = strconv.AppendFloat((*bp)[:0], f, 'g', -1, 64)
+		w.Write(*bp)
+		numBufPool.Put(bp)
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/pkg/metrics_store/metrics_store.go
+++ b/vendor/k8s.io/kube-state-metrics/pkg/metrics_store/metrics_store.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsstore
+
+import (
+	"io"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// FamilyByteSlicer represents a metric family that can be converted to its string
+// representation.
+type FamilyByteSlicer interface {
+	ByteSlice() []byte
+}
+
+// MetricsStore implements the k8s.io/client-go/tools/cache.Store
+// interface. Instead of storing entire Kubernetes objects, it stores metrics
+// generated based on those objects.
+type MetricsStore struct {
+	// Protects metrics
+	mutex sync.RWMutex
+	// metrics is a map indexed by Kubernetes object id, containing a slice of
+	// metric families, containing a slice of metrics. We need to keep metrics
+	// grouped by metric families in order to zip families with their help text in
+	// MetricsStore.WriteAll().
+	metrics map[types.UID][][]byte
+	// headers contains the header (TYPE and HELP) of each metric family. It is
+	// later on zipped with with their corresponding metric families in
+	// MetricStore.WriteAll().
+	headers []string
+
+	// generateMetricsFunc generates metrics based on a given Kubernetes object
+	// and returns them grouped by metric family.
+	generateMetricsFunc func(interface{}) []FamilyByteSlicer
+}
+
+// NewMetricsStore returns a new MetricsStore
+func NewMetricsStore(headers []string, generateFunc func(interface{}) []FamilyByteSlicer) *MetricsStore {
+	return &MetricsStore{
+		generateMetricsFunc: generateFunc,
+		headers:             headers,
+		metrics:             map[types.UID][][]byte{},
+	}
+}
+
+// Implementing k8s.io/client-go/tools/cache.Store interface
+
+// Add inserts adds to the MetricsStore by calling the metrics generator functions and
+// adding the generated metrics to the metrics map that underlies the MetricStore.
+func (s *MetricsStore) Add(obj interface{}) error {
+	o, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	families := s.generateMetricsFunc(obj)
+	familyStrings := make([][]byte, len(families))
+
+	for i, f := range families {
+		familyStrings[i] = f.ByteSlice()
+	}
+
+	s.metrics[o.GetUID()] = familyStrings
+
+	return nil
+}
+
+// Update updates the existing entry in the MetricsStore.
+func (s *MetricsStore) Update(obj interface{}) error {
+	// TODO: For now, just call Add, in the future one could check if the resource version changed?
+	return s.Add(obj)
+}
+
+// Delete deletes an existing entry in the MetricsStore.
+func (s *MetricsStore) Delete(obj interface{}) error {
+
+	o, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	delete(s.metrics, o.GetUID())
+
+	return nil
+}
+
+// List implements the List method of the store interface.
+func (s *MetricsStore) List() []interface{} {
+	return nil
+}
+
+// ListKeys implements the ListKeys method of the store interface.
+func (s *MetricsStore) ListKeys() []string {
+	return nil
+}
+
+// Get implements the Get method of the store interface.
+func (s *MetricsStore) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	return nil, false, nil
+}
+
+// GetByKey implements the GetByKey method of the store interface.
+func (s *MetricsStore) GetByKey(key string) (item interface{}, exists bool, err error) {
+	return nil, false, nil
+}
+
+// Replace will delete the contents of the store, using instead the
+// given list.
+func (s *MetricsStore) Replace(list []interface{}, _ string) error {
+	s.mutex.Lock()
+	s.metrics = map[types.UID][][]byte{}
+	s.mutex.Unlock()
+
+	for _, o := range list {
+		err := s.Add(o)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Resync implements the Resync method of the store interface.
+func (s *MetricsStore) Resync() error {
+	return nil
+}
+
+// WriteAll writes all metrics of the store into the given writer, zipped with the
+// help text of each metric family.
+func (s *MetricsStore) WriteAll(w io.Writer) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	for i, help := range s.headers {
+		w.Write([]byte(help))
+		w.Write([]byte{'\n'})
+		for _, metricFamilies := range s.metrics {
+			w.Write([]byte(metricFamilies[i]))
+		}
+	}
+}


### PR DESCRIPTION
Operator specific metrics are generated based on the api/kind given
deployed in the given namespace(s).

See https://github.com/operator-framework/operator-sdk/blob/master/doc/proposals/metering-operator-metrics.md for the full background on this work.

Things to be done:
- [x] kube-state-metrics has not been released yet, so currently pinning this to master, so we should wait until that is released so we can pin. But there should not be any major changes from master until the next release so this is ready for review and feedback.
- [x] Currently we detect the namespace in which the operator is deployed in and use that by default along with the namespaces passed by the user. In the future we might want to also detect in which namespace all the CRs are deployed in, if the operator is cluster scoped. Not sure if we want this done in the current PR? Since everything will be done in the kube-metrics package and will not be user facing I think it can be done at a later point.
- [ ] Expose the metrics port in the Service file. This includes breaking changes and would prefer to do it in another PR as this one large enough to review. 
- [ ]  Update proposal to done once this is merged.

Closes https://github.com/operator-framework/operator-sdk/issues/616