### PR TITLE
documentation: add note operator-sdk version

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The following workflow is for a new **Helm** operator:
 
 Follow the steps in the [installation guide][install_guide] to learn how to install the Operator SDK CLI tool.
 
+**Note:** If you are using a release version of the SDK, make sure to follow the documentation for that version. e.g.: For version 0.8.1, see docs in https://github.com/operator-framework/operator-sdk/tree/v0.8.1.
+
 ### Create and deploy an app-operator
 
 ```sh


### PR DESCRIPTION
it was not clear that to avoid issues in the quick start, that
one should use the specific version of the operator-sdk that matches
the version of the quick start they are following.

**Description of the change:**

Adds line to README about using the same version of operator-sdk as the version of the quick start one is following.

**Motivation for the change:**

Failure to use the exact version of the sdk (in this case, viewing the master branch readme, and installing operator-sdk 0.8.1) can lead to build errors and frustration.

