### PR TITLE
Add --operator-name flag to olm-catalog gen-csv

### DIFF
--- a/cmd/operator-sdk/olmcatalog/gen-csv.go
+++ b/cmd/operator-sdk/olmcatalog/gen-csv.go
@@ -36,6 +36,7 @@ var (
 	fromVersion   string
 	csvConfigPath string
 	updateCRDs    bool
+	operatorName  string
 )
 
 func newGenCSVCmd() *cobra.Command {
@@ -58,6 +59,7 @@ Configure CSV generation by writing a config file 'deploy/olm-catalog/csv-config
 	genCSVCmd.Flags().StringVar(&fromVersion, "from-version", "", "Semantic version of an existing CSV to use as a base")
 	genCSVCmd.Flags().StringVar(&csvConfigPath, "csv-config", "", "Path to CSV config file. Defaults to deploy/olm-catalog/csv-config.yaml")
 	genCSVCmd.Flags().BoolVar(&updateCRDs, "update-crds", false, "Update CRD manifests in deploy/{operator-name}/{csv-version} the using latest API's")
+	genCSVCmd.Flags().StringVar(&operatorName, "operator-name", "", "Operator name to use while generating CSV")
 
 	return genCSVCmd
 }
@@ -82,11 +84,16 @@ func genCSVFunc(cmd *cobra.Command, args []string) error {
 
 	log.Infof("Generating CSV manifest version %s", csvVersion)
 
+	if operatorName == "" {
+		operatorName = filepath.Base(absProjectPath)
+	}
+
 	s := &scaffold.Scaffold{}
 	csv := &catalog.CSV{
 		CSVVersion:     csvVersion,
 		FromVersion:    fromVersion,
 		ConfigFilePath: csvConfigPath,
+		OperatorName:   operatorName,
 	}
 	if err := s.Execute(cfg, csv); err != nil {
 		return fmt.Errorf("catalog scaffold failed: (%v)", err)

--- a/internal/pkg/scaffold/olm-catalog/csv.go
+++ b/internal/pkg/scaffold/olm-catalog/csv.go
@@ -56,6 +56,8 @@ type CSV struct {
 	// manifest with this version should exist at:
 	// deploy/olm-catalog/{from_version}/operator-name.v{from_version}.{CSVYamlFileExt}
 	FromVersion string
+	// OperatorName is the operator's name, ex. app-operator
+	OperatorName string
 
 	once       sync.Once
 	fs         afero.Fs // For testing, ex. afero.NewMemMapFs()
@@ -79,14 +81,14 @@ func (s *CSV) GetInput() (input.Input, error) {
 		return input.Input{}, ErrNoCSVVersion
 	}
 	if s.Path == "" {
-		lowerProjName := strings.ToLower(s.ProjectName)
+		operatorName := strings.ToLower(s.OperatorName)
 		// Path is what the operator-registry expects:
 		// {manifests -> olm-catalog}/{operator_name}/{semver}/{operator_name}.v{semver}.clusterserviceversion.yaml
 		s.Path = filepath.Join(s.pathPrefix,
 			scaffold.OLMCatalogDir,
-			lowerProjName,
+			operatorName,
 			s.CSVVersion,
-			getCSVFileName(lowerProjName, s.CSVVersion),
+			getCSVFileName(operatorName, s.CSVVersion),
 		)
 	}
 	if s.ConfigFilePath == "" {
@@ -182,7 +184,7 @@ func getCSVFileName(name, version string) string {
 }
 
 func (s *CSV) getCSVPath(ver string) string {
-	lowerProjName := strings.ToLower(s.ProjectName)
+	lowerProjName := strings.ToLower(s.OperatorName)
 	name := getCSVFileName(lowerProjName, ver)
 	return filepath.Join(s.pathPrefix, scaffold.OLMCatalogDir, lowerProjName, ver, name)
 }
@@ -228,13 +230,13 @@ func (s *CSV) initCSVFields(csv *olmapiv1alpha1.ClusterServiceVersion) {
 	// Metadata
 	csv.TypeMeta.APIVersion = olmapiv1alpha1.ClusterServiceVersionAPIVersion
 	csv.TypeMeta.Kind = olmapiv1alpha1.ClusterServiceVersionKind
-	csv.SetName(getCSVName(strings.ToLower(s.ProjectName), s.CSVVersion))
+	csv.SetName(getCSVName(strings.ToLower(s.OperatorName), s.CSVVersion))
 	csv.SetNamespace("placeholder")
 	csv.SetAnnotations(map[string]string{"capabilities": "Basic Install"})
 
 	// Spec fields
 	csv.Spec.Version = *semver.New(s.CSVVersion)
-	csv.Spec.DisplayName = getDisplayName(s.ProjectName)
+	csv.Spec.DisplayName = getDisplayName(s.OperatorName)
 	csv.Spec.Description = "Placeholder description"
 	csv.Spec.Maturity = "alpha"
 	csv.Spec.Provider = olmapiv1alpha1.AppLink{}
@@ -329,7 +331,7 @@ func (s *CSV) updateCSVVersions(csv *olmapiv1alpha1.ClusterServiceVersion) error
 	}
 
 	// Now replace all references to the old operator name.
-	lowerProjName := strings.ToLower(s.ProjectName)
+	lowerProjName := strings.ToLower(s.OperatorName)
 	oldCSVName := getCSVName(lowerProjName, oldVer)
 	newCSVName := getCSVName(lowerProjName, newVer)
 	err := replaceAllBytes(csv, []byte(oldCSVName), []byte(newCSVName))

--- a/internal/pkg/scaffold/olm-catalog/csv_test.go
+++ b/internal/pkg/scaffold/olm-catalog/csv_test.go
@@ -48,9 +48,10 @@ func TestCSVNew(t *testing.T) {
 		},
 	}
 	csvVer := "0.1.0"
-	projectName := "app-operator"
+	projectName := "app-operator-dir"
+	operatorName := "app-operator"
 
-	sc := &CSV{CSVVersion: csvVer, pathPrefix: testDataDir}
+	sc := &CSV{CSVVersion: csvVer, pathPrefix: testDataDir, OperatorName: operatorName}
 	err := s.Execute(&input.Config{ProjectName: projectName}, sc)
 	if err != nil {
 		t.Fatalf("Failed to execute the scaffold: (%v)", err)
@@ -70,7 +71,8 @@ func TestCSVNew(t *testing.T) {
 
 func TestCSVFromOld(t *testing.T) {
 	s := &scaffold.Scaffold{Fs: afero.NewMemMapFs()}
-	projectName := "app-operator"
+	projectName := "app-operator-dir"
+	operatorName := "app-operator"
 	oldCSVVer, newCSVVer := "0.1.0", "0.2.0"
 
 	// Write all files in testdata/deploy to fs so manifests are present when
@@ -80,9 +82,10 @@ func TestCSVFromOld(t *testing.T) {
 	}
 
 	sc := &CSV{
-		CSVVersion:  newCSVVer,
-		FromVersion: oldCSVVer,
-		pathPrefix:  testDataDir,
+		CSVVersion:   newCSVVer,
+		FromVersion:  oldCSVVer,
+		pathPrefix:   testDataDir,
+		OperatorName: operatorName,
 	}
 	err := s.Execute(&input.Config{ProjectName: projectName}, sc)
 	if err != nil {
@@ -99,23 +102,26 @@ func TestCSVFromOld(t *testing.T) {
 		t.Fatalf("New CSV does not exist at %s", newCSVPath)
 	}
 
-	expName := getCSVName(projectName, newCSVVer)
+	expName := getCSVName(operatorName, newCSVVer)
 	if newCSV.ObjectMeta.Name != expName {
 		t.Errorf("Expected CSV metadata.name %s, got %s", expName, newCSV.ObjectMeta.Name)
 	}
-	expReplaces := getCSVName(projectName, oldCSVVer)
+	expReplaces := getCSVName(operatorName, oldCSVVer)
 	if newCSV.Spec.Replaces != expReplaces {
 		t.Errorf("Expected CSV spec.replaces %s, got %s", expReplaces, newCSV.Spec.Replaces)
 	}
 }
 
 func TestUpdateVersion(t *testing.T) {
-	projectName := "app-operator"
+	projectName := "app-operator-dir"
+	operatorName := "app-operator"
+
 	oldCSVVer, newCSVVer := "0.1.0", "0.2.0"
 	sc := &CSV{
-		Input:      input.Input{ProjectName: projectName},
-		CSVVersion: newCSVVer,
-		pathPrefix: testDataDir,
+		Input:        input.Input{ProjectName: projectName},
+		CSVVersion:   newCSVVer,
+		pathPrefix:   testDataDir,
+		OperatorName: operatorName,
 	}
 	csvExpBytes, err := ioutil.ReadFile(sc.getCSVPath(oldCSVVer))
 	if err != nil {
@@ -134,7 +140,7 @@ func TestUpdateVersion(t *testing.T) {
 	if !csv.Spec.Version.Equal(*wantedSemver) {
 		t.Errorf("Wanted csv version %v, got %v", *wantedSemver, csv.Spec.Version)
 	}
-	wantedName := getCSVName(projectName, newCSVVer)
+	wantedName := getCSVName(operatorName, newCSVVer)
 	if csv.ObjectMeta.Name != wantedName {
 		t.Errorf("Wanted csv name %s, got %s", wantedName, csv.ObjectMeta.Name)
 	}
@@ -155,7 +161,7 @@ func TestUpdateVersion(t *testing.T) {
 		t.Errorf("Podspec image changed from %s to %s", wantedImage, csvPodImage)
 	}
 
-	wantedReplaces := getCSVName(projectName, "0.1.0")
+	wantedReplaces := getCSVName(operatorName, "0.1.0")
 	if csv.Spec.Replaces != wantedReplaces {
 		t.Errorf("Wanted csv replaces %s, got %s", wantedReplaces, csv.Spec.Replaces)
 	}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This patch adds a flag `--operator-name` to specify the operator name
while generating CSV using `operator-sdk gen-csv` command

The default value (when flag is absent) is base directory name as before

**Motivation for the change:**
At present operator-sdk  assumes project-directory-name (ProjectName) is the operator name.
The operator-name and the project-directory-name can be different.
(because of change in source control, project home, organizational policies etc)

Without an --operator-name flag we will have to rename, copy-paste generated CSVs
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>