### PR TITLE
doc/*: Fix links

### DIFF
--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -299,7 +299,7 @@ At this point you should be able to build and run your operator to verify that i
 [v0.1.0-changes-doc]: ./v0.1.0-changes.md
 [v0.0.7-memcached-operator]: https://github.com/operator-framework/operator-sdk-samples/tree/aa15bd278eec0959595e0a0a7282a26055d7f9d6/memcached-operator
 [v0.1.0-memcached-operator]: https://github.com/operator-framework/operator-sdk-samples/tree/4c6934448684a6953ece4d3d9f3f77494b1c125e/memcached-operator
-[controller-conventions]: https://github.com/kubernetes/community/blob/master/contributors/devel/controllers.md#guidelines
+[controller-conventions]: https://github.com/kubernetes/community/blob/cbe9c8ac5f71a99179d7ffe4a008b9018830af72/contributors/devel/sig-api-machinery/controllers.md#guidelines
 [reconciler-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Reconciler
 [watching-eventhandling-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg#hdr-Watching_and_EventHandling
 [controller-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg#hdr-Controller

--- a/doc/proposals/ansible-operator-status.md
+++ b/doc/proposals/ansible-operator-status.md
@@ -20,7 +20,7 @@ Add a new field to the watches.yaml entry, which tells the operator whether or n
 
 Add a new Ansible module, named `k8s_status` that is usable when running inside Ansible Operator.
 
-The `k8s_status` module would take the apiVersion, kind, name, namespace as well as a status blob and list of conditions. It would then set the status on the specified resource using that blob. The conditions would be validated to conform to the [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties). It would then take this status blob and call to update the status subresource for the specified resource (which should be the CR that is being reconciled).\
+The `k8s_status` module would take the apiVersion, kind, name, namespace as well as a status blob and list of conditions. It would then set the status on the specified resource using that blob. The conditions would be validated to conform to the [Kubernetes API conventions](https://github.com/kubernetes/community/blob/cbe9c8ac5f71a99179d7ffe4a008b9018830af72/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties). It would then take this status blob and call to update the status subresource for the specified resource (which should be the CR that is being reconciled).\
 _**Note - likely this module would inherit from k8s_common, and include the same general authentication/etc options as the other k8s modules*_
 
 The Go-side of the Ansible Operator would need two changes:

--- a/doc/proposals/metering-operator-metrics.md
+++ b/doc/proposals/metering-operator-metrics.md
@@ -6,7 +6,7 @@ We want to be able to generate the metering reports based on the operator specif
 
 ### Overview of the metrics
 
-To follow both the Prometheus instrumentation [best practices](https://prometheus.io/docs/practices/naming/) as well as the official Kubernetes instrumentation [guide](https://github.com/kubernetes/community/blob/master/contributors/devel/instrumentation.md), the metrics will have the following format:
+To follow both the Prometheus instrumentation [best practices](https://prometheus.io/docs/practices/naming/) as well as the official Kubernetes instrumentation [guide](https://github.com/kubernetes/community/blob/cbe9c8ac5f71a99179d7ffe4a008b9018830af72/contributors/devel/sig-instrumentation/instrumentation.md), the metrics will have the following format:
 
 ```
 crd_kind_info{namespace="namespace",crdkind="instance-name"} 1


### PR DESCRIPTION
**Description of the change:**

The links have moved to subdirectories, this PR adjusts to point to the
current commit so we don't have to adjust this in the future.

**Motivation for the change:**

Currently CI marker test is failing, due to the following errors, this PR fixes them.
```
./hack/ci/marker --root=doc
Found broken url       (Kubernetes API conventions -> https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#typical-status-properties) at doc/proposals/ansible-operator-status.md:23 : 404 Not Found
Found broken url       (guide -> https://github.com/kubernetes/community/blob/master/contributors/devel/instrumentation.md) at doc/proposals/metering-operator-metrics.md:9 : 404 Not Found
Found broken url       (controller conventions -> https://github.com/kubernetes/community/blob/master/contributors/devel/controllers.md#guidelines) at doc/migration/v0.1.0-migration-guide.md:107 : 404 Not Found
make: *** [test/markdown] Error 1
```

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
