### PR TITLE
hack/lib/test_lib.sh: `listFiles` is GOPATH-agnostic

### DIFF
--- a/hack/lib/test_lib.sh
+++ b/hack/lib/test_lib.sh
@@ -2,20 +2,13 @@
 
 source hack/lib/common.sh
 
-function listPkgs() {
-	go list ./cmd/... ./pkg/... ./test/... | grep -v generated
+function listPkgDirs() {
+	go list -f '{{.Dir}}' ./cmd/... ./pkg/... ./test/... ./internal/... | grep -v generated
 }
 
 function listFiles() {
-	# make it work with composed gopath
-	for gopath in ${GOPATH//:/ }; do
-		if [[ "$(pwd)" =~ "$gopath" ]]; then
-			GOPATH="$gopath"
-			break
-		fi
-	done
 	# pipeline is much faster than for loop
-	listPkgs | xargs -I {} find "${GOPATH}/src/{}" -name '*.go' | grep -v generated
+	listPkgDirs | xargs -I {} find {} -name '*.go' | grep -v generated
 }
 
 #===================================================================

--- a/internal/pkg/scaffold/olm-catalog/csv_updaters.go
+++ b/internal/pkg/scaffold/olm-catalog/csv_updaters.go
@@ -191,7 +191,7 @@ func depHasOLMNamespaces(dep *appsv1.Deployment) bool {
 	b, err := dep.Spec.Template.Marshal()
 	if err != nil {
 		// Something is wrong with the deployment manifest, not with CLI inputs.
-		log.Fatalf("marshal Deployment spec: %v", err)
+		log.Fatalf("Marshal Deployment spec: %v", err)
 	}
 	return bytes.Index(b, []byte(olmTNMeta)) != -1
 }

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -117,7 +117,7 @@ func CheckGoProjectCmd(cmd *cobra.Command) error {
 	if IsOperatorGo() {
 		return nil
 	}
-	return fmt.Errorf("'%s' can only be run for Go operators; %s does not exist.", cmd.CommandPath(), mainFile)
+	return fmt.Errorf("'%s' can only be run for Go operators; %s does not exist", cmd.CommandPath(), mainFile)
 }
 
 func MustGetwd() string {


### PR DESCRIPTION
**Description of the change:** `listPkgDirs` gets `internal` package, and all other packages, by dir using a `go list` pipeline. `listFiles` is now GOPATH-agnostic because `go list` considers modules.

**Motivation for the change:** we should be getting `internal` package dirs because they need to be tested by e2e. See #1475 for more details on why the GOPATH requirement was removed from `listFiles`.