### PR TITLE
cmd/operator-sdk/build: expand env in go build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixes a regression that causes Helm RBAC generation to contain an empty custom ruleset when the chart's default manifest contains only namespaced resources. ([#1456](https://github.com/operator-framework/operator-sdk/pull/1456))
 - Fixes an issue that causes Helm RBAC generation to fail when creating new operators with a Kubernetes context configured to connect to an OpenShift cluster. ([#1461](https://github.com/operator-framework/operator-sdk/pull/1461))
 - Generated CSV's that include a deployment install strategy will be checked for a reference to `metadata.annotations['olm.targetNamespaces']`, and if one is not found a reference will be added to the `WATCH_NAMESPACE` env var for all containers in the deployment. This is a bug because any other value that references the CSV's namespace is incorrect. ([#1396](https://github.com/operator-framework/operator-sdk/pull/1396))
+- Build `-trimpath` was not being respected. `$GOPATH` was not expending because `exec.Cmd{}` is not executed in a shell environment. ([#1535](https://github.com/operator-framework/operator-sdk/pull/1535))
 
 ## v0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Fixes a regression that causes Helm RBAC generation to contain an empty custom ruleset when the chart's default manifest contains only namespaced resources. ([#1456](https://github.com/operator-framework/operator-sdk/pull/1456))
 - Fixes an issue that causes Helm RBAC generation to fail when creating new operators with a Kubernetes context configured to connect to an OpenShift cluster. ([#1461](https://github.com/operator-framework/operator-sdk/pull/1461))
 - Generated CSV's that include a deployment install strategy will be checked for a reference to `metadata.annotations['olm.targetNamespaces']`, and if one is not found a reference will be added to the `WATCH_NAMESPACE` env var for all containers in the deployment. This is a bug because any other value that references the CSV's namespace is incorrect. ([#1396](https://github.com/operator-framework/operator-sdk/pull/1396))
-- Build `-trimpath` was not being respected. `$GOPATH` was not expending because `exec.Cmd{}` is not executed in a shell environment. ([#1535](https://github.com/operator-framework/operator-sdk/pull/1535))
+- Build `-trimpath` was not being respected. `$GOPATH` was not expanding because `exec.Cmd{}` is not executed in a shell environment. ([#1535](https://github.com/operator-framework/operator-sdk/pull/1535))
 
 ## v0.8.0
 

--- a/cmd/operator-sdk/build/cmd.go
+++ b/cmd/operator-sdk/build/cmd.go
@@ -93,7 +93,8 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 		goBuildEnv = append(goBuildEnv, "CGO_ENABLED=0")
 	}
 
-	goTrimFlags := []string{"-gcflags", "all=-trimpath=${GOPATH}", "-asmflags", "all=-trimpath=${GOPATH}"}
+	trimPath := os.ExpandEnv("all=-trimpath=${GOPATH}")
+	goTrimFlags := []string{"-gcflags", trimPath, "-asmflags", trimPath}
 	absProjectPath := projutil.MustGetwd()
 	projectName := filepath.Base(absProjectPath)
 

--- a/internal/util/projutil/exec.go
+++ b/internal/util/projutil/exec.go
@@ -113,8 +113,9 @@ func getGeneralArgs(cmd string, opts GoCmdOptions) ([]string, error) {
 }
 
 func setCommandFields(c *exec.Cmd, opts GoCmdOptions) {
+	c.Env = append(c.Env, os.Environ()...)
 	if len(opts.Env) != 0 {
-		c.Env = append(os.Environ(), opts.Env...)
+		c.Env = append(c.Env, opts.Env...)
 	}
 	if opts.Dir != "" {
 		c.Dir = opts.Dir


### PR DESCRIPTION
**Description of the change:** expand environment variables in `operator-sdk build`'s `go build` process, and always append os.Environ() to `go` commands.

**Motivation for the change:** `exec.Cmd`'s are not run in a shell, so env variables are not expanded.

Closes #1530 