### PR TITLE
pkg/ansible: pass along requests for virtual resources to cluster

### DIFF
--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -13,6 +13,7 @@ pip install --user docker openshift jmespath
 
 deploy_prereqs() {
     kubectl create -f "$OPERATORDIR/deploy/service_account.yaml"
+    oc adm policy add-cluster-role-to-user cluster-admin -z memcached-operator || :
     kubectl create -f "$OPERATORDIR/deploy/role.yaml"
     kubectl create -f "$OPERATORDIR/deploy/role_binding.yaml"
     kubectl create -f "$OPERATORDIR/deploy/crds/ansible_v1alpha1_memcached_crd.yaml"
@@ -37,6 +38,7 @@ cat "$ROOTDIR/test/ansible-memcached/watches-finalizer.yaml" >> memcached-operat
 cat "$ROOTDIR/test/ansible-memcached/prepare-test-image.yml" >> memcached-operator/molecule/test-local/prepare.yml
 # Append v1 kind to watches to test watching already registered GVK
 cat "$ROOTDIR/test/ansible-memcached/watches-v1-kind.yaml" >> memcached-operator/watches.yaml
+
 
 
 # Test local

--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -14,6 +14,7 @@ trap_add 'rm -rf $GOTMP' EXIT
 
 deploy_operator() {
     kubectl create -f "$OPERATORDIR/deploy/service_account.yaml"
+    oc adm policy add-cluster-role-to-user cluster-admin -z memcached-operator || :
     kubectl create -f "$OPERATORDIR/deploy/role.yaml"
     kubectl create -f "$OPERATORDIR/deploy/role_binding.yaml"
     kubectl create -f "$OPERATORDIR/deploy/crds/ansible_v1alpha1_memcached_crd.yaml"

--- a/pkg/ansible/runner/eventapi/eventapi.go
+++ b/pkg/ansible/runner/eventapi/eventapi.go
@@ -160,6 +160,7 @@ func (e *EventReceiver) handleEvents(w http.ResponseWriter, r *http.Request) {
 	// https://ansible-runner.readthedocs.io/en/latest/external_interface.html#event-structure
 	if event.UUID == "" {
 		e.logger.V(1).Info("Dropping event that is not a JobEvent")
+		e.logger.V(2).Info("Dropped event", "event", event, "request", string(body))
 	} else {
 		// timeout if the channel blocks for too long
 		timeout := time.NewTimer(10 * time.Second)

--- a/test/ansible-memcached/asserts.yml
+++ b/test/ansible-memcached/asserts.yml
@@ -60,7 +60,8 @@
       - name: Verify that test-service was created
         assert:
           that: lookup('k8s', kind='Service', api_version='v1', namespace=namespace, resource_name='test-service')
-      
+        when: "'project.openshift.io' in lookup('k8s', cluster_info='api_groups')"
+
       - name: Verify that project testing-foo was created
         assert:
           that: lookup('k8s', kind='Namespace', api_version='v1', resource_name='testing-foo')

--- a/test/ansible-memcached/asserts.yml
+++ b/test/ansible-memcached/asserts.yml
@@ -60,11 +60,11 @@
       - name: Verify that test-service was created
         assert:
           that: lookup('k8s', kind='Service', api_version='v1', namespace=namespace, resource_name='test-service')
-        when: "'project.openshift.io' in lookup('k8s', cluster_info='api_groups')"
 
       - name: Verify that project testing-foo was created
         assert:
           that: lookup('k8s', kind='Namespace', api_version='v1', resource_name='testing-foo')
+        when: "'project.openshift.io' in lookup('k8s', cluster_info='api_groups')"
 
       - when: molecule_yml.scenario.name == "test-local"
         block:

--- a/test/ansible-memcached/asserts.yml
+++ b/test/ansible-memcached/asserts.yml
@@ -60,6 +60,10 @@
       - name: Verify that test-service was created
         assert:
           that: lookup('k8s', kind='Service', api_version='v1', namespace=namespace, resource_name='test-service')
+      
+      - name: Verify that project testing-foo was created
+        assert:
+          that: lookup('k8s', kind='Namespace', api_version='v1', resource_name='testing-foo')
 
       - when: molecule_yml.scenario.name == "test-local"
         block:

--- a/test/ansible-memcached/tasks.yml
+++ b/test/ansible-memcached/tasks.yml
@@ -53,3 +53,14 @@
         namespace: "{{ meta.namespace }}"
       data:
         test: aGVsbG8K
+- name: Get cluster api_groups
+  set_fact:
+    api_groups: "{{ lookup('k8s', cluster_info='api_groups', kubeconfig=lookup('env', 'K8S_AUTH_KUBECONFIG')) }}"
+
+- name: create project if projects are available
+  k8s:
+    api_version: project.openshift.io/v1
+    kind: Project
+    metadata:
+      name: testing-foo
+  when: projects.openshift.io in api_groups

--- a/test/ansible-memcached/tasks.yml
+++ b/test/ansible-memcached/tasks.yml
@@ -59,8 +59,9 @@
 
 - name: create project if projects are available
   k8s:
-    api_version: project.openshift.io/v1
-    kind: Project
-    metadata:
-      name: testing-foo
-  when: projects.openshift.io in api_groups
+    definition:
+      apiVersion: project.openshift.io/v1
+      kind: Project
+      metadata:
+        name: testing-foo
+  when: "'project.openshift.io' in api_groups"


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
* Defining virtual resources as any resource that does not have the
  ability to "get", "list", and "watch" as all are needed for the cache.
* creating a new struct to handle the caching of the cluster APIResources
**Motivation for the change:**

Using a virtual resource in the cache will cause issues because the informer is unable to be started.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
