### PR TITLE
Backport: commands/.../generate: verbose codegen by default (#1271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Subcommands of [`operator-sdk generate`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#generate) are now verbose by default. ([#1271](https://github.com/operator-framework/operator-sdk/pull/1271))
+
 ### Deprecated
 
 ### Removed

--- a/commands/operator-sdk/cmd/generate/internal/genutil.go
+++ b/commands/operator-sdk/cmd/generate/internal/genutil.go
@@ -44,6 +44,7 @@ func runGoBuildCodegen(binDir, repoDir, genDir string) error {
 		cmd.Env = append(os.Environ(), projutil.GoFlagsEnv+"="+gf)
 	}
 
+	// Only print binary build info if verbosity is explicitly set.
 	if projutil.IsGoVerbose() {
 		return projutil.ExecCmd(cmd)
 	}

--- a/commands/operator-sdk/cmd/generate/k8s.go
+++ b/commands/operator-sdk/cmd/generate/k8s.go
@@ -16,7 +16,6 @@ package generate
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -118,14 +117,7 @@ func deepcopyGen(binDir, repoPkg string, gvMap map[string][]string) (err error) 
 		"--bounding-dirs", apisPkg,
 	}
 	cmd := exec.Command(filepath.Join(binDir, "deepcopy-gen"), args...)
-	if projutil.IsGoVerbose() {
-		err = projutil.ExecCmd(cmd)
-	} else {
-		cmd.Stdout = ioutil.Discard
-		cmd.Stderr = ioutil.Discard
-		err = cmd.Run()
-	}
-	if err != nil {
+	if err = projutil.ExecCmd(cmd); err != nil {
 		return fmt.Errorf("failed to perform deepcopy code-generation: %v", err)
 	}
 	return nil
@@ -138,14 +130,7 @@ func defaulterGen(binDir, repoPkg string, gvMap map[string][]string) (err error)
 		"--output-file-base", "zz_generated.defaults",
 	}
 	cmd := exec.Command(filepath.Join(binDir, "defaulter-gen"), args...)
-	if projutil.IsGoVerbose() {
-		err = projutil.ExecCmd(cmd)
-	} else {
-		cmd.Stdout = ioutil.Discard
-		cmd.Stderr = ioutil.Discard
-		err = cmd.Run()
-	}
-	if err != nil {
+	if err = projutil.ExecCmd(cmd); err != nil {
 		return fmt.Errorf("failed to perform defaulter code-generation: %v", err)
 	}
 	return nil

--- a/commands/operator-sdk/cmd/generate/openapi.go
+++ b/commands/operator-sdk/cmd/generate/openapi.go
@@ -167,14 +167,7 @@ func openAPIGen(binDir string, fqApis []string) (err error) {
 			"--go-header-file", headerFile,
 		}
 		cmd := exec.Command(cgPath, args...)
-		if projutil.IsGoVerbose() {
-			err = projutil.ExecCmd(cmd)
-		} else {
-			cmd.Stdout = ioutil.Discard
-			cmd.Stderr = ioutil.Discard
-			err = cmd.Run()
-		}
-		if err != nil {
+		if err = projutil.ExecCmd(cmd); err != nil {
 			return fmt.Errorf("failed to perform openapi code-generation: %v", err)
 		}
 	}

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -161,10 +161,6 @@ func TestMemcached(t *testing.T) {
 		"api",
 		"--api-version=cache.example.com/v1alpha1",
 		"--kind=Memcached")
-	// Generators will print errors if -v is set.
-	if !projutil.IsGoVerbose() {
-		os.Setenv(projutil.GoFlagsEnv, os.Getenv(projutil.GoFlagsEnv)+" -v")
-	}
 	cmd.Env = os.Environ()
 	cmdOut, err = cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
See #1271