### PR TITLE
Add run local in debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## Unreleased
 
 ### Added
+
 - Adds support for building OCI images with [podman](https://podman.io/), e.g. `operator-sdk build --image-builder=podman`. ([#1488](https://github.com/operator-framework/operator-sdk/pull/1488))
-- New option for [`operator-sdk up local --debug](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#up), which can be used to start the operator in remote debug mode listening on port 2345.
+- New option for [`operator-sdk up local --debug`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#up), which can be used to start the operator in remote debug mode listening on port 2345.
 
 ### Changed
 - Remove TypeMeta declaration from the implementation of the objects [#1462](https://github.com/operator-framework/operator-sdk/pull/1462/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Added
 
 - Adds support for building OCI images with [podman](https://podman.io/), e.g. `operator-sdk build --image-builder=podman`. ([#1488](https://github.com/operator-framework/operator-sdk/pull/1488))
-- New option for [`operator-sdk up local --enable-delve`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#up), which can be used to start the operator in remote debug mode with the [delve](https://github.com/go-delve/delve) debugger listening on port 2345.
+- New option for [`operator-sdk up local --enable-delve`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#up), which can be used to start the operator in remote debug mode with the [delve](https://github.com/go-delve/delve) debugger listening on port 2345. ([#1422](https://github.com/operator-framework/operator-sdk/pull/1422))
 
 ### Changed
 - Remove TypeMeta declaration from the implementation of the objects [#1462](https://github.com/operator-framework/operator-sdk/pull/1462/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Unreleased
 
 ### Added
-
 - Adds support for building OCI images with [podman](https://podman.io/), e.g. `operator-sdk build --image-builder=podman`. ([#1488](https://github.com/operator-framework/operator-sdk/pull/1488))
+- New option for [`operator-sdk up local --debug](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#up), which can be used to start the operator in remote debug mode listening on port 2345.
 
 ### Changed
 - Remove TypeMeta declaration from the implementation of the objects [#1462](https://github.com/operator-framework/operator-sdk/pull/1462/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Added
 
 - Adds support for building OCI images with [podman](https://podman.io/), e.g. `operator-sdk build --image-builder=podman`. ([#1488](https://github.com/operator-framework/operator-sdk/pull/1488))
-- New option for [`operator-sdk up local --debug`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#up), which can be used to start the operator in remote debug mode listening on port 2345.
+- New option for [`operator-sdk up local --enable-delve`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#up), which can be used to start the operator in remote debug mode with the [delve](https://github.com/go-delve/delve) debugger listening on port 2345.
 
 ### Changed
 - Remove TypeMeta declaration from the implementation of the objects [#1462](https://github.com/operator-framework/operator-sdk/pull/1462/)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The following workflow is for a new **Helm** operator:
   - Alternatively [podman][podman_tool] `v1.2.0+` or [buildah][buildah_tool] `v1.7+`
 - [kubectl][kubectl_tool] version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.
+- Optional: [`delve`](https://github.com/go-delve/delve/tree/master/Documentation/installation) version 1.2.0+ (for `up local --enable-delve`).
 
 ## Quick Start
 

--- a/cmd/operator-sdk/up/local.go
+++ b/cmd/operator-sdk/up/local.go
@@ -119,6 +119,7 @@ func upLocal() error {
 
 	if debugFlag {
 		debugArgs := []string{"--listen=:2345", "--headless=true", "--api-version=2", "exec", outputBinName, "--"}
+		debugArgs = append(debugArgs, args...)
 
 		dc = exec.Command("dlv", debugArgs...)
 		log.Infof("Running as debug %#v", debugArgs)

--- a/cmd/operator-sdk/up/local.go
+++ b/cmd/operator-sdk/up/local.go
@@ -56,7 +56,7 @@ kubernetes cluster using a kubeconfig file.
 	upLocalCmd.Flags().StringVar(&operatorFlags, "operator-flags", "", "The flags that the operator needs. Example: \"--flag1 value1 --flag2=value2\"")
 	upLocalCmd.Flags().StringVar(&namespace, "namespace", "", "The namespace where the operator watches for changes.")
 	upLocalCmd.Flags().StringVar(&ldFlags, "go-ldflags", "", "Set Go linker options")
-	upLocalCmd.Flags().BoolVar(&debugFlag, "debug", false, "Start in debug mode")
+	upLocalCmd.Flags().BoolVar(&debugFlag, "enable-delve", false, "Start the operator using the delve debugger")
 	switch projutil.GetOperatorType() {
 	case projutil.OperatorTypeAnsible:
 		ansibleOperatorFlags = aoflags.AddTo(upLocalCmd.Flags(), "(ansible operator)")

--- a/cmd/operator-sdk/up/local.go
+++ b/cmd/operator-sdk/up/local.go
@@ -197,6 +197,9 @@ func buildLocal(outputBinName string) error {
 	if ldFlags != "" {
 		args = []string{"-ldflags", ldFlags}
 	}
+	if debugFlag {
+		args = append(args, "-gcflags=\"all=-N -l\"")
+	}
 	opts := projutil.GoCmdOptions{
 		BinName:     outputBinName,
 		PackagePath: filepath.Join(projutil.CheckAndGetProjectGoPkg(), scaffold.ManagerDir),

--- a/cmd/operator-sdk/up/local.go
+++ b/cmd/operator-sdk/up/local.go
@@ -118,11 +118,11 @@ func upLocal() error {
 	var dc *exec.Cmd
 
 	if enableDelve {
-		debugArgs := []string{"--listen=:2345", "--headless=true", "--api-version=2", "exec", outputBinName, "--"}
-		debugArgs = append(debugArgs, args...)
+		delveArgs := []string{"--listen=:2345", "--headless=true", "--api-version=2", "exec", outputBinName, "--"}
+		delveArgs = append(delveArgs, args...)
 
-		dc = exec.Command("dlv", debugArgs...)
-		log.Infof("Running as debug %#v", debugArgs)
+		dc = exec.Command("dlv", delveArgs...)
+		log.Infof("Delve debugger enabled with args %s", delveArgs)
 	} else {
 		dc = exec.Command(outputBinName, args...)
 	}

--- a/cmd/operator-sdk/up/local.go
+++ b/cmd/operator-sdk/up/local.go
@@ -56,7 +56,7 @@ kubernetes cluster using a kubeconfig file.
 	upLocalCmd.Flags().StringVar(&operatorFlags, "operator-flags", "", "The flags that the operator needs. Example: \"--flag1 value1 --flag2=value2\"")
 	upLocalCmd.Flags().StringVar(&namespace, "namespace", "", "The namespace where the operator watches for changes.")
 	upLocalCmd.Flags().StringVar(&ldFlags, "go-ldflags", "", "Set Go linker options")
-	upLocalCmd.Flags().BoolVar(&debugFlag, "enable-delve", false, "Start the operator using the delve debugger")
+	upLocalCmd.Flags().BoolVar(&enableDelve, "enable-delve", false, "Start the operator using the delve debugger")
 	switch projutil.GetOperatorType() {
 	case projutil.OperatorTypeAnsible:
 		ansibleOperatorFlags = aoflags.AddTo(upLocalCmd.Flags(), "(ansible operator)")
@@ -71,7 +71,7 @@ var (
 	operatorFlags        string
 	namespace            string
 	ldFlags              string
-	debugFlag            bool
+	enableDelve          bool
 	ansibleOperatorFlags *aoflags.AnsibleOperatorFlags
 	helmOperatorFlags    *hoflags.HelmOperatorFlags
 )
@@ -117,7 +117,7 @@ func upLocal() error {
 
 	var dc *exec.Cmd
 
-	if debugFlag {
+	if enableDelve {
 		debugArgs := []string{"--listen=:2345", "--headless=true", "--api-version=2", "exec", outputBinName, "--"}
 		debugArgs = append(debugArgs, args...)
 
@@ -197,7 +197,7 @@ func buildLocal(outputBinName string) error {
 	if ldFlags != "" {
 		args = []string{"-ldflags", ldFlags}
 	}
-	if debugFlag {
+	if enableDelve {
 		args = append(args, "-gcflags=\"all=-N -l\"")
 	}
 	opts := projutil.GoCmdOptions{

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -19,6 +19,7 @@ Usage:
 
 * `--image-build-args` string - extra, optional image build arguments as one string such as `"--build-arg https_proxy=$https_proxy"` (default "")
 * `--image-builder` string - tool to build OCI images. One of: `[docker, podman, buildah]` (default "docker")
+* `--debug` bool - starts the operator locally and enables attaching a debugger on port 2345
 * `-h, --help` - help for build
 
 ### Use

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -19,7 +19,6 @@ Usage:
 
 * `--image-build-args` string - extra, optional image build arguments as one string such as `"--build-arg https_proxy=$https_proxy"` (default "")
 * `--image-builder` string - tool to build OCI images. One of: `[docker, podman, buildah]` (default "docker")
-* `--debug` bool - starts the operator locally and enables attaching a debugger on port 2345
 * `-h, --help` - help for build
 
 ### Use

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -524,7 +524,7 @@ the operator-sdk binary itself as the operator.
 
 ##### Flags
 
-* `--debug` bool - starts the operator locally and enables attaching a debugger on port 2345
+* `--enable-delve` bool - starts the operator locally and enables the delve debugger listening on port 2345
 * `--go-ldflags` string - Set Go linker options
 * `--kubeconfig` string - The file path to Kubernetes configuration file; defaults to $HOME/.kube/config
 * `--namespace` string - The namespace where the operator watches for changes. (default "default")

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -524,6 +524,7 @@ the operator-sdk binary itself as the operator.
 
 ##### Flags
 
+* `--debug` bool - starts the operator locally and enables attaching a debugger on port 2345
 * `--go-ldflags` string - Set Go linker options
 * `--kubeconfig` string - The file path to Kubernetes configuration file; defaults to $HOME/.kube/config
 * `--namespace` string - The namespace where the operator watches for changes. (default "default")


### PR DESCRIPTION
**Description of the change:**
Add a debug flag for operator-sdk up local, which wraps the built binary into the dlv command to attach a remote debugger

**Motivation for the change:**
To simplify the process to attach a debugger when developing an operator locally