### PR TITLE
internal/util/projutil/project_util.go: fix repo lookup when CWD is $GOPATH/src

### DIFF
--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -142,7 +142,7 @@ func CheckAndGetProjectGoPkg() string {
 	gopath := MustSetGopath(MustGetGopath())
 	goSrc := filepath.Join(gopath, SrcDir)
 	wd := MustGetwd()
-	currPkg := strings.Replace(wd, goSrc+fsep, "", 1)
+	currPkg := strings.Replace(wd, goSrc, "", 1)
 	// strip any "/" prefix from the repo path.
 	return strings.TrimPrefix(currPkg, fsep)
 }


### PR DESCRIPTION
**Description of the change:**
Fixes logic that extracts repo portion of path from $GOPATH when CWD is $GOPATH/src

**Motivation for the change:**
Closes #1423 
