### PR TITLE
internal/pkg/scaffold/*,hack/tests/: use osdk master when not on tagged commit

### DIFF
--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -133,15 +133,17 @@ then
     exit 1
 fi
 
-# We can't reliably run `dep ensure` because when there are changes to
-# operator-sdk itself, and those changes are not merged upstream, we hit this
-# bug: https://github.com/golang/dep/issues/1747
-# Instead, this re-uses operator-sdk's own vendor directory.
-cp -a "$ROOTDIR"/vendor ./
-mkdir -p vendor/github.com/operator-framework/operator-sdk/
-# We cannot just use operator-sdk from $GOPATH because compilation tries to use
-# its vendor directory, which can conflict with the local one.
-cp -a "$ROOTDIR"/{internal,pkg,version,LICENSE} vendor/github.com/operator-framework/operator-sdk/
+# Right now, SDK projects still need a vendor directory, so run `go mod vendor`
+# to pull down the deps specified by the scaffolded `go.mod` file.
+go mod vendor
+
+# Use the local operator-sdk directory as the repo. To make the go toolchain
+# happy, the directory needs a `go.mod` file that specifies the module name,
+# so we need this temporary hack until we update the SDK repo itself to use
+# go modules.
+echo "module github.com/operator-framework/operator-sdk" > $ROOTDIR/go.mod
+trap_add 'rm $ROOTDIR/go.mod' EXIT
+go mod edit -replace=github.com/operator-framework/operator-sdk=$ROOTDIR
 
 operator-sdk build "$DEST_IMAGE"
 

--- a/hack/tests/e2e-helm.sh
+++ b/hack/tests/e2e-helm.sh
@@ -123,15 +123,17 @@ then
     exit 1
 fi
 
-# We can't reliably run `dep ensure` because when there are changes to
-# operator-sdk itself, and those changes are not merged upstream, we hit this
-# bug: https://github.com/golang/dep/issues/1747
-# Instead, this re-uses operator-sdk's own vendor directory.
-cp -a "$ROOTDIR"/vendor ./
-mkdir -p vendor/github.com/operator-framework/operator-sdk/
-# We cannot just use operator-sdk from $GOPATH because compilation tries to use
-# its vendor directory, which can conflict with the local one.
-cp -a "$ROOTDIR"/{internal,pkg,version,LICENSE} vendor/github.com/operator-framework/operator-sdk/
+# Right now, SDK projects still need a vendor directory, so run `go mod vendor`
+# to pull down the deps specified by the scaffolded `go.mod` file.
+go mod vendor
+
+# Use the local operator-sdk directory as the repo. To make the go toolchain
+# happy, the directory needs a `go.mod` file that specifies the module name,
+# so we need this temporary hack until we update the SDK repo itself to use
+# go modules.
+echo "module github.com/operator-framework/operator-sdk" > $ROOTDIR/go.mod
+trap_add 'rm $ROOTDIR/go.mod' EXIT
+go mod edit -replace=github.com/operator-framework/operator-sdk=$ROOTDIR
 
 operator-sdk build "$DEST_IMAGE"
 

--- a/internal/pkg/scaffold/ansible/go_mod.go
+++ b/internal/pkg/scaffold/ansible/go_mod.go
@@ -64,7 +64,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
-	github.com/operator-framework/operator-sdk v0.7.1-0.20190423132450-ec538b5b4e4c
+	github.com/operator-framework/operator-sdk master
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect

--- a/internal/pkg/scaffold/go_mod.go
+++ b/internal/pkg/scaffold/go_mod.go
@@ -56,7 +56,7 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.8.5 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
-	github.com/operator-framework/operator-sdk v0.7.1-0.20190423132450-ec538b5b4e4c
+	github.com/operator-framework/operator-sdk master
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/spf13/pflag v1.0.3

--- a/internal/pkg/scaffold/go_mod_test.go
+++ b/internal/pkg/scaffold/go_mod_test.go
@@ -57,7 +57,7 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.8.5 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
-	github.com/operator-framework/operator-sdk v0.7.1-0.20190423132450-ec538b5b4e4c
+	github.com/operator-framework/operator-sdk master
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/spf13/pflag v1.0.3

--- a/internal/pkg/scaffold/helm/go_mod.go
+++ b/internal/pkg/scaffold/helm/go_mod.go
@@ -99,7 +99,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
-	github.com/operator-framework/operator-sdk v0.7.1-0.20190423132450-ec538b5b4e4c
+	github.com/operator-framework/operator-sdk master
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.1 // indirect


### PR DESCRIPTION
**Description of the change:**
- Removes hardcoded SDK reference in templated `go.mod` files, and replaces it to reference `master` which will be resolved by the go toolchain on first run of `go mod tidy`, `go mod vendor`, `go build`, etc.
- Updates ansible and helm e2e tests to use the same `go mod` replace method as the go e2e test

**Motivation for the change:**
- Non-release SDK versions should use the SDK master branch in `go.mod`, which is [the same thing we do when using `dep`](https://github.com/operator-framework/operator-sdk/blob/d4a98bc5d2694f65ad6060db5c735163dd28714c/internal/pkg/scaffold/gopkgtoml.go#L98).