### PR TITLE
*types.go: set kubebuilder subresource status annotation in go source

### DIFF
--- a/internal/pkg/scaffold/crd_test.go
+++ b/internal/pkg/scaffold/crd_test.go
@@ -65,6 +65,8 @@ spec:
     plural: memcacheds
     singular: memcached
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/internal/pkg/scaffold/types.go
+++ b/internal/pkg/scaffold/types.go
@@ -71,6 +71,7 @@ type {{.Resource.Kind}}Status struct {
 
 // {{.Resource.Kind}} is the Schema for the {{ .Resource.Resource }} API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 type {{.Resource.Kind}} struct {
 	metav1.TypeMeta   ` + "`" + `json:",inline"` + "`" + `
 	metav1.ObjectMeta ` + "`" + `json:"metadata,omitempty"` + "`" + `

--- a/internal/pkg/scaffold/types_test.go
+++ b/internal/pkg/scaffold/types_test.go
@@ -66,6 +66,7 @@ type AppServiceStatus struct {
 
 // AppService is the Schema for the appservices API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 type AppService struct {
 	metav1.TypeMeta   ` + "`" + `json:",inline"` + "`" + `
 	metav1.ObjectMeta ` + "`" + `json:"metadata,omitempty"` + "`" + `

--- a/test/test-framework/pkg/apis/cache/v1alpha1/memcached_types.go
+++ b/test/test-framework/pkg/apis/cache/v1alpha1/memcached_types.go
@@ -34,6 +34,7 @@ type MemcachedStatus struct {
 
 // Memcached is the Schema for the memcacheds API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 type Memcached struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/test/test-framework/pkg/apis/cache/v1alpha1/memcachedrs_types.go
+++ b/test/test-framework/pkg/apis/cache/v1alpha1/memcachedrs_types.go
@@ -38,6 +38,7 @@ type MemcachedRSStatus struct {
 
 // MemcachedRS is the Schema for the memcachedrs API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 type MemcachedRS struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
**Description of the change:** add the `// +kubebuilder:subresource:status` annotation to all `Kind` types in generated API `*_types.go` files.


**Motivation for the change:** now that we [overwrite CRD's](https://github.com/operator-framework/operator-sdk/pull/1278/files) when regenerating them, `spec.subresources.status` is removed unless the above annotation exists for a `Kind` type.
