### PR TITLE
internal/pkg/scaffold: use `Resource.GoImportGroup` in CRD/CR file names

### DIFF
--- a/internal/pkg/scaffold/cr.go
+++ b/internal/pkg/scaffold/cr.go
@@ -38,7 +38,7 @@ type CR struct {
 func (s *CR) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		fileName := fmt.Sprintf("%s_%s_%s_cr.yaml",
-			strings.ToLower(s.Resource.Group),
+			strings.ToLower(s.Resource.GoImportGroup),
 			strings.ToLower(s.Resource.Version),
 			s.Resource.LowerKind)
 		s.Path = filepath.Join(CRDsDir, fileName)

--- a/internal/pkg/scaffold/cr.go
+++ b/internal/pkg/scaffold/cr.go
@@ -38,7 +38,7 @@ type CR struct {
 func (s *CR) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		fileName := fmt.Sprintf("%s_%s_%s_cr.yaml",
-			strings.ToLower(s.Resource.GoImportGroup),
+			s.Resource.GoImportGroup,
 			strings.ToLower(s.Resource.Version),
 			s.Resource.LowerKind)
 		s.Path = filepath.Join(CRDsDir, fileName)

--- a/internal/pkg/scaffold/crd.go
+++ b/internal/pkg/scaffold/crd.go
@@ -58,7 +58,7 @@ func (s *CRD) getFS() afero.Fs {
 func (s *CRD) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		fileName := fmt.Sprintf("%s_%s_%s_crd.yaml",
-			strings.ToLower(s.Resource.Group),
+			strings.ToLower(s.Resource.GoImportGroup),
 			strings.ToLower(s.Resource.Version),
 			s.Resource.LowerKind)
 		s.Path = filepath.Join(CRDsDir, fileName)

--- a/internal/pkg/scaffold/crd.go
+++ b/internal/pkg/scaffold/crd.go
@@ -59,7 +59,7 @@ func (s *CRD) getFS() afero.Fs {
 func (s *CRD) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		fileName := fmt.Sprintf("%s_%s_%s_crd.yaml",
-			strings.ToLower(s.Resource.GoImportGroup),
+			s.Resource.GoImportGroup,
 			strings.ToLower(s.Resource.Version),
 			s.Resource.LowerKind)
 		s.Path = filepath.Join(CRDsDir, fileName)

--- a/internal/pkg/scaffold/crd.go
+++ b/internal/pkg/scaffold/crd.go
@@ -16,6 +16,7 @@ package scaffold
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -125,6 +126,10 @@ func (s *CRD) CustomRender() ([]byte, error) {
 
 		b, err := afero.ReadFile(cache, path)
 		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, fmt.Errorf("no API exists for Group %s Version %s Kind %s",
+					s.Resource.GoImportGroup, s.Resource.Version, s.Resource.Kind)
+			}
 			return nil, err
 		}
 		if err = yaml.Unmarshal(b, crd); err != nil {


### PR DESCRIPTION
**Description of the change:** use `Resource.GoImportGroup` in CRD and CR file names.

**Motivation for the change:** the `controller-tools` CRD generator uses API import path in CRD file names, causing a "cache miss" in the SDK's CRD generator wrapper. See #1368 for more details.

Closes #1368
