### PR TITLE
.travis.yaml: Add $GOPATH/pkg/mod to travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: required
 cache:
   directories:
     - $HOME/.cache/go-build
+    - $GOPATH/pkg/mod
 
 go:
 - 1.12.x


### PR DESCRIPTION
**Description of the change:**
Adds `$GOPATH/pkg/mod` to travis cache

**Motivation for the change:**
This directory contains cached go modules, which take significant time to re-download during each build. Adding this to the travis cache should speed up builds.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
