### PR TITLE
cmd: Avoid trailing whitespace in new operators

### DIFF
--- a/cmd/operator-sdk/new/cmd.go
+++ b/cmd/operator-sdk/new/cmd.go
@@ -306,7 +306,7 @@ func doHelmScaffold() error {
 	}
 
 	valuesPath := filepath.Join("<project_dir>", helm.HelmChartsDir, chart.GetMetadata().GetName(), "values.yaml")
-	crSpec := fmt.Sprintf("# Default values copied from %s\n\n%s", valuesPath, chart.GetValues().GetRaw())
+	crSpec := fmt.Sprintf("# Default values copied from %s\n%s", valuesPath, chart.GetValues().GetRaw())
 
 	k8sCfg, err := config.GetConfig()
 	if err != nil {


### PR DESCRIPTION
When creating a new operator, the deploy/crds/charts_*_cr.yaml file
contains a line with trailing whitespace. This causes common linters to
fail by default on new operators.

The generated file contains a line of docs, saying where default values
were copied from, then one blank line with trailing whitespace, then the
YAML with values. The whitespace seems to come in from later formatting,
not the logic that adds the comment and values YAML. As a simple
solution, simply don't create the blank line and let the YAML immediately
precede the inline comment explaining their providence.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>