### PR TITLE
internal/annotations/prefix.go: define annotation separators, join and split functions

### DIFF
--- a/internal/annotations/prefix.go
+++ b/internal/annotations/prefix.go
@@ -32,12 +32,20 @@ func JoinPrefix(tokens ...string) string {
 }
 
 func SplitPrefix(prefix string) ([]string, error) {
+	if !strings.Contains(prefix, prefixSep) {
+		return nil, fmt.Errorf(`prefix "%s" does not contain the prefix separator "%s"`, prefix, prefixSep)
+	}
 	split := strings.Split(prefix, prefixSep)
 	if len(split) == 0 || (len(split) == 1 && split[0] == "") {
-		return nil, fmt.Errorf("prefix '%s' has no prefix tokens delimited by '%s'", prefix, prefixSep)
+		return nil, fmt.Errorf(`prefix "%s" has no prefix tokens delimited by "%s"`, prefix, prefixSep)
 	}
 	if strings.TrimSpace(split[0]) != SDKPrefix {
-		return nil, fmt.Errorf("prefix '%s' does not have SDK prefix '%s'", prefix, prefixSep)
+		return nil, fmt.Errorf(`prefix "%s" does not have SDK prefix "%s"`, prefix, prefixSep)
+	}
+	for i, p := range split {
+		if strings.TrimSpace(p) == "" {
+			return nil, fmt.Errorf(`prefix "%s" contains an empty token after colon %d`, prefix, i)
+		}
 	}
 	return split, nil
 }
@@ -47,9 +55,17 @@ func JoinPath(elements ...string) string {
 }
 
 func SplitPath(path string) ([]string, error) {
+	if !strings.Contains(path, pathSep) {
+		return nil, fmt.Errorf(`path "%s" does not contain the path separator "%s"`, path, pathSep)
+	}
 	split := strings.Split(path, pathSep)
 	if len(split) == 0 || (len(split) == 1 && split[0] == "") {
-		return nil, fmt.Errorf("path '%s' has no path elements delimited by '%s'", path, pathSep)
+		return nil, fmt.Errorf(`path "%s" has no path elements delimited by "%s"`, path, pathSep)
+	}
+	for i, p := range split {
+		if strings.TrimSpace(p) == "" {
+			return nil, fmt.Errorf(`path "%s" contains an empty path element after dot %d`, path, i)
+		}
 	}
 	return split, nil
 }
@@ -59,9 +75,18 @@ func JoinAnnotation(prefixedPath, value string) string {
 }
 
 func SplitAnnotation(annotation string) (prefixedPath, val string, err error) {
+	if !strings.Contains(annotation, valueSep) {
+		return "", "", fmt.Errorf(`annotation "%s" does not contain the value separator "%s"`, annotation, valueSep)
+	}
 	split := strings.Split(annotation, valueSep)
 	if len(split) != 2 {
-		return "", "", fmt.Errorf("annotation '%s' does not have exactly one value separator '%s'", annotation, valueSep)
+		return "", "", fmt.Errorf(`annotation "%s" does not have exactly one value separator "%s"`, annotation, valueSep)
+	}
+	if strings.TrimSpace(split[0]) == "" {
+		return "", "", fmt.Errorf(`annotation "%s" contains an empty annotation component`, annotation)
+	}
+	if strings.TrimSpace(split[1]) == "" {
+		return "", "", fmt.Errorf(`annotation "%s" contains an empty value component`, annotation)
 	}
 	return split[0], split[1], nil
 }

--- a/internal/annotations/prefix.go
+++ b/internal/annotations/prefix.go
@@ -40,11 +40,11 @@ func SplitPrefix(prefix string) ([]string, error) {
 		return nil, fmt.Errorf(`prefix "%s" has no prefix tokens delimited by "%s"`, prefix, prefixSep)
 	}
 	if strings.TrimSpace(split[0]) != SDKPrefix {
-		return nil, fmt.Errorf(`prefix "%s" does not have SDK prefix "%s"`, prefix, prefixSep)
+		return nil, fmt.Errorf(`prefix "%s" does not have SDK prefix "%s"`, prefix, SDKPrefix)
 	}
 	for i, p := range split {
 		if strings.TrimSpace(p) == "" {
-			return nil, fmt.Errorf(`prefix "%s" contains an empty token after colon %d`, prefix, i)
+			return nil, fmt.Errorf(`prefix "%s" contains an empty token after colon index %d`, prefix, i)
 		}
 	}
 	return split, nil
@@ -64,7 +64,7 @@ func SplitPath(path string) ([]string, error) {
 	}
 	for i, p := range split {
 		if strings.TrimSpace(p) == "" {
-			return nil, fmt.Errorf(`path "%s" contains an empty path element after dot %d`, path, i)
+			return nil, fmt.Errorf(`path "%s" contains an empty path element after dot index %d`, path, i)
 		}
 	}
 	return split, nil

--- a/internal/annotations/prefix.go
+++ b/internal/annotations/prefix.go
@@ -1,0 +1,67 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotations
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	SDKPrefix = "+operator-sdk"
+
+	prefixSep = ":"
+	pathSep   = "."
+	valueSep  = "="
+)
+
+func JoinPrefix(tokens ...string) string {
+	return strings.Join(tokens, prefixSep)
+}
+
+func SplitPrefix(prefix string) ([]string, error) {
+	split := strings.Split(prefix, prefixSep)
+	if len(split) == 0 || (len(split) == 1 && split[0] == "") {
+		return nil, fmt.Errorf("prefix '%s' has no prefix tokens delimited by '%s'", prefix, prefixSep)
+	}
+	if strings.TrimSpace(split[0]) != SDKPrefix {
+		return nil, fmt.Errorf("prefix '%s' does not have SDK prefix '%s'", prefix, prefixSep)
+	}
+	return split, nil
+}
+
+func JoinPath(elements ...string) string {
+	return strings.Join(elements, pathSep)
+}
+
+func SplitPath(path string) ([]string, error) {
+	split := strings.Split(path, pathSep)
+	if len(split) == 0 || (len(split) == 1 && split[0] == "") {
+		return nil, fmt.Errorf("path '%s' has no path elements delimited by '%s'", path, pathSep)
+	}
+	return split, nil
+}
+
+func JoinAnnotation(prefixedPath, value string) string {
+	return prefixedPath + valueSep + value
+}
+
+func SplitAnnotation(annotation string) (prefixedPath, val string, err error) {
+	split := strings.Split(annotation, valueSep)
+	if len(split) != 2 {
+		return "", "", fmt.Errorf("annotation '%s' does not have exactly one value separator '%s'", annotation, valueSep)
+	}
+	return split[0], split[1], nil
+}

--- a/internal/annotations/prefix_test.go
+++ b/internal/annotations/prefix_test.go
@@ -1,0 +1,87 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotations
+
+import (
+	"testing"
+)
+
+func TestSplitPrefix(t *testing.T) {
+	cases := []struct {
+		prefix    string
+		result    []string
+		wantError bool
+	}{
+		{"", nil, true},
+		{"+operator-sdk", nil, true},
+		{"+operator-sdk:", nil, true},
+		{"+operator-sdk:foo", []string{"foo"}, false},
+		{"+operator-sdk:foo:bar", []string{"foo", "bar"}, false},
+	}
+
+	for i, c := range cases {
+		got, err := SplitPrefix(c.prefix)
+		if err != nil && !c.wantError {
+			t.Errorf("Case %d: wanted result %+q, got error: %v", i, c.result, err)
+		} else if err == nil && c.wantError {
+			t.Errorf("Case %d: wanted error, got result %+q", i, got)
+		}
+	}
+}
+
+func TestSplitPath(t *testing.T) {
+	cases := []struct {
+		path      string
+		result    []string
+		wantError bool
+	}{
+		{"", nil, true},
+		{"+operator-sdk", nil, true},
+		{"+operator-sdk:foo", nil, true},
+		{"+operator-sdk:foo:bar.", nil, true},
+		{"+operator-sdk:foo:bar.baz", []string{"+operator-sdk:foo:bar", "baz"}, false},
+	}
+
+	for i, c := range cases {
+		got, err := SplitPath(c.path)
+		if err != nil && !c.wantError {
+			t.Errorf("Case %d: wanted result %+q, got error: %v", i, c.result, err)
+		} else if err == nil && c.wantError {
+			t.Errorf("Case %d: wanted error, got result %+q", i, got)
+		}
+	}
+}
+
+func TestSplitAnnotation(t *testing.T) {
+	cases := []struct {
+		annotation string
+		path, val  string
+		wantError  bool
+	}{
+		{"", "", "", true},
+		{"+operator-sdk", "", "", true},
+		{"+operator-sdk:foo:bar.baz=", "", "", true},
+		{"+operator-sdk:foo:bar.baz=value", "+operator-sdk:foo:bar.baz", "value", false},
+	}
+
+	for i, c := range cases {
+		gotPath, gotVal, err := SplitAnnotation(c.annotation)
+		if err != nil && !c.wantError {
+			t.Errorf("Case %d: wanted path %s and val %s, got error: %v", i, c.path, c.val, err)
+		} else if err == nil && c.wantError {
+			t.Errorf("Case %d: wanted error, got path %s and val %s", i, gotPath, gotVal)
+		}
+	}
+}

--- a/internal/annotations/prefix_test.go
+++ b/internal/annotations/prefix_test.go
@@ -20,68 +20,77 @@ import (
 
 func TestSplitPrefix(t *testing.T) {
 	cases := []struct {
+		name      string
 		prefix    string
 		result    []string
 		wantError bool
 	}{
-		{"", nil, true},
-		{"+operator-sdk", nil, true},
-		{"+operator-sdk:", nil, true},
-		{"+operator-sdk:foo", []string{"foo"}, false},
-		{"+operator-sdk:foo:bar", []string{"foo", "bar"}, false},
+		{"empty", "", nil, true},
+		{"no prefix separator or use case prefix", "+operator-sdk", nil, true},
+		{"no use case prefix", "+operator-sdk:", nil, true},
+		{"use case prefix", "+operator-sdk:foo", []string{"foo"}, false},
+		{"use case prefix and one path token", "+operator-sdk:foo:bar", []string{"foo", "bar"}, false},
 	}
 
-	for i, c := range cases {
-		got, err := SplitPrefix(c.prefix)
-		if err != nil && !c.wantError {
-			t.Errorf("Case %d: wanted result %+q, got error: %v", i, c.result, err)
-		} else if err == nil && c.wantError {
-			t.Errorf("Case %d: wanted error, got result %+q", i, got)
-		}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := SplitPrefix(c.prefix)
+			if err != nil && !c.wantError {
+				t.Errorf("Wanted result %+q, got error: %v", c.result, err)
+			} else if err == nil && c.wantError {
+				t.Errorf("Wanted error, got result %+q", got)
+			}
+		})
 	}
 }
 
 func TestSplitPath(t *testing.T) {
 	cases := []struct {
+		name      string
 		path      string
 		result    []string
 		wantError bool
 	}{
-		{"", nil, true},
-		{"+operator-sdk", nil, true},
-		{"+operator-sdk:foo", nil, true},
-		{"+operator-sdk:foo:bar.", nil, true},
-		{"+operator-sdk:foo:bar.baz", []string{"+operator-sdk:foo:bar", "baz"}, false},
+		{"empty", "", nil, true},
+		{"no prefix separator or use case prefix", "+operator-sdk", nil, true},
+		{"use case prefix", "+operator-sdk:foo", nil, true},
+		{"use case prefix and path element with empty child path element", "+operator-sdk:foo:bar.", nil, true},
+		{"use case prefix and path elements", "+operator-sdk:foo:bar.baz", []string{"+operator-sdk:foo:bar", "baz"}, false},
 	}
 
-	for i, c := range cases {
-		got, err := SplitPath(c.path)
-		if err != nil && !c.wantError {
-			t.Errorf("Case %d: wanted result %+q, got error: %v", i, c.result, err)
-		} else if err == nil && c.wantError {
-			t.Errorf("Case %d: wanted error, got result %+q", i, got)
-		}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := SplitPath(c.path)
+			if err != nil && !c.wantError {
+				t.Errorf("Wanted result %+q, got error: %v", c.result, err)
+			} else if err == nil && c.wantError {
+				t.Errorf("Wanted error, got result %+q", got)
+			}
+		})
 	}
 }
 
 func TestSplitAnnotation(t *testing.T) {
 	cases := []struct {
+		name       string
 		annotation string
 		path, val  string
 		wantError  bool
 	}{
-		{"", "", "", true},
-		{"+operator-sdk", "", "", true},
-		{"+operator-sdk:foo:bar.baz=", "", "", true},
-		{"+operator-sdk:foo:bar.baz=value", "+operator-sdk:foo:bar.baz", "value", false},
+		{"empty", "", "", "", true},
+		{"no prefix separator or use case prefix", "+operator-sdk", "", "", true},
+		{"prefixed path with empty value", "+operator-sdk:foo:bar.baz=", "", "", true},
+		{"prefixed path with value", "+operator-sdk:foo:bar.baz=value", "+operator-sdk:foo:bar.baz", "value", false},
 	}
 
-	for i, c := range cases {
-		gotPath, gotVal, err := SplitAnnotation(c.annotation)
-		if err != nil && !c.wantError {
-			t.Errorf("Case %d: wanted path %s and val %s, got error: %v", i, c.path, c.val, err)
-		} else if err == nil && c.wantError {
-			t.Errorf("Case %d: wanted error, got path %s and val %s", i, gotPath, gotVal)
-		}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotPath, gotVal, err := SplitAnnotation(c.annotation)
+			if err != nil && !c.wantError {
+				t.Errorf("Wanted path %s and val %s, got error: %v", c.path, c.val, err)
+			} else if err == nil && c.wantError {
+				t.Errorf("Wanted error, got path %s and val %s", gotPath, gotVal)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**Description of the change:** implementation of code annotation parser helpers described in #1324 

**Motivation for the change:** #1324 added a spec for SDK code annotations. These constants and helper functions are primitives for reading and writing general SDK annotations. They are to be used by parsers for specific implementations of annotations.
