### PR TITLE
pkg/restmapper,scaffold/cmd.go: override default restmapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - New option for [`operator-sdk build --image-builder`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#build), which can be used to specify which image builder to use. Adds support for [buildah](https://github.com/containers/buildah/). ([#1311](https://github.com/operator-framework/operator-sdk/pull/1311))
+- Manager is now configured with a new `DynamicRESTMapper`, which accounts for the fact that the default `RESTMapper`, which only checks resource types at startup, can't handle the case of first creating a CRD and then an instance of that CRD. ([#1329](https://github.com/operator-framework/operator-sdk/pull/1329))
 
 ### Changed
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1770,6 +1770,7 @@
     "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/apimachinery/pkg/util/net",
     "k8s.io/apimachinery/pkg/util/proxy",
+    "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/util/validation",
     "k8s.io/apimachinery/pkg/util/wait",

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -53,6 +53,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
+	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -122,6 +123,7 @@ func main() {
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
 		Namespace:          namespace,
+		MapperProvider:     restmapper.NewDynamicRESTMapper,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})	
 	if err != nil {

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
+	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -121,6 +122,7 @@ func main() {
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
 		Namespace:          namespace,
+		MapperProvider:     restmapper.NewDynamicRESTMapper,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})
 	if err != nil {

--- a/pkg/restmapper/dynamicrestmapper.go
+++ b/pkg/restmapper/dynamicrestmapper.go
@@ -1,0 +1,124 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restmapper
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+)
+
+type DynamicRESTMapper struct {
+	client   discovery.DiscoveryInterface
+	delegate meta.RESTMapper
+}
+
+// NewDynamicRESTMapper returns a RESTMapper that dynamically discovers resource
+// types at runtime. This is in contrast to controller-manager's default RESTMapper, which
+// only checks resource types at startup, and so can't handle the case of first creating a
+// CRD and then creating an instance of that CRD.
+func NewDynamicRESTMapper(cfg *rest.Config) (meta.RESTMapper, error) {
+	client, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	drm := &DynamicRESTMapper{client: client}
+	if err := drm.reload(); err != nil {
+		return nil, err
+	}
+	return drm, nil
+}
+
+func (drm *DynamicRESTMapper) reload() error {
+	gr, err := restmapper.GetAPIGroupResources(drm.client)
+	if err != nil {
+		return err
+	}
+	drm.delegate = restmapper.NewDiscoveryRESTMapper(gr)
+	return nil
+}
+
+// reloadOnError checks if an error indicates that the delegated RESTMapper needs to be
+// reloaded, and if so, reloads it and returns true.
+func (drm *DynamicRESTMapper) reloadOnError(err error) bool {
+	if _, matches := err.(*meta.NoKindMatchError); !matches {
+		return false
+	}
+	err = drm.reload()
+	if err != nil {
+		utilruntime.HandleError(err)
+	}
+	return err == nil
+}
+
+func (drm *DynamicRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	gvk, err := drm.delegate.KindFor(resource)
+	if drm.reloadOnError(err) {
+		gvk, err = drm.delegate.KindFor(resource)
+	}
+	return gvk, err
+}
+
+func (drm *DynamicRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	gvks, err := drm.delegate.KindsFor(resource)
+	if drm.reloadOnError(err) {
+		gvks, err = drm.delegate.KindsFor(resource)
+	}
+	return gvks, err
+}
+
+func (drm *DynamicRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	gvr, err := drm.delegate.ResourceFor(input)
+	if drm.reloadOnError(err) {
+		gvr, err = drm.delegate.ResourceFor(input)
+	}
+	return gvr, err
+}
+
+func (drm *DynamicRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	gvrs, err := drm.delegate.ResourcesFor(input)
+	if drm.reloadOnError(err) {
+		gvrs, err = drm.delegate.ResourcesFor(input)
+	}
+	return gvrs, err
+}
+
+func (drm *DynamicRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	m, err := drm.delegate.RESTMapping(gk, versions...)
+	if drm.reloadOnError(err) {
+		m, err = drm.delegate.RESTMapping(gk, versions...)
+	}
+	return m, err
+}
+
+func (drm *DynamicRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	ms, err := drm.delegate.RESTMappings(gk, versions...)
+	if drm.reloadOnError(err) {
+		ms, err = drm.delegate.RESTMappings(gk, versions...)
+	}
+	return ms, err
+}
+
+func (drm *DynamicRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
+	s, err := drm.delegate.ResourceSingularizer(resource)
+	if drm.reloadOnError(err) {
+		s, err = drm.delegate.ResourceSingularizer(resource)
+	}
+	return s, err
+}


### PR DESCRIPTION
This addresses a controller-runtime bug which can affect operators
that create CRD's and then CR's that refer to them, as the default
mapper never "sees" the new CRD's.

Fixes #1328 (originally from @danwinship)
