### PR TITLE
remove trailing whitespaces

### DIFF
--- a/doc/ansible/dev/testing_guide.md
+++ b/doc/ansible/dev/testing_guide.md
@@ -10,7 +10,7 @@ To begin, you sould have:
 - [Ansible](https://github.com/ansible/ansible) >= v2.7
 - [jmespath](https://pypi.org/project/jmespath/)
 - [The OpenShift Python client](https://github.com/openshift/openshift-restclient-python) >= v0.8
-- An initialized Ansible Operator project, with the molecule directory present. If you initialized a project with a previous 
+- An initialized Ansible Operator project, with the molecule directory present. If you initialized a project with a previous
   version of operator-sdk, you can generate a new dummy project and copy in the `molecule` directory. Just be sure
   to generate the dummy project with the same `api-version` and `kind`, or some of the generated files will not work
   without modification. Your top-level project structure should look like this:
@@ -54,9 +54,9 @@ Below we will walk through the structure and function of each file for each scen
 #### default
 The default scenario is intended for use during the development of your Ansible role or playbook, and will run it
 outside of the context of an operator.
-You can run this scenario with 
+You can run this scenario with
 `molecule test`
-or 
+or
 `molecule converge`. There is no corresponding `operator-sdk` command for this scenario.
 
 The scenario has the following structure:
@@ -69,12 +69,12 @@ molecule/default
 └── prepare.yml
 ```
 
-`asserts.yml` is an Ansible playbook contains Ansible assert tasks that will be run by all three scenarios. 
+`asserts.yml` is an Ansible playbook contains Ansible assert tasks that will be run by all three scenarios.
 If you would like to write specific asserts for individual scenarios, you can instead remove the `asserts.yml`
 playbook import from that scenario's `playbook.yml`, or if you only want to add additional asserts, you can
 create a new playbook in that scenario and import it at the bottom of that scenario's `playbook.yml`.
 
-`molecule.yml` for this scenario tells molecule to use the docker driver to bring up a Kubernetes-in-Docker container, 
+`molecule.yml` for this scenario tells molecule to use the docker driver to bring up a Kubernetes-in-Docker container,
 and exposes the API on the host's port 9443. It also specifies a few inventory and environment
 variables which are used in `prepare.yml` and `playbook.yml`.
 
@@ -86,7 +86,7 @@ available before allowing testing to begin.
 #### test-local
 The test-local scenario is a more full integration test of your operator. It brings up a Kubernetes-in-docker cluster, builds your Operator, deploys it
 into the cluster, and then creates an instance of your CustomResource and runs your assertions to make sure the Operator responded properly. You can run
-this scenario with 
+this scenario with
 `molecule test -s local`, which is equivalent to `operator-sdk test local`, or with `molecule converge -s test-local`, which will leave the environment up
 afterward.
 
@@ -110,7 +110,7 @@ resources specified in the `deploy/` directory.
 Kubernetes-in-Docker container, and uses your mounted project root to build your Operator.
 This makes your Operator available to the cluster without needing to push it to an external
 registry. Next, it will ensure that a fresh deployment of your Operator is present in the
-cluster, and once there is it will create an instance of your Custom Resource 
+cluster, and once there is it will create an instance of your Custom Resource
 (specified in `deploy/crds/`). It will then wait for the CustomResource to report a successful
 run, and once it has, will import the `asserts.yml` from the default scenario.
 
@@ -119,7 +119,7 @@ The test-cluster scenario is intended as a full integration test against
 an existing Kubernetes cluster, and assumes that the cluster is already available, the dependent resources from the `deploy/` directory
 are created, the operator image is built with `--enable-tests`, and that the image is available in a container registry. It connects
 to the existing Kubernetes cluster and deploys the test Operator, creates a Custom Resource, and runs your asserts.  You shouldn't
-call this scenario directly, rather you should build your operator with the `--enable-tests` flag, in which case a new entrypoint will 
+call this scenario directly, rather you should build your operator with the `--enable-tests` flag, in which case a new entrypoint will
 be added that runs this scenario when the container starts up. It is recommended that you only interact with this scenario through
 `operator-sdk test cluster`.
 
@@ -131,14 +131,14 @@ molecule/test-cluster
 └── playbook.yml
 ```
 `molecule.yml` for this scenario is very simple, as it assumes an environment is already
-present. It essentially is just specifying the metadata of the scenario, and telling molecule 
+present. It essentially is just specifying the metadata of the scenario, and telling molecule
 not to try and create or destroy anything when run.
 
 `playbook.yml` is also pretty simple, compared to the previous scenarios. All it does is create
 an instance of your Custom Resource (specified in `deploy/crds`), and then import the `asserts.yml` from the `default` scenario.
 
 #### converge vs test
-The two most common molecule commands for testing during development are `molecule test` and `molecule converge`. 
+The two most common molecule commands for testing during development are `molecule test` and `molecule converge`.
 `molecule test` performs a full loop, bringing a cluster up, preparing it, running your tasks, and tearing it down.
 `molecule converge` is more useful for iterative development, as it leaves your environment up between runs. This
 can cause unexpected problems if you end up corrupting your environment during testing, but running `molecule destroy`
@@ -190,7 +190,7 @@ We'll be adding the task to `roles/example/tasks/main.yml`, which should now loo
 
 ### Adding a test
 
-Now that our Operator actually does some work, we can add a corresponding assert to `molecule/default/asserts.yml`. 
+Now that our Operator actually does some work, we can add a corresponding assert to `molecule/default/asserts.yml`.
 We'll also add a debug message so that we can see what the ConfigMap looks like.
 The file should now look like this:
 

--- a/doc/ansible/project_layout.md
+++ b/doc/ansible/project_layout.md
@@ -1,6 +1,6 @@
 # Project Scaffolding Layout
 
-After creating a new operator project using 
+After creating a new operator project using
 `operator-sdk new --type ansible`, the project directory has numerous generated folders and files. The following table describes a basic rundown of each generated file/directory.
 
 

--- a/doc/design/long-term/testing-operators.md
+++ b/doc/design/long-term/testing-operators.md
@@ -1,10 +1,10 @@
 ## Make testing an Operator simple and easy
 
-**Goal:** Make local development of Operators easy, so software vendors can produce high quality software. 
+**Goal:** Make local development of Operators easy, so software vendors can produce high quality software.
 Make functional tests easy to integrate into a big matrix (upstream, OpenShift, GKE, etc) since we want the SDK to work equally well on all platforms.
 
 **Problem:** Operators are inherently tied to a clustered environment, which complicates testing. Running a full cluster locally can be hard, and requiring a remote cluster is clunky. Aside from a single test cluster, running your Operator against the range of Kubernetes offering requires a ton of industry knowledge and expertise.
- 
+
 **Why is this important:** We think Operators are the best way to ship software on Kubernetes. This will naturally happen if we provide methods to build high quality software, of which testing is a huge part.
 
 **Proposed work streams to accomplish this:**

--- a/doc/design/milestone-0.0.2/action-api.md
+++ b/doc/design/milestone-0.0.2/action-api.md
@@ -35,7 +35,7 @@ The SDK should provide an API to Create, Update and Delete objects from inside t
 This method also aligns with the original goal of ensuring that all actions of the operator are taken through the SDK.
 
 ## API
-**Note:** `sdkTypes.Object` is just the kubernetes `runtime.Object` 
+**Note:** `sdkTypes.Object` is just the kubernetes `runtime.Object`
 
 ### Handler:
 
@@ -48,11 +48,11 @@ func Handle(ctx context.Context, event sdkTypes.Event) error
 
 ### Create Update Delete:
 ```Go
-// Create creates the provided object on the server, and updates 
+// Create creates the provided object on the server, and updates
 // the local object with the generated result from the server(UID, resourceVersion, etc).
 // Returns an error if the object’s TypeMeta(Kind, APIVersion) or ObjectMeta(Name, Namespace) is missing or incorrect.
 // Can also return an api error from the server
-// e.g AlreadyExists https://github.com/kubernetes/apimachinery/blob/master/pkg/api/errors/errors.go#L423 
+// e.g AlreadyExists https://github.com/kubernetes/apimachinery/blob/master/pkg/api/errors/errors.go#L423
 func Create(object sdkTypes.Object) error
 ```
 
@@ -61,7 +61,7 @@ func Create(object sdkTypes.Object) error
 // the local object with the generated result from the server(UID, resourceVersion, etc).
 // Returns an error if the object’s TypeMeta(Kind, APIVersion) or ObjectMeta(Name, Namespace) is missing or incorrect.
 // Can also return an api error from the server
-// e.g Conflict https://github.com/kubernetes/apimachinery/blob/master/pkg/api/errors/errors.go#L428 
+// e.g Conflict https://github.com/kubernetes/apimachinery/blob/master/pkg/api/errors/errors.go#L428
 func Update(object sdkTypes.Object) error
 ```
 
@@ -112,13 +112,13 @@ func Handle(ctx context.Context, event sdkType.Event) {
     }
 
     ...
-	
+
     // Delete with default options
     err := sdk.Delete(pod)
     if err != nil {
         return errors.New("failed to delete pod")
     }
-    
+
     // Delete with custom options
     gracePeriodSeconds := int64(5)
     metav1DeleteOptions := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriodSeconds}
@@ -137,7 +137,7 @@ type DeleteOp struct {
 }
 
 // DeleteOption configures DeleteOp
-type DeleteOption func(*DeleteOp) 
+type DeleteOption func(*DeleteOp)
 
 // WithDeleteOptions sets the meta_v1.DeleteOptions for
 // the Delete() operation.

--- a/doc/design/milestone-0.0.2/query-api.md
+++ b/doc/design/milestone-0.0.2/query-api.md
@@ -37,7 +37,7 @@ To simplify the retrieval of Kubernetes objects, the SDK can use a dynamic resou
 func Get(into sdkTypes.Object, opts ...GetOption) error
 ```
 
-Get() accepts GetOption as variadic functional parameters. In this way, we follow the open-close principle 
+Get() accepts GetOption as variadic functional parameters. In this way, we follow the open-close principle
 which allows us to extend the Get API with unforeseen parameters without modifying the API itself. See the reference section on how the options are implemented.
 
 Example Usage:
@@ -56,7 +56,7 @@ d := &apps_v1.Deployment{
 }
 // Get with default options
 err := sdk.Get(d)
-// Get with custom options 
+// Get with custom options
 o := &meta_v1.GetOptions{ResourceVersion: "0"}
 err := sdk.Get(d, sdk.WithGetOptions(o))
 ```
@@ -97,7 +97,7 @@ err = sdk.List("default", dl, op.WithListOptions(o))
 
 
 
-## Reference: 
+## Reference:
 
 ### GetOptions:
 

--- a/doc/dev/reporting_bugs.md
+++ b/doc/dev/reporting_bugs.md
@@ -4,9 +4,9 @@ If any part of the operator-sdk project has bugs or documentation mistakes, plea
 
 To make the bug report accurate and easy to understand, please try to create bug reports that are:
 
-- Specific. Include as much details as possible: which version, what environment, what configuration, etc. 
+- Specific. Include as much details as possible: which version, what environment, what configuration, etc.
 
-- Reproducible. Include the steps to reproduce the problem. We understand some issues might be hard to reproduce, please include the steps that might lead to the problem. 
+- Reproducible. Include the steps to reproduce the problem. We understand some issues might be hard to reproduce, please include the steps that might lead to the problem.
 
 - Isolated. Please try to isolate and reproduce the bug with minimum dependencies. It would significantly slow down the speed to fix a bug if too many dependencies are involved in a bug report. Debugging external systems that rely on operator-sdk is out of scope, but we are happy to provide guidance in the right direction or help with using operator-sdk itself.
 

--- a/doc/helm/user-guide.md
+++ b/doc/helm/user-guide.md
@@ -225,7 +225,7 @@ export OPERATOR_NAMESPACE=$(kubectl config view --minify -o jsonpath='{.contexts
 sed -i "s|REPLACE_NAMESPACE|$OPERATOR_NAMESPACE|g" deploy/role_binding.yaml
 ```
 
-**Note**  
+**Note**
 If you are performing these steps on OSX, use the following commands instead:
 
 ```sh

--- a/doc/proposals/TEMPLATE.md
+++ b/doc/proposals/TEMPLATE.md
@@ -3,11 +3,11 @@
 Implementation Owner: < github username >
 Status: Draft
 
-[Background](#Background)  
-[Goals](#Goals)  
-[Design overview](#Design_overview)   
-[User facing usage](#User_facing_usage)  
-[Observations and open questions](#Observations_and_open_questions)   
+[Background](#Background)
+[Goals](#Goals)
+[Design overview](#Design_overview)
+[User facing usage](#User_facing_usage)
+[Observations and open questions](#Observations_and_open_questions)
 
 ### Background
 

--- a/doc/proposals/ansible-operator-testing.md
+++ b/doc/proposals/ansible-operator-testing.md
@@ -23,7 +23,7 @@ All operators should fit into the e2e testing framework used by operator-sdk, in
 1. Add a custom entrypoint for testing that will spin up the operator and then run the proper molecule scenario, which can be included in the
    Ansible Operator image when it is built with the `--enable-tests` option
 1. Update the `test local` subcommand so that when it is run in the context of an Ansible Operator, it will trigger a molecule run of the proper scenario
-1. Update the `test cluster` subcommand so that when it is run in the context of an Ansible Operator, a deployment of the operator with the custom testing entrypoint 
+1. Update the `test cluster` subcommand so that when it is run in the context of an Ansible Operator, a deployment of the operator with the custom testing entrypoint
    is created. The behavior here should approximate the Golang operator equivalent, in terms of reporting/termination
 
 ## Discussion / Further Investigation

--- a/doc/proposals/ansible-operator.md
+++ b/doc/proposals/ansible-operator.md
@@ -4,15 +4,15 @@
 
 Not everyone is a golang developer, and therefore gaining adoption for the operator-sdk is capped by the number of golang developers. Also, tooling for Kubernetes in other languages is lacking support for things such as informers, caches, and listers.
 
-Operators purpose is to codify the operations of an application on Kubernetes. [Ansible](https://www.ansible.com/) is already an industry standard tool for automation and is a good fit for the kind of work that Kubernetes operators need to do. Adding the ability for users of the SDK to choose which between ansible and golang to follow will increase the number of potential users, and will grant existing users even more behavior. 
+Operators purpose is to codify the operations of an application on Kubernetes. [Ansible](https://www.ansible.com/) is already an industry standard tool for automation and is a good fit for the kind of work that Kubernetes operators need to do. Adding the ability for users of the SDK to choose which between ansible and golang to follow will increase the number of potential users, and will grant existing users even more behavior.
 
 ### Goals
 
-The goal of the Ansible Operator will be to create a fully functional framework for Ansible developers to create operators. It will also expose a library for golang users to use ansible in their operator if they so choose. These two goals in conjunction will allow users to select the best technology for their project or skillset. 
+The goal of the Ansible Operator will be to create a fully functional framework for Ansible developers to create operators. It will also expose a library for golang users to use ansible in their operator if they so choose. These two goals in conjunction will allow users to select the best technology for their project or skillset.
 
 ### New Operator Type
 
-This proposal creates a new type of operator called `ansible`.  The new type is used to tell the tooling to act on that type of operator. 
+This proposal creates a new type of operator called `ansible`.  The new type is used to tell the tooling to act on that type of operator.
 
 ### Package Structure
 Packages will be added to the operator-sdk. These packages are designed to be usable by the end user if they choose to and should have a well documented public API. The proposed packages are:

--- a/doc/proposals/tls-utilities.md
+++ b/doc/proposals/tls-utilities.md
@@ -17,7 +17,7 @@ To provide TLS utilities for operator developers to create self signed Certifica
 We will break down the TLS workflow into the following steps:
 
 1. Generate a Certificate Authority (CA): A CA is a centralized trusted third party that signs the certificates. We need to generate a CA key and CA Certificate to get started. If the users want to provide their own CA, we can add an option to do so. The generated CA certificate can be saved in a ConfigMap as follows:
-	
+
 	Inputs:
 
 	* CR-kind
@@ -32,21 +32,21 @@ We will break down the TLS workflow into the following steps:
 	kind: ConfigMap
 	apiVersion: v1
 	metadata:
-  	name: <crd-kind>-<crd-name>-ca
-  	namespace: <ns>
+	name: <crd-kind>-<crd-name>-ca
+	namespace: <ns>
 	data:
-  	ca.crt: ...
+	ca.crt: ...
             ```
         * A secret that contains the CA key:
 
            ```
- 	kind: Secret
- 	apiVersion: v1
- 	metadata:
-  	name: <cr-kind>-<cr-name>-ca
-  	namespace: <ns>
- 	data:
-  	ca.key: ...
+	kind: Secret
+	apiVersion: v1
+	metadata:
+	name: <cr-kind>-<cr-name>-ca
+	namespace: <ns>
+	data:
+	ca.key: ...
 	```
 
 2. Verify the CA certificate: The newly generated CA certificate in ConfigMap should be validated i.e. the digital signature should be checked, the expiry, activation dates and validity period should be checked, etc.
@@ -54,7 +54,7 @@ We will break down the TLS workflow into the following steps:
 3. Generate Server or Client Certificate: We assume that the components inside an application communicate through a service. Therefore, we generate a TLS private key and certificate for that service.
 
 	Inputs:
-	
+
 	* CR-kind
 	* CR-name
 	* Namespace
@@ -115,7 +115,7 @@ func GenerateCert(cr runtime.Object, service *v1.Service, config *CertConfig) (*
 
 ```
 
-Please note that the `GenerateCert` method cannot be used to generate TLS assets for a service of type [`ExternalName`](https://kubernetes.io/docs/concepts/services-networking/service/#externalname). This is because in the current design the fully qualified domain name (FQDN) of the Service object is used as the SAN for the certificate by default. Currently we do not have a way to customize the SAN value, we will add a field in `CertConfig` for this purpose later on. 
+Please note that the `GenerateCert` method cannot be used to generate TLS assets for a service of type [`ExternalName`](https://kubernetes.io/docs/concepts/services-networking/service/#externalname). This is because in the current design the fully qualified domain name (FQDN) of the Service object is used as the SAN for the certificate by default. Currently we do not have a way to customize the SAN value, we will add a field in `CertConfig` for this purpose later on.
 
 The `GenerateCert` method can be used in the operator handler function to set up TLS for the desired application
 

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -142,7 +142,7 @@ pkg/apis/app/v1alpha1/
 
 $ operator-sdk generate k8s
 INFO[0000] Running deepcopy code-generation for Custom Resource group versions: [app:[v1alpha1], ]
-INFO[0001] Code-generation complete.                    
+INFO[0001] Code-generation complete.
 
 $ tree pkg/apis/app/v1alpha1/
 pkg/apis/app/v1alpha1/
@@ -170,7 +170,7 @@ pkg/apis/app/v1alpha1/
 $ operator-sdk generate openapi
 INFO[0000] Running OpenAPI code-generation for Custom Resource group versions: [app:[v1alpha1], ]
 INFO[0001] Created deploy/crds/app_v1alpha1_appservice_crd.yaml
-INFO[0001] Code-generation complete.                    
+INFO[0001] Code-generation complete.
 
 $ tree pkg/apis/app/v1alpha1/
 pkg/apis/app/v1alpha1/
@@ -205,7 +205,7 @@ INFO[0000] Fill in the following required fields in file deploy/olm-catalog/oper
 	spec.maintainers
 	spec.provider
 	spec.labels
-INFO[0000] Created deploy/olm-catalog/operator-name/0.1.0/operator-name.v0.1.0.clusterserviceversion.yaml     
+INFO[0000] Created deploy/olm-catalog/operator-name/0.1.0/operator-name.v0.1.0.clusterserviceversion.yaml
 ```
 
 ## migrate
@@ -327,16 +327,16 @@ Adds the API definition for a new custom resource under `pkg/apis` and generates
 $ operator-sdk add api --api-version app.example.com/v1alpha1 --kind AppService
 INFO[0000] Generating api version app.example.com/v1alpha1 for kind AppService.
 INFO[0000] Created pkg/apis/app/v1alpha1/appservice_types.go
-INFO[0000] Created pkg/apis/addtoscheme_app_v1alpha1.go  
-INFO[0000] Created pkg/apis/app/v1alpha1/register.go     
-INFO[0000] Created pkg/apis/app/v1alpha1/doc.go          
+INFO[0000] Created pkg/apis/addtoscheme_app_v1alpha1.go
+INFO[0000] Created pkg/apis/app/v1alpha1/register.go
+INFO[0000] Created pkg/apis/app/v1alpha1/doc.go
 INFO[0000] Created deploy/crds/app_v1alpha1_appservice_cr.yaml
 INFO[0000] Created deploy/crds/app_v1alpha1_appservice_crd.yaml
 INFO[0001] Running deepcopy code-generation for Custom Resource group versions: [app:[v1alpha1], ]
-INFO[0002] Code-generation complete.                    
+INFO[0002] Code-generation complete.
 INFO[0002] Running OpenAPI code-generation for Custom Resource group versions: [app:[v1alpha1], ]
 INFO[0004] Created deploy/crds/app_v1alpha1_appservice_crd.yaml
-INFO[0004] Code-generation complete.                    
+INFO[0004] Code-generation complete.
 INFO[0004] API generation complete.
 ```
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -168,7 +168,7 @@ func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Res
   memcached := &cachev1alpha1.Memcached{}
   err := r.client.Get(context.TODO(), request.NamespacedName, memcached)
   ...
-}  
+}
 ```
 
 Based on the return values, [`Result`][result_go_doc] and error, the `Request` may be requeued and the reconcile loop may be triggered again:

--- a/doc/user/client.md
+++ b/doc/user/client.md
@@ -30,7 +30,7 @@ type ReconcileKind struct {
 }
 ```
 
-A split client reads (Get and List) from the Cache and writes (Create, Update, Delete) to the API server. Reading from the Cache significantly reduces request load on the API server; as long as the Cache is updated by the API server, read operations are eventually consistent. 
+A split client reads (Get and List) from the Cache and writes (Create, Update, Delete) to the API server. Reading from the Cache significantly reduces request load on the API server; as long as the Cache is updated by the API server, read operations are eventually consistent.
 
 ### Non-default Client
 
@@ -87,7 +87,7 @@ type ReconcileKind struct {
 	// a type registry for converting group, version, and kind information
 	// to and from Go schemas, and mappings between Go schemas of different
 	// versions. A scheme is the foundation for a versioned API and versioned
-	// configuration over time. 
+	// configuration over time.
 	scheme *runtime.Scheme
 }
 
@@ -170,7 +170,7 @@ import (
 
 func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	...
-	
+
 	// Return all pods in the request namespace with a label of `app=<name>`
 	opts := &client.ListOptions{}
 	opts.SetLabelSelector(fmt.Sprintf("app=%s", request.NamespacedName.Name))
@@ -188,7 +188,7 @@ func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, e
 
 ```Go
 // Create saves the object obj in the Kubernetes cluster.
-// Returns an error 
+// Returns an error
 func (c Client) Create(ctx context.Context, obj runtime.Object) error
 ```
 Example:
@@ -201,7 +201,7 @@ import (
 
 func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	...
-	
+
 	app := &v1.Deployment{ // Any cluster object you want to create.
 		...
 	}

--- a/doc/user/metrics/README.md
+++ b/doc/user/metrics/README.md
@@ -29,7 +29,7 @@ By default, the metrics are served on `0.0.0.0:8383/metrics`. To modify the port
             Namespace:          namespace,
             MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
         })
-        
+
         ...
 
         // Create Service object to expose the metrics port.

--- a/doc/user/metrics/service-monitor.md
+++ b/doc/user/metrics/service-monitor.md
@@ -18,8 +18,8 @@ The `GenerateServiceMonitor` function takes a `Service` object and generates a `
         "github.com/operator-framework/operator-sdk/pkg/metrics"
     )
 
-    func main() {    
-        
+    func main() {
+
         ...
 
         // Populate below with the Service(s) for which you want to create ServiceMonitors.
@@ -28,7 +28,7 @@ The `GenerateServiceMonitor` function takes a `Service` object and generates a `
         // Create one `ServiceMonitor` per application per namespace.
         // Change below value to name of the Namespace you want the `ServiceMonitor` to be created in.
         ns := "default"
-        
+
         // Pass the Service(s) to the helper function, which in turn returns the array of `ServiceMonitor` objects.
         serviceMonitors, err := metrics.CreateServiceMonitors(restConfig, ns, services)
         if err != nil {

--- a/doc/user/olm-catalog/generating-a-csv.md
+++ b/doc/user/olm-catalog/generating-a-csv.md
@@ -43,7 +43,7 @@ Some fields might not have values after running `gen-csv` the first time. The SD
 
 ```console
 $ operator-sdk olm-catalog gen-csv --csv-version 0.0.1
-INFO[0000] Generating CSV manifest version 0.0.1        
+INFO[0000] Generating CSV manifest version 0.0.1
 INFO[0000] Required csv fields not filled in file deploy/olm-catalog/app-operator/0.0.1/app-operator.v0.0.1.clusterserviceversion.yaml:
 	spec.keywords
 	spec.maintainers


### PR DESCRIPTION
Remove the trailing white space from all of the docs. I purposely ignored the developer-guide because that was fixed with a different PR since I also edited it: https://github.com/operator-framework/operator-sdk/pull/1381