### PR TITLE
cmd/operator-sdk/main.go: remove --version flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Removed
 
 - The SDK will no longer run `defaulter-gen` on running `operator-sdk generate k8s`. Defaulting for CRDs should be handled with mutating admission webhooks. ([#1288](https://github.com/operator-framework/operator-sdk/pull/1288))
+- The `--version` flag was removed. Users should use the `operator-sdk version` command. ([#link](link))
 - **Breaking Change**: The `test cluster` subcommand and the corresponding `--enable-tests` flag for the `build` subcommand have been removed ([#1414](https://github.com/operator-framework/operator-sdk/pull/1414))
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 ### Removed
 
 - The SDK will no longer run `defaulter-gen` on running `operator-sdk generate k8s`. Defaulting for CRDs should be handled with mutating admission webhooks. ([#1288](https://github.com/operator-framework/operator-sdk/pull/1288))
-- The `--version` flag was removed. Users should use the `operator-sdk version` command. ([#link](link))
+- The `--version` flag was removed. Users should use the `operator-sdk version` command. ([#1444](https://github.com/operator-framework/operator-sdk/pull/1444))
 - **Breaking Change**: The `test cluster` subcommand and the corresponding `--enable-tests` flag for the `build` subcommand have been removed ([#1414](https://github.com/operator-framework/operator-sdk/pull/1414))
 
 ### Bug Fixes

--- a/cmd/operator-sdk/main.go
+++ b/cmd/operator-sdk/main.go
@@ -34,7 +34,6 @@ import (
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/up"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/version"
 	flags "github.com/operator-framework/operator-sdk/internal/pkg/flags"
-	osdkversion "github.com/operator-framework/operator-sdk/version"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -44,9 +43,8 @@ import (
 
 func main() {
 	root := &cobra.Command{
-		Use:     "operator-sdk",
-		Short:   "An SDK for building operators with ease",
-		Version: osdkversion.Version,
+		Use:   "operator-sdk",
+		Short: "An SDK for building operators with ease",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if viper.GetBool(flags.VerboseOpt) {
 				err := projutil.SetGoVerbose()


### PR DESCRIPTION
**Description of the change:**
Removing `--version` flag.

**Motivation for the change:**
We currently have two implementations of printing the version. This and `operator-sdk version`, which prints more information. Removing this is easier than continuing to maintain both.
