### PR TITLE
cmd/operator-sdk/up/local.go: sdk up local build by package than only the main file

### DIFF
--- a/cmd/operator-sdk/up/local.go
+++ b/cmd/operator-sdk/up/local.go
@@ -183,7 +183,7 @@ func buildLocal(outputBinName string) error {
 	}
 	opts := projutil.GoCmdOptions{
 		BinName:     outputBinName,
-		PackagePath: filepath.Join(scaffold.ManagerDir, scaffold.CmdFile),
+		PackagePath: filepath.Join(projutil.CheckAndGetProjectGoPkg(), scaffold.ManagerDir),
 		Args:        args,
 	}
 	return projutil.GoBuild(opts)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Description of the change: The current sdk up local only build main.go. It would be better to build by cmd/manager/ pacakge.

**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
