### PR TITLE
use dynamic mapper

### DIFF
--- a/pkg/ansible/run.go
+++ b/pkg/ansible/run.go
@@ -27,6 +27,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
+	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -67,6 +68,7 @@ func Run(flags *aoflags.AnsibleOperatorFlags) error {
 	mgr, err := manager.New(cfg, manager.Options{
 		Namespace:          namespace,
 		MetricsBindAddress: "0.0.0.0:8383",
+		MapperProvider:     restmapper.NewDynamicRESTMapper,
 	})
 	if err != nil {
 		log.Error(err, "Failed to create a new manager.")


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Using the dynamic rest mapper so ansible can create CRDs and then use that API

**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
@jmazzitelli