### PR TITLE
Fix multiline boilerplates

### DIFF
--- a/internal/pkg/scaffold/boilerplate_go_txt_test.go
+++ b/internal/pkg/scaffold/boilerplate_go_txt_test.go
@@ -47,7 +47,33 @@ func TestBoilerplate(t *testing.T) {
 	}
 }
 
-const boilerplate = `// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ac
+func TestBoilerplateMultiline(t *testing.T) {
+	s, buf := setupScaffoldAndWriter()
+	s.Fs = afero.NewMemMapFs()
+	f, err := afero.TempFile(s.Fs, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = f.Write([]byte(boilerplateMulti)); err != nil {
+		t.Fatal(err)
+	}
+	if err = f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s.BoilerplatePath = f.Name()
+	err = s.Execute(appConfig, &Apis{})
+	if err != nil {
+		t.Fatalf("Failed to execute the scaffold: (%v)", err)
+	}
+
+	if boilerplateMultiExp != buf.String() {
+		diffs := diffutil.Diff(boilerplateMultiExp, buf.String())
+		t.Fatalf("Expected vs actual differs.\n%v", diffs)
+	}
+}
+
+const (
+	boilerplate = `// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ac
 // velit a lacus tempor accumsan sit amet eu velit. Mauris orci lectus,
 // rutrum vitae porttitor in, interdum nec mauris. Praesent porttitor
 // lectus a sem volutpat, ac fringilla magna fermentum. Donec a nibh
@@ -55,5 +81,22 @@ const boilerplate = `// Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 // varius, blandit risus quis, porta tellus. Vivamus scelerisque turpis
 // quis viverra rhoncus. Aenean non arcu velit.
 `
+	boilerplateExp   = boilerplate + "\n" + apisExp
+	boilerplateMulti = `/*
+Copyright The Project Authors.
 
-const boilerplateExp = boilerplate + "\n" + apisExp
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+`
+	boilerplateMultiExp = boilerplateMulti + "\n" + apisExp
+)

--- a/internal/pkg/scaffold/scaffold.go
+++ b/internal/pkg/scaffold/scaffold.go
@@ -97,14 +97,8 @@ func validateBoilerplateBytes(b []byte) error {
 			cb = append(cb, []byte(strings.TrimSpace(c.Text)+"\n")...)
 		}
 	}
-	// Remove empty lines before comparison.
 	var tb []byte
-	for _, l := range bytes.Split(b, []byte("\n")) {
-		if len(l) > 0 {
-			tb = append(tb, append(bytes.TrimSpace(l), []byte("\n")...)...)
-		}
-	}
-	tb, cb = bytes.TrimSpace(tb), bytes.TrimSpace(cb)
+	tb, cb = bytes.TrimSpace(b), bytes.TrimSpace(cb)
 	if bytes.Compare(tb, cb) != 0 {
 		return fmt.Errorf(`boilerplate contains text other than comments:\n"%s"\n`, tb)
 	}


### PR DESCRIPTION
**Description of the change:**
Go permits multiline, block-style comments. It's common for boilerplates to utilize these for licences (e.g. Apache-2.0's standard boilerplate).

This PR removes the line-by-line stripping of whitespace, and adds a test for it.

**Motivation for the change:**
Allow existing projects with compliant, multiline boilerplates to use them.