### PR TITLE
internal/pkg/scaffold/ansible/go_mod.go: pin to prometheus-operator v0.29.0

### DIFF
--- a/internal/pkg/scaffold/ansible/go_mod.go
+++ b/internal/pkg/scaffold/ansible/go_mod.go
@@ -106,6 +106,7 @@ replace (
 )
 
 replace (
+	github.com/coreos/prometheus-operator => github.com/coreos/prometheus-operator v0.29.0
 	k8s.io/code-generator => k8s.io/code-generator v0.0.0-20181117043124-c2090bec4d9b
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20180711000925-0cf8f7e6ed1d
 )


### PR DESCRIPTION
**Description of the change:**
Pins a migrated ansible operator to use `github.com/coreos/prometheus-operator` at `v0.29.0`

**Motivation for the change:**
Fixes the currently broken master branch. The latest  prometheus-operator release (`v0.30.0`) bumped its Kubernetes dependencies and code generation to `v1.14`, which breaks SDK's usage.

Build errors that are resolved by this PR:
```
# github.com/operator-framework/operators/memcached-operator/vendor/github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1
vendor/github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1/openapi_generated.go:13056:31: "github.com/operator-framework/operators/memcached-operator/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".Duration literal.OpenAPISchemaType undefined (type "github.com/operator-framework/operators/memcached-operator/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".Duration has no field or method OpenAPISchemaType)
vendor/github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1/openapi_generated.go:13057:31: "github.com/operator-framework/operators/memcached-operator/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".Duration literal.OpenAPISchemaFormat undefined (type "github.com/operator-framework/operators/memcached-operator/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".Duration has no field or method OpenAPISchemaFormat)
```