### PR TITLE
test/test-framework,test/e2e: retry conflict updates

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1830,6 +1830,7 @@
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api",
     "k8s.io/client-go/transport",
+    "k8s.io/client-go/util/retry",
     "k8s.io/client-go/util/workqueue",
     "k8s.io/code-generator/cmd/deepcopy-gen/args",
     "k8s.io/gengo/args",

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -487,13 +487,14 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 		return fmt.Errorf("failed to get memcached object: %s", err)
 	}
 
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		// update memcached CR size to `toReplicas` replicas
 		spec, ok := obj.Object["spec"].(map[string]interface{})
 		if !ok {
 			return errors.New("memcached object missing spec field")
 		}
 		spec["size"] = toReplicas
+		t.Logf("Attempting memcached CR update, resourceVersion: %s", obj.GetResourceVersion())
 		return f.Client.Update(context.TODO(), &obj)
 	})
 	if err != nil {

--- a/test/test-framework/test/e2e/memcached_test.go
+++ b/test/test-framework/test/e2e/memcached_test.go
@@ -81,8 +81,9 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 		return fmt.Errorf("could not get example-memcached: %v", err)
 	}
 
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		exampleMemcached.Spec.Size = int32(toReplicas)
+		t.Logf("Attempting memcached CR update, resourceVersion: %s", exampleMemcached.GetResourceVersion())
 		return f.Client.Update(goctx.TODO(), exampleMemcached)
 	})
 	if err != nil {


### PR DESCRIPTION
**Description of the change:**
Adds retry logic when conflicts occur in the memcached e2e tests for updating the CR.

**Motivation for the change:**
More fixes for flaky tests:
https://travis-ci.org/operator-framework/operator-sdk/jobs/548776852#L1424