### PR TITLE
internal/util: don't panic if project directory is outside go path

### DIFF
--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -192,17 +192,12 @@ func MustGetGopath() string {
 func MustSetGopath(currentGopath string) string {
 	var (
 		newGopath   string
-		cwdInGopath bool
 		wd          = MustGetwd()
 	)
 	for _, newGopath = range strings.Split(currentGopath, ":") {
 		if strings.HasPrefix(filepath.Dir(wd), newGopath) {
-			cwdInGopath = true
 			break
 		}
-	}
-	if !cwdInGopath {
-		log.Fatalf("Project not in $GOPATH")
 	}
 	if err := os.Setenv(GoPathEnv, newGopath); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
MustSetGopath was panic'ing (log.Fatalf) if the project directory wasn't in $GOPATH. However, with go modules this is perfectly reasonable now. Since go modules are default, I figured this should just be removed. Perhaps a new check should be added when under '--dep-manager dep'? I'm open to adding that with some direction, but this unblocked me for now.



