### PR TITLE
cmd/.../scorecard: increase init-timeout default to 60s

### DIFF
--- a/cmd/operator-sdk/scorecard/cmd.go
+++ b/cmd/operator-sdk/scorecard/cmd.go
@@ -39,7 +39,7 @@ func NewCmd() *cobra.Command {
 	scorecardCmd.Flags().String(scorecard.ConfigOpt, "", "config file (default is <project_dir>/.osdk-yaml)")
 	scorecardCmd.Flags().String(scorecard.NamespaceOpt, "", "Namespace of custom resource created in cluster")
 	scorecardCmd.Flags().String(scorecard.KubeconfigOpt, "", "Path to kubeconfig of custom resource created in cluster")
-	scorecardCmd.Flags().Int(scorecard.InitTimeoutOpt, 10, "Timeout for status block on CR to be created in seconds")
+	scorecardCmd.Flags().Int(scorecard.InitTimeoutOpt, 60, "Timeout for status block on CR to be created in seconds")
 	scorecardCmd.Flags().Bool(scorecard.OlmDeployedOpt, false, "The OLM has deployed the operator. Use only the CSV for test data")
 	scorecardCmd.Flags().String(scorecard.CSVPathOpt, "", "Path to CSV being tested")
 	scorecardCmd.Flags().Bool(scorecard.BasicTestsOpt, true, "Enable basic operator checks")


### PR DESCRIPTION
**Description of the change:** Increase default value for `--init-timeout` flag to 60.


**Motivation for the change:** Many (probably most) operators take longer than 10 seconds to initialize and update a new CR. 60 seconds is a more reasonable default timeout for the initialization timeout.