### PR TITLE
internal/../crd.go: Add check to prevent index panic

### DIFF
--- a/internal/pkg/scaffold/crd.go
+++ b/internal/pkg/scaffold/crd.go
@@ -108,9 +108,18 @@ func (s *CRD) CustomRender() ([]byte, error) {
 		// controller-tools' generators read and make crds for all apis in pkg/apis,
 		// so generate crds in a cached, in-memory fs to extract the data we need.
 		if !cache.fileExists(path) {
+			// This sets domain as empty string when we can't extract it from FullGroup.
+			// In turn this defaults to extracting the domain from project root file
+			// in controller-tools.
+			fg := strings.SplitN(s.Resource.FullGroup, ".", 2)
+			domain := ""
+			if len(fg) > 1 {
+				domain = fg[1]
+			}
+
 			g := &crdgenerator.Generator{
 				RootPath:          s.AbsProjectPath,
-				Domain:            strings.SplitN(s.Resource.FullGroup, ".", 2)[1],
+				Domain:            domain,
 				Repo:              s.Repo,
 				OutputDir:         ".",
 				SkipMapValidation: false,

--- a/internal/pkg/scaffold/crd.go
+++ b/internal/pkg/scaffold/crd.go
@@ -112,7 +112,7 @@ func (s *CRD) CustomRender() ([]byte, error) {
 			// In turn this defaults to extracting the domain from project root file
 			// in controller-tools.
 			fg := strings.SplitN(s.Resource.FullGroup, ".", 2)
-			domain := ""
+			domain := s.Resource.FullGroup
 			if len(fg) > 1 {
 				domain = fg[1]
 			}


### PR DESCRIPTION


**Description of the change:**

This sets domain as empty string when we can't extract it from FullGroup.
In turn this defaults to extracting the domain from project root file
in controller-tools.

**Motivation for the change:**

Closes https://github.com/operator-framework/operator-sdk/issues/1579


cc @estroz 

I was not sure if we should error out early if we cannot extract the domain, but I noticed in controller-tools there is an option to leave the domain empty.  https://github.com/operator-framework/operator-sdk/blob/6aac3b6efddd6824ea8578b5187eb360c42b1e63//vendor/sigs.k8s.io/controller-tools/pkg/crd/generator/generator.go#L85-L89

I find the error msg there a bit confusing if domain is not empty and the project cannot be found from the path, so not sure if we should warn the user or not?
