### PR TITLE
pkg/helm/controller/reconcile.go: fix conditions logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Bug Fixes
 
+- In Helm-based operators, when a custom resource with a failing release is reverted back to a working state, the `ReleaseFailed` condition is now correctly removed. ([#1321](https://github.com/operator-framework/operator-sdk/pull/1321))
+
 ## v0.7.0
 
 ### Added

--- a/pkg/helm/controller/reconcile.go
+++ b/pkg/helm/controller/reconcile.go
@@ -242,6 +242,14 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{RequeueAfter: r.ReconcilePeriod}, err
 	}
 
+	// If a change is made to the CR spec that causes a release failure, a
+	// ConditionReleaseFailed is added to the status conditions. If that change
+	// is then reverted to its previous state, the operator will stop
+	// attempting the release and will resume reconciling. In this case, we
+	// need to remove the ConditionReleaseFailed because the failing release is
+	// no longer being attempted.
+	status.RemoveCondition(types.ConditionReleaseFailed)
+
 	expectedRelease, err := manager.ReconcileRelease(context.TODO())
 	if err != nil {
 		log.Error(err, "Failed to reconcile release")


### PR DESCRIPTION
**Description of the change:**
Remove `ReleaseFailed` condition when reconciling an existing deployed release.

**Motivation for the change:**
If a change is made to the CR spec that causes a release failure, a `ReleaseFailed` condition is added to the status conditions. If that change is then reverted to its previous state, the operator will stop attempting the release and will resume reconciling.

In this case, we need to remove the `ReleaseFailed` condition because the failing release is no longer being attempted.