### PR TITLE
.travis.yml: don't run travis on release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+branches:
+  except:
+    - release-4.2
+    - release-4.3
+
 language: go
 go_import_path: github.com/operator-framework/operator-sdk
 sudo: required


### PR DESCRIPTION
**Description of the change:** Don't run travis on branches `release-4.2` and `release-4.3`.


**Motivation for the change:** These are currently just mirroring master and slow down CI as it causes us to hit the job limit quickly. Currently just limiting the branches directly without a regex, as we might need to re-enable travis testing if we haven't fully migrated to openshift-ci by the 4.2 final freeze.