### PR TITLE
Helm: RBAC generation fixes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Bug Fixes
 
+- Fixes a regression that causes Helm RBAC generation to contain an empty custom ruleset when the chart's default manifest contains only namespaced resources. ([#1456](https://github.com/operator-framework/operator-sdk/pull/1456))
+- Fixes an issue that causes Helm RBAC generation to fail when creating new operators with a Kubernetes context configured to connect to an OpenShift cluster. ([#1461](https://github.com/operator-framework/operator-sdk/pull/1461))
+
 ## v0.8.0
 
 ### Added

--- a/hack/tests/e2e-helm.sh
+++ b/hack/tests/e2e-helm.sh
@@ -94,7 +94,12 @@ fi
 
 # create and build the operator
 pushd "$GOTMP"
-operator-sdk new nginx-operator --api-version=helm.example.com/v1alpha1 --kind=Nginx --type=helm
+log=$(operator-sdk new nginx-operator --api-version=helm.example.com/v1alpha1 --kind=Nginx --type=helm 2>&1)
+echo $log
+if echo $log | grep -q "failed to generate RBAC rules"; then
+    echo FAIL expected successful generation of RBAC rules
+    exit 1
+fi
 
 pushd nginx-operator
 sed -i 's|\(FROM quay.io/operator-framework/helm-operator\)\(:.*\)\?|\1:dev|g' build/Dockerfile

--- a/internal/pkg/scaffold/helm/role.go
+++ b/internal/pkg/scaffold/helm/role.go
@@ -184,12 +184,13 @@ func getServerVersionAndResources(cfg *rest.Config) (*version.Info, []*metav1.AP
 }
 
 func getDefaultManifests(c *chart.Chart, kubeVersion *version.Info) ([]tiller.Manifest, error) {
+	v := strings.TrimSuffix(fmt.Sprintf("%s.%s", kubeVersion.Major, kubeVersion.Minor), "+")
 	renderOpts := renderutil.Options{
 		ReleaseOptions: chartutil.ReleaseOptions{
 			IsInstall: true,
 			IsUpgrade: false,
 		},
-		KubeVersion: fmt.Sprintf("%s.%s", kubeVersion.Major, kubeVersion.Minor),
+		KubeVersion: v,
 	}
 
 	renderedTemplates, err := renderutil.Render(c, &chart.Config{}, renderOpts)

--- a/internal/pkg/scaffold/helm/role.go
+++ b/internal/pkg/scaffold/helm/role.go
@@ -70,6 +70,7 @@ func CreateRoleScaffold(cfg *rest.Config, chart *chart.Chart) (*scaffold.Role, e
 	if err != nil {
 		log.Warnf("Using default RBAC rules: failed to generate RBAC rules: %s", err)
 		roleScaffold.SkipDefaultRules = false
+		return roleScaffold, nil
 	}
 
 	// Use a ClusterRole if cluster scoped resources are listed in the chart


### PR DESCRIPTION
**Description of the change:**
- Fail e2e test if RBAC generation fails
- Fix RBAC version parsing to handle OCP versions
- Return role scaffold immediately upon rule generation failure

**Motivation for the change:**
This is a follow-on to #1456, which fixed a regression in the Helm RBAC rule generation.

In CI, the RBAC rule generation is currently failing and falling back to the default rule set when using the OCP cluster in Travis. In OCP, the kubernetes version number is reported as `1.11+` (in minikube and upstream kubernetes, it is reported as `1.11`). Helm's libraries to generate manifests fail to parse the kubernetes version when it contains the plus sign, so Helm e2e testing has fallen back to the default non-generated rules ever since RBAC generation was added.

The reason that the regression made it through CI is that the changes from #1434 affect only the code path for successful RBAC generation. Since that code path is not running in Travis, it was never tested, and the e2e tests continued to pass because the default non-generated RBAC rules are sufficient for the helm chart used in the e2e tests.

This PR fixes the underlying issue with kubernetes version parsing and improves the e2e test so that future regressions in RBAC rule generation are caught more easily.


