### PR TITLE
internal/util/projutil: standardize operator type checks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1716,6 +1716,7 @@
     "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1",
     "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install",
     "github.com/pborman/uuid",
+    "github.com/pkg/errors",
     "github.com/prometheus/prometheus/util/promlint",
     "github.com/sergi/go-diff/diffmatchpatch",
     "github.com/sirupsen/logrus",

--- a/cmd/operator-sdk/build/cmd.go
+++ b/cmd/operator-sdk/build/cmd.go
@@ -188,7 +188,7 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	if enableTests {
-		if projutil.GetOperatorType() == projutil.OperatorTypeGo {
+		if projutil.IsOperatorGo() {
 			testBinary := filepath.Join(absProjectPath, scaffold.BuildBinDir, projectName+"-test")
 			goTestBuildArgs := append(append([]string{"test"}, goTrimFlags...), "-c", "-o", testBinary, testLocationBuild+"/...")
 			buildTestCmd := exec.Command("go", goTestBuildArgs...)
@@ -212,8 +212,7 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 			}
 
 			s := &scaffold.Scaffold{}
-			t := projutil.GetOperatorType()
-			switch t {
+			switch t := projutil.GetOperatorType(); t {
 			case projutil.OperatorTypeGo:
 				err = s.Execute(cfg,
 					&scaffold.TestFrameworkDockerfile{},
@@ -225,7 +224,7 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 			case projutil.OperatorTypeHelm:
 				return fmt.Errorf("test scaffolding for Helm Operators is not implemented")
 			default:
-				return fmt.Errorf("unknown operator type '%v'", t)
+				return projutil.ErrUnknownOperatorType{}
 			}
 
 			if err != nil {

--- a/cmd/operator-sdk/new/cmd.go
+++ b/cmd/operator-sdk/new/cmd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/input"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -309,7 +310,7 @@ func doHelmScaffold() error {
 
 func verifyFlags() error {
 	if operatorType != projutil.OperatorTypeGo && operatorType != projutil.OperatorTypeAnsible && operatorType != projutil.OperatorTypeHelm {
-		return fmt.Errorf("value of --type can only be `go`, `ansible`, or `helm`")
+		return errors.Wrap(projutil.ErrUnknownOperatorType{Type: operatorType}, "value of --type can only be `go`, `ansible`, or `helm`")
 	}
 	if operatorType != projutil.OperatorTypeAnsible && generatePlaybook {
 		return fmt.Errorf("value of --generate-playbook can only be used with --type `ansible`")

--- a/cmd/operator-sdk/test/cluster.go
+++ b/cmd/operator-sdk/test/cluster.go
@@ -84,9 +84,9 @@ func testClusterFunc(cmd *cobra.Command, args []string) error {
 	case projutil.OperatorTypeAnsible:
 		testCmd = []string{"/" + ansible.BuildTestFrameworkAnsibleTestScriptFile}
 	case projutil.OperatorTypeHelm:
-		log.Fatal("`test cluster` for Helm operators is not implemented")
+		return fmt.Errorf("`test cluster` for Helm operators is not implemented")
 	default:
-		log.Fatal("Failed to determine operator type")
+		return projutil.ErrUnknownOperatorType{}
 	}
 
 	// cobra prints its help message on error; we silence that here because any errors below

--- a/cmd/operator-sdk/test/local.go
+++ b/cmd/operator-sdk/test/local.go
@@ -75,8 +75,7 @@ func newTestLocalCmd() *cobra.Command {
 }
 
 func testLocalFunc(cmd *cobra.Command, args []string) error {
-	t := projutil.GetOperatorType()
-	switch t {
+	switch t := projutil.GetOperatorType(); t {
 	case projutil.OperatorTypeGo:
 		return testLocalGoFunc(cmd, args)
 	case projutil.OperatorTypeAnsible:
@@ -84,7 +83,7 @@ func testLocalFunc(cmd *cobra.Command, args []string) error {
 	case projutil.OperatorTypeHelm:
 		return fmt.Errorf("`test local` for Helm operators is not implemented")
 	}
-	return fmt.Errorf("unknown operator type '%v'", t)
+	return projutil.ErrUnknownOperatorType{}
 }
 
 func testLocalAnsibleFunc(cmd *cobra.Command, args []string) error {

--- a/cmd/operator-sdk/up/local.go
+++ b/cmd/operator-sdk/up/local.go
@@ -87,8 +87,7 @@ func upLocalFunc(cmd *cobra.Command, args []string) error {
 	}
 	log.Infof("Using namespace %s.", namespace)
 
-	t := projutil.GetOperatorType()
-	switch t {
+	switch t := projutil.GetOperatorType(); t {
 	case projutil.OperatorTypeGo:
 		return upLocal()
 	case projutil.OperatorTypeAnsible:
@@ -96,7 +95,7 @@ func upLocalFunc(cmd *cobra.Command, args []string) error {
 	case projutil.OperatorTypeHelm:
 		return upLocalHelm()
 	}
-	return fmt.Errorf("unknown operator type '%v'", t)
+	return projutil.ErrUnknownOperatorType{}
 }
 
 func upLocal() error {

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -22,10 +22,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold"
-	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/ansible"
-	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/helm"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -34,9 +30,13 @@ const (
 	GopathEnv  = "GOPATH"
 	GoFlagsEnv = "GOFLAGS"
 	SrcDir     = "src"
-)
 
-var mainFile = filepath.Join(scaffold.ManagerDir, scaffold.CmdFile)
+	fsep            = string(filepath.Separator)
+	mainFile        = "cmd" + fsep + "manager" + fsep + "main.go"
+	buildDockerfile = "build" + fsep + "Dockerfile"
+	rolesDir        = "roles"
+	helmChartsDir   = "helm-charts"
+)
 
 // OperatorType - the type of operator
 type OperatorType = string
@@ -52,28 +52,35 @@ const (
 	OperatorTypeUnknown OperatorType = "unknown"
 )
 
-// MustInProjectRoot checks if the current dir is the project root and returns the current repo's import path
-// e.g github.com/example-inc/app-operator
+type ErrUnknownOperatorType struct {
+	Type string
+}
+
+func (e ErrUnknownOperatorType) Error() string {
+	if e.Type == "" {
+		return "unknown operator type"
+	}
+	return fmt.Sprintf(`unknown operator type "%v"`, e.Type)
+}
+
+// MustInProjectRoot checks if the current dir is the project root and returns
+// the current repo's import path, ex github.com/example-inc/app-operator
 func MustInProjectRoot() {
-	// if the current directory has the "./build/dockerfile" file, then it is safe to say
+	// If the current directory has a "build/dockerfile", then it is safe to say
 	// we are at the project root.
-	_, err := os.Stat(filepath.Join(scaffold.BuildDir, scaffold.DockerfileFile))
-	if err != nil {
+	if _, err := os.Stat(buildDockerfile); err != nil {
 		if os.IsNotExist(err) {
-			log.Fatal("Must run command in project root dir: project structure requires ./build/Dockerfile")
+			log.Fatalf("Must run command in project root dir: project structure requires %s", buildDockerfile)
 		}
 		log.Fatalf("Error while checking if current directory is the project root: (%v)", err)
 	}
 }
 
 func CheckGoProjectCmd(cmd *cobra.Command) error {
-	t := GetOperatorType()
-	switch t {
-	case OperatorTypeGo:
-	default:
-		return fmt.Errorf("'%s' can only be run for Go operators; %s does not exist.", cmd.CommandPath(), mainFile)
+	if IsOperatorGo() {
+		return nil
 	}
-	return nil
+	return fmt.Errorf("'%s' can only be run for Go operators; %s does not exist.", cmd.CommandPath(), mainFile)
 }
 
 func MustGetwd() string {
@@ -90,30 +97,38 @@ func CheckAndGetProjectGoPkg() string {
 	gopath := MustSetGopath(MustGetGopath())
 	goSrc := filepath.Join(gopath, SrcDir)
 	wd := MustGetwd()
-	currPkg := strings.Replace(wd, goSrc+string(filepath.Separator), "", 1)
+	currPkg := strings.Replace(wd, goSrc+fsep, "", 1)
 	// strip any "/" prefix from the repo path.
-	return strings.TrimPrefix(currPkg, string(filepath.Separator))
+	return strings.TrimPrefix(currPkg, fsep)
 }
 
-// GetOperatorType returns type of operator is in cwd
-// This function should be called after verifying the user is in project root
-// e.g: "go", "ansible"
+// GetOperatorType returns type of operator is in cwd.
+// This function should be called after verifying the user is in project root.
 func GetOperatorType() OperatorType {
-	// Assuming that if main.go exists then this is a Go operator
-	if _, err := os.Stat(mainFile); err == nil {
+	switch {
+	case IsOperatorGo():
 		return OperatorTypeGo
-	}
-	if stat, err := os.Stat(ansible.RolesDir); err == nil && stat.IsDir() {
+	case IsOperatorAnsible():
 		return OperatorTypeAnsible
-	}
-	if stat, err := os.Stat(helm.HelmChartsDir); err == nil && stat.IsDir() {
+	case IsOperatorHelm():
 		return OperatorTypeHelm
 	}
 	return OperatorTypeUnknown
 }
 
 func IsOperatorGo() bool {
-	return GetOperatorType() == OperatorTypeGo
+	_, err := os.Stat(mainFile)
+	return err == nil
+}
+
+func IsOperatorAnsible() bool {
+	stat, err := os.Stat(rolesDir)
+	return err == nil && stat.IsDir()
+}
+
+func IsOperatorHelm() bool {
+	stat, err := os.Stat(helmChartsDir)
+	return err == nil && stat.IsDir()
 }
 
 // MustGetGopath gets GOPATH and ensures it is set and non-empty. If GOPATH


### PR DESCRIPTION
**Description of the change:**
* internal/util/projutil/project_util.go: functions for detecting operator type
* internal/util/projutil/project_util.go: remove scaffold dependency
* cmd/operator-sdk: return `projutil.ErrUnknownOperatorType` if no valid operator type found

**Motivation for the change:** new functions in `projutil` will help type checking projects for `print-deps` in #1001. Code that checks operator type should return a standard error.

