### PR TITLE
Makefile,version,cmd/operator-sdk/version: add git compile-time variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ else
 endif
 
 VERSION = $(shell git describe --dirty --tags --always)
+GIT_COMMIT = $(shell git rev-parse HEAD)
 REPO = github.com/operator-framework/operator-sdk
 BUILD_PATH = $(REPO)/cmd/operator-sdk
 PKGS = $(shell go list ./... | grep -v /vendor/)
@@ -42,7 +43,14 @@ clean:
 .PHONY: all test format dep clean
 
 install:
-	$(Q)go install -gcflags "all=-trimpath=${GOPATH}" -asmflags "all=-trimpath=${GOPATH}" $(BUILD_PATH)
+	$(Q)go install \
+		-gcflags "all=-trimpath=${GOPATH}" \
+		-asmflags "all=-trimpath=${GOPATH}" \
+		-ldflags " \
+			-X '${REPO}/version.GitVersion=${VERSION}' \
+			-X '${REPO}/version.GitCommit=${GIT_COMMIT}' \
+		" \
+		$(BUILD_PATH)
 
 release_x86_64 := \
 	build/operator-sdk-$(VERSION)-x86_64-linux-gnu \
@@ -54,7 +62,14 @@ build/operator-sdk-%-x86_64-linux-gnu: GOARGS = GOOS=linux GOARCH=amd64
 build/operator-sdk-%-x86_64-apple-darwin: GOARGS = GOOS=darwin GOARCH=amd64
 
 build/%: $(SOURCES)
-	$(Q)$(GOARGS) go build -gcflags "all=-trimpath=${GOPATH}" -asmflags "all=-trimpath=${GOPATH}" -o $@ $(BUILD_PATH)
+	$(Q)$(GOARGS) go build \
+		-gcflags "all=-trimpath=${GOPATH}" \
+		-asmflags "all=-trimpath=${GOPATH}" \
+		-ldflags " \
+			-X '${REPO}/version.GitVersion=${VERSION}' \
+			-X '${REPO}/version.GitCommit=${GIT_COMMIT}' \
+		" \
+		-o $@ $(BUILD_PATH)
 
 build/%.asc:
 	$(Q){ \

--- a/cmd/operator-sdk/version/cmd.go
+++ b/cmd/operator-sdk/version/cmd.go
@@ -27,7 +27,11 @@ func NewCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Prints the version of operator-sdk",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("operator-sdk version:", ver.Version)
+			version := ver.GitVersion
+			if version == "unknown" {
+				version = ver.Version
+			}
+			fmt.Printf("operator-sdk version: %s, commit: %s\n", version, ver.GitCommit)
 		},
 	}
 	return versionCmd

--- a/release.sh
+++ b/release.sh
@@ -31,7 +31,7 @@ fi
 
 # Detect whether versions in code were updated.
 VER_FILE="version/version.go"
-CURR_VER="$(sed -nr 's|Version = "(.+)"|\1|p' "$VER_FILE" | tr -d ' \t\n')"
+CURR_VER="$(sed -nr 's|\s+Version\s+= "(.+)"|\1|p' "$VER_FILE" | tr -d ' \t\n')"
 if [[ "$VER" != "$CURR_VER" ]]; then
 	echo "version is not set correctly in $VER_FILE"
 	exit 1

--- a/version/version.go
+++ b/version/version.go
@@ -15,5 +15,7 @@
 package version
 
 var (
-	Version = "v0.7.0+git"
+	Version    = "v0.7.0+git"
+	GitVersion = "unknown"
+	GitCommit  = "unknown"
 )


### PR DESCRIPTION
**Description of the change:**
- Adds `version.GitVersion` and `version.GitCommit`
- Updates `operator-sdk version` command to print them
- Updates Makefile to set them at compile-time.

**Motivation for the change:**
Many users seem to be using non-release versions of `operator-sdk`, so lots of issues typically only report the version as something like `v0.7.0+git`.

To make it easier to troubleshoot issues, it would be nice to have the `operator-sdk version` command print the git version and commit strings.
