### PR TITLE
V0.7.x backport: pin ansible version (#1348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bug Fixes
 
+- Pin dependency versions in Ansible build and test framework Dockerfiles to fix broken build and test framework images. ([#1348](https://github.com/operator-framework/operator-sdk/pull/1348))
+
 ## v0.7.0
 
 ### Added

--- a/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
+++ b/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
@@ -40,7 +40,10 @@ func (b *BuildTestFrameworkDockerfile) GetInput() (input.Input, error) {
 const buildTestFrameworkDockerfileAnsibleTmpl = `ARG BASEIMAGE
 FROM ${BASEIMAGE}
 USER 0
-RUN yum install -y python-devel gcc libffi-devel && pip install molecule
+
+RUN yum install -y python-devel gcc libffi-devel
+RUN pip install molecule==2.20.1
+
 ARG NAMESPACEDMAN
 ADD $NAMESPACEDMAN /namespaced.yaml
 ADD build/test-framework/ansible-test.sh /ansible-test.sh

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -44,14 +44,20 @@ func (d *DockerfileHybrid) GetInput() (input.Input, error) {
 	return d.Input, nil
 }
 
-const dockerFileHybridAnsibleTmpl = `FROM ansible/ansible-runner
+const dockerFileHybridAnsibleTmpl = `FROM ansible/ansible-runner:1.2
 
 RUN yum remove -y ansible python-idna
 RUN yum install -y inotify-tools && yum clean all
 RUN pip uninstall ansible-runner -y
 
-RUN pip install --upgrade setuptools
-RUN pip install ansible ansible-runner openshift kubernetes ansible-runner-http idna==2.7
+RUN pip install --upgrade setuptools==41.0.1
+RUN pip install "urllib3>=1.23,<1.25"
+RUN pip install ansible==2.7.10 \
+	ansible-runner==1.2 \
+	ansible-runner-http==1.0.0 \
+	idna==2.7 \
+	"kubernetes>=8.0.0,<9.0.0" \
+	openshift==0.8.8
 
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \


### PR DESCRIPTION
**Description of the change:** backport of #1348 to `v0.7.x`.


**Motivation for the change:** `v0.7.0` images are broken as they pull latest versions of ansible dependencies, which have a conflict.