### PR TITLE
internal/util/projutil: add Go{Build,Test{() functions to run go build/test

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -613,6 +613,14 @@
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:f9f72e583aaacf1d1ac5d6121abd4afd3c690baa9e14e1d009df26bf831ba347"
+  name = "github.com/mitchellh/go-homedir"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "af06845cf3004701891bf4fdb884bfe4920b3727"
+  version = "v1.1.0"
+
+[[projects]]
   digest = "1:9f63926f52745d1f9d6053f8fbbb3bd3983c2c97c0565957e682b8d2f7aad3af"
   name = "github.com/mitchellh/go-wordwrap"
   packages = ["."]
@@ -1733,6 +1741,7 @@
     "github.com/markbates/inflect",
     "github.com/martinlindhe/base36",
     "github.com/mattbaird/jsonpatch",
+    "github.com/mitchellh/go-homedir",
     "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1",
     "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/install",
     "github.com/pborman/uuid",

--- a/cmd/operator-sdk/build/cmd.go
+++ b/cmd/operator-sdk/build/cmd.go
@@ -179,11 +179,11 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 
 	// Don't need to build Go code if a non-Go Operator.
 	if projutil.IsOperatorGo() {
-		opts := projutil.GoBuildOptions{
-			BinName:   filepath.Join(absProjectPath, scaffold.BuildBinDir, projectName),
-			BuildPath: filepath.Join(projutil.CheckAndGetProjectGoPkg(), scaffold.ManagerDir),
-			BuildArgs: goTrimFlags,
-			Env:       goBuildEnv,
+		opts := projutil.GoCmdOptions{
+			BinName:     filepath.Join(absProjectPath, scaffold.BuildBinDir, projectName),
+			PackagePath: filepath.Join(projutil.CheckAndGetProjectGoPkg(), scaffold.ManagerDir),
+			Args:        goTrimFlags,
+			Env:         goBuildEnv,
 		}
 		if err := projutil.GoBuild(opts); err != nil {
 			return fmt.Errorf("failed to build operator binary: (%v)", err)
@@ -212,11 +212,11 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 
 	if enableTests {
 		if projutil.IsOperatorGo() {
-			opts := projutil.GoBuildOptions{
-				BinName:   filepath.Join(absProjectPath, scaffold.BuildBinDir, projectName+"-test"),
-				BuildPath: testLocationBuild + "/...",
-				BuildArgs: append(goTrimFlags, "-c"),
-				Env:       goBuildEnv,
+			opts := projutil.GoCmdOptions{
+				BinName:     filepath.Join(absProjectPath, scaffold.BuildBinDir, projectName+"-test"),
+				PackagePath: testLocationBuild + "/...",
+				Args:        append(goTrimFlags, "-c"),
+				Env:         goBuildEnv,
 			}
 			if err := projutil.GoTest(opts); err != nil {
 				return fmt.Errorf("failed to build test binary: (%v)", err)

--- a/cmd/operator-sdk/build/cmd.go
+++ b/cmd/operator-sdk/build/cmd.go
@@ -212,11 +212,13 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 
 	if enableTests {
 		if projutil.IsOperatorGo() {
-			opts := projutil.GoCmdOptions{
-				BinName:     filepath.Join(absProjectPath, scaffold.BuildBinDir, projectName+"-test"),
-				PackagePath: testLocationBuild + "/...",
-				Args:        append(goTrimFlags, "-c"),
-				Env:         goBuildEnv,
+			opts := projutil.GoTestOptions{
+				GoCmdOptions: projutil.GoCmdOptions{
+					BinName:     filepath.Join(absProjectPath, scaffold.BuildBinDir, projectName+"-test"),
+					PackagePath: testLocationBuild + "/...",
+					Args:        append(goTrimFlags, "-c"),
+					Env:         goBuildEnv,
+				},
 			}
 			if err := projutil.GoTest(opts); err != nil {
 				return fmt.Errorf("failed to build test binary: (%v)", err)

--- a/cmd/operator-sdk/test/local.go
+++ b/cmd/operator-sdk/test/local.go
@@ -208,10 +208,12 @@ func testLocalGoFunc(cmd *cobra.Command, args []string) error {
 	if tlConfig.upLocal {
 		testArgs = append(testArgs, "-"+test.LocalOperatorFlag)
 	}
-	opts := projutil.GoCmdOptions{
-		PackagePath:    args[0] + "/...",
-		Env:            append(os.Environ(), fmt.Sprintf("%v=%v", test.TestNamespaceEnv, tlConfig.namespace)),
-		Dir:            projutil.MustGetwd(),
+	opts := projutil.GoTestOptions{
+		GoCmdOptions: projutil.GoCmdOptions{
+			PackagePath: args[0] + "/...",
+			Env:         append(os.Environ(), fmt.Sprintf("%v=%v", test.TestNamespaceEnv, tlConfig.namespace)),
+			Dir:         projutil.MustGetwd(),
+		},
 		TestBinaryArgs: testArgs,
 	}
 	if err := projutil.GoTest(opts); err != nil {

--- a/cmd/operator-sdk/test/local.go
+++ b/cmd/operator-sdk/test/local.go
@@ -208,11 +208,11 @@ func testLocalGoFunc(cmd *cobra.Command, args []string) error {
 	if tlConfig.upLocal {
 		testArgs = append(testArgs, "-"+test.LocalOperatorFlag)
 	}
-	opts := projutil.GoBuildOptions{
-		BuildPath: args[0] + "/...",
-		BuildArgs: testArgs,
-		Env:       append(os.Environ(), fmt.Sprintf("%v=%v", test.TestNamespaceEnv, tlConfig.namespace)),
-		Dir:       projutil.MustGetwd(),
+	opts := projutil.GoCmdOptions{
+		PackagePath:    args[0] + "/...",
+		Env:            append(os.Environ(), fmt.Sprintf("%v=%v", test.TestNamespaceEnv, tlConfig.namespace)),
+		Dir:            projutil.MustGetwd(),
+		TestBinaryArgs: testArgs,
 	}
 	if err := projutil.GoTest(opts); err != nil {
 		return fmt.Errorf("failed to build test binary: (%v)", err)

--- a/cmd/operator-sdk/up/local.go
+++ b/cmd/operator-sdk/up/local.go
@@ -177,17 +177,12 @@ func setupOperatorEnv() error {
 }
 
 func buildLocal(outputBinName string) error {
-	args := []string{"build", "-o", outputBinName}
+	var args []string
 	if ldFlags != "" {
-		args = append(args, "-ldflags", ldFlags)
+		args = []string{"-ldflags", ldFlags}
 	}
-	args = append(args, filepath.Join(scaffold.ManagerDir, scaffold.CmdFile))
-
-	bc := exec.Command("go", args...)
-	if err := projutil.ExecCmd(bc); err != nil {
-		return err
-	}
-	return nil
+	managerDir := filepath.Join(scaffold.ManagerDir, scaffold.CmdFile)
+	return projutil.GoBuild(outputBinName, managerDir, args...)
 }
 
 func printVersion() {

--- a/cmd/operator-sdk/up/local.go
+++ b/cmd/operator-sdk/up/local.go
@@ -181,10 +181,10 @@ func buildLocal(outputBinName string) error {
 	if ldFlags != "" {
 		args = []string{"-ldflags", ldFlags}
 	}
-	opts := projutil.GoBuildOptions{
-		BinName:   outputBinName,
-		BuildPath: filepath.Join(scaffold.ManagerDir, scaffold.CmdFile),
-		BuildArgs: args,
+	opts := projutil.GoCmdOptions{
+		BinName:     outputBinName,
+		PackagePath: filepath.Join(scaffold.ManagerDir, scaffold.CmdFile),
+		Args:        args,
 	}
 	return projutil.GoBuild(opts)
 }

--- a/cmd/operator-sdk/up/local.go
+++ b/cmd/operator-sdk/up/local.go
@@ -181,8 +181,12 @@ func buildLocal(outputBinName string) error {
 	if ldFlags != "" {
 		args = []string{"-ldflags", ldFlags}
 	}
-	managerDir := filepath.Join(scaffold.ManagerDir, scaffold.CmdFile)
-	return projutil.GoBuild(outputBinName, managerDir, args...)
+	opts := projutil.GoBuildOptions{
+		BinName:   outputBinName,
+		BuildPath: filepath.Join(scaffold.ManagerDir, scaffold.CmdFile),
+		BuildArgs: args,
+	}
+	return projutil.GoBuild(opts)
 }
 
 func printVersion() {

--- a/internal/util/projutil/exec.go
+++ b/internal/util/projutil/exec.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -45,10 +46,10 @@ type GoBuildOptions struct {
 	Env []string
 	// Dir is the dir to run "go build" in; exec.Command.Dir is set to this value.
 	Dir string
-	// NoGoMod determines whether to set the "-mod=vendor" flag.
-	// If false, GoBuild will use go modules.
-	// If true, "go build" will not use modules.
-	NoGoMod bool
+	// GoMod determines whether to set the "-mod=vendor" flag.
+	// If true, "go build" will use modules.
+	// If false, "go build" will not use go modules. This is the default.
+	GoMod bool
 }
 
 const (
@@ -77,7 +78,7 @@ func goCmd(cmd string, opts GoBuildOptions) error {
 	}
 	bargs = append(bargs, opts.BuildArgs...)
 	// Modules can be used if either GO111MODULE=on or we're not in $GOPATH/src.
-	if !opts.NoGoMod {
+	if opts.GoMod {
 		inGoPath, err := wdInGoPath()
 		if err != nil {
 			return err
@@ -112,5 +113,6 @@ func wdInGoPath() (bool, error) {
 		return false, err
 	}
 	goPath, ok := os.LookupEnv(GoPathEnv)
-	return (!ok && strings.HasPrefix(wd, hd)) || (goPath != "" && strings.HasPrefix(wd, goPath)), nil
+	defaultGoPath := filepath.Join(hd, "go")
+	return (!ok && strings.HasPrefix(wd, defaultGoPath)) || (goPath != "" && strings.HasPrefix(wd, goPath)), nil
 }

--- a/internal/util/projutil/exec.go
+++ b/internal/util/projutil/exec.go
@@ -51,21 +51,29 @@ type GoBuildOptions struct {
 	NoGoMod bool
 }
 
+const (
+	goBuildCmd = "build"
+	goTestCmd  = "test"
+)
+
 // GoBuild runs "go build" configured with opts.
 func GoBuild(opts GoBuildOptions) error {
-	return goCmd("build", opts)
+	return goCmd(goBuildCmd, opts)
 }
 
 // GoBuild runs "go test" configured with opts.
 func GoTest(opts GoBuildOptions) error {
-	return goCmd("test", opts)
+	return goCmd(goTestCmd, opts)
 }
 
-// goCmd runs "go {cmd}"
+// goCmd runs "go {cmd}", where cmd is either "build" or "test".
 func goCmd(cmd string, opts GoBuildOptions) error {
 	bargs := []string{cmd}
 	if opts.BinName != "" {
 		bargs = append(bargs, "-o", opts.BinName)
+	}
+	if cmd == goTestCmd {
+		bargs = append(bargs, opts.BuildPath)
 	}
 	bargs = append(bargs, opts.BuildArgs...)
 	// Modules can be used if either GO111MODULE=on or we're not in $GOPATH/src.
@@ -78,7 +86,10 @@ func goCmd(cmd string, opts GoBuildOptions) error {
 			bargs = append(bargs, "-mod=vendor")
 		}
 	}
-	c := exec.Command("go", append(bargs, opts.BuildPath)...)
+	if cmd == goBuildCmd {
+		bargs = append(bargs, opts.BuildPath)
+	}
+	c := exec.Command("go", bargs...)
 	if len(opts.Env) != 0 {
 		c.Env = append(os.Environ(), opts.Env...)
 	}

--- a/internal/util/projutil/exec.go
+++ b/internal/util/projutil/exec.go
@@ -1,0 +1,50 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projutil
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func ExecCmd(cmd *exec.Cmd) error {
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to exec %#v: %v", cmd.Args, err)
+	}
+	return nil
+}
+
+// GoBuild runs 'go build -o binName args...' with '-mod=vendor' if using
+// go modules.
+func GoBuild(binName, buildPath string, args ...string) error {
+	bargs := []string{"build", "-o", binName}
+	bargs = append(bargs, args...)
+	// Modules can be used if either GO111MODULE=on or we're not in $GOPATH/src.
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	goPath := os.Getenv(GoPathEnv)
+	if os.Getenv(GoModEnv) == "on" || goPath == "" || !strings.HasPrefix(wd, goPath) {
+		bargs = append(bargs, "-mod=vendor")
+	}
+	bc := exec.Command("go", append(bargs, buildPath)...)
+	bc.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0")
+	return ExecCmd(bc)
+}

--- a/internal/util/projutil/exec.go
+++ b/internal/util/projutil/exec.go
@@ -62,7 +62,7 @@ func GoBuild(opts GoBuildOptions) error {
 	return goCmd(goBuildCmd, opts)
 }
 
-// GoBuild runs "go test" configured with opts.
+// GoTest runs "go test" configured with opts.
 func GoTest(opts GoBuildOptions) error {
 	return goCmd(goTestCmd, opts)
 }

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -17,7 +17,6 @@ package projutil
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -27,8 +26,9 @@ import (
 )
 
 const (
-	GopathEnv  = "GOPATH"
+	GoPathEnv  = "GOPATH"
 	GoFlagsEnv = "GOFLAGS"
+	GoModEnv   = "GO111MODULE"
 	SrcDir     = "src"
 
 	fsep            = string(filepath.Separator)
@@ -134,7 +134,7 @@ func IsOperatorHelm() bool {
 // MustGetGopath gets GOPATH and ensures it is set and non-empty. If GOPATH
 // is not set or empty, MustGetGopath exits.
 func MustGetGopath() string {
-	gopath, ok := os.LookupEnv(GopathEnv)
+	gopath, ok := os.LookupEnv(GoPathEnv)
 	if !ok || len(gopath) == 0 {
 		log.Fatal("GOPATH env not set")
 	}
@@ -159,20 +159,10 @@ func MustSetGopath(currentGopath string) string {
 	if !cwdInGopath {
 		log.Fatalf("Project not in $GOPATH")
 	}
-	if err := os.Setenv(GopathEnv, newGopath); err != nil {
+	if err := os.Setenv(GoPathEnv, newGopath); err != nil {
 		log.Fatal(err)
 	}
 	return newGopath
-}
-
-func ExecCmd(cmd *exec.Cmd) error {
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	if err != nil {
-		return fmt.Errorf("failed to exec %#v: %v", cmd.Args, err)
-	}
-	return nil
 }
 
 var flagRe = regexp.MustCompile("(.* )?-v(.* )?")

--- a/pkg/test/main_entry.go
+++ b/pkg/test/main_entry.go
@@ -64,13 +64,10 @@ func MainEntry(m *testing.M) {
 	var localCmd *exec.Cmd
 	var localCmdOutBuf, localCmdErrBuf bytes.Buffer
 	if *localOperator {
-		absProjectPath := projutil.MustGetwd()
-		projectName := filepath.Base(absProjectPath)
+		projectName := filepath.Base(projutil.MustGetwd())
 		outputBinName := filepath.Join(scaffold.BuildBinDir, projectName+"-local")
-		args := []string{"build", "-o", outputBinName}
-		args = append(args, filepath.Join(scaffold.ManagerDir, scaffold.CmdFile))
-		bc := exec.Command("go", args...)
-		if err := projutil.ExecCmd(bc); err != nil {
+		managerDir := filepath.Join(scaffold.ManagerDir, scaffold.CmdFile)
+		if err := projutil.GoBuild(outputBinName, managerDir); err != nil {
 			log.Fatalf("Failed to build local operator binary: %s", err)
 		}
 		localCmd = exec.Command(outputBinName)

--- a/pkg/test/main_entry.go
+++ b/pkg/test/main_entry.go
@@ -66,8 +66,11 @@ func MainEntry(m *testing.M) {
 	if *localOperator {
 		projectName := filepath.Base(projutil.MustGetwd())
 		outputBinName := filepath.Join(scaffold.BuildBinDir, projectName+"-local")
-		managerDir := filepath.Join(scaffold.ManagerDir, scaffold.CmdFile)
-		if err := projutil.GoBuild(outputBinName, managerDir); err != nil {
+		opts := projutil.GoBuildOptions{
+			BinName:   outputBinName,
+			BuildPath: filepath.Join(scaffold.ManagerDir, scaffold.CmdFile),
+		}
+		if err := projutil.GoBuild(opts); err != nil {
 			log.Fatalf("Failed to build local operator binary: %s", err)
 		}
 		localCmd = exec.Command(outputBinName)

--- a/pkg/test/main_entry.go
+++ b/pkg/test/main_entry.go
@@ -66,9 +66,9 @@ func MainEntry(m *testing.M) {
 	if *localOperator {
 		projectName := filepath.Base(projutil.MustGetwd())
 		outputBinName := filepath.Join(scaffold.BuildBinDir, projectName+"-local")
-		opts := projutil.GoBuildOptions{
-			BinName:   outputBinName,
-			BuildPath: filepath.Join(scaffold.ManagerDir, scaffold.CmdFile),
+		opts := projutil.GoCmdOptions{
+			BinName:     outputBinName,
+			PackagePath: filepath.Join(scaffold.ManagerDir, scaffold.CmdFile),
 		}
 		if err := projutil.GoBuild(opts); err != nil {
 			log.Fatalf("Failed to build local operator binary: %s", err)

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -60,7 +60,7 @@ func TestMemcached(t *testing.T) {
 	// get global framework variables
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
-	gopath, ok := os.LookupEnv(projutil.GopathEnv)
+	gopath, ok := os.LookupEnv(projutil.GoPathEnv)
 	if !ok {
 		t.Fatalf("$GOPATH not set")
 	}

--- a/vendor/github.com/mitchellh/go-homedir/LICENSE
+++ b/vendor/github.com/mitchellh/go-homedir/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/go-homedir/homedir.go
+++ b/vendor/github.com/mitchellh/go-homedir/homedir.go
@@ -1,0 +1,167 @@
+package homedir
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// DisableCache will disable caching of the home directory. Caching is enabled
+// by default.
+var DisableCache bool
+
+var homedirCache string
+var cacheLock sync.RWMutex
+
+// Dir returns the home directory for the executing user.
+//
+// This uses an OS-specific method for discovering the home directory.
+// An error is returned if a home directory cannot be detected.
+func Dir() (string, error) {
+	if !DisableCache {
+		cacheLock.RLock()
+		cached := homedirCache
+		cacheLock.RUnlock()
+		if cached != "" {
+			return cached, nil
+		}
+	}
+
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+
+	var result string
+	var err error
+	if runtime.GOOS == "windows" {
+		result, err = dirWindows()
+	} else {
+		// Unix-like system, so just assume Unix
+		result, err = dirUnix()
+	}
+
+	if err != nil {
+		return "", err
+	}
+	homedirCache = result
+	return result, nil
+}
+
+// Expand expands the path to include the home directory if the path
+// is prefixed with `~`. If it isn't prefixed with `~`, the path is
+// returned as-is.
+func Expand(path string) (string, error) {
+	if len(path) == 0 {
+		return path, nil
+	}
+
+	if path[0] != '~' {
+		return path, nil
+	}
+
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return "", errors.New("cannot expand user-specific home dir")
+	}
+
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, path[1:]), nil
+}
+
+// Reset clears the cache, forcing the next call to Dir to re-detect
+// the home directory. This generally never has to be called, but can be
+// useful in tests if you're modifying the home directory via the HOME
+// env var or something.
+func Reset() {
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+	homedirCache = ""
+}
+
+func dirUnix() (string, error) {
+	homeEnv := "HOME"
+	if runtime.GOOS == "plan9" {
+		// On plan9, env vars are lowercase.
+		homeEnv = "home"
+	}
+
+	// First prefer the HOME environmental variable
+	if home := os.Getenv(homeEnv); home != "" {
+		return home, nil
+	}
+
+	var stdout bytes.Buffer
+
+	// If that fails, try OS specific commands
+	if runtime.GOOS == "darwin" {
+		cmd := exec.Command("sh", "-c", `dscl -q . -read /Users/"$(whoami)" NFSHomeDirectory | sed 's/^[^ ]*: //'`)
+		cmd.Stdout = &stdout
+		if err := cmd.Run(); err == nil {
+			result := strings.TrimSpace(stdout.String())
+			if result != "" {
+				return result, nil
+			}
+		}
+	} else {
+		cmd := exec.Command("getent", "passwd", strconv.Itoa(os.Getuid()))
+		cmd.Stdout = &stdout
+		if err := cmd.Run(); err != nil {
+			// If the error is ErrNotFound, we ignore it. Otherwise, return it.
+			if err != exec.ErrNotFound {
+				return "", err
+			}
+		} else {
+			if passwd := strings.TrimSpace(stdout.String()); passwd != "" {
+				// username:password:uid:gid:gecos:home:shell
+				passwdParts := strings.SplitN(passwd, ":", 7)
+				if len(passwdParts) > 5 {
+					return passwdParts[5], nil
+				}
+			}
+		}
+	}
+
+	// If all else fails, try the shell
+	stdout.Reset()
+	cmd := exec.Command("sh", "-c", "cd && pwd")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	result := strings.TrimSpace(stdout.String())
+	if result == "" {
+		return "", errors.New("blank output when reading home directory")
+	}
+
+	return result, nil
+}
+
+func dirWindows() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	// Prefer standard environment variable USERPROFILE
+	if home := os.Getenv("USERPROFILE"); home != "" {
+		return home, nil
+	}
+
+	drive := os.Getenv("HOMEDRIVE")
+	path := os.Getenv("HOMEPATH")
+	home := drive + path
+	if drive == "" || path == "" {
+		return "", errors.New("HOMEDRIVE, HOMEPATH, or USERPROFILE are blank")
+	}
+
+	return home, nil
+}


### PR DESCRIPTION
**Description of the change:**
* internal/util/projutil/exec.go: move commands executing external binaries to exec.go, add `GoBuild()` and `GoTest()` functions to run `go build`/`go test`, and `GoBuildOptions` to configure both
* cmd/operator-sdk/{build/cmd.go,up/local.go}: use `GoBuild()` and `GoTest()`
* pkg/test/main_entry.go: use GoBuild() to run go build

**Motivation for the change:** The SDK calls `go build` and `go test` in several places. These functions provide convenient wrappers that sets up args based on the users' environment.

This code was split out and enhanced from #1001