### PR TITLE
Add --local-operator-flags for testing with --up-local

### DIFF
--- a/cmd/operator-sdk/test/local.go
+++ b/cmd/operator-sdk/test/local.go
@@ -40,16 +40,17 @@ import (
 var deployTestDir = filepath.Join(scaffold.DeployDir, "test")
 
 type testLocalConfig struct {
-	kubeconfig        string
-	globalManPath     string
-	namespacedManPath string
-	goTestFlags       string
-	moleculeTestFlags string
-	namespace         string
-	upLocal           bool
-	noSetup           bool
-	debug             bool
-	image             string
+	kubeconfig         string
+	globalManPath      string
+	namespacedManPath  string
+	goTestFlags        string
+	moleculeTestFlags  string
+	namespace          string
+	upLocal            bool
+	noSetup            bool
+	debug              bool
+	image              string
+	localOperatorFlags string
 }
 
 var tlConfig testLocalConfig
@@ -70,6 +71,7 @@ func newTestLocalCmd() *cobra.Command {
 	testCmd.Flags().BoolVar(&tlConfig.noSetup, "no-setup", false, "Disable test resource creation")
 	testCmd.Flags().BoolVar(&tlConfig.debug, "debug", false, "Enable debug-level logging")
 	testCmd.Flags().StringVar(&tlConfig.image, "image", "", "Use a different operator image from the one specified in the namespaced manifest")
+	testCmd.Flags().StringVar(&tlConfig.localOperatorFlags, "local-operator-flags", "", "The flags that the operator needs (while using --up-local). Example: \"--flag1 value1 --flag2=value2\"")
 
 	return testCmd
 }
@@ -207,6 +209,9 @@ func testLocalGoFunc(cmd *cobra.Command, args []string) error {
 	}
 	if tlConfig.upLocal {
 		testArgs = append(testArgs, "-"+test.LocalOperatorFlag)
+		if tlConfig.localOperatorFlags != "" {
+			testArgs = append(testArgs, "-"+test.LocalOperatorArgs, tlConfig.localOperatorFlags)
+		}
 	}
 	opts := projutil.GoTestOptions{
 		GoCmdOptions: projutil.GoCmdOptions{

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -487,6 +487,7 @@ Runs the tests locally
 * `--go-test-flags` string - Additional flags to pass to go test
 * `--molecule-test-flags` string - Additional flags to pass to molecule test
 * `--up-local` - enable running operator locally with go run instead of as an image in the cluster
+* `--local-operator-flags` string - flags that the operator needs, while using --up-local (e.g. \"--flag1 value1 --flag2=value2\")
 * `--no-setup` - disable test resource creation
 * `--image` string - use a different operator image from the one specified in the namespaced manifest
 * `-h, --help` - help for local

--- a/pkg/test/main_entry.go
+++ b/pkg/test/main_entry.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -42,6 +43,7 @@ const (
 	SingleNamespaceFlag   = "singleNamespace"
 	TestNamespaceEnv      = "TEST_NAMESPACE"
 	LocalOperatorFlag     = "localOperator"
+	LocalOperatorArgs     = "localOperatorArgs"
 )
 
 func MainEntry(m *testing.M) {
@@ -51,6 +53,7 @@ func MainEntry(m *testing.M) {
 	namespacedManPath := flag.String(NamespacedManPathFlag, "", "path to rbac manifest")
 	singleNamespace = flag.Bool(SingleNamespaceFlag, false, "enable single namespace mode")
 	localOperator := flag.Bool(LocalOperatorFlag, false, "enable if operator is running locally (not in cluster)")
+	localOperatorArgs := flag.String(LocalOperatorArgs, "", "flags that the operator needs (while using --up-local). example: \"--flag1 value1 --flag2=value2\"")
 	flag.Parse()
 	// go test always runs from the test directory; change to project root
 	err := os.Chdir(*projRoot)
@@ -74,7 +77,11 @@ func MainEntry(m *testing.M) {
 		if err := projutil.GoBuild(opts); err != nil {
 			log.Fatalf("Failed to build local operator binary: %s", err)
 		}
-		localCmd = exec.Command(outputBinName)
+		args := []string{}
+		if *localOperatorArgs != "" {
+			args = append(args, strings.Split(*localOperatorArgs, " ")...)
+		}
+		localCmd = exec.Command(outputBinName, args...)
 		localCmd.Stdout = &localCmdOutBuf
 		localCmd.Stderr = &localCmdErrBuf
 		c := make(chan os.Signal)


### PR DESCRIPTION
**operator-sdk test** : add `--local-operator-flags` to `operator-sdk test local --up-local` command

**why this change was made**: without this flag, we cannot write tests to test operator code that uses command line flags. A flag like this is already there in `operator-sdk up local` command (`--operator-flags`). 

Fixes https://github.com/operator-framework/operator-sdk/issues/1476

**Description of the change:**

This patch adds `--local-operator-flags` to
`operator-sdk test local --up-local` command

It is provides the functionality provided by
`--operator-flags` flag in `operator-sdk up local --operator-flags` command.

**Motivation for the change:**

At present there is no way to pass command line flags to an operator
while testing using `operator-sdk test local --up-local` command.

There is a flag `--go-test-flags` but it cannot be used to pass flags to
the operator code being tested using `--up-local` flag

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
Signed-off-by: Nikhil Thomas <nikthoma@redhat.com >