### PR TITLE
*: use "/" for Go package paths and filepath.Separator for on-disk paths

### DIFF
--- a/cmd/operator-sdk/build/cmd.go
+++ b/cmd/operator-sdk/build/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -100,7 +101,7 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 	if projutil.IsOperatorGo() {
 		opts := projutil.GoCmdOptions{
 			BinName:     filepath.Join(absProjectPath, scaffold.BuildBinDir, projectName),
-			PackagePath: filepath.Join(projutil.CheckAndGetProjectGoPkg(), scaffold.ManagerDir),
+			PackagePath: path.Join(projutil.CheckAndGetProjectGoPkg(), filepath.ToSlash(scaffold.ManagerDir)),
 			Args:        goTrimFlags,
 			Env:         goBuildEnv,
 			GoMod:       projutil.IsDepManagerGoMod(),

--- a/cmd/operator-sdk/new/cmd.go
+++ b/cmd/operator-sdk/new/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -146,7 +147,7 @@ func mustBeNewProject() {
 
 func doGoScaffold() error {
 	cfg := &input.Config{
-		Repo:           filepath.Join(projutil.CheckAndGetProjectGoPkg(), projectName),
+		Repo:           path.Join(projutil.CheckAndGetProjectGoPkg(), projectName),
 		AbsProjectPath: filepath.Join(projutil.MustGetwd(), projectName),
 		ProjectName:    projectName,
 	}

--- a/cmd/operator-sdk/up/local.go
+++ b/cmd/operator-sdk/up/local.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -183,7 +184,7 @@ func buildLocal(outputBinName string) error {
 	}
 	opts := projutil.GoCmdOptions{
 		BinName:     outputBinName,
-		PackagePath: filepath.Join(projutil.CheckAndGetProjectGoPkg(), scaffold.ManagerDir),
+		PackagePath: path.Join(projutil.CheckAndGetProjectGoPkg(), filepath.ToSlash(scaffold.ManagerDir)),
 		Args:        args,
 		GoMod:       projutil.IsDepManagerGoMod(),
 	}

--- a/internal/pkg/scaffold/test_setup.go
+++ b/internal/pkg/scaffold/test_setup.go
@@ -29,7 +29,7 @@ import (
 const (
 	// test constants describing an app operator project
 	appProjectName = "app-operator"
-	appRepo        = "github.com" + filePathSep + "example-inc" + filePathSep + appProjectName
+	appRepo        = "github.com/example-inc/" + appProjectName
 	appApiVersion  = "app.example.com/v1alpha1"
 	appKind        = "AppService"
 )
@@ -47,7 +47,7 @@ func mustGetImportPath() string {
 	if err != nil {
 		log.Fatalf("Failed to get working directory: (%v)", err)
 	}
-	return filepath.Join(wd, appRepo)
+	return filepath.Join(wd, filepath.FromSlash(appRepo))
 }
 
 func setupScaffoldAndWriter() (*Scaffold, *bytes.Buffer) {

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -136,15 +136,17 @@ func getHomeDir() (string, error) {
 	return homedir.Expand(hd)
 }
 
-// CheckAndGetProjectGoPkg checks if this project's repository path is rooted under $GOPATH and returns the current directory's import path
+// CheckAndGetProjectGoPkg checks if this project's repository path is rooted
+// under $GOPATH and returns the current directory's import path,
 // e.g: "github.com/example-inc/app-operator"
 func CheckAndGetProjectGoPkg() string {
 	gopath := MustSetGopath(MustGetGopath())
 	goSrc := filepath.Join(gopath, SrcDir)
 	wd := MustGetwd()
-	currPkg := strings.Replace(wd, goSrc, "", 1)
-	// strip any "/" prefix from the repo path.
-	return strings.TrimPrefix(currPkg, fsep)
+	pathedPkg := strings.Replace(wd, goSrc, "", 1)
+	// Make sure package only contains the "/" separator and no others, and
+	// trim any leading/trailing "/".
+	return strings.Trim(filepath.ToSlash(pathedPkg), "/")
 }
 
 // GetOperatorType returns type of operator is in cwd.

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -105,7 +105,7 @@ func TestMemcached(t *testing.T) {
 	}
 
 	sdkRepo := "github.com/operator-framework/operator-sdk"
-	localSDKPath := filepath.Join(gopath, "src", sdkRepo)
+	localSDKPath := filepath.Join(gopath, "src", filepath.FromSlash(sdkRepo))
 
 	replace := getGoModReplace(t, localSDKPath)
 	if replace.repo != sdkRepo {
@@ -114,7 +114,7 @@ func TestMemcached(t *testing.T) {
 			// stub go.mod into the local SDK repo referred to in
 			// memcached-operator's go.mod, which allows go to recognize
 			// the local SDK repo as a module.
-			sdkModPath := filepath.Join(replace.repo, "go.mod")
+			sdkModPath := filepath.Join(filepath.FromSlash(replace.repo), "go.mod")
 			err = ioutil.WriteFile(sdkModPath, []byte("module "+sdkRepo), fileutil.DefaultFileMode)
 			if err != nil {
 				t.Fatalf("Failed to write main repo go.mod file: %v", err)


### PR DESCRIPTION
**Description of the change:** ensure all import/package paths use `/` and file/dir paths use `filepath.Separator`.

**Motivation for the change:** Even though we do not officially support windows, we should still use proper path separators in all cases.
