### PR TITLE
 internal/pkg/scaffold/ansible/k8s_status.go: use proper template delims

### DIFF
--- a/internal/pkg/scaffold/ansible/k8s_status.go
+++ b/internal/pkg/scaffold/ansible/k8s_status.go
@@ -32,7 +32,7 @@ func (k *K8sStatus) GetInput() (input.Input, error) {
 	}
 
 	k.TemplateBody = k8sStatusTmpl
-
+	k.Delims = AnsibleDelims
 	return k.Input, nil
 }
 


### PR DESCRIPTION
**Description of the change:** use `[[]]` instead of `{{}}` as template delimiters in `internal/pkg/scaffold/ansible/k8s_status.go`.

**Motivation for the change:** bug
