### PR TITLE
doc/*: Change underscore links for marker tool to work

### DIFF
--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -4,22 +4,22 @@ This guide walks through an example of building a simple memcached-operator powe
 
 ## Prerequisites
 
-- [git][git_tool]
-- [docker][docker_tool] version 17.03+.
-- [kubectl][kubectl_tool] version v1.9.0+.
-- [ansible][ansible_tool] version v2.6.0+
-- [ansible-runner][ansible_runner_tool] version v1.1.0+
-- [ansible-runner-http][ansible_runner_http_plugin] version v1.0.0+
-- [dep][dep_tool] version v0.5.0+. (Optional if you aren't installing from source)
-- [go][go_tool] version v1.12+. (Optional if you aren't installing from source)
+- [git][git-tool]
+- [docker][docker-tool] version 17.03+.
+- [kubectl][kubectl-tool] version v1.9.0+.
+- [ansible][ansible-tool] version v2.6.0+
+- [ansible-runner][ansible-runner-tool] version v1.1.0+
+- [ansible-runner-http][ansible-runner-http-plugin] version v1.0.0+
+- [dep][dep-tool] version v0.5.0+. (Optional if you aren't installing from source)
+- [go][go-tool] version v1.12+. (Optional if you aren't installing from source)
 - Access to a Kubernetes v.1.9.0+ cluster.
 
-**Note**: This guide uses [minikube][minikube_tool] version v0.25.0+ as the
-local Kubernetes cluster and [quay.io][quay_link] for the public registry.
+**Note**: This guide uses [minikube][minikube-tool] version v0.25.0+ as the
+local Kubernetes cluster and [quay.io][quay-link] for the public registry.
 
 ## Install the Operator SDK CLI
 
-Follow the steps in the [installation guide][install_guide] to learn how to install the Operator SDK CLI tool.
+Follow the steps in the [installation guide][install-guide] to learn how to install the Operator SDK CLI tool.
 
 ## Create a new project
 
@@ -35,11 +35,11 @@ Memcached resource with APIVersion `cache.example.com/v1apha1` and Kind
 `Memcached`.
 
 To learn more about the project directory structure, see [project
-layout][layout_doc] doc.
+layout][layout-doc] doc.
 
 #### Operator scope
 
-Read the [operator scope][operator_scope] documentation on how to run your operator as namespace-scoped vs cluster-scoped.
+Read the [operator scope][operator-scope] documentation on how to run your operator as namespace-scoped vs cluster-scoped.
 
 ### Watches file
 
@@ -282,8 +282,8 @@ memcached-operator       1         1         1            1           1m
 
 This method is preferred during the development cycle to speed up deployment and testing.
 
-**Note**: Ensure that [Ansible Runner][ansible_runner_tool] and [Ansible Runner
-HTTP Plugin][ansible_runner_http_plugin] is installed or else you will see
+**Note**: Ensure that [Ansible Runner][ansible-runner-tool] and [Ansible Runner
+HTTP Plugin][ansible-runner-http-plugin] is installed or else you will see
 unexpected errors from Ansible Runner when a Custom Resource is created.
 
 It is also important that the `role` path referenced in `watches.yaml` exists
@@ -410,17 +410,17 @@ $ kubectl delete -f deploy/service_account.yaml
 $ kubectl delete -f deploy/crds/cache_v1alpha1_memcached_crd.yaml
 ```
 
-[operator_scope]:./../operator-scope.md
-[install_guide]: ../user/install-operator-sdk.md
-[layout_doc]:./project_layout.md
-[homebrew_tool]:https://brew.sh/
-[dep_tool]:https://golang.github.io/dep/docs/installation.html
-[git_tool]:https://git-scm.com/downloads
-[go_tool]:https://golang.org/dl/
-[docker_tool]:https://docs.docker.com/install/
-[kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
-[minikube_tool]:https://github.com/kubernetes/minikube#installation
-[ansible_tool]:https://docs.ansible.com/ansible/latest/index.html
-[ansible_runner_tool]:https://ansible-runner.readthedocs.io/en/latest/install.html
-[ansible_runner_http_plugin]:https://github.com/ansible/ansible-runner-http
-[quay_link]:https://quay.io
+[operator-scope]:./../operator-scope.md
+[install-guide]: ../user/install-operator-sdk.md
+[layout-doc]:./project_layout.md
+[homebrew-tool]:https://brew.sh/
+[dep-tool]:https://golang.github.io/dep/docs/installation.html
+[git-tool]:https://git-scm.com/downloads
+[go-tool]:https://golang.org/dl/
+[docker-tool]:https://docs.docker.com/install/
+[kubectl-tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
+[minikube-tool]:https://github.com/kubernetes/minikube#installation
+[ansible-tool]:https://docs.ansible.com/ansible/latest/index.html
+[ansible-runner-tool]:https://ansible-runner.readthedocs.io/en/latest/install.html
+[ansible-runner-http-plugin]:https://github.com/ansible/ansible-runner-http
+[quay-link]:https://quay.io

--- a/doc/dev/developer_guide.md
+++ b/doc/dev/developer_guide.md
@@ -3,13 +3,13 @@
 This document explains how to setup your dev environment.
 
 ## Prerequisites
-- [dep][dep_tool] version v0.5.0+
-- [git][git_tool]
-- [go][go_tool] version v1.12+
+- [dep][dep-tool] version v0.5.0+
+- [git][git-tool]
+- [go][go-tool] version v1.12+
 
 ## Download Operator SDK
 
-Go to the [Operator SDK repo][repo_sdk] and follow the [fork guide][fork_guide] to fork, clone, and setup the local operator-sdk repository.
+Go to the [Operator SDK repo][repo-sdk] and follow the [fork guide][fork-guide] to fork, clone, and setup the local operator-sdk repository.
 
 ## Vendor dependencies
 
@@ -47,14 +47,14 @@ $ make test
 For more information on running testing and correctly configuring your environment,
 refer to the [`Running the Tests Locally`][running-the-tests] document.
 
-See the project [README][sdk_readme] for more details.
+See the project [README][sdk-readme] for more details.
 
-[dep_tool]:https://golang.github.io/dep/docs/installation.html
-[git_tool]:https://git-scm.com/downloads
-[go_tool]:https://golang.org/dl/
-[repo_sdk]:https://github.com/operator-framework/operator-sdk
-[fork_guide]:https://help.github.com/en/articles/fork-a-repo
-[docker_tool]:https://docs.docker.com/install/
-[kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
-[sdk_readme]:../../README.md
+[dep-tool]:https://golang.github.io/dep/docs/installation.html
+[git-tool]:https://git-scm.com/downloads
+[go-tool]:https://golang.org/dl/
+[repo-sdk]:https://github.com/operator-framework/operator-sdk
+[fork-guide]:https://help.github.com/en/articles/fork-a-repo
+[docker-tool]:https://docs.docker.com/install/
+[kubectl-tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
+[sdk-readme]:../../README.md
 [running-the-tests]: ./testing/running-the-tests.md

--- a/doc/helm/user-guide.md
+++ b/doc/helm/user-guide.md
@@ -4,19 +4,19 @@ This guide walks through an example of building a simple nginx-operator powered 
 
 ## Prerequisites
 
-- [git][git_tool]
-- [docker][docker_tool] version 17.03+.
-- [kubectl][kubectl_tool] version v1.11.3+.
-- [dep][dep_tool] version v0.5.0+. (Optional if you aren't installing from source)
-- [go][go_tool] version v1.12+. (Optional if you aren't installing from source)
+- [git][git-tool]
+- [docker][docker-tool] version 17.03+.
+- [kubectl][kubectl-tool] version v1.11.3+.
+- [dep][dep-tool] version v0.5.0+. (Optional if you aren't installing from source)
+- [go][go-tool] version v1.12+. (Optional if you aren't installing from source)
 - Access to a Kubernetes v1.11.3+ cluster.
 
-**Note**: This guide uses [minikube][minikube_tool] version v0.25.0+ as the
-local Kubernetes cluster and [quay.io][quay_link] for the public registry.
+**Note**: This guide uses [minikube][minikube-tool] version v0.25.0+ as the
+local Kubernetes cluster and [quay.io][quay-link] for the public registry.
 
 ## Install the Operator SDK CLI
 
-Follow the steps in the [installation guide][install_guide] to learn how to install the Operator SDK CLI tool.
+Follow the steps in the [installation guide][install-guide] to learn how to install the Operator SDK CLI tool.
 
 ## Create a new project
 
@@ -37,7 +37,7 @@ chart's default manifest. Be sure to double check that the rules generated
 in `deploy/role.yaml` meet the operator's permission requirements.
 
 To learn more about the project directory structure, see the
-[project layout][layout_doc] doc.
+[project layout][layout-doc] doc.
 
 ### Use an existing chart
 
@@ -66,7 +66,7 @@ If `--helm-chart-version` is not set, the SDK will fetch the latest available ve
 
 ### Operator scope
 
-Read the [operator scope][operator_scope] documentation on how to run your operator as namespace-scoped vs cluster-scoped.
+Read the [operator scope][operator-scope] documentation on how to run your operator as namespace-scoped vs cluster-scoped.
 
 
 ## Customize the operator logic
@@ -102,11 +102,11 @@ resources, along with a NOTES.txt template, which Helm chart developers use
 to convey helpful information about a release.
 
 If you aren't already familiar with Helm Charts, take a moment to review
-the [Helm Chart developer documentation][helm_charts].
+the [Helm Chart developer documentation][helm-charts].
 
 ### Understanding the Nginx CR spec
 
-Helm uses a concept called [values][helm_values] to provide customizations
+Helm uses a concept called [values][helm-values] to provide customizations
 to a Helm chart's defaults, which are defined in the Helm chart's `values.yaml`
 file.
 
@@ -329,16 +329,16 @@ kubectl delete -f deploy/service_account.yaml
 kubectl delete -f deploy/crds/example_v1alpha1_nginx_crd.yaml
 ```
 
-[operator_scope]:./../operator-scope.md
-[install_guide]: ../user/install-operator-sdk.md
-[layout_doc]:./project_layout.md
-[homebrew_tool]:https://brew.sh/
-[dep_tool]:https://golang.github.io/dep/docs/installation.html
-[git_tool]:https://git-scm.com/downloads
-[go_tool]:https://golang.org/dl/
-[docker_tool]:https://docs.docker.com/install/
-[kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
-[minikube_tool]:https://github.com/kubernetes/minikube#installation
-[helm_charts]:https://helm.sh/docs/developing_charts/
-[helm_values]:https://helm.sh/docs/using_helm/#customizing-the-chart-before-installing
-[quay_link]:https://quay.io
+[operator-scope]:./../operator-scope.md
+[install-guide]: ../user/install-operator-sdk.md
+[layout-doc]:./project_layout.md
+[homebrew-tool]:https://brew.sh/
+[dep-tool]:https://golang.github.io/dep/docs/installation.html
+[git-tool]:https://git-scm.com/downloads
+[go-tool]:https://golang.org/dl/
+[docker-tool]:https://docs.docker.com/install/
+[kubectl-tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
+[minikube-tool]:https://github.com/kubernetes/minikube#installation
+[helm-charts]:https://helm.sh/docs/developing_charts/
+[helm-values]:https://helm.sh/docs/using_helm/#customizing-the-chart-before-installing
+[quay-link]:https://quay.io


### PR DESCRIPTION

**Motivation for the change:**
PRs have been having failing marker tests for no reason. Network is working inside the pods, I could resolve URLs that are failing in the tests. Changing as per the suggestion in https://github.com/operator-framework/operator-sdk/blob/a87a07686fba330b18611daf67f1b972f14fe3be/doc/dev/testing/travis-build.md#markdown 
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
