### PR TITLE
internal/pkg/scaffold/gopkgtoml*: Update prometheus-operator

### DIFF
--- a/internal/pkg/scaffold/gopkgtoml.go
+++ b/internal/pkg/scaffold/gopkgtoml.go
@@ -93,7 +93,7 @@ required = [
 
 [[override]]
   name = "github.com/coreos/prometheus-operator"
-  version = "=v0.26.0"
+  version = "=v0.29.0"
 
 [[override]]
   name = "sigs.k8s.io/controller-runtime"

--- a/internal/pkg/scaffold/gopkgtoml_test.go
+++ b/internal/pkg/scaffold/gopkgtoml_test.go
@@ -85,7 +85,7 @@ required = [
 
 [[override]]
   name = "github.com/coreos/prometheus-operator"
-  version = "=v0.26.0"
+  version = "=v0.29.0"
 
 [[override]]
   name = "sigs.k8s.io/controller-runtime"


### PR DESCRIPTION
Bumps up prometheus-operator to 0.29.0 release.