### PR TITLE
cmd/operator-sdk/new/cmd.go: only validate new go projects

### DIFF
--- a/cmd/operator-sdk/new/cmd.go
+++ b/cmd/operator-sdk/new/cmd.go
@@ -61,7 +61,7 @@ generates a skeletal app-operator application in $GOPATH/src/github.com/example.
 	newCmd.Flags().BoolVar(&skipGit, "skip-git-init", false, "Do not init the directory as a git repository")
 	newCmd.Flags().StringVar(&headerFile, "header-file", "", "Path to file containing headers for generated Go files. Copied to hack/boilerplate.go.txt")
 	newCmd.Flags().BoolVar(&makeVendor, "vendor", false, "Use a vendor directory for dependencies. This flag only applies when --dep-manager=modules (the default)")
-	newCmd.Flags().BoolVar(&skipValidation, "skip-validation", false, "Do not validate the resulting project's structure and dependencies")
+	newCmd.Flags().BoolVar(&skipValidation, "skip-validation", false, "Do not validate the resulting project's structure and dependencies. (Only used for --type go)")
 	newCmd.Flags().BoolVar(&generatePlaybook, "generate-playbook", false, "Generate a playbook skeleton. (Only used for --type ansible)")
 
 	newCmd.Flags().StringVar(&helmChartRef, "helm-chart", "", "Initialize helm operator with existing helm chart (<URL>, <repo>/<name>, or local path)")

--- a/cmd/operator-sdk/new/cmd.go
+++ b/cmd/operator-sdk/new/cmd.go
@@ -107,18 +107,18 @@ func newFunc(cmd *cobra.Command, args []string) error {
 		if err := getDeps(); err != nil {
 			return err
 		}
+		if !skipValidation {
+			if err := validateProject(); err != nil {
+				return err
+			}
+		}
+
 	case projutil.OperatorTypeAnsible:
 		if err := doAnsibleScaffold(); err != nil {
 			return err
 		}
 	case projutil.OperatorTypeHelm:
 		if err := doHelmScaffold(); err != nil {
-			return err
-		}
-	}
-
-	if !skipValidation {
-		if err := validateProject(); err != nil {
 			return err
 		}
 	}

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -264,7 +264,7 @@ Scaffolds a new operator project.
 * `--dep-manager` string - Dependency manager the new project will use (choices: "dep", "modules") (default "modules")
 * `--skip-git-init` - Do not init the directory as a git repository
 * `--vendor` - Use a vendor directory for dependencies. This flag only applies when `--dep-manager=modules` (the default)
-* `--skip-validation` - Do not validate the resulting project's structure and dependencies
+* `--skip-validation` - Do not validate the resulting project's structure and dependencies. (Only used for --type go)
 * `-h, --help` - help for new
 
 ### Example


### PR DESCRIPTION
**Description of the change:**
Move project validation to only check new go projects 

**Motivation for the change:**
Ansible and Helm projects don't use dependency managers, and don't have go code, so there's nothing to validate.
