### PR TITLE
test/test-framework,test/e2e: get latest resource during RetryOnConflict

### DIFF
--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -483,12 +483,12 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 	}
 	obj.SetNamespace(key.Namespace)
 
-	err = f.Client.Get(context.TODO(), key, &obj)
-	if err != nil {
-		return fmt.Errorf("could not get memcached CR %q: %v", key, err)
-	}
-
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		err = f.Client.Get(context.TODO(), key, &obj)
+		if err != nil {
+			return fmt.Errorf("could not get memcached CR %q: %v", key, err)
+		}
+
 		// update memcached CR size to `toReplicas` replicas
 		spec, ok := obj.Object["spec"].(map[string]interface{})
 		if !ok {

--- a/test/test-framework/test/e2e/memcached_test.go
+++ b/test/test-framework/test/e2e/memcached_test.go
@@ -77,12 +77,12 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 		return fmt.Errorf("failed waiting for %d deployment/%s replicas: %v", fromReplicas, key.Name, err)
 	}
 
-	err = f.Client.Get(goctx.TODO(), key, exampleMemcached)
-	if err != nil {
-		return fmt.Errorf("could not get memcached CR %q: %v", key, err)
-	}
-
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		err = f.Client.Get(goctx.TODO(), key, exampleMemcached)
+		if err != nil {
+			return fmt.Errorf("could not get memcached CR %q: %v", key, err)
+		}
+
 		exampleMemcached.Spec.Size = int32(toReplicas)
 		t.Logf("Attempting memcached %q update, resourceVersion: %s", key, exampleMemcached.GetResourceVersion())
 		return f.Client.Update(goctx.TODO(), exampleMemcached)


### PR DESCRIPTION
**Description of the change:**
Fixes a flake that happens sometimes during the Go e2e test, related to CR updates failing with conflic errors during the scale test.

The original PR that attempted to fix this is here: #1585 

**Motivation for the change:**
The original PR to fix this issue didn't actually fix the issue because it didn't re-fetch the latest version of the resource.
