### PR TITLE
pkg/helm,hack/tests: slim down release information in Helm CR status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 
 - When Helm operator projects are created, the SDK now generates RBAC rules in `deploy/role.yaml` based on the chart's default manifest. ([#1188](https://github.com/operator-framework/operator-sdk/pull/1188))
+- Reduces Helm release information in CR status to only the release name and manifest and moves it from `status.conditions` to a new top-level `deployedRelease` field. ([#1309](https://github.com/operator-framework/operator-sdk/pull/1309))
+  - **WARNING**: Users with active CRs and releases who are upgrading their helm-based operator should upgrade to one based on v0.7.0 before upgrading further. Helm operators based on v0.8.0+ will not seamlessly transition release state to the persistent backend, and will instead uninstall and reinstall all managed releases.
 
 ### Deprecated
 

--- a/hack/tests/e2e-helm.sh
+++ b/hack/tests/e2e-helm.sh
@@ -36,13 +36,13 @@ test_operator() {
     # create CR
     kubectl create -f deploy/crds/helm_v1alpha1_nginx_cr.yaml
     trap_add 'kubectl delete --ignore-not-found -f ${OPERATORDIR}/deploy/crds/helm_v1alpha1_nginx_cr.yaml' EXIT
-    if ! timeout 1m bash -c -- 'until kubectl get nginxes.helm.example.com example-nginx -o jsonpath="{..status.conditions[1].release.info.status.code}" | grep 1; do sleep 1; done';
+    if ! timeout 1m bash -c -- 'until kubectl get nginxes.helm.example.com example-nginx -o jsonpath="{..status.deployedRelease.name}" | grep "example-nginx"; do sleep 1; done';
     then
         kubectl logs deployment/nginx-operator
         exit 1
     fi
 
-    release_name=$(kubectl get nginxes.helm.example.com example-nginx -o jsonpath="{..status.conditions[1].release.name}")
+    release_name=$(kubectl get nginxes.helm.example.com example-nginx -o jsonpath="{..status.deployedRelease.name}")
     nginx_deployment=$(kubectl get deployment -l "app.kubernetes.io/instance=${release_name}" -o jsonpath="{..metadata.name}")
 
     if ! timeout 1m kubectl rollout status deployment/${nginx_deployment};

--- a/pkg/helm/controller/reconcile.go
+++ b/pkg/helm/controller/reconcile.go
@@ -146,6 +146,7 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 				Status: types.StatusFalse,
 				Reason: types.ReasonUninstallSuccessful,
 			})
+			status.DeployedRelease = nil
 		}
 		if err := r.updateResourceStatus(o, status); err != nil {
 			return reconcile.Result{}, err
@@ -173,7 +174,6 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 				Status:  types.StatusTrue,
 				Reason:  types.ReasonInstallError,
 				Message: err.Error(),
-				Release: installedRelease,
 			})
 			_ = r.updateResourceStatus(o, status)
 			return reconcile.Result{}, err
@@ -197,8 +197,11 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 			Status:  types.StatusTrue,
 			Reason:  types.ReasonInstallSuccessful,
 			Message: installedRelease.GetInfo().GetStatus().GetNotes(),
-			Release: installedRelease,
 		})
+		status.DeployedRelease = &types.HelmAppRelease{
+			Name:     installedRelease.Name,
+			Manifest: installedRelease.Manifest,
+		}
 		err = r.updateResourceStatus(o, status)
 		return reconcile.Result{RequeueAfter: r.ReconcilePeriod}, err
 	}
@@ -212,7 +215,6 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 				Status:  types.StatusTrue,
 				Reason:  types.ReasonUpdateError,
 				Message: err.Error(),
-				Release: updatedRelease,
 			})
 			_ = r.updateResourceStatus(o, status)
 			return reconcile.Result{}, err
@@ -236,8 +238,11 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 			Status:  types.StatusTrue,
 			Reason:  types.ReasonUpdateSuccessful,
 			Message: updatedRelease.GetInfo().GetStatus().GetNotes(),
-			Release: updatedRelease,
 		})
+		status.DeployedRelease = &types.HelmAppRelease{
+			Name:     updatedRelease.Name,
+			Manifest: updatedRelease.Manifest,
+		}
 		err = r.updateResourceStatus(o, status)
 		return reconcile.Result{RequeueAfter: r.ReconcilePeriod}, err
 	}
@@ -264,6 +269,10 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	log.Info("Reconciled release")
+	status.DeployedRelease = &types.HelmAppRelease{
+		Name:     expectedRelease.Name,
+		Manifest: expectedRelease.Manifest,
+	}
 	err = r.updateResourceStatus(o, status)
 	return reconcile.Result{RequeueAfter: r.ReconcilePeriod}, err
 }

--- a/pkg/helm/internal/types/types.go
+++ b/pkg/helm/internal/types/types.go
@@ -20,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/helm/pkg/proto/hapi/release"
 )
 
 type HelmAppList struct {
@@ -47,9 +46,13 @@ type HelmAppCondition struct {
 	Status  ConditionStatus        `json:"status"`
 	Reason  HelmAppConditionReason `json:"reason,omitempty"`
 	Message string                 `json:"message,omitempty"`
-	Release *release.Release       `json:"release,omitempty"`
 
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+}
+
+type HelmAppRelease struct {
+	Name     string `json:"name,omitempty"`
+	Manifest string `json:"manifest,omitempty"`
 }
 
 const (
@@ -72,7 +75,8 @@ const (
 )
 
 type HelmAppStatus struct {
-	Conditions []HelmAppCondition `json:"conditions"`
+	Conditions      []HelmAppCondition `json:"conditions"`
+	DeployedRelease *HelmAppRelease    `json:"deployedRelease,omitempty"`
 }
 
 func (s *HelmAppStatus) ToMap() (map[string]interface{}, error) {

--- a/pkg/helm/release/manager.go
+++ b/pkg/helm/release/manager.go
@@ -94,14 +94,6 @@ func (m manager) IsUpdateRequired() bool {
 // Sync ensures the Helm storage backend is in sync with the status of the
 // custom resource.
 func (m *manager) Sync(ctx context.Context) error {
-	// TODO: We're now persisting releases as secrets. To support seamless upgrades, we
-	// need to sync the release status from the CR to the persistent storage backend.
-	// Once we release the storage backend migration, this function (and comment)
-	// can be removed.
-	if err := m.syncReleaseStatus(*m.status); err != nil {
-		return fmt.Errorf("failed to sync release status to storage backend: %s", err)
-	}
-
 	// Get release history for this release name
 	releases, err := m.storageBackend.History(m.releaseName)
 	if err != nil && !notFoundErr(err) {
@@ -149,31 +141,6 @@ func (m *manager) Sync(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func (m manager) syncReleaseStatus(status types.HelmAppStatus) error {
-	var release *rpb.Release
-	for _, condition := range status.Conditions {
-		if condition.Type == types.ConditionDeployed && condition.Status == types.StatusTrue {
-			release = condition.Release
-			break
-		}
-	}
-	if release == nil {
-		return nil
-	}
-
-	name := release.GetName()
-	version := release.GetVersion()
-	_, err := m.storageBackend.Get(name, version)
-	if err == nil {
-		return nil
-	}
-
-	if !notFoundErr(err) {
-		return err
-	}
-	return m.storageBackend.Create(release)
 }
 
 func notFoundErr(err error) bool {


### PR DESCRIPTION
**Description of the change:**

This PR removes the full release status from the status condition and adds a new `deployedRelease` field on the top level status that contains just the release name and manifest.

This PR also removes code that syncs the release state from the status condition to the storage backend, which was leftover from when the Helm operator used the in-memory backend. Now that the CR status does not contain the full release state, there is nothing to sync.

**Motivation for the change:**

With the Helm storage backend moved to in-cluster secrets, it is no longer necessary to store the full release state on the CR status. This change will de-clutter the CR status to make it easier for users to find what they're looking for.