### PR TITLE
cmd: allow CGO_ENABLED=1

### DIFF
--- a/cmd/operator-sdk/build/cmd.go
+++ b/cmd/operator-sdk/build/cmd.go
@@ -172,7 +172,13 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	projutil.MustInProjectRoot()
-	goBuildEnv := append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0")
+	goBuildEnv := append(os.Environ(), "GOOS=linux", "GOARCH=amd64")
+
+	// If CGO_ENABLED is not set, set it to '0'.
+	if _, ok := os.LookupEnv("CGO_ENABLED"); !ok {
+		goBuildEnv = append(goBuildEnv, "CGO_ENABLED=0")
+	}
+
 	goTrimFlags := []string{"-gcflags", "all=-trimpath=${GOPATH}", "-asmflags", "all=-trimpath=${GOPATH}"}
 	absProjectPath := projutil.MustGetwd()
 	projectName := filepath.Base(absProjectPath)


### PR DESCRIPTION
stop overriding `CGO_ENABLED` on build

Fixes #1404