### PR TITLE
Added a note to the user guide on running the docker client without sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ $ operator-sdk add api --api-version=app.example.com/v1alpha1 --kind=AppService
 $ operator-sdk add controller --api-version=app.example.com/v1alpha1 --kind=AppService
 
 # Build and push the app-operator image to a public registry such as quay.io
+$ go mod vendor
 $ operator-sdk build quay.io/example/app-operator
 $ docker push quay.io/example/app-operator
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -233,6 +233,8 @@ Once this is done, there are two ways to run the operator:
 
 ### 1. Run as a Deployment inside the cluster
 
+**Note**: `operator-sdk build` invokes `docker build`. Make sure your docker daemon is running and that you can run the docker client without sudo. You can check if this is the case by running `docker version`, which should complete without errors. Follow instructions for your OS/distribution on how to start the docker daemon and configure your access permissions, if needed.
+
 Build the memcached-operator image and push it to a registry:
 ```
 $ operator-sdk build quay.io/example/memcached-operator:v0.0.1

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -82,7 +82,7 @@ The Operator SDK uses [vendoring][go_vendoring] to supply dependencies to operat
 A namespace-scoped operator (the default) watches and manages resources in a single namespace, whereas a cluster-scoped operator watches and manages resources cluster-wide. Namespace-scoped operators are preferred because of their flexibility. They enable decoupled upgrades, namespace isolation for failures and monitoring, and differing API definitions. However, there are use cases where a cluster-scoped operator may make sense. For example, the [cert-manager](https://github.com/jetstack/cert-manager) operator is often deployed with cluster-scoped permissions and watches so that it can manage issuing certificates for an entire cluster.
 
 If you'd like to create your memcached-operator project to be cluster-scoped use the following `operator-sdk new` command instead:
-```
+```sh
 $ operator-sdk new memcached-operator --cluster-scoped
 ```
 
@@ -235,22 +235,28 @@ Once this is done, there are two ways to run the operator:
 
 **Note**: `operator-sdk build` invokes `docker build`. Make sure your docker daemon is running and that you can run the docker client without sudo. You can check if this is the case by running `docker version`, which should complete without errors. Follow instructions for your OS/distribution on how to start the docker daemon and configure your access permissions, if needed.
 
-Build the memcached-operator image and push it to a registry:
+**Note**: If using go modules, run
+```sh
+$ go mod vendor
 ```
+before building the memcached-operator image.
+
+Build the memcached-operator image and push it to a registry:
+```sh
 $ operator-sdk build quay.io/example/memcached-operator:v0.0.1
 $ sed -i 's|REPLACE_IMAGE|quay.io/example/memcached-operator:v0.0.1|g' deploy/operator.yaml
 $ docker push quay.io/example/memcached-operator:v0.0.1
 ```
 
 If you created your operator using `--cluster-scoped=true`, update the service account namespace in the generated `ClusterRoleBinding` to match where you are deploying your operator.
-```
+```sh
 $ export OPERATOR_NAMESPACE=$(kubectl config view --minify -o jsonpath='{.contexts[0].context.namespace}')
 $ sed -i "s|REPLACE_NAMESPACE|$OPERATOR_NAMESPACE|g" deploy/role_binding.yaml
 ```
 
 **Note**
 If you are performing these steps on OSX, use the following commands instead:
-```
+```sh
 $ sed -i "" 's|REPLACE_IMAGE|quay.io/example/memcached-operator:v0.0.1|g' deploy/operator.yaml
 $ sed -i "" "s|REPLACE_NAMESPACE|$OPERATOR_NAMESPACE|g" deploy/role_binding.yaml
 ```

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -211,7 +211,7 @@ Once this is done, there are two ways to run the operator:
 
 ### 1. Run as a Deployment inside the cluster
 
-**Note**: `operator-sdk build` invokes `docker build`. Make sure your docker daemon is running and that you can run the docker client without sudo. You can check if this is the case by running `docker version`, which should complete without errors. Follow instructions for your OS/distribution on how to start the docker daemon and configure your access permissions, if needed.
+**Note**: `operator-sdk build` invokes `docker build` by default, and optionally `buildah bud`. If using `buildah`, skip to the `operator-sdk build` invocation instructions below. If using `docker`, make sure your docker daemon is running and that you can run the docker client without sudo. You can check if this is the case by running `docker version`, which should complete without errors. Follow instructions for your OS/distribution on how to start the docker daemon and configure your access permissions, if needed.
 
 **Note**: If using go modules, run
 ```sh


### PR DESCRIPTION
**Description of the change:**
Added a note to the user guide on running the docker client without sudo

**Motivation for the change:**
Minimize surprise for users running "operator-sdk build" and seeing the following two errors:

[foo@localhost memcached-operator]$ operator-sdk build quay.io/example/memcached-operator:v0.0.1
INFO[0018] Building OCI image quay.io/example/memcached-operator:v0.0.1 
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
Error: failed to output build image quay.io/example/memcached-operator:v0.0.1: (failed to exec []string{"docker", "build", "-f", "build/Dockerfile", "-t", "quay.io/example/memcached-operator:v0.0.1", "."}: exit status 1)

and

[foo@localhost memcached-operator]$ operator-sdk build quay.io/example/memcached-operator:v0.0.1
INFO[0000] Building OCI image quay.io/example/memcached-operator:v0.0.1 
Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post http://%2Fvar%2Frun%2Fdocker.sock/v1.26/build?buildargs=%7B%7D&buildbinds=null&cachefrom=%5B%5D&cgroupparent=&cpuperiod=0&cpuquota=0&cpusetcpus=&cpusetmems=&cpushares=0&dockerfile=build%2FDockerfile&labels=%7B%7D&memory=0&memswap=0&networkmode=default&rm=1&shmsize=0&t=quay.io%2Fexample%2Fmemcached-operator%3Av0.0.1&ulimits=null: dial unix /var/run/docker.sock: connect: permission denied
Error: failed to output build image quay.io/example/memcached-operator:v0.0.1: (failed to exec []string{"docker", "build", "-f", "build/Dockerfile", "-t", "quay.io/example/memcached-operator:v0.0.1", "."}: exit status 1)

that are seen on OOTB Fedora 30.