### PR TITLE
Specify --keyserver to gpg(1) call if needed

### DIFF
--- a/doc/user/install-operator-sdk.md
+++ b/doc/user/install-operator-sdk.md
@@ -47,6 +47,12 @@ To download the key, use the following command, replacing `$KEY_ID` with the RSA
 $ gpg --recv-key "$KEY_ID"
 ```
 
+You'll need to specify a key server if one hasn't been configured. For example:
+
+```sh
+$ gpg --keyserver keyserver.ubuntu.com --recv-key "$KEY_ID"
+```
+
 Now you should be able to verify the binary.
 
 


### PR DESCRIPTION
If one hasn't been configured yet, the user will need to specify a keyserver when running gpg(1).

Thanks for the quick review on the previous PR, I didn't find an existing one for this :-)