### PR TITLE
Enable ServiceMonitor creation by default

### DIFF
--- a/doc/user/metrics/README.md
+++ b/doc/user/metrics/README.md
@@ -6,7 +6,7 @@
 
 ### General metrics
 
-The `"CreateMetricsService(ctx context.Context, cfg *rest.Config, servicePorts []v1.ServicePort) (*v1.Service, error)` function exposes general metrics about the running program. These metrics are inherited from controller-runtime. To understand which metrics are exposed, read the metrics package doc of [controller-runtime][controller-metrics]. The `ExposeMetricsPort` function creates a [Service][service] object with the metrics port exposed, which can then be accessed by Prometheus. The Service object is [garbage collected][gc] when the leader pod's root owner is deleted.
+The `CreateMetricsService(ctx context.Context, cfg *rest.Config, servicePorts []v1.ServicePort) (*v1.Service, error)` function exposes general metrics about the running program. These metrics are inherited from controller-runtime. To understand which metrics are exposed, read the metrics package doc of [controller-runtime][controller-metrics]. The function creates a [Service][service] object with the metrics port exposed, which can then be accessed by Prometheus. The Service object is [garbage collected][gc] when the leader pod's root owner is deleted.
 
 By default, the metrics are served on `0.0.0.0:8383/metrics`. To modify the port the metrics are exposed on, change the `var metricsPort int32 = 8383` variable in the `cmd/manager/main.go` file of the generated operator.
 

--- a/doc/user/metrics/service-monitor.md
+++ b/doc/user/metrics/service-monitor.md
@@ -4,7 +4,7 @@
 
 `ServiceMonitor` is a CustomResource of the prometheus-operator, which discovers the `Endpoints` in `Service` objects and configures Prometheus to monitor those pods. See the prometheus-operator [documentation][service-monitor] to learn more about `ServiceMonitor`.
 
-The `GenerateServiceMonitor` function takes a `Service` object and generates a `ServiceMonitor` resource based on it. To add `Service` target discovery of your created monitoring `Service` you can use the `metrics.CreateServiceMonitor()` helper function, which accepts the newly created `Service`.
+The `CreateServiceMonitors` function takes `Service` objects and generates `ServiceMonitor` resources based on the endpoints. To add `Service` target discovery of your created monitoring `Service` you can use the `metrics.CreateServiceMonitors()` helper function, which accepts the newly created `Service`.
 
 ### Prerequisites:
 

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -159,7 +159,7 @@ func main() {
 		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
 	}
 	// Create Service object to expose the metrics port(s).
-	service, err = metrics.CreateMetricsService(ctx, cfg, servicePorts)
+	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
 	if err != nil {
 		log.Info("Could not create metrics Service: ", err.Error())
 	}

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -161,7 +161,7 @@ func main() {
 	// Create Service object to expose the metrics port(s).
 	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
 	if err != nil {
-		log.Info("Could not create metrics Service: ", err.Error())
+		log.Info("Could not create metrics Service", "error:", err.Error())
 	}
 
 	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
@@ -171,7 +171,7 @@ func main() {
 	services := []*v1.Service{service}
 	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
 	if err != nil {
-		log.Info("Could not create ServiceMonitor object: ", err.Error())
+		log.Info("Could not create ServiceMonitor object", "error:", err.Error())
 	}
 
 	log.Info("Starting the Cmd.")

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -164,8 +164,10 @@ func main() {
 		log.Info("Could not create metrics Service: ", err.Error())
 	}
 
-	// Remove below code if you do not have Prometheus operator running in the cluster.
-	// Populate services with any additional Service(s) for which you want to create ServiceMonitors.
+	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
+	// necessary to configure Prometheus to scrape metrics from this operator.
+	// If this operator is deployed to a cluster without the prometheus-operator running, it will return
+	// ErrServiceMonitorNotPresent,which can be used to safely skip ServiceMonitor creation.
 	services := []*v1.Service{service}
 	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
 	if err != nil {

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -161,18 +161,21 @@ func main() {
 	// Create Service object to expose the metrics port(s).
 	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
 	if err != nil {
-		log.Info("Could not create metrics Service", "error:", err.Error())
+		log.Info("Could not create metrics Service", "error", err.Error())
 	}
 
-	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
-	// necessary to configure Prometheus to scrape metrics from this operator.
-	// If this operator is deployed to a cluster without the prometheus-operator running, it will return
-	// ErrServiceMonitorNotPresent,which can be used to safely skip ServiceMonitor creation.
-	services := []*v1.Service{service}
-	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
-	if err != nil {
-		log.Info("Could not create ServiceMonitor object", "error:", err.Error())
-	}
+    // CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
+    // necessary to configure Prometheus to scrape metrics from this operator.
+    services := []*v1.Service{service}
+    _, err = metrics.CreateServiceMonitors(cfg, namespace, services)
+    if err != nil {
+        log.Info("Could not create ServiceMonitor object", "error", err.Error())
+        // If this operator is deployed to a cluster without the prometheus-operator running, it will return
+        // ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.
+        if err == metrics.ErrServiceMonitorNotPresent {
+            log.Info("Install prometheus-operator in your cluster to create ServiceMonitor objects", "error", err.Error())
+        }
+    }
 
 	log.Info("Starting the Cmd.")
 

--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -159,9 +159,17 @@ func main() {
 		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
 	}
 	// Create Service object to expose the metrics port(s).
-	_, err = metrics.CreateMetricsService(ctx, cfg, servicePorts)
+	service, err = metrics.CreateMetricsService(ctx, cfg, servicePorts)
 	if err != nil {
-		log.Info(err.Error())
+		log.Info("Could not create metrics Service: ", err.Error())
+	}
+
+	// Remove below code if you do not have Prometheus operator running in the cluster.
+	// Populate services with any additional Service(s) for which you want to create ServiceMonitors.
+	services := []*v1.Service{service}
+	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
+	if err != nil {
+		log.Info("Could not create ServiceMonitor object: ", err.Error())
 	}
 
 	log.Info("Starting the Cmd.")

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -158,9 +158,17 @@ func main() {
 		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
 	}
 	// Create Service object to expose the metrics port(s).
-	_, err = metrics.CreateMetricsService(ctx, cfg, servicePorts)
+	service, err = metrics.CreateMetricsService(ctx, cfg, servicePorts)
 	if err != nil {
-		log.Info(err.Error())
+		log.Info("Could not create metrics Service: ", err.Error())
+	}
+
+	// Remove below code if you do not have Prometheus operator running in the cluster.
+	// Populate services with any additional Service(s) for which you want to create ServiceMonitors.
+	services := []*v1.Service{service}
+	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
+	if err != nil {
+		log.Info("Could not create ServiceMonitor object: ", err.Error())
 	}
 
 	log.Info("Starting the Cmd.")

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -163,8 +163,10 @@ func main() {
 		log.Info("Could not create metrics Service: ", err.Error())
 	}
 
-	// Remove below code if you do not have Prometheus operator running in the cluster.
-	// Populate services with any additional Service(s) for which you want to create ServiceMonitors.
+	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
+	// necessary to configure Prometheus to scrape metrics from this operator.
+	// If this operator is deployed to a cluster without the prometheus-operator running, it will return
+	// ErrServiceMonitorNotPresent,which can be used to safely skip ServiceMonitor creation.
 	services := []*v1.Service{service}
 	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
 	if err != nil {

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -160,17 +160,20 @@ func main() {
 	// Create Service object to expose the metrics port(s).
 	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
 	if err != nil {
-		log.Info("Could not create metrics Service", "error:", err.Error())
+		log.Info("Could not create metrics Service", "error", err.Error())
 	}
 
 	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
 	// necessary to configure Prometheus to scrape metrics from this operator.
-	// If this operator is deployed to a cluster without the prometheus-operator running, it will return
-	// ErrServiceMonitorNotPresent,which can be used to safely skip ServiceMonitor creation.
 	services := []*v1.Service{service}
 	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
 	if err != nil {
-		log.Info("Could not create ServiceMonitor object", "error:", err.Error())
+		log.Info("Could not create ServiceMonitor object", "error", err.Error())
+		// If this operator is deployed to a cluster without the prometheus-operator running, it will return
+		// ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.
+		if err == metrics.ErrServiceMonitorNotPresent {
+			log.Info("Install prometheus-operator in your cluster to create ServiceMonitor objects", "error", err.Error())
+		}
 	}
 
 	log.Info("Starting the Cmd.")

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -160,7 +160,7 @@ func main() {
 	// Create Service object to expose the metrics port(s).
 	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
 	if err != nil {
-		log.Info("Could not create metrics Service: ", err.Error())
+		log.Info("Could not create metrics Service", "error:", err.Error())
 	}
 
 	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
@@ -170,7 +170,7 @@ func main() {
 	services := []*v1.Service{service}
 	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
 	if err != nil {
-		log.Info("Could not create ServiceMonitor object: ", err.Error())
+		log.Info("Could not create ServiceMonitor object", "error:", err.Error())
 	}
 
 	log.Info("Starting the Cmd.")

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -158,7 +158,7 @@ func main() {
 		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
 	}
 	// Create Service object to expose the metrics port(s).
-	service, err = metrics.CreateMetricsService(ctx, cfg, servicePorts)
+	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
 	if err != nil {
 		log.Info("Could not create metrics Service: ", err.Error())
 	}

--- a/internal/pkg/scaffold/role.go
+++ b/internal/pkg/scaffold/role.go
@@ -165,6 +165,7 @@ rules:
   resources:
   - pods
   - services
+  - services/finalizers
   - endpoints
   - persistentvolumeclaims
   - events

--- a/internal/pkg/scaffold/role_test.go
+++ b/internal/pkg/scaffold/role_test.go
@@ -84,6 +84,7 @@ rules:
   resources:
   - pods
   - services
+  - services/finalizers
   - endpoints
   - persistentvolumeclaims
   - events
@@ -139,6 +140,7 @@ rules:
   resources:
   - pods
   - services
+  - services/finalizers
   - endpoints
   - persistentvolumeclaims
   - events

--- a/pkg/metrics/service-monitor.go
+++ b/pkg/metrics/service-monitor.go
@@ -15,6 +15,8 @@
 package metrics
 
 import (
+	"fmt"
+
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	monclientv1 "github.com/coreos/prometheus-operator/pkg/client/versioned/typed/monitoring/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -23,6 +25,8 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 )
+
+var ErrServiceMonitorNotPresent = fmt.Errorf("ServiceMonitor is not registered with the API")
 
 // CreateServiceMonitors creates ServiceMonitors objects based on an array of Service objects.
 // If CR ServiceMonitor is not registered in the Cluster it will not attempt at creating resources.
@@ -33,9 +37,7 @@ func CreateServiceMonitors(config *rest.Config, ns string, services []*v1.Servic
 		return nil, err
 	}
 	if !exists {
-		log.Info("ServiceMonitor object could not be created as ServiceMonitor is not registered with the API")
-		// ServiceMonitor was not registered, but we don't want to produce more errors just return.
-		return nil, nil
+		return nil, ErrServiceMonitorNotPresent
 	}
 
 	var serviceMonitors []*monitoringv1.ServiceMonitor

--- a/pkg/metrics/service-monitor.go
+++ b/pkg/metrics/service-monitor.go
@@ -61,12 +61,23 @@ func GenerateServiceMonitor(s *v1.Service) *monitoringv1.ServiceMonitor {
 		labels[k] = v
 	}
 	endpoints := populateEndpointsFromServicePorts(s)
+	boolTrue := true
 
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      s.ObjectMeta.Name,
 			Namespace: s.ObjectMeta.Namespace,
 			Labels:    labels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "v1",
+					BlockOwnerDeletion: &boolTrue,
+					Controller:         &boolTrue,
+					Kind:               "Service",
+					Name:               s.Name,
+					UID:                s.UID,
+				},
+			},
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{

--- a/pkg/metrics/service-monitor.go
+++ b/pkg/metrics/service-monitor.go
@@ -33,6 +33,7 @@ func CreateServiceMonitors(config *rest.Config, ns string, services []*v1.Servic
 		return nil, err
 	}
 	if !exists {
+		log.Info("ServiceMonitor object could not be created as ServiceMonitor is not registered with the API")
 		// ServiceMonitor was not registered, but we don't want to produce more errors just return.
 		return nil, nil
 	}

--- a/pkg/metrics/service-monitor.go
+++ b/pkg/metrics/service-monitor.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-var ErrServiceMonitorNotPresent = fmt.Errorf("ServiceMonitor is not registered with the API")
+var ErrServiceMonitorNotPresent = fmt.Errorf("no ServiceMonitor registered with the API")
 
 // CreateServiceMonitors creates ServiceMonitors objects based on an array of Service objects.
 // If CR ServiceMonitor is not registered in the Cluster it will not attempt at creating resources.


### PR DESCRIPTION
**Description of the change:**
- Adds creation of ServiceMonitor objects in every users generated main.go file. We already have a check in place that logs and does not create the objects if they are not registered - so when prometheus-operator is not running in the cluster.

- Adds owner reference to the ServiceMonitor and sets Service as the owner, so when the Service is deleted it will clean up any ServiceMonitor objects as well.

**Motivation for the change:**

Closes https://github.com/operator-framework/operator-sdk/issues/1576

- [ ] Update CHANGELOG.md 

**Question:** Should we add an e2e test to check if the ServiceMonitor was created? For that we need to install prometheus-operator in the cluster which might take a while.