### PR TITLE
[WIP] Auto reload the local operator for code changes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1735,6 +1735,7 @@
     "github.com/coreos/go-semver/semver",
     "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1",
     "github.com/coreos/prometheus-operator/pkg/client/versioned/typed/monitoring/v1",
+    "github.com/fsnotify/fsnotify",
     "github.com/ghodss/yaml",
     "github.com/go-logr/logr",
     "github.com/go-logr/zapr",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -61,6 +61,10 @@
   name = "github.com/spf13/cobra"
   version = "0.0.3"
 
+[[constraint]]
+  name = "github.com/fsnotify/fsnotify"
+  version = "1.4.7"
+
 # We need overrides for the following imports because dep can't resolve them
 # correctly. The easiest way to get this right is to use the versions that
 # k8s.io/helm uses. See https://github.com/helm/helm/blob/v2.13.1/glide.lock

--- a/cmd/operator-sdk/up/local.go
+++ b/cmd/operator-sdk/up/local.go
@@ -35,6 +35,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 
+	"github.com/fsnotify/fsnotify"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -56,6 +57,7 @@ kubernetes cluster using a kubeconfig file.
 	upLocalCmd.Flags().StringVar(&operatorFlags, "operator-flags", "", "The flags that the operator needs. Example: \"--flag1 value1 --flag2=value2\"")
 	upLocalCmd.Flags().StringVar(&namespace, "namespace", "", "The namespace where the operator watches for changes.")
 	upLocalCmd.Flags().StringVar(&ldFlags, "go-ldflags", "", "Set Go linker options")
+	upLocalCmd.Flags().BoolVar(&disableAutoReload, "disable-auto-reload", false, "Disable auto reload of the operator for sources code changes.")
 	switch projutil.GetOperatorType() {
 	case projutil.OperatorTypeAnsible:
 		ansibleOperatorFlags = aoflags.AddTo(upLocalCmd.Flags(), "(ansible operator)")
@@ -70,6 +72,7 @@ var (
 	operatorFlags        string
 	namespace            string
 	ldFlags              string
+	disableAutoReload    bool
 	ansibleOperatorFlags *aoflags.AnsibleOperatorFlags
 	helmOperatorFlags    *hoflags.HelmOperatorFlags
 )
@@ -99,6 +102,7 @@ func upLocalFunc(cmd *cobra.Command, args []string) error {
 }
 
 func upLocal() error {
+	log.Debug("Running Go operator")
 	projutil.MustInProjectRoot()
 	absProjectPath := projutil.MustGetwd()
 	projectName := filepath.Base(absProjectPath)
@@ -112,27 +116,143 @@ func upLocal() error {
 		extraArgs := strings.Split(operatorFlags, " ")
 		args = append(args, extraArgs...)
 	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Fatalf("Failed to start the Filesystem watcher: (%v)", err)
+	}
+	defer watcher.Close()
+
 	dc := exec.Command(outputBinName, args...)
-	c := make(chan os.Signal)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-c
-		err := dc.Process.Kill()
-		if err != nil {
-			log.Fatalf("Failed to terminate the operator: (%v)", err)
-		}
-		os.Exit(0)
-	}()
 	dc.Env = os.Environ()
 	// only set env var if user explicitly specified a kubeconfig path
 	if kubeConfig != "" {
 		dc.Env = append(dc.Env, fmt.Sprintf("%v=%v", k8sutil.KubeConfigEnvVar, kubeConfig))
 	}
 	dc.Env = append(dc.Env, fmt.Sprintf("%v=%v", k8sutil.WatchNamespaceEnvVar, namespace))
-	if err := projutil.ExecCmd(dc); err != nil {
-		return fmt.Errorf("failed to run operator locally: (%v)", err)
+	if err := projutil.StartCmd(dc); err != nil {
+		log.Fatalf("Failed to run operator locally: (%v)", err)
+	}
+
+	closeChannel := make(chan os.Signal)
+	signal.Notify(closeChannel, os.Interrupt, syscall.SIGTERM)
+
+	if disableAutoReload {
+		go func() {
+			<-closeChannel
+			log.Debug("Received interrupt signal")
+			if err := dc.Process.Kill(); err != nil {
+				log.Fatalf("Failed to terminate the operator: (%v)", err)
+			}
+			os.Exit(0)
+		}()
+		if err := dc.Wait(); err != nil {
+			log.Fatalf("Failed to run and exit operator locally: (%v)", err)
+
+		}
+		return nil
+	}
+
+	done := make(chan bool)
+	go func(dc *exec.Cmd) {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				log.Debugf("Event triggered: (%v)", event)
+				if !ok {
+					log.Fatal("Filesystem watcher channel for events closed")
+				}
+				if !strings.HasSuffix(event.Name, ".go") {
+					continue
+				}
+				if err := dc.Process.Kill(); err != nil {
+					log.Fatalf("Failed to terminate the operator: (%v)", err)
+				}
+				dc = exec.Command(outputBinName, args...)
+				dc.Env = os.Environ()
+				// only set env var if user explicitly specified a kubeconfig path
+				if kubeConfig != "" {
+					dc.Env = append(dc.Env, fmt.Sprintf("%v=%v", k8sutil.KubeConfigEnvVar, kubeConfig))
+				}
+				dc.Env = append(dc.Env, fmt.Sprintf("%v=%v", k8sutil.WatchNamespaceEnvVar, namespace))
+
+				if err := buildLocal(outputBinName); err != nil {
+					log.Fatalf("Failed to build operator to run locally: (%v)", err)
+				}
+				if err := projutil.StartCmd(dc); err != nil {
+					log.Fatalf("Failed to run operator locally: (%v)", err)
+				}
+			case err, ok := <-watcher.Errors:
+				log.Debugf("Filesystem watcher error: (%v)", err)
+				if !ok {
+					log.Fatal("Filesystem watcher channel for events closed")
+				}
+			case <-closeChannel:
+				log.Debug("Received interrupt signal")
+				if err := dc.Process.Kill(); err != nil {
+					log.Fatalf("Failed to terminate the operator: (%v)", err)
+				}
+				os.Exit(0)
+			}
+		}
+	}(dc)
+
+	err = addRecursiveWatch(watcher, absProjectPath)
+	if err != nil {
+		log.Fatalf("Failed to watch directory recursively: (%v)", err)
+	}
+	<-done
+
+	return nil
+}
+
+// addRecursiveWatch handles adding watches recursively for the path provided
+// and its subdirectories.  If a non-directory is specified, this call is a no-op.
+// Taken from https://github.com/openshift/origin/blob/85eb37b34f0657631592356d020cef5a58470f8e/pkg/util/fsnotification/fsnotification.go#L16
+func addRecursiveWatch(watcher *fsnotify.Watcher, path string) error {
+	file, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("error introspecting path %s: %v", path, err)
+	}
+	if !file.IsDir() {
+		return nil
+	}
+
+	folders, err := getSubFolders(path)
+	for _, v := range folders {
+		if strings.HasPrefix(v, path+"/.git") {
+			continue
+		}
+		if strings.HasPrefix(v, path+"/build") {
+			continue
+		}
+		//log.Debugf("Adding watch on directory: %s", v)
+		err = watcher.Add(v)
+		if err != nil {
+			// "no space left on device" issues are usually resolved via
+			// $ sudo sysctl fs.inotify.max_user_watches=65536
+			return fmt.Errorf("error adding watcher for path %s: %v", v, err)
+		}
 	}
 	return nil
+}
+
+// getSubFolders recursively retrieves all subfolders of the specified path.
+func getSubFolders(path string) (paths []string, err error) {
+	err = filepath.Walk(path, func(newPath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			paths = append(paths, newPath)
+		}
+		return nil
+	})
+	return paths, err
 }
 
 func upLocalAnsible() error {

--- a/internal/util/projutil/exec.go
+++ b/internal/util/projutil/exec.go
@@ -24,11 +24,23 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// ExecCmd runs the given command and wait for completion
 func ExecCmd(cmd *exec.Cmd) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	log.Debugf("Running %#v", cmd.Args)
 	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to exec %#v: %v", cmd.Args, err)
+	}
+	return nil
+}
+
+// StartCmd runs the given command without waiting for completion
+func StartCmd(cmd *exec.Cmd) error {
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	log.Debugf("Running %#v", cmd.Args)
+	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to exec %#v: %v", cmd.Args, err)
 	}
 	return nil
@@ -121,14 +133,13 @@ func setCommandFields(c *exec.Cmd, opts GoCmdOptions) {
 	}
 }
 
+// GoModOn returns true if go modules are on in one of the above two ways.
 // From https://github.com/golang/go/wiki/Modules:
 //	You can activate module support in one of two ways:
 //	- Invoke the go command in a directory outside of the $GOPATH/src tree,
 //		with a valid go.mod file in the current directory or any parent of it and
 //		the environment variable GO111MODULE unset (or explicitly set to auto).
 //	- Invoke the go command with GO111MODULE=on environment variable set.
-//
-// GoModOn returns true if go modules are on in one of the above two ways.
 func GoModOn() (bool, error) {
 	v, ok := os.LookupEnv(GoModEnv)
 	if v == "off" {


### PR DESCRIPTION
When running the operator using `operator-sdk up local` command,
restart the operator whenever there is a change in Go source code
in the file-system.

Fixes #1484

- [x] Flag to disable auto-reload
- [ ] Tests
- [ ] Flag to set ignore directories (default: `.git,build`)