### PR TITLE
pkg/log/zap: Adding ability to get client-go and trace level logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - When Helm operator projects are created, the SDK now generates RBAC rules in `deploy/role.yaml` based on the chart's default manifest. ([#1188](https://github.com/operator-framework/operator-sdk/pull/1188))
+- When debug level is 3 or higher, we will set the klog verbosity to that level. ([#1322](https://github.com/operator-framework/operator-sdk/pull/1322))
 
 ### Deprecated
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1806,6 +1806,7 @@
     "k8s.io/helm/pkg/storage/driver",
     "k8s.io/helm/pkg/tiller",
     "k8s.io/helm/pkg/tiller/environment",
+    "k8s.io/klog",
     "sigs.k8s.io/controller-runtime/pkg/cache",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",

--- a/doc/user/logging.md
+++ b/doc/user/logging.md
@@ -38,7 +38,7 @@ In the above example, we add the zap flagset to the operator's command line flag
 By default, `zap.Logger()` will return a logger that is ready for production use. It uses a JSON encoder, logs starting at the `info` level, and has [sampling][zap_sampling] enabled. To customize the default behavior, users can use the zap flagset and specify flags on the command line. The zap flagset includes the following flags that can be used to configure the logger:
 * `--zap-devel` - Enables the zap development config (changes defaults to console encoder, debug log level, and disables sampling) (default: `false`)
 * `--zap-encoder` string - Sets the zap log encoding (`json` or `console`)
-* `--zap-level` string or integer - Sets the zap log level (`debug`, `info`, `error`, or an integer value greater than 0)
+* `--zap-level` string or integer - Sets the zap log level (`debug`, `info`, `error`, or an integer value greater than 0). If 4 or greater the verbosity of client-go will be set to this level.
 * `--zap-sample` - Enables zap's sampling mode. Sampling will be disabled for integer log levels greater than 1.
 
 

--- a/pkg/log/zap/flags.go
+++ b/pkg/log/zap/flags.go
@@ -119,7 +119,10 @@ func (v *levelValue) Set(l string) error {
 	if lvl < -3 {
 		fs := flag.NewFlagSet("", flag.ContinueOnError)
 		klog.InitFlags(fs)
-		fs.Set("v", fmt.Sprintf("%v", -1*lvl))
+		err := fs.Set("v", fmt.Sprintf("%v", -1*lvl))
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/log/zap/flags.go
+++ b/pkg/log/zap/flags.go
@@ -15,6 +15,7 @@
 package zap
 
 import (
+	"flag"
 	"fmt"
 	"strconv"
 	"strings"
@@ -22,6 +23,7 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"k8s.io/klog"
 )
 
 var (
@@ -41,6 +43,7 @@ func init() {
 	zapFlagSet.Var(&sampleVal, "zap-sample", "Enable zap log sampling. Sampling will be disabled for integer log levels > 1")
 }
 
+// FlagSet - The zap logging flagset.
 func FlagSet() *pflag.FlagSet {
 	return zapFlagSet
 }
@@ -112,6 +115,12 @@ func (v *levelValue) Set(l string) error {
 		}
 	}
 	v.level = zapcore.Level(int8(lvl))
+	// If log level is greater than debug, set glog/klog level to that level.
+	if lvl < -3 {
+		fs := flag.NewFlagSet("", flag.ContinueOnError)
+		klog.InitFlags(fs)
+		fs.Set("v", fmt.Sprintf("%v", -1*lvl))
+	}
 	return nil
 }
 


### PR DESCRIPTION

**Description of the change:**
Adding the ability to set the log level for klog if the zap-level is for enough verbosity.

**Motivation for the change:**
Allowing users to get more debug level logs with help when diagnosing problems.
