### PR TITLE
cmd/operator-sdk/olmcatalog/gen-csv.go: --write-config to write CSV config to disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - New option for [`operator-sdk build --image-builder`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#build), which can be used to specify which image builder to use. Adds support for [buildah](https://github.com/containers/buildah/). ([#1311](https://github.com/operator-framework/operator-sdk/pull/1311))
 - Manager is now configured with a new `DynamicRESTMapper`, which accounts for the fact that the default `RESTMapper`, which only checks resource types at startup, can't handle the case of first creating a CRD and then an instance of that CRD. ([#1329](https://github.com/operator-framework/operator-sdk/pull/1329))
+- New optional flag `--write-csv-config[=path]` for [`operator-sdk olm-catalog`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#olm-catalog) and [`operator-sdk olm-catalog gen-csv`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#gen-csv) which writes a default CSV config file to `deploy/olm-catalog/csv-config.yaml` if no value is passed, or `path` if passed. This file can be modified and passed to `--csv-config` to configure `gen-csv`. ([#1346](https://github.com/operator-framework/operator-sdk/pull/1346))
 
 ### Changed
 

--- a/cmd/operator-sdk/olmcatalog/cmd.go
+++ b/cmd/operator-sdk/olmcatalog/cmd.go
@@ -15,16 +15,70 @@
 package olmcatalog
 
 import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold"
+	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/input"
+	catalog "github.com/operator-framework/operator-sdk/internal/pkg/scaffold/olm-catalog"
+	"github.com/operator-framework/operator-sdk/internal/util/projutil"
+
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+)
+
+var (
+	writeCSVConfigOpt = "write-csv-config"
+
+	writeCSVConfigPath string
 )
 
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "olm-catalog <olm-catalog-command>",
+		Use:   "olm-catalog [flags] <olm-catalog-command>",
 		Short: "Invokes a olm-catalog command",
 		Long: `The operator-sdk olm-catalog command invokes a command to perform
 Catalog related actions.`,
+		RunE: olmCatalogFunc,
 	}
 	cmd.AddCommand(newGenCSVCmd())
+
+	i, err := (&catalog.CSVConfig{}).GetInput()
+	if err != nil {
+		log.Fatalf("Error retrieving CSV config path: %v", err)
+	}
+	cmd.PersistentFlags().StringVar(&writeCSVConfigPath, writeCSVConfigOpt, "",
+		"Write a default CSV config file. A default path is used if no value is provided."+
+			" Set --write-csv-config=<path> to supply a non-default path")
+	cmd.Flag(writeCSVConfigOpt).NoOptDefVal = i.Path
+
 	return cmd
+}
+
+func olmCatalogFunc(cmd *cobra.Command, args []string) error {
+	if cmd.Flags().Changed(writeCSVConfigOpt) {
+		absProjectPath := projutil.MustGetwd()
+		cfg := &input.Config{
+			AbsProjectPath: absProjectPath,
+			ProjectName:    filepath.Base(absProjectPath),
+		}
+		if projutil.IsOperatorGo() {
+			cfg.Repo = projutil.CheckAndGetProjectGoPkg()
+		}
+		s := &scaffold.Scaffold{}
+		if err := writeConfig(s, cfg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func writeConfig(s *scaffold.Scaffold, cfg *input.Config) error {
+	log.Info("Writing new default CSV config.")
+	csvCfg := &catalog.CSVConfig{
+		Input: input.Input{Path: writeCSVConfigPath},
+	}
+	if err := s.Execute(cfg, csvCfg); err != nil {
+		return fmt.Errorf("error scaffolding CSV config: %v", err)
+	}
+	return nil
 }

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -180,6 +180,10 @@ pkg/apis/app/v1alpha1/
 
 Parent command for all OLM Catalog related commands.
 
+#### Flags
+
+* `--write-csv-config` string or empty - Write a default CSV config file. A default path is used if no value is provided. Set --write-csv-config=<path> to supply a non-default path
+
 ### gen-csv
 
 Writes a Cluster Service Version (CSV) manifest and optionally CRD files to `deploy/olm-catalog/{operator-name}/{csv-version}`.
@@ -188,7 +192,8 @@ Writes a Cluster Service Version (CSV) manifest and optionally CRD files to `dep
 
 * `--csv-version` string - (required) Semantic version of the CSV manifest.
 * `--from-version` string - Semantic version of CSV manifest to use as a base for a new version.
-* `--csv-config` string - Path to CSV config file. Defaults to deploy/olm-catalog/csv-config.yaml.
+* `--csv-config` string - Path to CSV config file. If unset, default file paths are used
+* `--write-csv-config` string or empty - Write a default CSV config file. A default path is used if no value is provided. Set --write-csv-config=<path> to supply a non-default path
 * `--update-crds` Update CRD manifests in deploy/{operator-name}/{csv-version} using the latest CRD manifests.
 
 #### Example

--- a/doc/user/olm-catalog/generating-a-csv.md
+++ b/doc/user/olm-catalog/generating-a-csv.md
@@ -17,15 +17,15 @@ Operator SDK projects have an expected [project layout][doc-project-layout]. In 
 
 `gen-csv` reads these files and adds their data to a CSV in an alternate form.
 
-By default, a `deploy/olm-catalog/csv-config.yaml` file is generated when `gen-csv` is first run. The defaults written in the following fields contain paths to the aforementioned files. From the [design doc][doc-csv-design]:
+Both `olm-catalog` and `olm-catalog gen-csv` can write a CSV configuration file that configures parts of the CSV generation process. By setting `--write-csv-config`, these commands write a default CSV config file to `deploy/olm-catalog/csv-config.yaml`; setting `--write-csv-confg=<path>` will write a default config file to `path` instead. The defaults written in the following fields contain paths to the aforementioned files:
 
->Users can configure CSV composition by populating several fields in the file `deploy/olm-catalog/csv-config.yaml`:
->
->- `crd-cr-path-list`: (string(, string)\*) a list of CRD and CR manifest file/directory paths. Defaults to `[deploy/crds]`.
->- `operator-path`: (string) the operator resource manifest file path. Defaults to `deploy/operator.yaml`.
->- `rbac-path-list`: (string(, string)\*) a list of RBAC role manifest file paths. Defaults to `[deploy/role.yaml]`.
+- `crd-cr-paths`: string , { string } - a list of CRD and CR manifest file/directory paths. Defaults to `[deploy/crds]`.
+- `operator-path`: string - the operator `Deployment` manifest file path. Defaults to `deploy/operator.yaml`.
+- `role-path`: string - the RBAC `Role` manifest file path. Defaults to `deploy/role.yaml`.
 
-Fields in this config file can be modified to point towards alternate manifest locations. For example, if I have one set of production CR/CRD manifests under `deploy/crds/production`, and a set of test manifests under `deploy/crds/test`, and I only want to include production manifests in my CSV, I can set `crd-cr-path-list: [deploy/crds/production]`. `gen-csv` will then ignore `deploy/crds/test` when getting CR/CRD data.
+**Note**: The [design doc][doc-csv-design] has outdated field information which should not be referenced.
+
+Fields in this config file can be modified to point towards alternate manifest locations, and passed to `gen-csv --csv-config=<path>` to configure CSV generation. For example, if I have one set of production CR/CRD manifests under `deploy/crds/production`, and a set of test manifests under `deploy/crds/test`, and I only want to include production manifests in my CSV, I can set `crd-cr-paths: [deploy/crds/production]`. `gen-csv` will then ignore `deploy/crds/test` when getting CR/CRD data.
 
 ## Versioning
 
@@ -33,7 +33,7 @@ CSV's are versioned in path, file name, and in their `metadata.name` field. For 
 
 `gen-csv` allows you to upgrade your CSV using the `--from-version` flag. If you have an existing CSV with version `0.0.1` and want to write a new version `0.0.2`, you can run `operator-sdk olm-catalog gen-csv --csv-version 0.0.2 --from-version 0.0.1`. This will write a new CSV manifest to `deploy/olm-catalog/<operator-name>/0.0.2/<operator-name>.v0.0.2.clusterserviceversion.yaml` containing user-defined data from `0.0.1` and any modifications you've made to `roles.yaml`, `operator.yaml`, CR's, or CRD's.
 
-The SDK can manage CRD's in your Operator bundle as well. You can pass the `--update-crds` flag to `gen-csv` to add or update your CRD's in your bundle by copying manifests pointed to by `crd-cr-path-list` in your config. CRD's in a bundle are not updated by default.
+The SDK can manage CRD's in your Operator bundle as well. You can pass the `--update-crds` flag to `gen-csv` to add or update your CRD's in your bundle by copying manifests pointed to by `crd-cr-paths` in your config. CRD's in a bundle are not updated by default.
 
 ## First Generation
 
@@ -89,7 +89,7 @@ Required:
 * `spec.labels`: (user) a list of `key:value` pairs to be used by Operator internals.
 * `spec.version`: semantic version of the Operator, ex. `0.1.1`.
 * `spec.installModes`: what mode of [installation namespacing][install-modes] OLM should use. Currently all but `MultiNamespace` are supported by SDK Operators.
-* `spec.customresourcedefinitions`: any CRD's the Operator uses. This field will be filled by the SDK if any CRD manifests pointed to by `crd-cr-path-list` in your config.
+* `spec.customresourcedefinitions`: any CRD's the Operator uses. This field will be filled by the SDK if any CRD manifests pointed to by `crd-cr-paths` in your config.
   * `description`: description of the CRD.
   * `resources`: any Kubernetes resources used by the CRD, ex. `Pod`'s and `ConfigMap`'s.
   * `specDescriptors`: UI hints for inputs and outputs of the Operator's spec.

--- a/internal/pkg/scaffold/constants.go
+++ b/internal/pkg/scaffold/constants.go
@@ -33,7 +33,6 @@ const (
 	BuildBinDir    = BuildDir + filePathSep + "_output" + filePathSep + "bin"
 	BuildScriptDir = BuildDir + filePathSep + "bin"
 	DeployDir      = "deploy"
-	OLMCatalogDir  = DeployDir + filePathSep + "olm-catalog"
 	CRDsDir        = DeployDir + filePathSep + "crds"
 	VersionDir     = "version"
 )

--- a/internal/pkg/scaffold/olm-catalog/config_test.go
+++ b/internal/pkg/scaffold/olm-catalog/config_test.go
@@ -25,7 +25,7 @@ import (
 func TestConfig(t *testing.T) {
 	crdsDir := filepath.Join(testDataDir, scaffold.CRDsDir)
 
-	cfg := &CSVConfig{
+	cfg := &CSVConfigFile{
 		CRDCRPaths: []string{crdsDir},
 	}
 	if err := cfg.setFields(); err != nil {
@@ -35,9 +35,7 @@ func TestConfig(t *testing.T) {
 		t.Errorf("Wanted 3 crd/cr files, got: %v", cfg.CRDCRPaths)
 	}
 
-	cfg = &CSVConfig{
-		CRDCRPaths: []string{crdsDir, filepath.Join(crdsDir, "app_v1alpha1_app_crd.yaml")},
-	}
+	cfg.CRDCRPaths = []string{crdsDir, filepath.Join(crdsDir, "app_v1alpha1_app_crd.yaml")}
 	if err := cfg.setFields(); err != nil {
 		t.Errorf("Set fields crd-cr paths dir file mix: (%v)", err)
 	}

--- a/internal/pkg/scaffold/olm-catalog/csv.go
+++ b/internal/pkg/scaffold/olm-catalog/csv.go
@@ -38,8 +38,10 @@ import (
 )
 
 const (
-	CSVYamlFileExt    = ".clusterserviceversion.yaml"
-	CSVConfigYamlFile = "csv-config.yaml"
+	filePathSep = string(filepath.Separator)
+
+	OLMCatalogDir  = scaffold.DeployDir + filePathSep + "olm-catalog"
+	CSVYamlFileExt = ".clusterserviceversion.yaml"
 )
 
 var ErrNoCSVVersion = errors.New("no CSV version supplied")
@@ -47,15 +49,14 @@ var ErrNoCSVVersion = errors.New("no CSV version supplied")
 type CSV struct {
 	input.Input
 
-	// ConfigFilePath is the location of a configuration file path for this
-	// projects' CSV file.
-	ConfigFilePath string
 	// CSVVersion is the CSV current version.
 	CSVVersion string
 	// FromVersion is the CSV version from which to build a new CSV. A CSV
 	// manifest with this version should exist at:
 	// deploy/olm-catalog/{from_version}/operator-name.v{from_version}.{CSVYamlFileExt}
 	FromVersion string
+	// CSVConfigFile is data from a file that configures CSV generation.
+	CSVConfigFile *CSVConfigFile
 
 	once       sync.Once
 	fs         afero.Fs // For testing, ex. afero.NewMemMapFs()
@@ -83,14 +84,17 @@ func (s *CSV) GetInput() (input.Input, error) {
 		// Path is what the operator-registry expects:
 		// {manifests -> olm-catalog}/{operator_name}/{semver}/{operator_name}.v{semver}.clusterserviceversion.yaml
 		s.Path = filepath.Join(s.pathPrefix,
-			scaffold.OLMCatalogDir,
+			OLMCatalogDir,
 			lowerProjName,
 			s.CSVVersion,
 			getCSVFileName(lowerProjName, s.CSVVersion),
 		)
 	}
-	if s.ConfigFilePath == "" {
-		s.ConfigFilePath = filepath.Join(s.pathPrefix, scaffold.OLMCatalogDir, CSVConfigYamlFile)
+	if s.CSVConfigFile == nil {
+		s.CSVConfigFile = &CSVConfigFile{}
+	}
+	if err := s.CSVConfigFile.setFields(); err != nil {
+		return input.Input{}, err
 	}
 	return s.Input, nil
 }
@@ -112,16 +116,11 @@ func (s *CSV) CustomRender() ([]byte, error) {
 		s.initCSVFields(csv)
 	}
 
-	cfg, err := GetCSVConfig(s.ConfigFilePath)
-	if err != nil {
-		return nil, err
-	}
-
 	setCSVDefaultFields(csv)
 	if err = s.updateCSVVersions(csv); err != nil {
 		return nil, err
 	}
-	if err = s.updateCSVFromManifestFiles(cfg, csv); err != nil {
+	if err = s.updateCSVFromManifestFiles(s.CSVConfigFile, csv); err != nil {
 		return nil, err
 	}
 
@@ -184,7 +183,7 @@ func getCSVFileName(name, version string) string {
 func (s *CSV) getCSVPath(ver string) string {
 	lowerProjName := strings.ToLower(s.ProjectName)
 	name := getCSVFileName(lowerProjName, ver)
-	return filepath.Join(s.pathPrefix, scaffold.OLMCatalogDir, lowerProjName, ver, name)
+	return filepath.Join(s.pathPrefix, OLMCatalogDir, lowerProjName, ver, name)
 }
 
 // getDisplayName turns a project dir name in any of {snake, chain, camel}
@@ -356,7 +355,7 @@ func replaceAllBytes(v interface{}, old, new []byte) error {
 
 // updateCSVFromManifestFiles gathers relevant data from generated and
 // user-defined manifests and updates csv.
-func (s *CSV) updateCSVFromManifestFiles(cfg *CSVConfig, csv *olmapiv1alpha1.ClusterServiceVersion) error {
+func (s *CSV) updateCSVFromManifestFiles(cfg *CSVConfigFile, csv *olmapiv1alpha1.ClusterServiceVersion) error {
 	store := NewUpdaterStore()
 	otherSpecs := make(map[string][][]byte)
 	for _, f := range append(cfg.CRDCRPaths, cfg.OperatorPath, cfg.RolePath) {

--- a/internal/pkg/scaffold/olm-catalog/csv_test.go
+++ b/internal/pkg/scaffold/olm-catalog/csv_test.go
@@ -36,7 +36,10 @@ import (
 
 const testDataDir = "testdata"
 
-var testDeployDir = filepath.Join(testDataDir, scaffold.DeployDir)
+var (
+	testDeployDir = filepath.Join(testDataDir, scaffold.DeployDir)
+	csvCfgPath    = filepath.Join(testDeployDir, "olm-catalog", CSVConfigYamlFile)
+)
 
 func TestCSVNew(t *testing.T) {
 	buf := &bytes.Buffer{}
@@ -48,8 +51,16 @@ func TestCSVNew(t *testing.T) {
 	csvVer := "0.1.0"
 	projectName := "app-operator"
 
-	sc := &CSV{CSVVersion: csvVer, pathPrefix: testDataDir}
-	err := s.Execute(&input.Config{ProjectName: projectName}, sc)
+	csvCfgFile, err := GetCSVConfigFile(csvCfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc := &CSV{
+		CSVVersion:    csvVer,
+		CSVConfigFile: csvCfgFile,
+		pathPrefix:    testDataDir,
+	}
+	err = s.Execute(&input.Config{ProjectName: projectName}, sc)
 	if err != nil {
 		t.Fatalf("Failed to execute the scaffold: (%v)", err)
 	}
@@ -96,12 +107,17 @@ func TestCSVFromOld(t *testing.T) {
 		t.Fatalf("Failed to write %s to in-memory test fs: (%v)", testDeployDir, err)
 	}
 
-	sc := &CSV{
-		CSVVersion:  newCSVVer,
-		FromVersion: oldCSVVer,
-		pathPrefix:  testDataDir,
+	csvCfgFile, err := GetCSVConfigFile(csvCfgPath)
+	if err != nil {
+		t.Fatal(err)
 	}
-	err := s.Execute(&input.Config{ProjectName: projectName}, sc)
+	sc := &CSV{
+		CSVVersion:    newCSVVer,
+		FromVersion:   oldCSVVer,
+		CSVConfigFile: csvCfgFile,
+		pathPrefix:    testDataDir,
+	}
+	err = s.Execute(&input.Config{ProjectName: projectName}, sc)
 	if err != nil {
 		t.Fatalf("Failed to execute the scaffold: (%v)", err)
 	}


### PR DESCRIPTION
**Description of the change:**
`internal/pkg/scaffold/olm-catalog`: Use a `CSVConfigFile` in a CSV scaffold directly instead of reading from a file. `CSVConfig` is now a scaffold that contains a `CSVConfigFile` with the actual data to write.

`cmd/operator-sdk/olmcatalog/gen-csv.go`: Add `--write-csv-config` flag to both `olm-catalog` and `olm-catalog gen-csv` so users can write a CSV config to a default path or the one passed to `--write-csv-config`.

**Motivation for the change:** #1259 does not directly pertain to the changes here but brought to my attention that CSV config files are not well understood. `--write-config` should help because it creates a default config with all fields populated.
