### PR TITLE
Option for starting operators out of cluster under the dlv debugger: operator-sdk up local --dlv

### DIFF
--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -523,6 +523,7 @@ the operator-sdk binary itself as the operator.
 
 ##### Flags
 
+* `--dlv` - Start the operator under the dlv debugger
 * `--go-ldflags` string - Set Go linker options
 * `--kubeconfig` string - The file path to Kubernetes configuration file; defaults to $HOME/.kube/config
 * `--namespace` string - The namespace where the operator watches for changes. (default "default")

--- a/internal/util/projutil/exec.go
+++ b/internal/util/projutil/exec.go
@@ -27,6 +27,7 @@ import (
 func ExecCmd(cmd *exec.Cmd) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
 	log.Debugf("Running %#v", cmd.Args)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to exec %#v: %v", cmd.Args, err)


### PR DESCRIPTION
**Description of the change:**
Added option for starting operators out of cluster under the dlv debugger: operator-sdk up local --dlv

**Motivation for the change:**
Make debugging of operators more convenient
