### PR TITLE
cmd/operator-sdk/build/cmd.go: support podman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- Adds support for building OCI images with [podman](https://podman.io/), e.g. `operator-sdk build --image-builder=podman`. ([#1488](https://github.com/operator-framework/operator-sdk/pull/1488))
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following workflow is for a new **Helm** operator:
 - [git][git_tool]
 - [go][go_tool] version v1.12+.
 - [docker][docker_tool] version 17.03+.
+  - Alternatively [podman][podman_tool] `v1.2.0+` or [buildah][buildah_tool] `v1.7+`
 - [kubectl][kubectl_tool] version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.
 
@@ -166,6 +167,8 @@ Operator SDK is under Apache 2.0 license. See the [LICENSE][license_file] file f
 [git_tool]:https://git-scm.com/downloads
 [go_tool]:https://golang.org/dl/
 [docker_tool]:https://docs.docker.com/install/
+[podman_tool]:https://github.com/containers/libpod/blob/master/install.md
+[buildah_tool]:https://github.com/containers/buildah/blob/master/install.md
 [kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [controller_runtime]: https://github.com/kubernetes-sigs/controller-runtime
 [ansible_user_guide]:./doc/ansible/user-guide.md

--- a/cmd/operator-sdk/build/cmd.go
+++ b/cmd/operator-sdk/build/cmd.go
@@ -52,14 +52,14 @@ For example:
 		RunE: buildFunc,
 	}
 	buildCmd.Flags().StringVar(&imageBuildArgs, "image-build-args", "", "Extra image build arguments as one string such as \"--build-arg https_proxy=$https_proxy\"")
-	buildCmd.Flags().StringVar(&imageBuilder, "image-builder", "docker", "Tool to build OCI images. One of: [docker, buildah]")
+	buildCmd.Flags().StringVar(&imageBuilder, "image-builder", "docker", "Tool to build OCI images. One of: [docker, podman, buildah]")
 	return buildCmd
 }
 
 func createBuildCommand(imageBuilder, context, dockerFile, image string, imageBuildArgs ...string) (*exec.Cmd, error) {
 	var args []string
 	switch imageBuilder {
-	case "docker":
+	case "docker", "podman":
 		args = append(args, "build", "-f", dockerFile, "-t", image)
 	case "buildah":
 		args = append(args, "bud", "--format=docker", "-f", dockerFile, "-t", image)

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -18,7 +18,7 @@ Usage:
 ### Flags
 
 * `--image-build-args` string - extra, optional image build arguments as one string such as `"--build-arg https_proxy=$https_proxy"` (default "")
-* `--image-builder` string - tool to build OCI images. One of: `[docker, buildah]` (default "docker")
+* `--image-builder` string - tool to build OCI images. One of: `[docker, podman, buildah]` (default "docker")
 * `-h, --help` - help for build
 
 ### Use


### PR DESCRIPTION
**Description of the change:**
Adds support for running `podman` during `operator-sdk build`

**Motivation for the change:**
See #1207
