### PR TITLE
cmd/operator-sdk/new: make git init opt-in with --git-init flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Changed
 
-- Remove TypeMeta declaration from the implementation of the objects [#1462](https://github.com/operator-framework/operator-sdk/pull/1462/)
+- Remove TypeMeta declaration from the implementation of the objects ([#1462](https://github.com/operator-framework/operator-sdk/pull/1462/))
 - Relaxed API version format check when parsing `pkg/apis` in code generators. API dir structures can now be of the format `pkg/apis/<group>/<anything>`, where `<anything>` was previously required to be in the Kubernetes version format, ex. `v1alpha1`. ([#1525](https://github.com/operator-framework/operator-sdk/pull/1525))
 - The SDK and operator projects will work outside of `$GOPATH/src` when using [Go modules](https://github.com/golang/go/wiki/Modules). ([#1475](https://github.com/operator-framework/operator-sdk/pull/1475))
 -  `CreateMetricsService()` function from the metrics package accepts an array of ServicePort objects ([]v1.ServicePort) as input to create Service metrics. `CRPortName` constant is added to describe the string of custom resource port name. ([#1560](https://github.com/operator-framework/operator-sdk/pull/1560))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Relaxed API version format check when parsing `pkg/apis` in code generators. API dir structures can now be of the format `pkg/apis/<group>/<anything>`, where `<anything>` was previously required to be in the Kubernetes version format, ex. `v1alpha1`. ([#1525](https://github.com/operator-framework/operator-sdk/pull/1525))
 - The SDK and operator projects will work outside of `$GOPATH/src` when using [Go modules](https://github.com/golang/go/wiki/Modules). ([#1475](https://github.com/operator-framework/operator-sdk/pull/1475))
 -  `CreateMetricsService()` function from the metrics package accepts an array of ServicePort objects ([]v1.ServicePort) as input to create Service metrics. `CRPortName` constant is added to describe the string of custom resource port name. ([#1560](https://github.com/operator-framework/operator-sdk/pull/1560))
+- `operator-sdk new` will no longer create the initial commit for the scaffolded project. It will still run `git init` in the project directory which can be skipped with [`--skip-git-init`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#new).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 - Relaxed API version format check when parsing `pkg/apis` in code generators. API dir structures can now be of the format `pkg/apis/<group>/<anything>`, where `<anything>` was previously required to be in the Kubernetes version format, ex. `v1alpha1`. ([#1525](https://github.com/operator-framework/operator-sdk/pull/1525))
 - The SDK and operator projects will work outside of `$GOPATH/src` when using [Go modules](https://github.com/golang/go/wiki/Modules). ([#1475](https://github.com/operator-framework/operator-sdk/pull/1475))
 -  `CreateMetricsService()` function from the metrics package accepts an array of ServicePort objects ([]v1.ServicePort) as input to create Service metrics. `CRPortName` constant is added to describe the string of custom resource port name. ([#1560](https://github.com/operator-framework/operator-sdk/pull/1560))
-- `operator-sdk new` will no longer create the initial commit for the scaffolded project. It will still run `git init` in the project directory which can be skipped with [`--skip-git-init`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#new).
+- Changed the flag `--skip-git-init` to [`--git-init`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#new). This changes the default behavior of `operator-sdk new` to not initialize the new project directory as a git repository with `git init`. This behavior is now opt-in with `--git-init`. ([#1588](https://github.com/operator-framework/operator-sdk/pull/1588))
+- `operator-sdk new` will no longer create the initial commit for a new project, even with `--git-init=true`. ([#1588](https://github.com/operator-framework/operator-sdk/pull/1588))
 
 ### Deprecated
 

--- a/cmd/operator-sdk/new/cmd.go
+++ b/cmd/operator-sdk/new/cmd.go
@@ -470,6 +470,7 @@ func initGit() error {
 	if err := execProjCmd("git", "init"); err != nil {
 		return errors.Wrapf(err, "failed to run git init")
 	}
+	log.Info("Run git init done")
 	return nil
 }
 

--- a/cmd/operator-sdk/new/cmd.go
+++ b/cmd/operator-sdk/new/cmd.go
@@ -22,8 +22,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"k8s.io/client-go/discovery"
-
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/ansible"
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/helm"
@@ -33,6 +31,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
@@ -462,17 +461,15 @@ func initGit() error {
 	if skipGit {
 		return nil
 	}
+	if _, err := exec.LookPath("git"); err != nil {
+		log.Infof("Skipping git init: %v", err)
+		return nil
+	}
+
 	log.Info("Running git init")
 	if err := execProjCmd("git", "init"); err != nil {
-		return err
+		return errors.Wrapf(err, "failed to run git init")
 	}
-	if err := execProjCmd("git", "add", "--all"); err != nil {
-		return err
-	}
-	if err := execProjCmd("git", "commit", "-q", "-m", "INITIAL COMMIT"); err != nil {
-		return err
-	}
-	log.Info("Run git init done")
 	return nil
 }
 

--- a/cmd/operator-sdk/new/cmd.go
+++ b/cmd/operator-sdk/new/cmd.go
@@ -58,7 +58,7 @@ generates a skeletal app-operator application in $HOME/projects/example.com/app-
 	newCmd.Flags().StringVar(&operatorType, "type", "go", "Type of operator to initialize (choices: \"go\", \"ansible\" or \"helm\")")
 	newCmd.Flags().StringVar(&depManager, "dep-manager", "modules", `Dependency manager the new project will use (choices: "dep", "modules")`)
 	newCmd.Flags().StringVar(&repo, "repo", "", "Project repository path for Go operators. Used as the project's Go import path. This must be set if outside of $GOPATH/src with Go modules, and cannot be set if --dep-manager=dep")
-	newCmd.Flags().BoolVar(&skipGit, "skip-git-init", false, "Do not init the directory as a git repository")
+	newCmd.Flags().BoolVar(&gitInit, "git-init", false, "Initialize the project directory as a git repository")
 	newCmd.Flags().StringVar(&headerFile, "header-file", "", "Path to file containing headers for generated Go files. Copied to hack/boilerplate.go.txt")
 	newCmd.Flags().BoolVar(&makeVendor, "vendor", false, "Use a vendor directory for dependencies. This flag only applies when --dep-manager=modules (the default)")
 	newCmd.Flags().BoolVar(&skipValidation, "skip-validation", false, "Do not validate the resulting project's structure and dependencies. (Only used for --type go)")
@@ -79,7 +79,7 @@ var (
 	depManager       string
 	headerFile       string
 	repo             string
-	skipGit          bool
+	gitInit          bool
 	makeVendor       bool
 	skipValidation   bool
 	generatePlaybook bool
@@ -458,12 +458,11 @@ func getDeps() error {
 }
 
 func initGit() error {
-	if skipGit {
+	if !gitInit {
 		return nil
 	}
 	if _, err := exec.LookPath("git"); err != nil {
-		log.Infof("Skipping git init: %v", err)
-		return nil
+		return errors.Wrapf(err, "failed to find git")
 	}
 
 	log.Info("Running git init")

--- a/cmd/operator-sdk/new/cmd.go
+++ b/cmd/operator-sdk/new/cmd.go
@@ -58,7 +58,7 @@ generates a skeletal app-operator application in $HOME/projects/example.com/app-
 	newCmd.Flags().StringVar(&operatorType, "type", "go", "Type of operator to initialize (choices: \"go\", \"ansible\" or \"helm\")")
 	newCmd.Flags().StringVar(&depManager, "dep-manager", "modules", `Dependency manager the new project will use (choices: "dep", "modules")`)
 	newCmd.Flags().StringVar(&repo, "repo", "", "Project repository path for Go operators. Used as the project's Go import path. This must be set if outside of $GOPATH/src with Go modules, and cannot be set if --dep-manager=dep")
-	newCmd.Flags().BoolVar(&gitInit, "git-init", false, "Initialize the project directory as a git repository")
+	newCmd.Flags().BoolVar(&gitInit, "git-init", false, "Initialize the project directory as a git repository (default false)")
 	newCmd.Flags().StringVar(&headerFile, "header-file", "", "Path to file containing headers for generated Go files. Copied to hack/boilerplate.go.txt")
 	newCmd.Flags().BoolVar(&makeVendor, "vendor", false, "Use a vendor directory for dependencies. This flag only applies when --dep-manager=modules (the default)")
 	newCmd.Flags().BoolVar(&skipValidation, "skip-validation", false, "Do not validate the resulting project's structure and dependencies. (Only used for --type go)")
@@ -127,8 +127,10 @@ func newFunc(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if err := initGit(); err != nil {
-		return err
+	if gitInit {
+		if err := initGit(); err != nil {
+			return err
+		}
 	}
 
 	log.Info("Project creation complete.")
@@ -458,13 +460,6 @@ func getDeps() error {
 }
 
 func initGit() error {
-	if !gitInit {
-		return nil
-	}
-	if _, err := exec.LookPath("git"); err != nil {
-		return errors.Wrapf(err, "failed to find git")
-	}
-
 	log.Info("Running git init")
 	if err := execProjCmd("git", "init"); err != nil {
 		return errors.Wrapf(err, "failed to run git init")

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -263,7 +263,7 @@ Scaffolds a new operator project.
 * `--header-file` string - Path to file containing headers for generated Go files. Copied to hack/boilerplate.go.txt
 * `--dep-manager` string - Dependency manager the new project will use (choices: "dep", "modules") (default "modules")
 * `--repo` string - Project repository path for Go operators. Used as the project's Go import path. This must be set if outside of `$GOPATH/src` with Go modules, and cannot be set if `--dep-manager=dep`
-* `--skip-git-init` - Do not init the directory as a git repository
+* `--git-init` - Initialize the project directory as a git repository (default `false`)
 * `--vendor` - Use a vendor directory for dependencies. This flag only applies when `--dep-manager=modules` (the default)
 * `--skip-validation` - Do not validate the resulting project's structure and dependencies. (Only used for --type go)
 * `-h, --help` - help for new


### PR DESCRIPTION
**Description of the change:**
Changed the flag `--skip-git-init` to `--git-init` to make `git init` opt-in instead of opt-out.
Also `operator-sdk new` will no longer create the initial commit.

**Motivation for the change:**
Creating the initial commit is unexpected behavior and can fail certain scenarios as described in #1198 .
~~Having `git init` as opt-out via `--skip-git-init` instead of opt-in is debatable, and so is unchanged at the moment.~~
~~I am leaning towards making `git init` opt-in but can address that in a follow up PR after we discuss it on the issue.~~
Changed `git init` to opt-in per the consensus from the community and maintainers.

Closes: #1198 
