### PR TITLE
fix ansible e2e

### DIFF
--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -114,8 +114,8 @@ sed -i 's|{{ pull_policy.default..Always.. }}|Never|g' deploy/operator.yaml
 
 OPERATORDIR="$(pwd)"
 
-trap_add 'remove_operator' EXIT
 deploy_operator
+trap_add 'remove_operator' EXIT
 test_operator
 remove_operator
 

--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -114,8 +114,8 @@ sed -i 's|{{ pull_policy.default..Always.. }}|Never|g' deploy/operator.yaml
 
 OPERATORDIR="$(pwd)"
 
-deploy_operator
 trap_add 'remove_operator' EXIT
+deploy_operator
 test_operator
 remove_operator
 

--- a/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
+++ b/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
@@ -40,7 +40,10 @@ func (b *BuildTestFrameworkDockerfile) GetInput() (input.Input, error) {
 const buildTestFrameworkDockerfileAnsibleTmpl = `ARG BASEIMAGE
 FROM ${BASEIMAGE}
 USER 0
-RUN yum install -y python-devel gcc libffi-devel && pip install molecule
+
+RUN yum install -y python-devel gcc libffi-devel
+RUN pip install molecule==2.20.1
+
 ARG NAMESPACEDMAN
 ADD $NAMESPACEDMAN /namespaced.yaml
 ADD build/test-framework/ansible-test.sh /ansible-test.sh

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -45,7 +45,7 @@ func (d *DockerfileHybrid) GetInput() (input.Input, error) {
 	return d.Input, nil
 }
 
-const dockerFileHybridAnsibleTmpl = `FROM ansible/ansible-runner:1.3.2
+const dockerFileHybridAnsibleTmpl = `FROM ansible/ansible-runner:1.2
 
 RUN yum remove -y ansible python-idna
 RUN yum install -y inotify-tools && yum clean all
@@ -54,7 +54,7 @@ RUN pip uninstall ansible-runner -y
 RUN pip install --upgrade setuptools==41.0.1
 RUN pip install "urllib3<1.25,>=1.23"
 RUN pip install ansible==2.7.10 \
-	ansible-runner==1.3.2 \
+	ansible-runner==1.2 \
 	ansible-runner-http==1.0.0 \
 	idna==2.7 \
 	kubernetes==9.0.0 \

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -45,7 +45,7 @@ func (d *DockerfileHybrid) GetInput() (input.Input, error) {
 	return d.Input, nil
 }
 
-const dockerFileHybridAnsibleTmpl = `FROM ansible/ansible-runner
+const dockerFileHybridAnsibleTmpl = `FROM ansible/ansible-runner:1.3.2
 
 RUN yum remove -y ansible python-idna
 RUN yum install -y inotify-tools && yum clean all
@@ -54,7 +54,7 @@ RUN pip uninstall ansible-runner -y
 RUN pip install --upgrade setuptools==41.0.1
 RUN pip install "urllib3<1.25,>=1.23"
 RUN pip install ansible==2.7.10 \
-	ansible-runner==1.3.3 \
+	ansible-runner==1.3.2 \
 	ansible-runner-http==1.0.0 \
 	idna==2.7 \
 	kubernetes==9.0.0 \

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -52,13 +52,13 @@ RUN yum install -y inotify-tools && yum clean all
 RUN pip uninstall ansible-runner -y
 
 RUN pip install --upgrade setuptools==41.0.1
-RUN pip install "urllib3<1.25,>=1.23"
+RUN pip install "urllib3>=1.23,<1.25"
 RUN pip install ansible==2.7.10 \
 	ansible-runner==1.2 \
 	ansible-runner-http==1.0.0 \
 	idna==2.7 \
-	kubernetes==9.0.0 \
-	openshift==0.8.7
+	"kubernetes>=8.0.0,<9.0.0" \
+	openshift==0.8.8
 
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -52,6 +52,7 @@ RUN yum install -y inotify-tools && yum clean all
 RUN pip uninstall ansible-runner -y
 
 RUN pip install --upgrade setuptools==41.0.1
+RUN pip install "urllib3<1.25,>=1.23"
 RUN pip install ansible==2.7.10 \
 	ansible-runner==1.3.3 \
 	ansible-runner-http==1.0.0 \

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -51,8 +51,13 @@ RUN yum remove -y ansible python-idna
 RUN yum install -y inotify-tools && yum clean all
 RUN pip uninstall ansible-runner -y
 
-RUN pip install --upgrade setuptools
-RUN pip install ansible ansible-runner openshift kubernetes ansible-runner-http idna==2.7
+RUN pip install --upgrade setuptools==41.0.1
+RUN pip install ansible==2.7.10 \
+	ansible-runner==1.3.3 \
+	ansible-runner-http==1.0.0 \
+	idna==2.7 \
+	kubernetes==9.0.0 \
+	openshift==0.8.7
 
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \


### PR DESCRIPTION
**Description of the change:** pin python library versions in `internal/pkg/scaffold/ansible/dockerfilehybrid.go` and `internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go`.


**Motivation for the change:**
- `urllib3` version conflict between [`kubernetes`](https://travis-ci.org/operator-framework/operator-sdk/jobs/524268811#L916-L917) and [`requests`](https://travis-ci.org/operator-framework/operator-sdk/jobs/524268811#L1178)
- `six` version conflict between [`molecule`](https://travis-ci.org/operator-framework/operator-sdk/jobs/524286120#L1444) and [`ansible-runner`](https://travis-ci.org/operator-framework/operator-sdk/jobs/524286120#L3159)
