### PR TITLE
fix: Fix a link in README

### DIFF
--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -325,7 +325,7 @@ $ kubectl delete -f deploy/crds/cache_v1alpha1_memcached_crd.yaml
 ```
 
 [memcached-sample]:https://github.com/operator-framework/operator-sdk-samples/tree/master/memcached-operator
-[framework-link]:https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/framework.go#L45
+[framework-link]:https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/framework.go
 [testctx-link]:https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/context.go
 [e2eutil-link]:https://github.com/operator-framework/operator-sdk/tree/master/pkg/test/e2eutil
 [memcached-test-link]:https://github.com/operator-framework/operator-sdk-samples/blob/master/memcached-operator/test/e2e/memcached_test.go


### PR DESCRIPTION
The link https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/framework.go#L45 may be inaccurate because of the file changes. 

Thus I think it is better to remove the line number in the link just like https://github.com/operator-framework/operator-sdk/pull/1617/files#diff-59ad6a5ff59239f33497d6206b778c43L329 does.

Please take a look, thanks for your time :smile:

Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebase