### PR TITLE
cmd/operator-sdk/internal/genutil: relax version dir check in `parseGroupVersions()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - Enables controller-runtime metrics in Helm operator projects. ([#1482](https://github.com/operator-framework/operator-sdk/pull/1482))
 
 ### Changed
+
 - Remove TypeMeta declaration from the implementation of the objects [#1462](https://github.com/operator-framework/operator-sdk/pull/1462/)
+- Relaxed API version format check when parsing `pkg/apis` in code generators. API dir structures can now be of the format `pkg/apis/<group>/<anything>`, where `<anything>` was previously required to be in the Kubernetes version format, ex. `v1alpha1`. ([#1525](https://github.com/operator-framework/operator-sdk/pull/1525))
 
 ### Deprecated
 

--- a/cmd/operator-sdk/internal/genutil/genutil.go
+++ b/cmd/operator-sdk/internal/genutil/genutil.go
@@ -54,7 +54,7 @@ func parseGroupVersions() (map[string][]string, error) {
 						return nil, fmt.Errorf("could not read %s directory to find api Versions: %v", verDir, err)
 					}
 					for _, f := range files {
-						if !f.IsDir() {
+						if !f.IsDir() && filepath.Ext(f.Name()) == ".go" {
 							gvs[g.Name()] = append(gvs[g.Name()], filepath.ToSlash(v.Name()))
 							break
 						}


### PR DESCRIPTION
**Description of the change:** remove requirement that the API dir structure `pkg/apis/<group>/<version>` have `<version>` match something like `v1alpha1`, and instead check if `<version>` is a dir (or dir hierarchy) that contains files.

**Motivation for the change:** having a API dir shared by multiple versions, ex `pkg/apis/operators/shared`, is valid and should be considered when running a code generator.