### PR TITLE
pkg/metrics: Allow multi port metrics Service creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,14 @@
 - Remove TypeMeta declaration from the implementation of the objects [#1462](https://github.com/operator-framework/operator-sdk/pull/1462/)
 - Relaxed API version format check when parsing `pkg/apis` in code generators. API dir structures can now be of the format `pkg/apis/<group>/<anything>`, where `<anything>` was previously required to be in the Kubernetes version format, ex. `v1alpha1`. ([#1525](https://github.com/operator-framework/operator-sdk/pull/1525))
 - The SDK and operator projects will work outside of `$GOPATH/src` when using [Go modules](https://github.com/golang/go/wiki/Modules). ([#1475](https://github.com/operator-framework/operator-sdk/pull/1475))
+-  `CreateMetricsService()` function from the metrics package accepts an array of ServicePort objects ([]v1.ServicePort) as input to create Service metrics. `CRPortName` constant is added to describe the string of custom resource port name. ([#1560](https://github.com/operator-framework/operator-sdk/pull/1560))
 
 ### Deprecated
 
 ### Removed
 
 - The SDK no longer depends on a `vendor/` directory to manage dependencies *only if* using [Go modules](https://github.com/golang/go/wiki/Modules). The SDK and operator projects will only use vendoring if using `dep`, or modules and a `vendor/` dir is present. ([#1519](https://github.com/operator-framework/operator-sdk/pull/1519))
+- `ExposeMetricsPort` is now depracted and was replaced with `CreateMetricsService()` function. `PrometheusPortName` constant is replaced with `OperatorPortName`. ([#1560](https://github.com/operator-framework/operator-sdk/pull/1560))
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 ### Removed
 
 - The SDK no longer depends on a `vendor/` directory to manage dependencies *only if* using [Go modules](https://github.com/golang/go/wiki/Modules). The SDK and operator projects will only use vendoring if using `dep`, or modules and a `vendor/` dir is present. ([#1519](https://github.com/operator-framework/operator-sdk/pull/1519))
-- `ExposeMetricsPort` is now depracted and was replaced with `CreateMetricsService()` function. `PrometheusPortName` constant is replaced with `OperatorPortName`. ([#1560](https://github.com/operator-framework/operator-sdk/pull/1560))
+- **Breaking change:** `ExposeMetricsPort` is removed and replaced with `CreateMetricsService()` function. `PrometheusPortName` constant is replaced with `OperatorPortName`. ([#1560](https://github.com/operator-framework/operator-sdk/pull/1560))
 
 ### Bug Fixes
 

--- a/doc/user/metrics/README.md
+++ b/doc/user/metrics/README.md
@@ -6,7 +6,7 @@
 
 ### General metrics
 
-The `ExposeMetricsPort(ctx context.Context, port int32) (*v1.Service, error)` function exposes general metrics about the running program. These metrics are inherited from controller-runtime. To understand which metrics are exposed, read the metrics package doc of [controller-runtime][controller-metrics]. The `ExposeMetricsPort` function creates a [Service][service] object with the metrics port exposed, which can then be accessed by Prometheus. The Service object is [garbage collected][gc] when the leader pod's root owner is deleted.
+The `"CreateMetricsService(ctx context.Context, servicePorts []v1.ServicePort) (*v1.Service, error)` function exposes general metrics about the running program. These metrics are inherited from controller-runtime. To understand which metrics are exposed, read the metrics package doc of [controller-runtime][controller-metrics]. The `ExposeMetricsPort` function creates a [Service][service] object with the metrics port exposed, which can then be accessed by Prometheus. The Service object is [garbage collected][gc] when the leader pod's root owner is deleted.
 
 By default, the metrics are served on `0.0.0.0:8383/metrics`. To modify the port the metrics are exposed on, change the `var metricsPort int32 = 8383` variable in the `cmd/manager/main.go` file of the generated operator.
 
@@ -14,8 +14,12 @@ By default, the metrics are served on `0.0.0.0:8383/metrics`. To modify the port
 
 ```go
     import(
+        "context"
+
         "github.com/operator-framework/operator-sdk/pkg/metrics"
         "sigs.k8s.io/controller-runtime/pkg/manager"
+        "k8s.io/api/core/v1"
+        "k8s.io/apimachinery/pkg/util/intstr"
     )
 
     func main() {
@@ -34,14 +38,19 @@ By default, the metrics are served on `0.0.0.0:8383/metrics`. To modify the port
 
         ...
 
+        // Add to the below struct any other metrics ports you want to expose.
+	    servicePorts := []v1.ServicePort{
+		    {Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
+	    }
+
         // Create Service object to expose the metrics port.
-        _, err = metrics.ExposeMetricsPort(ctx, metricsPort)
+        _, err = metrics.CreateMetricsService(context.TODO(), servicePorts)
         if err != nil {
             // handle error
-            log.Info(err.Error())
         }
 
         ...
+
     }
 ```
 

--- a/hack/tests/e2e-helm.sh
+++ b/hack/tests/e2e-helm.sh
@@ -34,15 +34,17 @@ test_operator() {
     fi
 
     # verify that metrics service was created
-    if ! timeout 20s bash -c -- "until kubectl get service/nginx-operator > /dev/null 2>&1; do sleep 1; done";
+    if ! timeout 20s bash -c -- "until kubectl get service/nginx-operator-metrics > /dev/null 2>&1; do sleep 1; done";
     then
+        echo "Failed to get metrics service"
         kubectl logs deployment/nginx-operator
         exit 1
     fi
 
     # verify that the metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator:8383/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator-metrics:8383/metrics; do sleep 1; done";
     then
+        echo "Failed to verify that metrics endpoint exists"
         kubectl logs deployment/nginx-operator
         exit 1
     fi

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -151,8 +151,13 @@ func main() {
 		log.Info("Could not generate and serve custom resource metrics: ", err.Error())
 	}
 
-	// Create Service object to expose the metrics port.
-	_, err = metrics.ExposeMetricsPort(ctx, metricsPort)
+	// Add to the below struct any other metrics ports you want to expose.
+	metricsService := []metrics.MetricService{
+		{Port: operatorMetricsPort, PortName: metrics.CRPortName},
+		{Port: metricsPort, PortName: metrics.OperatorPortName},
+	}
+	// Create Service object to expose the metrics port(s).
+	_, err = metrics.CreateMetricsService(ctx, metricsService)
 	if err != nil {
 		log.Info(err.Error())
 	}

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -64,7 +64,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // Change below variables to serve metrics on different host or port.

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -58,10 +58,13 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -150,14 +153,14 @@ func main() {
 	if err = serveCRMetrics(cfg); err != nil {
 		log.Info("Could not generate and serve custom resource metrics: ", err.Error())
 	}
-
+	
 	// Add to the below struct any other metrics ports you want to expose.
-	metricsService := []metrics.MetricService{
-		{Port: operatorMetricsPort, PortName: metrics.CRPortName},
-		{Port: metricsPort, PortName: metrics.OperatorPortName},
+	servicePorts := []v1.ServicePort{
+		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
+		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
 	}
 	// Create Service object to expose the metrics port(s).
-	_, err = metrics.CreateMetricsService(ctx, metricsService)
+	_, err = metrics.CreateMetricsService(ctx, servicePorts)
 	if err != nil {
 		log.Info(err.Error())
 	}

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -57,6 +57,8 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -151,12 +153,12 @@ func main() {
 	}
 
 	// Add to the below struct any other metrics ports you want to expose.
-	metricsService := []metrics.MetricService{
-		{Port: operatorMetricsPort, PortName: metrics.CRPortName},
-		{Port: metricsPort, PortName: metrics.OperatorPortName},
+	servicePorts := []v1.ServicePort{
+		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
+		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
 	}
 	// Create Service object to expose the metrics port(s).
-	_, err = metrics.CreateMetricsService(ctx, metricsService)
+	_, err = metrics.CreateMetricsService(ctx, servicePorts)
 	if err != nil {
 		log.Info(err.Error())
 	}

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -150,8 +150,13 @@ func main() {
 		log.Info("Could not generate and serve custom resource metrics: ", err.Error())
 	}
 
-	// Create Service object to expose the metrics port.
-	_, err = metrics.ExposeMetricsPort(ctx, metricsPort)
+	// Add to the below struct any other metrics ports you want to expose.
+	metricsService := []metrics.MetricService{
+		{Port: operatorMetricsPort, PortName: metrics.CRPortName},
+		{Port: metricsPort, PortName: metrics.OperatorPortName},
+	}
+	// Create Service object to expose the metrics port(s).
+	_, err = metrics.CreateMetricsService(ctx, metricsService)
 	if err != nil {
 		log.Info(err.Error())
 	}

--- a/pkg/ansible/run.go
+++ b/pkg/ansible/run.go
@@ -85,8 +85,11 @@ func Run(flags *aoflags.AnsibleOperatorFlags) error {
 		return err
 	}
 
+	metricsService := []metrics.MetricService{
+		{Port: 8383, PortName: metrics.OperatorPortName},
+	}
 	// TODO: probably should expose the port as an environment variable
-	_, err = metrics.ExposeMetricsPort(context.TODO(), 8383)
+	_, err = metrics.CreateMetricsService(context.TODO(), metricsService)
 	if err != nil {
 		log.Error(err, "Exposing metrics port failed.")
 		return err

--- a/pkg/helm/run.go
+++ b/pkg/helm/run.go
@@ -117,8 +117,12 @@ func Run(flags *hoflags.HelmOperatorFlags) error {
 		return err
 	}
 
-	// Create Service object to expose the metrics port.
-	_, err = metrics.ExposeMetricsPort(ctx, metricsPort)
+	// Add to the below struct any other metrics ports you want to expose.
+	metricsService := []metrics.MetricService{
+		{Port: metricsPort, PortName: metrics.OperatorPortName},
+	}
+	// Create Service object to expose the metrics port(s).
+	_, err = metrics.CreateMetricsService(ctx, metricsService)
 	if err != nil {
 		log.Info(err.Error())
 	}

--- a/pkg/helm/run.go
+++ b/pkg/helm/run.go
@@ -29,7 +29,9 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -117,12 +119,11 @@ func Run(flags *hoflags.HelmOperatorFlags) error {
 		return err
 	}
 
-	// Add to the below struct any other metrics ports you want to expose.
-	metricsService := []metrics.MetricService{
-		{Port: metricsPort, PortName: metrics.OperatorPortName},
+	servicePorts := []v1.ServicePort{
+		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
 	}
 	// Create Service object to expose the metrics port(s).
-	_, err = metrics.CreateMetricsService(ctx, metricsService)
+	_, err = metrics.CreateMetricsService(ctx, servicePorts)
 	if err != nil {
 		log.Info(err.Error())
 	}

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -633,7 +633,7 @@ func memcachedMetricsTest(t *testing.T, f *framework.Framework, ctx *framework.T
 
 	// Make sure metrics Service exists
 	s := v1.Service{}
-	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: operatorName, Namespace: namespace}, &s)
+	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("%s-metrics", operatorName), Namespace: namespace}, &s)
 	if err != nil {
 		return fmt.Errorf("could not get metrics Service: (%v)", err)
 	}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->



**Motivation for the change:**

With the recent addition of Custom Resource metrics we need to expose the port in the metrics Service. This also helps users who want to expose their own metrics ports in a Service as they can just pass in another port.

Note: We also changed the name of the Service that is being created by appending `-metrics` to the operator name, this makes it self descriptive as we did have questions what is this service for.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->

**TODO:**

- [x] adjust docs to match the changes to the functions
