### PR TITLE
Remove TypeMeta declaration from the implementation of the objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 ### Changed
+- Remove TypeMeta declaration from the implementation of the objects [#1462](https://github.com/operator-framework/operator-sdk/pull/1462/)
 
 ### Deprecated
 

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -79,12 +79,7 @@ To do this, pass the CRD's `AddToScheme` function and its List type object to th
 [AddToFrameworkScheme][scheme-link] function. For our example memcached-operator, it looks like this:
 
 ```go
-memcachedList := &cachev1alpha1.MemcachedList{
-    TypeMeta: metav1.TypeMeta{
-        Kind:       "Memcached",
-        APIVersion: "cache.example.com/v1alpha1",
-    },
-}
+memcachedList := &cachev1alpha1.MemcachedList{}
 err := framework.AddToFrameworkScheme(apis.AddToScheme, memcachedList)
 if err != nil {
     t.Fatalf("failed to add custom resource scheme to framework: %v", err)
@@ -168,10 +163,6 @@ This is how we can create a custom memcached custom resource with a size of 3:
 ```go
 // create memcached custom resource
 exampleMemcached := &cachev1alpha1.Memcached{
-    TypeMeta: metav1.TypeMeta{
-        Kind:       "Memcached",
-        APIVersion: "cache.example.com/v1alpha1",
-    },
     ObjectMeta: metav1.ObjectMeta{
         Name:      "example-memcached",
         Namespace: namespace,

--- a/doc/user/client.md
+++ b/doc/user/client.md
@@ -438,10 +438,6 @@ func (r *ReconcileKind) deploymentForApp(m *appv1alpha1.App) *appsv1.Deployment 
 	replicas := m.Spec.Size
 
 	dep := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name,
 			Namespace: m.Namespace,

--- a/example/memcached-operator/memcached_controller.go.tmpl
+++ b/example/memcached-operator/memcached_controller.go.tmpl
@@ -170,10 +170,6 @@ func (r *ReconcileMemcached) deploymentForMemcached(m *cachev1alpha1.Memcached) 
 	replicas := m.Spec.Size
 
 	dep := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name,
 			Namespace: m.Namespace,

--- a/internal/pkg/scorecard/helpers.go
+++ b/internal/pkg/scorecard/helpers.go
@@ -176,10 +176,6 @@ func UpdateSuiteStates(suite scapiv1alpha1.ScorecardSuiteResult) scapiv1alpha1.S
 
 func CombineScorecardOutput(outputs []scapiv1alpha1.ScorecardOutput, log string) scapiv1alpha1.ScorecardOutput {
 	output := scapiv1alpha1.ScorecardOutput{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ScorecardOutput",
-			APIVersion: "osdk.openshift.io/v1alpha1",
-		},
 		Log: log,
 	}
 	for _, item := range outputs {

--- a/pkg/leader/leader.go
+++ b/pkg/leader/leader.go
@@ -70,12 +70,7 @@ func Become(ctx context.Context, lockName string) error {
 	}
 
 	// check for existing lock from this pod, in case we got restarted
-	existing := &corev1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "ConfigMap",
-		},
-	}
+	existing := &corev1.ConfigMap{}
 	key := crclient.ObjectKey{Namespace: ns, Name: lockName}
 	err = client.Get(ctx, key, existing)
 
@@ -98,10 +93,6 @@ func Become(ctx context.Context, lockName string) error {
 	}
 
 	cm := &corev1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "ConfigMap",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            lockName,
 			Namespace:       ns,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -112,10 +112,6 @@ func initOperatorService(ctx context.Context, client crclient.Client, port int32
 			Namespace: namespace,
 			Labels:    label,
 		},
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
 				{

--- a/pkg/metrics/service-monitor.go
+++ b/pkg/metrics/service-monitor.go
@@ -61,10 +61,6 @@ func GenerateServiceMonitor(s *v1.Service) *monitoringv1.ServiceMonitor {
 	}
 
 	return &monitoringv1.ServiceMonitor{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ServiceMonitor",
-			APIVersion: "monitoring.coreos.com/v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      s.ObjectMeta.Name,
 			Namespace: s.ObjectMeta.Namespace,

--- a/pkg/test/framework.go
+++ b/pkg/test/framework.go
@@ -114,12 +114,7 @@ type addToSchemeFunc func(*runtime.Scheme) error
 // the addToScheme function (located in the register.go file of their operator
 // project) and the List struct for their custom resource. For example, for a
 // memcached operator, the list stuct may look like:
-// &MemcachedList{
-//	TypeMeta: metav1.TypeMeta{
-//		Kind: "Memcached",
-//		APIVersion: "cache.example.com/v1alpha1",
-//		},
-//	}
+// &MemcachedList{}
 // The List object is needed because the CRD has not always been fully registered
 // by the time this function is called. If the CRD takes more than 5 seconds to
 // become ready, this function throws an error

--- a/test/e2e/incluster-test-code/memcached_test.go.tmpl
+++ b/test/e2e/incluster-test-code/memcached_test.go.tmpl
@@ -37,12 +37,7 @@ var (
 )
 
 func TestMemcached(t *testing.T) {
-	memcachedList := &operator.MemcachedList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Memcached",
-			APIVersion: "cache.example.com/v1alpha1",
-		},
-	}
+	memcachedList := &operator.MemcachedList{}
 	err := framework.AddToFrameworkScheme(apis.AddToScheme, memcachedList)
 	if err != nil {
 		t.Fatalf("Failed to add custom resource scheme to framework: %v", err)
@@ -61,10 +56,6 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 	}
 	// create memcached custom resource
 	exampleMemcached := &operator.Memcached{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Memcached",
-			APIVersion: "cache.example.com/v1alpha1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-memcached",
 			Namespace: namespace,

--- a/test/test-framework/pkg/controller/memcachedrs/memcachedrs_controller.go
+++ b/test/test-framework/pkg/controller/memcachedrs/memcachedrs_controller.go
@@ -193,10 +193,6 @@ func (r *ReconcileMemcachedRS) replicaSetForMemcached(m *cachev1alpha1.Memcached
 	replicas := m.Spec.NumNodes
 
 	replicaSet := &appsv1.ReplicaSet{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "ReplicaSet",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name,
 			Namespace: m.Namespace,

--- a/test/test-framework/test/e2e/memcached_test.go
+++ b/test/test-framework/test/e2e/memcached_test.go
@@ -37,12 +37,7 @@ const (
 )
 
 func TestMemcached(t *testing.T) {
-	memcachedList := &operator.MemcachedList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Memcached",
-			APIVersion: "cache.example.com/v1alpha1",
-		},
-	}
+	memcachedList := &operator.MemcachedList{}
 	err := framework.AddToFrameworkScheme(apis.AddToScheme, memcachedList)
 	if err != nil {
 		t.Fatalf("Failed to add custom resource scheme to framework: %v", err)
@@ -61,10 +56,6 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 	}
 	// create memcached custom resource
 	exampleMemcached := &operator.Memcached{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Memcached",
-			APIVersion: "cache.example.com/v1alpha1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-memcached",
 			Namespace: namespace,


### PR DESCRIPTION
**Description of the change:**
* Remove TypeMeta declaration from the implementation of the objects

Note that the TypeMeta struct and its values are automatically filled when an object is initialized in this way is unnecessary to add this values and indeed shows a not good practice at all since the dev can add wrong values which will cause issues as for example not allow the client GET the object. 

Following an example which could cause error just to example this scenario. 
```go
    ...
    route := &routev1.Route{
        TypeMeta: v1.TypeMeta{  // TODO (user): Remove the TypeMeta declared
            APIVersion: "v1",   // the correct value should be `"route.openshift.io/v1"`
            Kind:       "Route",
        },
        ObjectMeta: v1.ObjectMeta{
            Name:      name,
            Namespace: namespace,
            Labels:    ls,
        },
    }
    ...
```

Following an example of the issue faced, it is because of the `TypeMeta.APIVersion` informed is invalid for the resource object schema. It is not recommended declared the `TypeMeta` since it will be implicitly generated. 

```shell
get route: (no kind "Route" is registered for version "v1" in scheme "k8s.io/client-go/kubernetes/scheme/register.go:61")
```

**Motivation for the change:**

Face issues like the above example because of this unnecessary declaration. 