### PR TITLE
Added changes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,33 +49,7 @@ The following workflow is for a new **Helm** operator:
 
 ### Install the Operator SDK CLI
 
-```sh
-$ go get github.com/operator-framework/operator-sdk
-$ cd $GOPATH/src/github.com/operator-framework/operator-sdk
-$ git checkout master
-$ make dep
-$ make install
-```
-
-Alternatively, if you are using [Homebrew][homebrew_tool], you can install the SDK CLI tool with the following command:
-
-```sh
-$ brew install operator-sdk
-```
-
-```sh
-$ go get -d github.com/operator-framework/operator-sdk #This will download the git repository and not install it
-$ cd $GOPATH/src/github.com/operator-framework/operator-sdk
-$ git checkout master
-$ make dep
-$ make install
-```
-
-Alternatively, if you are using [Homebrew][homebrew_tool], you can install the SDK CLI tool with the following command:
-
-```sh
-$ brew install operator-sdk
-```
+Follow the steps in the [installation guide][install_guide] to learn how to install the Operator SDK CLI tool.
 
 ### Create and deploy an app-operator
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,8 @@ The following workflow is for a new **Helm** operator:
 First, checkout and install the operator-sdk CLI:
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/operator-framework
-$ cd $GOPATH/src/github.com/operator-framework
-$ git clone https://github.com/operator-framework/operator-sdk
-$ cd operator-sdk
+$ go get github.com/operator-framework/operator-sdk
+$ cd $GOPATH/src/github.com/operator-framework/operator-sdk
 $ git checkout master
 $ make dep
 $ make install

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ Alternatively, if you are using [Homebrew][homebrew_tool], you can install the S
 $ brew install operator-sdk
 ```
 
+```sh
+$ go get github.com/operator-framework/operator-sdk
+$ cd $GOPATH/src/github.com/operator-framework/operator-sdk
+$ git checkout master
+$ make dep
+$ make install
+```
+
+Alternatively, if you are using [Homebrew][homebrew_tool], you can install the SDK CLI tool with the following command:
+
+```sh
+$ brew install operator-sdk
+```
+
 ### Create and deploy an app-operator
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ brew install operator-sdk
 ```
 
 ```sh
-$ go get github.com/operator-framework/operator-sdk
+$ go get -d github.com/operator-framework/operator-sdk #This will download the git repository and not install it
 $ cd $GOPATH/src/github.com/operator-framework/operator-sdk
 $ git checkout master
 $ make dep

--- a/doc/user/install-operator-sdk.md
+++ b/doc/user/install-operator-sdk.md
@@ -53,7 +53,7 @@ Now you should be able to verify the binary.
 ### Install the release binary in your PATH
 
 ```
-# Linux 
+# Linux
 $ chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu && sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk && rm operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
 # macOS
 $ chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin && sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin /usr/local/bin/operator-sdk && rm operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin
@@ -70,10 +70,8 @@ $ brew install operator-sdk
 ## Compile and install from master
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/operator-framework
-$ cd $GOPATH/src/github.com/operator-framework
-$ git clone https://github.com/operator-framework/operator-sdk
-$ cd operator-sdk
+$ go get -d github.com/operator-framework/operator-sdk #This will download the git repository and not install it
+$ cd $GOPATH/src/github.com/operator-framework/operator-sdk
 $ git checkout master
 $ make dep
 $ make install

--- a/doc/user/install-operator-sdk.md
+++ b/doc/user/install-operator-sdk.md
@@ -70,7 +70,7 @@ $ brew install operator-sdk
 ## Compile and install from master
 
 ```sh
-$ go get -d github.com/operator-framework/operator-sdk #This will download the git repository and not install it
+$ go get -d github.com/operator-framework/operator-sdk # This will download the git repository and not install it
 $ cd $GOPATH/src/github.com/operator-framework/operator-sdk
 $ git checkout master
 $ make dep


### PR DESCRIPTION
The old steps are overcoming the benefits provided by "go get <repo>" command, which automatically clones the repo in "$GOPATH/src/" . Hence, with this commit, I trying to leverage-up those benefits by introducing in "go get <repo>" in README.md .