### PR TITLE
hack/ci/setup-build-dependencies.sh: add setup script in SDK repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ x_base_steps:
   # before_install for jobs that require dep
   - &dep_before_install
     before_install:
-      - curl -Lo dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x dep && sudo mv dep /usr/local/bin/
+      - curl -Lo dep https://github.com/golang/dep/releases/download/v0.5.3/dep-linux-amd64 && chmod +x dep && sudo mv dep /usr/local/bin/
       - travis_retry dep ensure -v
   # before_install for jobs that require go builds and do not run for doc-only changes
   - &go_before_install
@@ -25,7 +25,7 @@ x_base_steps:
       # hack/ci/check-doc-only-update.sh needs to be sourced so
       # that it can properly exit the test early with success
       - source hack/ci/check-doc-only-update.sh
-      - curl -Lo dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x dep && sudo mv dep /usr/local/bin/
+      - curl -Lo dep https://github.com/golang/dep/releases/download/v0.5.3/dep-linux-amd64 && chmod +x dep && sudo mv dep /usr/local/bin/
       - travis_retry dep ensure -v
 
   # Base go, ansbile, and helm job

--- a/hack/ci/setup-build-dependencies.sh
+++ b/hack/ci/setup-build-dependencies.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Install dep
+curl -Lo dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x dep && mv dep /usr/local/bin/
+
+# Ensure vendor directory is up-to-date
+make dep

--- a/hack/ci/setup-build-dependencies.sh
+++ b/hack/ci/setup-build-dependencies.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Install dep
-curl -Lo dep https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x dep && mv dep /usr/local/bin/
+curl -Lo dep https://github.com/golang/dep/releases/download/v0.5.3/dep-linux-amd64 && chmod +x dep && mv dep /usr/local/bin/
 
 # Ensure vendor directory is up-to-date
 make dep


### PR DESCRIPTION
**Description of the change:**
Adds a setup script that can be used in OpenShift CI

**Motivation for the change:**
We currently [hard-code the `dep` setup commands](https://github.com/openshift/release/blob/master/ci-operator/config/operator-framework/operator-sdk/operator-framework-operator-sdk-master.yaml#L8) in the openshift/release repo.

Once this script is merged into master, we can update the OpenShift CI configuration to use it, which then gives us the flexibility to change the test setup from the SDK repo, rather than having to make coordinating changes in openshift/release.

This will be helpful in migrating the SDK from using `dep` to go modules (see #1566)

/cc @AlexNPavel 
