### PR TITLE
internal/pkg/scaffold/resource.go: relax group format check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Relaxed requirements for groups in new project API's. Groups passed to [`operator-sdk add api`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#api)'s `--api-version` flag can now have no subdomains, ex `core/v1`. See ([#1191](https://github.com/operator-framework/operator-sdk/issues/1191)) for discussion. ([#1313](https://github.com/operator-framework/operator-sdk/pull/1313))
+
 ### Deprecated
 
 ### Removed

--- a/internal/pkg/scaffold/resource.go
+++ b/internal/pkg/scaffold/resource.go
@@ -124,7 +124,7 @@ func (r *Resource) checkAndSetGroups() error {
 		return errors.New("full group cannot be empty")
 	}
 	g := strings.Split(fg[0], ".")
-	if len(g) < 2 || len(g[0]) == 0 {
+	if len(g) == 0 || len(g[0]) == 0 {
 		return errors.New("group cannot be empty")
 	}
 	r.FullGroup = fg[0]


### PR DESCRIPTION
**Description of the change:** only check if `group` in `group/version` is empty, not if it has a specific number of sub-domains.

**Motivation for the change:** From #1191 on adding new API's:
>But I guess that only makes sense for defining new apis. If you're adding a controller to watch a k8s resource(with a single word group) as the primary resource then that'll be a problem.

Closes #1191 
