### PR TITLE
support multi-arch for "operator-sdk build"

### DIFF
--- a/cmd/operator-sdk/build/cmd.go
+++ b/cmd/operator-sdk/build/cmd.go
@@ -88,7 +88,13 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	projutil.MustInProjectRoot()
-	goBuildEnv := append(os.Environ(), "GOOS=linux", "GOARCH=amd64")
+	goBuildEnv := append(os.Environ(), "GOOS=linux")
+
+	if value, ok := os.LookupEnv("GOARCH"); ok {
+		goBuildEnv = append(goBuildEnv, "GOARCH="+value)
+	} else {
+		goBuildEnv = append(goBuildEnv, "GOARCH=amd64")
+	}
 
 	// If CGO_ENABLED is not set, set it to '0'.
 	if _, ok := os.LookupEnv("CGO_ENABLED"); !ok {


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->
#1595 
**Description of the change:**
Make `operator-sdk build` support other architectures.
I do not change the original behavior, since I have no idea the reason `GOARCH=amd64` there.

**Motivation for the change:**
We try to use `operator-sdk build` for other architectures.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
