### PR TITLE
internal/pkg/scorecard/olm_tests.go: improve CRDsHaveResourcesTest

### DIFF
--- a/internal/pkg/scorecard/olm_tests.go
+++ b/internal/pkg/scorecard/olm_tests.go
@@ -237,6 +237,7 @@ func (t *CRDsHaveValidationTest) Run(ctx context.Context) *TestResult {
 // Run - implements Test interface
 func (t *CRDsHaveResourcesTest) Run(ctx context.Context) *TestResult {
 	res := &TestResult{Test: t}
+	var missingResources []string
 	for _, crd := range t.CSV.Spec.CustomResourceDefinitions.Owned {
 		res.MaximumPoints++
 		gvk := t.CR.GroupVersionKind()
@@ -255,6 +256,7 @@ func (t *CRDsHaveResourcesTest) Run(ctx context.Context) *TestResult {
 				}
 				if foundResource == false {
 					allResourcesListed = false
+					missingResources = append(missingResources, fmt.Sprintf("%s/%s", resource.Kind, resource.Version))
 				}
 			}
 			if allResourcesListed {
@@ -267,7 +269,7 @@ func (t *CRDsHaveResourcesTest) Run(ctx context.Context) *TestResult {
 		}
 	}
 	if res.EarnedPoints < res.MaximumPoints {
-		res.Suggestions = append(res.Suggestions, "Add resources to owned CRDs")
+		res.Suggestions = append(res.Suggestions, fmt.Sprintf("Add resources to owned CRDs for %s: %v", t.CR.GroupVersionKind(), missingResources))
 	}
 	return res
 }

--- a/internal/pkg/scorecard/olm_tests.go
+++ b/internal/pkg/scorecard/olm_tests.go
@@ -336,8 +336,7 @@ func getUsedResources(proxyPod *v1.Pod) ([]schema.GroupVersionKind, error) {
 			if splitURI[0] == "api" {
 				resources[schema.GroupVersionKind{Version: splitURI[1], Kind: splitURI[2]}] = true
 				break
-			}
-			if splitURI[0] == "apis" {
+			} else if splitURI[0] == "apis" {
 				resources[schema.GroupVersionKind{Group: splitURI[1], Version: splitURI[2], Kind: splitURI[3]}] = true
 				break
 			}
@@ -355,8 +354,7 @@ func getUsedResources(proxyPod *v1.Pod) ([]schema.GroupVersionKind, error) {
 			if splitURI[0] == "api" {
 				resources[schema.GroupVersionKind{Version: splitURI[1], Kind: splitURI[4]}] = true
 				break
-			}
-			if splitURI[0] == "apis" {
+			} else if splitURI[0] == "apis" {
 				resources[schema.GroupVersionKind{Group: splitURI[1], Version: splitURI[2], Kind: splitURI[5]}] = true
 				break
 			}

--- a/internal/pkg/scorecard/olm_tests.go
+++ b/internal/pkg/scorecard/olm_tests.go
@@ -289,14 +289,17 @@ func getUsedResources(proxyPod *v1.Pod) ([]schema.GroupVersionKind, error) {
 		/*
 			There are 6 formats a resource uri can have:
 			Cluster-Scoped:
-				Collection: /apis/GROUP/VERSION/KIND
-				Individual: /apis/GROUP/VERSION/KIND/NAME
-				Core:       /api/v1/KIND
+				Collection:      /apis/GROUP/VERSION/KIND
+				Individual:      /apis/GROUP/VERSION/KIND/NAME
+				Core:            /api/v1/KIND
+				Core Individual: /api/v1/KIND/NAME
+
 			Namespaces:
 				All Namespaces:          /apis/GROUP/VERSION/KIND (same as cluster collection)
 				Collection in Namespace: /apis/GROUP/VERSION/namespaces/NAMESPACE/KIND
 				Individual:              /apis/GROUP/VERSION/namespaces/NAMESPACE/KIND/NAME
 				Core:                    /api/v1/namespaces/NAMESPACE/KIND
+				Core Indiviual:          /api/v1/namespaces/NAMESPACE/KIND/NAME
 
 			These urls are also often appended with options, which are denoted by the '?' symbol
 		*/
@@ -328,6 +331,10 @@ func getUsedResources(proxyPod *v1.Pod) ([]schema.GroupVersionKind, error) {
 			}
 			log.Warnf("Invalid URI: \"%s\"", uri)
 		case 4:
+			if splitURI[0] == "api" {
+				resources[schema.GroupVersionKind{Version: splitURI[1], Kind: splitURI[2]}] = true
+				break
+			}
 			if splitURI[0] == "apis" {
 				resources[schema.GroupVersionKind{Group: splitURI[1], Version: splitURI[2], Kind: splitURI[3]}] = true
 				break
@@ -343,6 +350,10 @@ func getUsedResources(proxyPod *v1.Pod) ([]schema.GroupVersionKind, error) {
 			}
 			log.Warnf("Invalid URI: \"%s\"", uri)
 		case 6, 7:
+			if splitURI[0] == "api" {
+				resources[schema.GroupVersionKind{Version: splitURI[1], Kind: splitURI[4]}] = true
+				break
+			}
 			if splitURI[0] == "apis" {
 				resources[schema.GroupVersionKind{Group: splitURI[1], Version: splitURI[2], Kind: splitURI[5]}] = true
 				break


### PR DESCRIPTION
**Description of the change:**
- Adds new valid URI formats in scorecardProxy log parser
- Improves suggestion text to include missing resources

**Motivation for the change:**
- Some valid URI formats are not parsed correctly, resulting in tests that erroneously fail
- Give users better feedback about why their CRDsHaveResourcesTest failed.
