### PR TITLE
cmd/build: Add buildah support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ### Added
 
+- New option for [`operator-sdk build --image-builder`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#build), which can be used to specify which image builder to use. ([#1311](https://github.com/operator-framework/operator-sdk/pull/1311))
+
 ### Changed
 
 - When Helm operator projects are created, the SDK now generates RBAC rules in `deploy/role.yaml` based on the chart's default manifest. ([#1188](https://github.com/operator-framework/operator-sdk/pull/1188))
 - When debug level is 3 or higher, we will set the klog verbosity to that level. ([#1322](https://github.com/operator-framework/operator-sdk/pull/1322))
 - Relaxed requirements for groups in new project API's. Groups passed to [`operator-sdk add api`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#api)'s `--api-version` flag can now have no subdomains, ex `core/v1`. See ([#1191](https://github.com/operator-framework/operator-sdk/issues/1191)) for discussion. ([#1313](https://github.com/operator-framework/operator-sdk/pull/1313))
+- Renamed `--docker-build-args` option to `--image-build-args` option for `build` subcommand, because this option can now be shared with other image build tools than docker when `--image-builder` option is specified. ([#1311](https://github.com/operator-framework/operator-sdk/pull/1311))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- New option for [`operator-sdk build --image-builder`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#build), which can be used to specify which image builder to use. ([#1311](https://github.com/operator-framework/operator-sdk/pull/1311))
+- New option for [`operator-sdk build --image-builder`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#build), which can be used to specify which image builder to use. Adds support for [buildah](https://github.com/containers/buildah/). ([#1311](https://github.com/operator-framework/operator-sdk/pull/1311))
 
 ### Changed
 

--- a/cmd/operator-sdk/build/cmd.go
+++ b/cmd/operator-sdk/build/cmd.go
@@ -143,7 +143,7 @@ func verifyTestManifest(image string) error {
 	return nil
 }
 
-func createBuildCommand(imageBuilder, context, dockerFile, image, imageBuildArgs string) (*exec.Cmd, error) {
+func createBuildCommand(imageBuilder, context, dockerFile, image string, imageBuildArgs ...string) (*exec.Cmd, error) {
 	var args []string
 	switch imageBuilder {
 	case "docker":
@@ -154,9 +154,11 @@ func createBuildCommand(imageBuilder, context, dockerFile, image, imageBuildArgs
 		return nil, fmt.Errorf("%s is not supported image builder", imageBuilder)
 	}
 
-	if imageBuildArgs != "" {
-		splitArgs := strings.Fields(imageBuildArgs)
-		args = append(args, splitArgs...)
+	for _, bargs := range imageBuildArgs {
+		if bargs != "" {
+			splitArgs := strings.Fields(bargs)
+			args = append(args, splitArgs...)
+		}
 	}
 
 	args = append(args, context)
@@ -254,8 +256,8 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 
 		log.Infof("Building test OCI image %s", image)
 
-		testImageBuildArgs := fmt.Sprintf("%s --build-arg NAMESPACEDMAN=%s --build-arg BASEIMAGE=%s", imageBuildArgs, namespacedManBuild, baseImageName)
-		testBuildCmd, err := createBuildCommand(imageBuilder, ".", testDockerfile, image, testImageBuildArgs)
+		testImageBuildArgs := fmt.Sprintf("--build-arg NAMESPACEDMAN=%s --build-arg BASEIMAGE=%s", namespacedManBuild, baseImageName)
+		testBuildCmd, err := createBuildCommand(imageBuilder, ".", testDockerfile, image, imageBuildArgs, testImageBuildArgs)
 		if err != nil {
 			return err
 		}

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -16,7 +16,8 @@ Usage:
 * `--enable-tests` - enable in-cluster testing by adding test binary to the image
 * `--namespaced-manifest` string - path of namespaced resources manifest for tests (default "deploy/operator.yaml")
 * `--test-location` string - location of tests (default "./test/e2e")
-* `--docker-build-args` string - extra, optional docker build arguments as one string such as `"--build-arg https_proxy=$https_proxy"` (default "")
+* `--image-build-args` string - extra, optional image build arguments as one string such as `"--build-arg https_proxy=$https_proxy"` (default "")
+* `--image-builder` string - tool to build OCI images. One of: [docker, buildah] (default "docker")
 * `-h, --help` - help for build
 
 ### Use

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -17,7 +17,7 @@ Usage:
 * `--namespaced-manifest` string - path of namespaced resources manifest for tests (default "deploy/operator.yaml")
 * `--test-location` string - location of tests (default "./test/e2e")
 * `--image-build-args` string - extra, optional image build arguments as one string such as `"--build-arg https_proxy=$https_proxy"` (default "")
-* `--image-builder` string - tool to build OCI images. One of: [docker, buildah] (default "docker")
+* `--image-builder` string - tool to build OCI images. One of: `[docker, buildah]` (default "docker")
 * `-h, --help` - help for build
 
 ### Use


### PR DESCRIPTION
**Description of the change:**
This PR adds buildah support.

**Motivation for the change:**
operator-sdk should support building image by using buildah. 
There is an existing discussion for motivation in https://github.com/operator-framework/operator-sdk/pull/563 .


