### PR TITLE
scaffold/*: Use better Delims for Ansible to make templates readable

### DIFF
--- a/internal/pkg/scaffold/ansible/ao_logs.go
+++ b/internal/pkg/scaffold/ansible/ao_logs.go
@@ -22,7 +22,7 @@ import (
 
 //DockerfileHybrid - Dockerfile for a hybrid operator
 type AoLogs struct {
-	input.Input
+	StaticInput
 }
 
 // GetInput - gets the input

--- a/internal/pkg/scaffold/ansible/build_dockerfile.go
+++ b/internal/pkg/scaffold/ansible/build_dockerfile.go
@@ -38,17 +38,18 @@ func (b *BuildDockerfile) GetInput() (input.Input, error) {
 		b.Path = filepath.Join(scaffold.BuildDir, BuildDockerfileFile)
 	}
 	b.TemplateBody = buildDockerfileAnsibleTmpl
+	b.Delims = AnsibleDelims
 	b.RolesDir = RolesDir
 	b.ImageTag = strings.TrimSuffix(version.Version, "+git")
 	return b.Input, nil
 }
 
-const buildDockerfileAnsibleTmpl = `FROM quay.io/operator-framework/ansible-operator:{{.ImageTag}}
+const buildDockerfileAnsibleTmpl = `FROM quay.io/operator-framework/ansible-operator:[[.ImageTag]]
 
 COPY watches.yaml ${HOME}/watches.yaml
 
-COPY {{.RolesDir}}/ ${HOME}/{{.RolesDir}}/
-{{- if .GeneratePlaybook }}
+COPY [[.RolesDir]]/ ${HOME}/[[.RolesDir]]/
+[[- if .GeneratePlaybook ]]
 COPY playbook.yml ${HOME}/playbook.yml
-{{- end }}
+[[- end ]]
 `

--- a/internal/pkg/scaffold/ansible/build_test_framework_ansible_test_script.go
+++ b/internal/pkg/scaffold/ansible/build_test_framework_ansible_test_script.go
@@ -24,7 +24,7 @@ import (
 const BuildTestFrameworkAnsibleTestScriptFile = "ansible-test.sh"
 
 type BuildTestFrameworkAnsibleTestScript struct {
-	input.Input
+	StaticInput
 }
 
 // GetInput - gets the input

--- a/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
+++ b/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
@@ -24,7 +24,7 @@ import (
 const BuildTestFrameworkDockerfileFile = "Dockerfile"
 
 type BuildTestFrameworkDockerfile struct {
-	input.Input
+	StaticInput
 }
 
 // GetInput - gets the input

--- a/internal/pkg/scaffold/ansible/constants.go
+++ b/internal/pkg/scaffold/ansible/constants.go
@@ -26,3 +26,6 @@ const (
 	MoleculeDefaultDir     = MoleculeDir + filePathSep + "default"
 	MoleculeTestLocalDir   = MoleculeDir + filePathSep + "test-local"
 )
+
+// Arrays can't be constants but this should be a constant
+var AnsibleDelims = [2]string{"[[", "]]"}

--- a/internal/pkg/scaffold/ansible/deploy_operator.go
+++ b/internal/pkg/scaffold/ansible/deploy_operator.go
@@ -34,6 +34,7 @@ func (d *DeployOperator) GetInput() (input.Input, error) {
 		d.Path = filepath.Join(scaffold.DeployDir, DeployOperatorFile)
 	}
 	d.TemplateBody = deployOperatorAnsibleTmpl
+	d.Delims = AnsibleDelims
 
 	return d.Input, nil
 }
@@ -41,18 +42,18 @@ func (d *DeployOperator) GetInput() (input.Input, error) {
 const deployOperatorAnsibleTmpl = `apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{.ProjectName}}
+  name: [[.ProjectName]]
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: {{.ProjectName}}
+      name: [[.ProjectName]]
   template:
     metadata:
       labels:
-        name: {{.ProjectName}}
+        name: [[.ProjectName]]
     spec:
-      serviceAccountName: {{.ProjectName}}
+      serviceAccountName: [[.ProjectName]]
       containers:
         - name: ansible
           command:
@@ -60,34 +61,34 @@ spec:
           - /tmp/ansible-operator/runner
           - stdout
           # Replace this with the built image name
-          image: "{{ "{{ REPLACE_IMAGE }}" }}"
-          imagePullPolicy: "{{ "{{ pull_policy|default('Always') }}"}}"
+          image: "{{ REPLACE_IMAGE }}"
+          imagePullPolicy: "{{ pull_policy|default('Always') }}"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner
             readOnly: true
         - name: operator
           # Replace this with the built image name
-          image: "{{ "{{ REPLACE_IMAGE }}" }}"
-          imagePullPolicy: "{{ "{{ pull_policy|default('Always') }}"}}"
+          image: "{{ REPLACE_IMAGE }}"
+          imagePullPolicy: "{{ pull_policy|default('Always') }}"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner
           env:
             - name: WATCH_NAMESPACE
-              {{- if .IsClusterScoped }}
+              [[- if .IsClusterScoped ]]
               value: ""
-              {{- else }}
+              [[- else ]]
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-              {{- end}}
+              [[- end]]
             - name: POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "{{.ProjectName}}"
+              value: "[[.ProjectName]]"
       volumes:
         - name: runner
           emptyDir: {}

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -41,6 +41,7 @@ func (d *DockerfileHybrid) GetInput() (input.Input, error) {
 		d.Path = filepath.Join(scaffold.BuildDir, scaffold.DockerfileFile)
 	}
 	d.TemplateBody = dockerFileHybridAnsibleTmpl
+	d.Delims = AnsibleDelims
 	return d.Input, nil
 }
 
@@ -64,21 +65,21 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
     USER_NAME=ansible-operator\
     HOME=/opt/ansible
 
-{{- if .Watches }}
-COPY watches.yaml ${HOME}/watches.yaml{{ end }}
+[[- if .Watches ]]
+COPY watches.yaml ${HOME}/watches.yaml[[ end ]]
 
 # install operator binary
-COPY build/_output/bin/{{.ProjectName}} ${OPERATOR}
+COPY build/_output/bin/[[.ProjectName]] ${OPERATOR}
 # install k8s_status Ansible Module
 COPY library/k8s_status.py /usr/share/ansible/openshift/
 
 COPY bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
 
-{{- if .Roles }}
-COPY roles/ ${HOME}/roles/{{ end }}
-{{- if .Playbook }}
-COPY playbook.yml ${HOME}/playbook.yml{{ end }}
+[[- if .Roles ]]
+COPY roles/ ${HOME}/roles/[[ end ]]
+[[- if .Playbook ]]
+COPY playbook.yml ${HOME}/playbook.yml[[ end ]]
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 

--- a/internal/pkg/scaffold/ansible/entrypoint.go
+++ b/internal/pkg/scaffold/ansible/entrypoint.go
@@ -22,7 +22,7 @@ import (
 
 // Entrypoint - entrypoint script
 type Entrypoint struct {
-	input.Input
+	StaticInput
 }
 
 func (e *Entrypoint) GetInput() (input.Input, error) {

--- a/internal/pkg/scaffold/ansible/gopkgtoml.go
+++ b/internal/pkg/scaffold/ansible/gopkgtoml.go
@@ -21,7 +21,7 @@ import (
 
 // GopkgToml - the Gopkg.toml file for a hybrid operator
 type GopkgToml struct {
-	input.Input
+	StaticInput
 }
 
 func (s *GopkgToml) GetInput() (input.Input, error) {

--- a/internal/pkg/scaffold/ansible/input.go
+++ b/internal/pkg/scaffold/ansible/input.go
@@ -5,10 +5,13 @@ import (
 	"github.com/spf13/afero"
 )
 
+// StaticInput is the input for scaffolding a static file with
+// no parameteres
 type StaticInput struct {
 	input.Input
 }
 
+// CustomRender return the template body unmodified
 func (s *StaticInput) CustomRender() ([]byte, error) {
 	return []byte(s.TemplateBody), nil
 }

--- a/internal/pkg/scaffold/ansible/input.go
+++ b/internal/pkg/scaffold/ansible/input.go
@@ -1,0 +1,16 @@
+package ansible
+
+import (
+	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/input"
+	"github.com/spf13/afero"
+)
+
+type StaticInput struct {
+	input.Input
+}
+
+func (s *StaticInput) CustomRender() ([]byte, error) {
+	return []byte(s.TemplateBody), nil
+}
+
+func (s StaticInput) SetFS(_ afero.Fs) {}

--- a/internal/pkg/scaffold/ansible/input.go
+++ b/internal/pkg/scaffold/ansible/input.go
@@ -1,3 +1,16 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package ansible
 
 import (

--- a/internal/pkg/scaffold/ansible/k8s_status.go
+++ b/internal/pkg/scaffold/ansible/k8s_status.go
@@ -16,15 +16,13 @@ package ansible
 
 import (
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/input"
-
-	"github.com/spf13/afero"
 )
 
 const K8sStatusPythonFile = "library/k8s_status.py"
 
 // K8sStatus - the k8s status module tmpl wrapper
 type K8sStatus struct {
-	input.Input
+	StaticInput
 }
 
 // GetInput - gets the input
@@ -32,13 +30,10 @@ func (k *K8sStatus) GetInput() (input.Input, error) {
 	if k.Path == "" {
 		k.Path = K8sStatusPythonFile
 	}
+
+	k.TemplateBody = k8sStatusTmpl
+
 	return k.Input, nil
-}
-
-func (s K8sStatus) SetFS(_ afero.Fs) {}
-
-func (k K8sStatus) CustomRender() ([]byte, error) {
-	return []byte(k8sStatusTmpl), nil
 }
 
 const k8sStatusTmpl = `#!/usr/bin/python

--- a/internal/pkg/scaffold/ansible/main.go
+++ b/internal/pkg/scaffold/ansible/main.go
@@ -22,7 +22,7 @@ import (
 
 // Main - main source file for ansible operator
 type Main struct {
-	input.Input
+	StaticInput
 }
 
 func (m *Main) GetInput() (input.Input, error) {

--- a/internal/pkg/scaffold/ansible/molecule_default_asserts.go
+++ b/internal/pkg/scaffold/ansible/molecule_default_asserts.go
@@ -32,6 +32,7 @@ func (m *MoleculeDefaultAsserts) GetInput() (input.Input, error) {
 		m.Path = filepath.Join(MoleculeDefaultDir, MoleculeDefaultAssertsFile)
 	}
 	m.TemplateBody = moleculeDefaultAssertsAnsibleTmpl
+	m.Delims = AnsibleDelims
 
 	return m.Input, nil
 }
@@ -42,13 +43,13 @@ const moleculeDefaultAssertsAnsibleTmpl = `---
   hosts: localhost
   connection: local
   vars:
-    ansible_python_interpreter: '{{"{{ ansible_playbook_python }}"}}'
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
   tasks:
-    - name: Get all pods in {{"{{ namespace }}"}}
+    - name: Get all pods in {{ namespace }}
       k8s_facts:
         api_version: v1
         kind: Pod
-        namespace: '{{"{{ namespace }}"}}'
+        namespace: '{{ namespace }}'
       register: pods
 
     - name: Output pods

--- a/internal/pkg/scaffold/ansible/molecule_default_molecule.go
+++ b/internal/pkg/scaffold/ansible/molecule_default_molecule.go
@@ -23,7 +23,7 @@ import (
 const MoleculeDefaultMoleculeFile = "molecule.yml"
 
 type MoleculeDefaultMolecule struct {
-	input.Input
+	StaticInput
 }
 
 // GetInput - gets the input

--- a/internal/pkg/scaffold/ansible/molecule_default_playbook.go
+++ b/internal/pkg/scaffold/ansible/molecule_default_playbook.go
@@ -35,24 +35,25 @@ func (m *MoleculeDefaultPlaybook) GetInput() (input.Input, error) {
 		m.Path = filepath.Join(MoleculeDefaultDir, MoleculeDefaultPlaybookFile)
 	}
 	m.TemplateBody = moleculeDefaultPlaybookAnsibleTmpl
+	m.Delims = AnsibleDelims
 
 	return m.Input, nil
 }
 
 const moleculeDefaultPlaybookAnsibleTmpl = `---
-{{- if .GeneratePlaybook }}
-- import_playbook: '{{"{{ playbook_dir }}/../../playbook.yml"}}'
-{{- end }}
+[[- if .GeneratePlaybook ]]
+- import_playbook: '{{ playbook_dir }}/../../playbook.yml'
+[[- end ]]
 
-  {{- if not .GeneratePlaybook }}
+  [[- if not .GeneratePlaybook ]]
 - name: Converge
   hosts: localhost
   connection: local
   vars:
-    ansible_python_interpreter: '{{ "{{ ansible_playbook_python }}" }}'
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
   roles:
-    - {{.Resource.LowerKind}}
-  {{- end }}
+    - [[.Resource.LowerKind]]
+  [[- end ]]
 
-- import_playbook: '{{"{{ playbook_dir }}/asserts.yml"}}'
+- import_playbook: '{{ playbook_dir }}/asserts.yml'
 `

--- a/internal/pkg/scaffold/ansible/molecule_default_prepare.go
+++ b/internal/pkg/scaffold/ansible/molecule_default_prepare.go
@@ -32,6 +32,7 @@ func (m *MoleculeDefaultPrepare) GetInput() (input.Input, error) {
 		m.Path = filepath.Join(MoleculeDefaultDir, MoleculeDefaultPrepareFile)
 	}
 	m.TemplateBody = moleculeDefaultPrepareAnsibleTmpl
+	m.Delims = AnsibleDelims
 
 	return m.Input, nil
 }
@@ -41,25 +42,25 @@ const moleculeDefaultPrepareAnsibleTmpl = `---
   hosts: k8s
   gather_facts: no
   vars:
-    kubeconfig: "{{"{{ lookup('env', 'KUBECONFIG') }}"}}"
+    kubeconfig: '{{ lookup('env', 'KUBECONFIG') }}'
   tasks:
     - name: delete the kubeconfig if present
       file:
-        path: '{{"{{ kubeconfig }}"}}'
+        path: '{{ kubeconfig }}'
         state: absent
       delegate_to: localhost
 
     - name: Fetch the kubeconfig
       fetch:
-        dest: '{{ "{{ kubeconfig }}" }}'
+        dest: '{{ kubeconfig }}'
         flat: yes
         src: /root/.kube/config
 
     - name: Change the kubeconfig port to the proper value
       replace:
         regexp: 8443
-        replace: "{{"{{ lookup('env', 'KIND_PORT') }}"}}"
-        path: '{{ "{{ kubeconfig }}" }}'
+        replace: '{{ lookup('env', 'KIND_PORT') }}'
+        path: '{{ kubeconfig }}'
       delegate_to: localhost
 
     - name: Wait for the Kubernetes API to become available (this could take a minute)

--- a/internal/pkg/scaffold/ansible/molecule_default_prepare.go
+++ b/internal/pkg/scaffold/ansible/molecule_default_prepare.go
@@ -42,7 +42,7 @@ const moleculeDefaultPrepareAnsibleTmpl = `---
   hosts: k8s
   gather_facts: no
   vars:
-    kubeconfig: '{{ lookup('env', 'KUBECONFIG') }}'
+    kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
   tasks:
     - name: delete the kubeconfig if present
       file:
@@ -59,7 +59,7 @@ const moleculeDefaultPrepareAnsibleTmpl = `---
     - name: Change the kubeconfig port to the proper value
       replace:
         regexp: 8443
-        replace: '{{ lookup('env', 'KIND_PORT') }}'
+        replace: "{{ lookup('env', 'KIND_PORT') }}"
         path: '{{ kubeconfig }}'
       delegate_to: localhost
 

--- a/internal/pkg/scaffold/ansible/molecule_test_cluster_molecule.go
+++ b/internal/pkg/scaffold/ansible/molecule_test_cluster_molecule.go
@@ -23,7 +23,7 @@ import (
 const MoleculeTestClusterMoleculeFile = "molecule.yml"
 
 type MoleculeTestClusterMolecule struct {
-	input.Input
+	StaticInput
 }
 
 // GetInput - gets the input

--- a/internal/pkg/scaffold/ansible/molecule_test_cluster_playbook.go
+++ b/internal/pkg/scaffold/ansible/molecule_test_cluster_playbook.go
@@ -46,7 +46,7 @@ const moleculeTestClusterPlaybookAnsibleTmpl = `---
   connection: local
   vars:
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
-    deploy_dir: '{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy'
+    deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
     image_name: [[.Resource.FullGroup]]/[[.ProjectName]]:testing
     custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'crds/[[.Resource.Group]]_[[.Resource.Version]]_[[.Resource.LowerKind]]_cr.yaml'])) | from_yaml }}"
   tasks:

--- a/internal/pkg/scaffold/ansible/molecule_test_cluster_playbook.go
+++ b/internal/pkg/scaffold/ansible/molecule_test_cluster_playbook.go
@@ -34,6 +34,7 @@ func (m *MoleculeTestClusterPlaybook) GetInput() (input.Input, error) {
 		m.Path = filepath.Join(MoleculeTestClusterDir, MoleculeTestClusterPlaybookFile)
 	}
 	m.TemplateBody = moleculeTestClusterPlaybookAnsibleTmpl
+	m.Delims = AnsibleDelims
 
 	return m.Input, nil
 }
@@ -44,31 +45,31 @@ const moleculeTestClusterPlaybookAnsibleTmpl = `---
   hosts: localhost
   connection: local
   vars:
-    ansible_python_interpreter: '{{ "{{ ansible_playbook_python }}" }}'
-    deploy_dir: "{{"{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"}}"
-    image_name: {{.Resource.FullGroup}}/{{.ProjectName}}:testing
-    custom_resource: "{{"{{"}} lookup('file', '/'.join([deploy_dir, 'crds/{{.Resource.Group}}_{{.Resource.Version}}_{{.Resource.LowerKind}}_cr.yaml'])) | from_yaml {{"}}"}}"
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+    deploy_dir: '{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy'
+    image_name: [[.Resource.FullGroup]]/[[.ProjectName]]:testing
+    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'crds/[[.Resource.Group]]_[[.Resource.Version]]_[[.Resource.LowerKind]]_cr.yaml'])) | from_yaml }}"
   tasks:
-  - name: Create the {{.Resource.FullGroup}}/{{.Resource.Version}}.{{.Resource.Kind}}
+  - name: Create the [[.Resource.FullGroup]]/[[.Resource.Version]].[[.Resource.Kind]]
     k8s:
-      namespace: '{{ "{{ namespace }}" }}'
-      definition: "{{"{{"}} lookup('file', '/'.join([deploy_dir, 'crds/{{.Resource.Group}}_{{.Resource.Version}}_{{.Resource.LowerKind}}_cr.yaml'])) {{"}}"}}"
+      namespace: '{{ namespace }}'
+      definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/[[.Resource.Group]]_[[.Resource.Version]]_[[.Resource.LowerKind]]_cr.yaml'])) }}"
 
   - name: Get the newly created Custom Resource
     debug:
-      msg: "{{"{{"}} lookup('k8s', group='{{.Resource.FullGroup}}', api_version='{{.Resource.Version}}', kind='{{.Resource.Kind}}', namespace=namespace, resource_name=custom_resource.metadata.name) {{"}}"}}"
+      msg: "{{ lookup('k8s', group='[[.Resource.FullGroup]]', api_version='[[.Resource.Version]]', kind='[[.Resource.Kind]]', namespace=namespace, resource_name=custom_resource.metadata.name) }}"
 
   - name: Wait 40s for reconciliation to run
     k8s_facts:
-      api_version: '{{.Resource.Version}}'
-      kind: '{{.Resource.Kind }}'
-      namespace: '{{"{{"}} namespace {{"}}"}}'
-      name: '{{"{{"}} custom_resource.metadata.name {{"}}"}}'
+      api_version: '[[.Resource.Version]]'
+      kind: '[[.Resource.Kind]]'
+      namespace: '{{ namespace }}'
+      name: '{{ custom_resource.metadata.name }}'
     register: reconcile_cr
     until:
     - "'Successful' in (reconcile_cr | json_query('resources[].status.conditions[].reason'))"
     delay: 4
     retries: 10
 
-- import_playbook: "{{"{{ playbook_dir }}/../default/asserts.yml"}}"
+- import_playbook: '{{ playbook_dir }}/../default/asserts.yml'
 `

--- a/internal/pkg/scaffold/ansible/molecule_test_local_molecule.go
+++ b/internal/pkg/scaffold/ansible/molecule_test_local_molecule.go
@@ -23,7 +23,7 @@ import (
 const MoleculeTestLocalMoleculeFile = "molecule.yml"
 
 type MoleculeTestLocalMolecule struct {
-	input.Input
+	StaticInput
 }
 
 // GetInput - gets the input

--- a/internal/pkg/scaffold/ansible/molecule_test_local_playbook.go
+++ b/internal/pkg/scaffold/ansible/molecule_test_local_playbook.go
@@ -34,6 +34,7 @@ func (m *MoleculeTestLocalPlaybook) GetInput() (input.Input, error) {
 		m.Path = filepath.Join(MoleculeTestLocalDir, MoleculeTestLocalPlaybookFile)
 	}
 	m.TemplateBody = moleculeTestLocalPlaybookAnsibleTmpl
+	m.Delims = AnsibleDelims
 
 	return m.Input, nil
 }
@@ -43,7 +44,7 @@ const moleculeTestLocalPlaybookAnsibleTmpl = `---
 - name: Build Operator in Kubernetes docker container
   hosts: k8s
   vars:
-    image_name: {{.Resource.FullGroup}}/{{.ProjectName}}:testing
+    image_name: [[.Resource.FullGroup]]/[[.ProjectName]]:testing
   tasks:
   # using command so we don't need to install any dependencies
   - name: Get existing image hash
@@ -60,29 +61,29 @@ const moleculeTestLocalPlaybookAnsibleTmpl = `---
   hosts: localhost
   connection: local
   vars:
-    ansible_python_interpreter: '{{ "{{ ansible_playbook_python }}" }}'
-    deploy_dir: "{{"{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"}}"
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+    deploy_dir: '{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy'
     pull_policy: Never
-    REPLACE_IMAGE: {{.Resource.FullGroup}}/{{.ProjectName}}:testing
-    custom_resource: "{{"{{"}} lookup('file', '/'.join([deploy_dir, 'crds/{{.Resource.Group}}_{{.Resource.Version}}_{{.Resource.LowerKind}}_cr.yaml'])) | from_yaml {{"}}"}}"
+    REPLACE_IMAGE: [[.Resource.FullGroup]]/[[.ProjectName]]:testing
+    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'crds/[[.Resource.Group]]_[[.Resource.Version]]_[[.Resource.LowerKind]]_cr.yaml'])) | from_yaml }}"
   tasks:
   - block:
     - name: Delete the Operator Deployment
       k8s:
         state: absent
-        namespace: '{{ "{{ namespace }}" }}'
-        definition: "{{"{{"}} lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) {{"}}"}}"
+        namespace: '{{ namespace }}'
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) }}"
       register: delete_deployment
       when: hostvars[groups.k8s.0].build_cmd.changed
 
     - name: Wait 30s for Operator Deployment to terminate
       k8s_facts:
-        api_version: '{{"{{"}} definition.apiVersion {{"}}"}}'
-        kind: '{{"{{"}} definition.kind {{"}}"}}'
-        namespace: '{{"{{"}} namespace {{"}}"}}'
-        name: '{{"{{"}} definition.metadata.name {{"}}"}}'
+        api_version: '{{ definition.apiVersion }}'
+        kind: '{{ definition.kind }}'
+        namespace: '{{ namespace }}'
+        name: '{{ definition.metadata.name }}'
       vars:
-        definition: "{{"{{"}} lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml {{"}}"}}"
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
       register: deployment
       until: not deployment.resources
       delay: 3
@@ -91,21 +92,21 @@ const moleculeTestLocalPlaybookAnsibleTmpl = `---
 
     - name: Create the Operator Deployment
       k8s:
-        namespace: '{{ "{{ namespace }}" }}'
-        definition: "{{"{{"}} lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) {{"}}"}}"
+        namespace: '{{ namespace }}'
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) }}"
 
-    - name: Create the {{.Resource.FullGroup}}/{{.Resource.Version}}.{{.Resource.Kind}}
+    - name: Create the [[.Resource.FullGroup]]/[[.Resource.Version]].[[.Resource.Kind]]
       k8s:
         state: present
-        namespace: '{{ "{{ namespace }}" }}'
-        definition: "{{ "{{ custom_resource }}" }}"
+        namespace: '{{ namespace }}'
+        definition: '{{ custom_resource }}'
 
     - name: Wait 40s for reconciliation to run
       k8s_facts:
-        api_version: '{{"{{"}} custom_resource.apiVersion {{"}}"}}'
-        kind: '{{"{{"}} custom_resource.kind {{"}}"}}'
-        namespace: '{{"{{"}} namespace {{"}}"}}'
-        name: '{{"{{"}} custom_resource.metadata.name {{"}}"}}'
+        api_version: '{{ custom_resource.apiVersion }}'
+        kind: '{{ custom_resource.kind }}'
+        namespace: '{{ namespace }}'
+        name: '{{ custom_resource.metadata.name }}'
       register: cr
       until:
       - "'Successful' in (cr | json_query('resources[].status.conditions[].reason'))"
@@ -118,12 +119,12 @@ const moleculeTestLocalPlaybookAnsibleTmpl = `---
       debug:
         var: debug_cr
       vars:
-        debug_cr: '{{"{{"}} lookup("k8s",
+        debug_cr: '{{ lookup("k8s",
           kind=custom_resource.kind,
           api_version=custom_resource.apiVersion,
           namespace=namespace,
           resource_name=custom_resource.metadata.name
-        ){{"}}"}}'
+        )}}'
 
     - name: debug memcached lookup
       ignore_errors: yes
@@ -131,21 +132,21 @@ const moleculeTestLocalPlaybookAnsibleTmpl = `---
       debug:
         var: deploy
       vars:
-        deploy: '{{"{{"}} lookup("k8s",
+        deploy: '{{ lookup("k8s",
           kind="Deployment",
           api_version="apps/v1",
           namespace=namespace,
           label_selector="app=memcached"
-        ){{"}}"}}'
+        )}}'
 
     - name: get operator logs
       ignore_errors: yes
       failed_when: false
-      command: kubectl logs deployment/{{"{{"}} definition.metadata.name {{"}}"}} -n {{"{{"}} namespace {{"}}"}}
+      command: kubectl logs deployment/{{ definition.metadata.name }} -n {{ namespace }}
       environment:
-        KUBECONFIG: '{{"{{"}} lookup("env", "KUBECONFIG") {{"}}"}}'
+        KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
       vars:
-        definition: "{{"{{"}} lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml {{"}}"}}"
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
       register: log
 
     - debug: var=log.stdout_lines
@@ -153,5 +154,5 @@ const moleculeTestLocalPlaybookAnsibleTmpl = `---
     - fail:
         msg: "Failed on action: converge"
 
-- import_playbook: '{{"{{ playbook_dir }}/../default/asserts.yml"}}'
+- import_playbook: '{{ playbook_dir }}/../default/asserts.yml'
 `

--- a/internal/pkg/scaffold/ansible/molecule_test_local_playbook.go
+++ b/internal/pkg/scaffold/ansible/molecule_test_local_playbook.go
@@ -48,12 +48,12 @@ const moleculeTestLocalPlaybookAnsibleTmpl = `---
   tasks:
   # using command so we don't need to install any dependencies
   - name: Get existing image hash
-    command: docker images -q {{"{{image_name}}"}}
+    command: docker images -q {{ image_name }}
     register: prev_hash
     changed_when: false
 
   - name: Build Operator Image
-    command: docker build -f /build/build/Dockerfile -t {{"{{ image_name }}"}} /build
+    command: docker build -f /build/build/Dockerfile -t {{ image_name }} /build
     register: build_cmd
     changed_when: not prev_hash.stdout or (prev_hash.stdout and prev_hash.stdout not in ''.join(build_cmd.stdout_lines[-2:]))
 
@@ -62,7 +62,7 @@ const moleculeTestLocalPlaybookAnsibleTmpl = `---
   connection: local
   vars:
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
-    deploy_dir: '{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy'
+    deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
     pull_policy: Never
     REPLACE_IMAGE: [[.Resource.FullGroup]]/[[.ProjectName]]:testing
     custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'crds/[[.Resource.Group]]_[[.Resource.Version]]_[[.Resource.LowerKind]]_cr.yaml'])) | from_yaml }}"

--- a/internal/pkg/scaffold/ansible/molecule_test_local_prepare.go
+++ b/internal/pkg/scaffold/ansible/molecule_test_local_prepare.go
@@ -34,6 +34,7 @@ func (m *MoleculeTestLocalPrepare) GetInput() (input.Input, error) {
 		m.Path = filepath.Join(MoleculeTestLocalDir, MoleculeTestLocalPrepareFile)
 	}
 	m.TemplateBody = moleculeTestLocalPrepareAnsibleTmpl
+	m.Delims = AnsibleDelims
 
 	return m.Input, nil
 }
@@ -45,23 +46,23 @@ const moleculeTestLocalPrepareAnsibleTmpl = `---
   hosts: localhost
   connection: local
   vars:
-    ansible_python_interpreter: '{{ "{{ ansible_playbook_python }}" }}'
-    deploy_dir: "{{"{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"}}"
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+    deploy_dir: '{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy'
   tasks:
   - name: Create Custom Resource Definition
     k8s:
-      definition: "{{"{{"}} lookup('file', '/'.join([deploy_dir, 'crds/{{.Resource.Group}}_{{.Resource.Version}}_{{.Resource.LowerKind}}_crd.yaml'])) {{"}}"}}"
+      definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/[[.Resource.Group]]_[[.Resource.Version]]_[[.Resource.LowerKind]]_crd.yaml'])) }}"
 
   - name: Ensure specified namespace is present
     k8s:
       api_version: v1
       kind: Namespace
-      name: '{{ "{{ namespace }}" }}'
+      name: '{{ namespace }}'
 
   - name: Create RBAC resources
     k8s:
-      definition: "{{"{{"}} lookup('template', '/'.join([deploy_dir, item])) {{"}}"}}"
-      namespace: '{{ "{{ namespace }}" }}'
+      definition: "{{ lookup('template', '/'.join([deploy_dir, item])) }}"
+      namespace: '{{ namespace }}'
     with_items:
       - role.yaml
       - role_binding.yaml

--- a/internal/pkg/scaffold/ansible/molecule_test_local_prepare.go
+++ b/internal/pkg/scaffold/ansible/molecule_test_local_prepare.go
@@ -47,7 +47,7 @@ const moleculeTestLocalPrepareAnsibleTmpl = `---
   connection: local
   vars:
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
-    deploy_dir: '{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy'
+    deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
   tasks:
   - name: Create Custom Resource Definition
     k8s:

--- a/internal/pkg/scaffold/ansible/playbook.go
+++ b/internal/pkg/scaffold/ansible/playbook.go
@@ -33,6 +33,7 @@ func (p *Playbook) GetInput() (input.Input, error) {
 		p.Path = PlaybookYamlFile
 	}
 	p.TemplateBody = playbookTmpl
+	p.Delims = AnsibleDelims
 	return p.Input, nil
 }
 
@@ -40,5 +41,5 @@ const playbookTmpl = `- hosts: localhost
   gather_facts: no
   tasks:
   - import_role:
-      name: "{{.Resource.LowerKind}}"
+      name: "[[.Resource.LowerKind]]"
 `

--- a/internal/pkg/scaffold/ansible/roles_defaults_main.go
+++ b/internal/pkg/scaffold/ansible/roles_defaults_main.go
@@ -34,10 +34,11 @@ func (r *RolesDefaultsMain) GetInput() (input.Input, error) {
 		r.Path = filepath.Join(RolesDir, r.Resource.LowerKind, RolesDefaultsMainFile)
 	}
 	r.TemplateBody = rolesDefaultsMainAnsibleTmpl
+	r.Delims = AnsibleDelims
 
 	return r.Input, nil
 }
 
 const rolesDefaultsMainAnsibleTmpl = `---
-# defaults file for {{.Resource.LowerKind}}
+# defaults file for [[.Resource.LowerKind]]
 `

--- a/internal/pkg/scaffold/ansible/roles_files.go
+++ b/internal/pkg/scaffold/ansible/roles_files.go
@@ -24,7 +24,7 @@ import (
 const RolesFilesDir = "files" + filePathSep + ".placeholder"
 
 type RolesFiles struct {
-	input.Input
+	StaticInput
 	Resource scaffold.Resource
 }
 

--- a/internal/pkg/scaffold/ansible/roles_handlers_main.go
+++ b/internal/pkg/scaffold/ansible/roles_handlers_main.go
@@ -34,10 +34,11 @@ func (r *RolesHandlersMain) GetInput() (input.Input, error) {
 		r.Path = filepath.Join(RolesDir, r.Resource.LowerKind, RolesHandlersMainFile)
 	}
 	r.TemplateBody = rolesHandlersMainAnsibleTmpl
+	r.Delims = AnsibleDelims
 
 	return r.Input, nil
 }
 
 const rolesHandlersMainAnsibleTmpl = `---
-# handlers file for {{.Resource.LowerKind}}
+# handlers file for [[.Resource.LowerKind]]
 `

--- a/internal/pkg/scaffold/ansible/roles_meta_main.go
+++ b/internal/pkg/scaffold/ansible/roles_meta_main.go
@@ -24,7 +24,7 @@ import (
 const RolesMetaMainFile = "meta" + filePathSep + "main.yml"
 
 type RolesMetaMain struct {
-	input.Input
+	StaticInput
 	Resource scaffold.Resource
 }
 

--- a/internal/pkg/scaffold/ansible/roles_readme.go
+++ b/internal/pkg/scaffold/ansible/roles_readme.go
@@ -24,7 +24,7 @@ import (
 const RolesReadmeFile = "README.md"
 
 type RolesReadme struct {
-	input.Input
+	StaticInput
 	Resource scaffold.Resource
 }
 

--- a/internal/pkg/scaffold/ansible/roles_tasks_main.go
+++ b/internal/pkg/scaffold/ansible/roles_tasks_main.go
@@ -34,10 +34,11 @@ func (r *RolesTasksMain) GetInput() (input.Input, error) {
 		r.Path = filepath.Join(RolesDir, r.Resource.LowerKind, RolesTasksMainFile)
 	}
 	r.TemplateBody = rolesTasksMainAnsibleTmpl
+	r.Delims = AnsibleDelims
 
 	return r.Input, nil
 }
 
 const rolesTasksMainAnsibleTmpl = `---
-# tasks file for {{.Resource.LowerKind}}
+# tasks file for [[.Resource.LowerKind]]
 `

--- a/internal/pkg/scaffold/ansible/roles_templates.go
+++ b/internal/pkg/scaffold/ansible/roles_templates.go
@@ -24,7 +24,7 @@ import (
 const RolesTemplatesDir = "templates" + filePathSep + ".placeholder"
 
 type RolesTemplates struct {
-	input.Input
+	StaticInput
 	Resource scaffold.Resource
 }
 

--- a/internal/pkg/scaffold/ansible/roles_vars_main.go
+++ b/internal/pkg/scaffold/ansible/roles_vars_main.go
@@ -34,10 +34,11 @@ func (r *RolesVarsMain) GetInput() (input.Input, error) {
 		r.Path = filepath.Join(RolesDir, r.Resource.LowerKind, RolesVarsMainFile)
 	}
 	r.TemplateBody = rolesVarsMainAnsibleTmpl
+	r.Delims = AnsibleDelims
 
 	return r.Input, nil
 }
 
 const rolesVarsMainAnsibleTmpl = `---
-# vars file for {{.Resource.LowerKind}}
+# vars file for [[.Resource.LowerKind]]
 `

--- a/internal/pkg/scaffold/ansible/travis.go
+++ b/internal/pkg/scaffold/ansible/travis.go
@@ -19,7 +19,7 @@ import "github.com/operator-framework/operator-sdk/internal/pkg/scaffold/input"
 const TravisFile = ".travis.yml"
 
 type Travis struct {
-	input.Input
+	StaticInput
 }
 
 // GetInput - gets the input

--- a/internal/pkg/scaffold/ansible/usersetup.go
+++ b/internal/pkg/scaffold/ansible/usersetup.go
@@ -22,7 +22,7 @@ import (
 
 // UserSetup - userSetup script
 type UserSetup struct {
-	input.Input
+	StaticInput
 }
 
 func (u *UserSetup) GetInput() (input.Input, error) {

--- a/internal/pkg/scaffold/ansible/watches.go
+++ b/internal/pkg/scaffold/ansible/watches.go
@@ -34,17 +34,18 @@ func (w *Watches) GetInput() (input.Input, error) {
 		w.Path = WatchesFile
 	}
 	w.TemplateBody = watchesAnsibleTmpl
+	w.Delims = AnsibleDelims
 	w.RolesDir = RolesDir
 	return w.Input, nil
 }
 
 const watchesAnsibleTmpl = `---
-- version: {{.Resource.Version}}
-  group: {{.Resource.FullGroup}}
-  kind: {{.Resource.Kind}}
-  {{- if .GeneratePlaybook }}
+- version: [[.Resource.Version]]
+  group: [[.Resource.FullGroup]]
+  kind: [[.Resource.Kind]]
+  [[- if .GeneratePlaybook ]]
   playbook: /opt/ansible/playbook.yml
-  {{- else }}
-  role: /opt/ansible/{{.RolesDir}}/{{.Resource.LowerKind}}
-  {{- end }}
+  [[- else ]]
+  role: /opt/ansible/[[.RolesDir]]/[[.Resource.LowerKind]]
+  [[- end ]]
 `

--- a/internal/pkg/scaffold/input/input.go
+++ b/internal/pkg/scaffold/input/input.go
@@ -60,6 +60,10 @@ type Input struct {
 
 	// ProjectName is the operator's name, ex. app-operator
 	ProjectName string
+
+	// Delims is a slice of two strings representing the left and right delimiter
+	// defaults to {{ }}
+	Delims [2]string
 }
 
 // Repo allows a repo to be set on an object

--- a/internal/pkg/scaffold/scaffold.go
+++ b/internal/pkg/scaffold/scaffold.go
@@ -195,5 +195,8 @@ func newTemplate(i input.Input) (*template.Template, error) {
 	if len(i.TemplateFuncs) > 0 {
 		t.Funcs(i.TemplateFuncs)
 	}
+	if i.Delims[0] != "" && i.Delims[1] != "" {
+		t.Delims(i.Delims[0], i.Delims[1])
+	}
 	return t.Parse(i.TemplateBody)
 }


### PR DESCRIPTION
**Description of the change:**
Allows templates to specify the delimiters to use during templating. Change Ansible templates to use '[[ ]]' instead of '{{ }}'.

**Motivation for the change:**
This makes the Ansible templates readable by not doubling up on the {{ templating (where we needed to escape jinja templates)
