### PR TITLE
Makefile: add targets to scaffold ansible and helm base image files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,12 @@ test/markdown:
 
 image: image/build image/push
 
+image/scaffold/ansible:
+	go run ./hack/image/ansible/scaffold-ansible-image.go
+
+image/scaffold/helm:
+	go run ./hack/image/helm/scaffold-helm-image.go
+
 image/build: image/build/ansible image/build/helm image/build/scorecard-proxy
 
 image/build/ansible: build/operator-sdk-dev-x86_64-linux-gnu
@@ -163,4 +169,4 @@ image/push/helm:
 image/push/scorecard-proxy:
 	./hack/image/push-image-tags.sh $(SCORECARD_PROXY_BASE_IMAGE):dev $(SCORECARD_PROXY_IMAGE)
 
-.PHONY: image image/build image/build/ansible image/build/helm image/push image/push/ansible image/push/helm
+.PHONY: image image/scaffold/ansible image/scaffold/helm image/build image/build/ansible image/build/helm image/push image/push/ansible image/push/helm


### PR DESCRIPTION
**Description of the change:**
Add `make` targets to run the ansible and helm image scaffolding go main functions

**Motivation for the change:**
When OpenShift CI runs CI for PRs, it uses Dockerfiles from the base branch, and not from the PR. The OpenShift CI ansible e2e tests currrently run `go run` directly in the Dockerfile, so tweaking the go build arguments and environment is more cumbersome because of the aforementioned use of the base branch Dockerfile.

This PR is the first step in transitioning the `go run` commands out of the Dockerfiles and back to the SDK repo, where things can be more easily changed and tested. Once this is merged, a follow on PR will be added to switch the Dockerfiles to use these targets.

This is necessary to support the transition of the SDK from `dep` to go modules. See #1566. 
