### PR TITLE
internal/pkg/scaffold/types.go: remove broken kubebuilder book link

### DIFF
--- a/internal/pkg/scaffold/types.go
+++ b/internal/pkg/scaffold/types.go
@@ -56,7 +56,7 @@ import (
 type {{.Resource.Kind}}Spec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io
+	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 }
 
 // {{.Resource.Kind}}Status defines the observed state of {{.Resource.Kind}}

--- a/internal/pkg/scaffold/types.go
+++ b/internal/pkg/scaffold/types.go
@@ -64,7 +64,7 @@ type {{.Resource.Kind}}Spec struct {
 type {{.Resource.Kind}}Status struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io
+	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/internal/pkg/scaffold/types.go
+++ b/internal/pkg/scaffold/types.go
@@ -56,7 +56,7 @@ import (
 type {{.Resource.Kind}}Spec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
+	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io
 }
 
 // {{.Resource.Kind}}Status defines the observed state of {{.Resource.Kind}}
@@ -64,7 +64,7 @@ type {{.Resource.Kind}}Spec struct {
 type {{.Resource.Kind}}Status struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
+	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/internal/pkg/scaffold/types_test.go
+++ b/internal/pkg/scaffold/types_test.go
@@ -51,7 +51,7 @@ import (
 type AppServiceSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
+	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 }
 
 // AppServiceStatus defines the observed state of AppService
@@ -59,7 +59,7 @@ type AppServiceSpec struct {
 type AppServiceStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
+	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
validation documentation deep link to book.kubebuilder.io in generated CR types was invalid.
