### PR TITLE
internal/pkg/scaffold/ansible: bump molecule retries to wait 60s

### DIFF
--- a/internal/pkg/scaffold/ansible/molecule_test_cluster_playbook.go
+++ b/internal/pkg/scaffold/ansible/molecule_test_cluster_playbook.go
@@ -59,7 +59,7 @@ const moleculeTestClusterPlaybookAnsibleTmpl = `---
     debug:
       msg: "{{ lookup('k8s', group='[[.Resource.FullGroup]]', api_version='[[.Resource.Version]]', kind='[[.Resource.Kind]]', namespace=namespace, resource_name=custom_resource.metadata.name) }}"
 
-  - name: Wait 40s for reconciliation to run
+  - name: Wait 60s for reconciliation to run
     k8s_facts:
       api_version: '[[.Resource.Version]]'
       kind: '[[.Resource.Kind]]'
@@ -68,7 +68,7 @@ const moleculeTestClusterPlaybookAnsibleTmpl = `---
     register: reconcile_cr
     until:
     - "'Successful' in (reconcile_cr | json_query('resources[].status.conditions[].reason'))"
-    delay: 4
+    delay: 6
     retries: 10
 
 - import_playbook: '{{ playbook_dir }}/../default/asserts.yml'

--- a/internal/pkg/scaffold/ansible/molecule_test_local_playbook.go
+++ b/internal/pkg/scaffold/ansible/molecule_test_local_playbook.go
@@ -101,7 +101,7 @@ const moleculeTestLocalPlaybookAnsibleTmpl = `---
         namespace: '{{ namespace }}'
         definition: '{{ custom_resource }}'
 
-    - name: Wait 40s for reconciliation to run
+    - name: Wait 60s for reconciliation to run
       k8s_facts:
         api_version: '{{ custom_resource.apiVersion }}'
         kind: '{{ custom_resource.kind }}'
@@ -110,7 +110,7 @@ const moleculeTestLocalPlaybookAnsibleTmpl = `---
       register: cr
       until:
       - "'Successful' in (cr | json_query('resources[].status.conditions[].reason'))"
-      delay: 4
+      delay: 6
       retries: 10
     rescue:
     - name: debug cr


### PR DESCRIPTION
**Description of the change:**
Increase ansible molecule test waits from 40s to 60s

**Motivation for the change:**
The 40s waits are sometimes to short, causing the ansible CI test runs to be flaky.
