### PR TITLE
internal/pkg/scaffold/helm/role.go: add custom rules for namespaced scope

### DIFF
--- a/internal/pkg/scaffold/helm/role.go
+++ b/internal/pkg/scaffold/helm/role.go
@@ -76,8 +76,8 @@ func CreateRoleScaffold(cfg *rest.Config, chart *chart.Chart) (*scaffold.Role, e
 	if len(clusterResourceRules) > 0 {
 		log.Info("Scaffolding ClusterRole and ClusterRolebinding for cluster scoped resources in the helm chart")
 		roleScaffold.IsClusterScoped = true
-		roleScaffold.CustomRules = append(roleScaffold.CustomRules, append(clusterResourceRules, namespacedResourceRules...)...)
 	}
+	roleScaffold.CustomRules = append(roleScaffold.CustomRules, append(clusterResourceRules, namespacedResourceRules...)...)
 
 	log.Warn("The RBAC rules generated in deploy/role.yaml are based on the chart's default manifest." +
 		" Some rules may be missing for resources that are only enabled with custom values, and" +


### PR DESCRIPTION
**Description of the change:**
Always add custom roles when generating Helm role rules, regardless of whether the operator is cluster-scoped or not.

**Motivation for the change:**
This is a regression that should be fixed. We didn't catch it in reviews and CI somehow passed for #1434.