### PR TITLE
test/e2e/memcached_test.go: improve test isolation, cleanup temp files

### DIFF
--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -178,7 +178,7 @@ func TestMemcached(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Could not read template from %s: %s", src, err)
 		}
-		dstData := strings.ReplaceAll(string(srcTmpl), "github.com/example-inc", filepath.Base(absProjectPath))
+		dstData := strings.Replace(string(srcTmpl), "github.com/example-inc", filepath.Base(absProjectPath), -1)
 		if err := ioutil.WriteFile(dst, []byte(dstData), fileutil.DefaultFileMode); err != nil {
 			t.Fatalf("Could not write template output to %s: %s", dst, err)
 		}


### PR DESCRIPTION
**Description of the change:**
Use a unique temporary directory for the go e2e test, and cleanup temp files created during the test.

**Motivation for the change:**
Running the go e2e tests repeatedly locally fails when a previous run was killed because the `$GOPATH/src/example-inc` still exists.

This change puts the test directory in a more obvious temporary location (`$GOPATH/src/tmp.XXXXXXX`) and it makes it easier to re-run tests without old temporary directories getting in the way.

Lastly, this PR adds a couple of extra cleanup functions for temporary global and namespaced manifest files created during the test.
