### PR TITLE
pkg/helm/release/manager.go: improve error handling with failed releases

### DIFF
--- a/pkg/helm/controller/reconcile.go
+++ b/pkg/helm/controller/reconcile.go
@@ -169,7 +169,7 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 	if !manager.IsInstalled() {
 		installedRelease, err := manager.InstallRelease(context.TODO())
 		if err != nil {
-			log.Error(err, "Failed to install release")
+			log.Error(err, "Release failed")
 			status.SetCondition(types.HelmAppCondition{
 				Type:    types.ConditionReleaseFailed,
 				Status:  types.StatusTrue,
@@ -210,7 +210,7 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 	if manager.IsUpdateRequired() {
 		previousRelease, updatedRelease, err := manager.UpdateRelease(context.TODO())
 		if err != nil {
-			log.Error(err, "Failed to update release")
+			log.Error(err, "Release failed")
 			status.SetCondition(types.HelmAppCondition{
 				Type:    types.ConditionReleaseFailed,
 				Status:  types.StatusTrue,

--- a/pkg/helm/release/manager.go
+++ b/pkg/helm/release/manager.go
@@ -226,15 +226,22 @@ func installRelease(ctx context.Context, tiller *tiller.ReleaseServer, namespace
 		// Workaround for helm/helm#3338
 		if releaseResponse.GetRelease() != nil {
 			uninstallReq := &services.UninstallReleaseRequest{
-				Name:  releaseResponse.GetRelease().GetName(),
+				Name:  name,
 				Purge: true,
 			}
 			_, uninstallErr := tiller.UninstallRelease(ctx, uninstallReq)
-			if uninstallErr != nil {
-				return nil, fmt.Errorf("failed to roll back failed installation: %s: %s", uninstallErr, err)
+
+			// In certain cases, InstallRelease will return a partial release in
+			// the response even when it doesn't record the release in its release
+			// store. In that case the rollback will fail with a not found error
+			// because there was nothing to rollback. So we check for that and
+			// skip logging the rollback error when the error was that it didn't
+			// exist.
+			if uninstallErr != nil && !notFoundErr(uninstallErr) {
+				return nil, fmt.Errorf("failed installation (%s) and failed rollback (%s)", err, uninstallErr)
 			}
 		}
-		return nil, err
+		return nil, fmt.Errorf("failed to install release: %s", err)
 	}
 	return releaseResponse.GetRelease(), nil
 }
@@ -260,12 +267,18 @@ func updateRelease(ctx context.Context, tiller *tiller.ReleaseServer, name strin
 				Name:  name,
 				Force: true,
 			}
+
+			// As of Helm 2.13, if UpdateRelease returns a non-nil release, that
+			// means the release was also recorded in the release store.
+			// Therefore, we should perform the rollback when we have a non-nil
+			// release. Any rollback error here would be unexpected, so always
+			// log both the update and rollback errors.
 			_, rollbackErr := tiller.RollbackRelease(ctx, rollbackReq)
 			if rollbackErr != nil {
-				return nil, fmt.Errorf("failed to roll back failed update: %s: %s", rollbackErr, err)
+				return nil, fmt.Errorf("failed update (%s) and failed rollback (%s)", err, rollbackErr)
 			}
 		}
-		return nil, err
+		return nil, fmt.Errorf("failed to update release: %s", err)
 	}
 	return releaseResponse.GetRelease(), nil
 }

--- a/pkg/helm/release/manager.go
+++ b/pkg/helm/release/manager.go
@@ -233,10 +233,12 @@ func installRelease(ctx context.Context, tiller *tiller.ReleaseServer, namespace
 
 			// In certain cases, InstallRelease will return a partial release in
 			// the response even when it doesn't record the release in its release
-			// store. In that case the rollback will fail with a not found error
-			// because there was nothing to rollback. So we check for that and
-			// skip logging the rollback error when the error was that it didn't
-			// exist.
+			// store (e.g. when there is an error rendering the release manifest).
+			// In that case the rollback will fail with a not found error because
+			// there was nothing to rollback.
+			//
+			// Only log a message about a rollback failure if the failure was caused
+			// by something other than the release not being found.
 			if uninstallErr != nil && !notFoundErr(uninstallErr) {
 				return nil, fmt.Errorf("failed installation (%s) and failed rollback (%s)", err, uninstallErr)
 			}


### PR DESCRIPTION
**Description of the change:**
Improves handling of errors that can occur when rolling back failed releases.

**Motivation for the change:**
See #1505
