### PR TITLE
pkg/metrics/service-monitor.go: Populate all ports

### DIFF
--- a/pkg/metrics/service-monitor.go
+++ b/pkg/metrics/service-monitor.go
@@ -59,6 +59,7 @@ func GenerateServiceMonitor(s *v1.Service) *monitoringv1.ServiceMonitor {
 	for k, v := range s.ObjectMeta.Labels {
 		labels[k] = v
 	}
+	endpoints := populateEndpointsFromServicePorts(s)
 
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
@@ -70,13 +71,17 @@ func GenerateServiceMonitor(s *v1.Service) *monitoringv1.ServiceMonitor {
 			Selector: metav1.LabelSelector{
 				MatchLabels: labels,
 			},
-			Endpoints: []monitoringv1.Endpoint{
-				{
-					Port: s.Spec.Ports[0].Name,
-				},
-			},
+			Endpoints: endpoints,
 		},
 	}
+}
+
+func populateEndpointsFromServicePorts(s *v1.Service) []monitoringv1.Endpoint {
+	var endpoints []monitoringv1.Endpoint
+	for _, port := range s.Spec.Ports {
+		endpoints = append(endpoints, monitoringv1.Endpoint{Port: port.Name})
+	}
+	return endpoints
 }
 
 // hasServiceMonitor checks if ServiceMonitor is registered in the cluster.


### PR DESCRIPTION
**Description of the change:**

Whenever there are multiple ports in the Service object we take all of
them to map to the Endpoints of the ServiceMonitor object. 

**Motivation for the change:**
This way we can have one ServiceMonitor per Service with multiple ports exposed.
I cam across this while working and testing https://github.com/operator-framework/operator-sdk/pull/1560 but they don't depend on each other, so can be merged separately.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
