### PR TITLE
ansible-operator: Add extra var containing watched resource spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - New flags `--vendor` and `--skip-validation` for [`operator-sdk new`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#new) that direct the SDK to initialize a new project with a `vendor/` directory, and without validating project dependencies. `vendor/` is not written by default. ([#1519](https://github.com/operator-framework/operator-sdk/pull/1519))
 - Generating and serving info metrics about each custom resource. By default these metrics are exposed on port 8686. ([#1277](https://github.com/operator-framework/operator-sdk/pull/1277))
 - Scaffold a `pkg/apis/<group>/group.go` package file to avoid `go/build` errors when running Kubernetes code generators. ([#1401](https://github.com/operator-framework/operator-sdk/pull/1401))
+- Adds a new extra variable containing the unmodified CR spec for ansible based operators. [#1563](https://github.com/operator-framework/operator-sdk/pull/1563)
 
 ### Changed
 

--- a/doc/ansible/dev/developer_guide.md
+++ b/doc/ansible/dev/developer_guide.md
@@ -470,6 +470,9 @@ The structure passed to Ansible as extra vars is:
   "_app_example_com_database": {
      <Full CRD>
    },
+  "_app_example_com_database_spec": {
+     <Full CRD .spec>
+   },
 }
 ```
 `message` and `newParameter` are set in the top level as extra variables, and


### PR DESCRIPTION
Necessary to allow accessing the CR unmodified `spec` without also
accessing a variable containing the CR `status`. If the CR status is
managed by ansible-operator directly, then it's possible the status can
contain invalid jinja expressions which will be evaluated if you
access a variable containing the `status`. See #1471 for more details.

Closes #1471