### PR TITLE
Move to ubi-based base image for Ansible Operator

### DIFF
--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -17,7 +17,8 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
     HOME=/opt/ansible
 
 # Install python dependencies
-RUN yum install -y python-devel gcc \
+RUN (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true) \
+ && yum install -y python-devel gcc inotify-tools \
  && easy_install pip \
  && pip install -U --no-cache-dir setuptools pip \
  && pip install --no-cache-dir --ignore-installed ipaddress \
@@ -31,6 +32,7 @@ RUN yum install -y python-devel gcc \
 # install operator binary
 COPY --from=builder /memcached-operator ${OPERATOR}
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/library/k8s_status.py /usr/share/ansible/openshift/
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/bin/ao-logs /usr/local/bin/ao-logs
 COPY --from=builder /ansible/memcached-operator/watches.yaml ${HOME}/watches.yaml
 COPY --from=builder /ansible/memcached-operator/roles/ ${HOME}/roles/
 

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -5,6 +5,9 @@ RUN ci/tests/e2e-ansible-scaffold-hybrid.sh
 
 FROM registry.access.redhat.com/ubi7/ubi
 
+# Temporary for CI, reset /etc/passwd
+RUN chmod 0644 /etc/passwd
+
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
     && echo '[defaults]' > /etc/ansible/ansible.cfg \

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -3,20 +3,7 @@ FROM osdk-builder as builder
 RUN make image/scaffold/ansible
 RUN ci/tests/e2e-ansible-scaffold-hybrid.sh
 
-FROM ansible/ansible-runner:1.2
-
-RUN yum remove -y ansible python-idna
-RUN yum install -y inotify-tools && yum clean all
-RUN pip uninstall ansible-runner -y
-
-RUN pip install --upgrade setuptools==41.0.1
-RUN pip install "urllib3>=1.23,<1.25"
-RUN pip install ansible==2.7.10 \
-	ansible-runner==1.2 \
-	ansible-runner-http==1.0.0 \
-	idna==2.7 \
-	"kubernetes>=8.0.0,<9.0.0" \
-	openshift==0.8.8
+FROM registry.access.redhat.com/ubi7/ubi
 
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
@@ -29,19 +16,32 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
     USER_NAME=ansible-operator\
     HOME=/opt/ansible
 
-COPY --from=builder /ansible/memcached-operator/watches.yaml ${HOME}/watches.yaml
-
-COPY --from=builder /ansible/memcached-operator/roles/ ${HOME}/roles/
+# Install python dependencies
+RUN yum install -y python-devel gcc \
+ && easy_install pip \
+ && pip install -U --no-cache-dir setuptools pip \
+ && pip install --no-cache-dir --ignore-installed ipaddress \
+      ansible-runner==1.2 \
+      ansible-runner-http==1.0.0 \
+      openshift==0.8.9 \
+ && yum remove -y gcc python-devel \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
 # install operator binary
 COPY --from=builder /memcached-operator ${OPERATOR}
-
-# install k8s_status Ansible Module
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/library/k8s_status.py /usr/share/ansible/openshift/
+COPY --from=builder /ansible/memcached-operator/watches.yaml ${HOME}/watches.yaml
+COPY --from=builder /ansible/memcached-operator/roles/ ${HOME}/roles/
 
-COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/bin /usr/local/bin
-RUN /usr/local/bin/user_setup
+# Ensure directory permissions are properly set
+RUN mkdir -p ${HOME}/.ansible/tmp \
+ && chown -R ${USER_UID}:0 ${HOME} \
+ && chmod -R ug+rwx ${HOME}
 
-ENTRYPOINT ["/usr/local/bin/entrypoint"]
+ADD https://github.com/krallin/tini/releases/latest/download/tini /tini
+RUN chmod +x /tini
+
+ENTRYPOINT ["/tini", "--", "bash", "-c", "${OPERATOR} run ansible --watches-file=/opt/ansible/watches.yaml $@"]
 
 USER ${USER_UID}

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -4,6 +4,9 @@ RUN make image/scaffold/ansible
 
 FROM registry.access.redhat.com/ubi7/ubi
 
+# Temporary for CI, reset /etc/passwd
+RUN chmod 0644 /etc/passwd
+
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
     && echo '[defaults]' > /etc/ansible/ansible.cfg \

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -2,20 +2,7 @@ FROM osdk-builder as builder
 
 RUN make image/scaffold/ansible
 
-FROM ansible/ansible-runner:1.2
-
-RUN yum remove -y ansible python-idna
-RUN yum install -y inotify-tools && yum clean all
-RUN pip uninstall ansible-runner -y
-
-RUN pip install --upgrade setuptools==41.0.1
-RUN pip install "urllib3>=1.23,<1.25"
-RUN pip install ansible==2.7.10 \
-	ansible-runner==1.2 \
-	ansible-runner-http==1.0.0 \
-	idna==2.7 \
-	"kubernetes>=8.0.0,<9.0.0" \
-	openshift==0.8.8
+FROM registry.access.redhat.com/ubi7/ubi
 
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
@@ -28,14 +15,29 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
     USER_NAME=ansible-operator\
     HOME=/opt/ansible
 
-# install operator binary
+# Install python dependencies
+RUN yum install -y python-devel gcc \
+ && easy_install pip \
+ && pip install -U --no-cache-dir setuptools pip \
+ && pip install --no-cache-dir --ignore-installed ipaddress \
+      ansible-runner==1.2 \
+      ansible-runner-http==1.0.0 \
+      openshift==0.8.9 \
+ && yum remove -y gcc python-devel \
+ && yum clean all \
+ && rm -rf /var/cache/yum
+
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk ${OPERATOR}
-# install k8s_status Ansible Module
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/library/k8s_status.py /usr/share/ansible/openshift/
 
-COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/bin /usr/local/bin
-RUN /usr/local/bin/user_setup
+# Ensure directory permissions are properly set
+RUN mkdir -p ${HOME}/.ansible/tmp \
+ && chown -R ${USER_UID}:0 ${HOME} \
+ && chmod -R ug+rwx ${HOME}
 
-ENTRYPOINT ["/usr/local/bin/entrypoint"]
+ADD https://github.com/krallin/tini/releases/latest/download/tini /tini
+RUN chmod +x /tini
+
+ENTRYPOINT ["/tini", "--", "bash", "-c", "${OPERATOR} run ansible --watches-file=/opt/ansible/watches.yaml $@"]
 
 USER ${USER_UID}

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -16,7 +16,8 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
     HOME=/opt/ansible
 
 # Install python dependencies
-RUN yum install -y python-devel gcc \
+RUN (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true) \
+ && yum install -y python-devel gcc inotify-tools \
  && easy_install pip \
  && pip install -U --no-cache-dir setuptools pip \
  && pip install --no-cache-dir --ignore-installed ipaddress \
@@ -29,6 +30,7 @@ RUN yum install -y python-devel gcc \
 
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk ${OPERATOR}
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/library/k8s_status.py /usr/share/ansible/openshift/
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/bin/ao-logs /usr/local/bin/ao-logs
 
 # Ensure directory permissions are properly set
 RUN mkdir -p ${HOME}/.ansible/tmp \

--- a/ci/tests/e2e-ansible.sh
+++ b/ci/tests/e2e-ansible.sh
@@ -54,6 +54,7 @@ test_operator() {
     if ! timeout 1m kubectl rollout status deployment/memcached-operator;
     then
         echo FAIL: operator failed to run
+        kubectl describe pods
         kubectl logs deployment/memcached-operator -c operator
         kubectl logs deployment/memcached-operator -c ansible
         exit 1
@@ -64,6 +65,7 @@ test_operator() {
     if ! timeout 20s bash -c -- 'until kubectl get deployment -l app=memcached | grep memcached; do sleep 1; done';
     then
         echo FAIL: operator failed to create memcached Deployment
+        kubectl describe pods
         kubectl logs deployment/memcached-operator -c operator
         kubectl logs deployment/memcached-operator -c ansible
         exit 1
@@ -72,6 +74,7 @@ test_operator() {
     if ! timeout 1m kubectl rollout status deployment/${memcached_deployment};
     then
         echo FAIL: memcached Deployment failed rollout
+        kubectl describe pods
         kubectl logs deployment/${memcached_deployment}
         exit 1
     fi
@@ -86,6 +89,7 @@ test_operator() {
     if kubectl get configmap deleteme 2> /dev/null;
     then
         echo FAIL: the finalizer did not delete the configmap
+        kubectl describe pods
         kubectl logs deployment/memcached-operator -c operator
         kubectl logs deployment/memcached-operator -c ansible
         exit 1
@@ -95,6 +99,7 @@ test_operator() {
     if ! timeout 20s bash -c -- "while kubectl get deployment ${memcached_deployment} 2> /dev/null; do sleep 1; done";
     then
         echo FAIL: memcached Deployment did not get garbage collected
+        kubectl describe pods
         kubectl logs deployment/memcached-operator -c operator
         kubectl logs deployment/memcached-operator -c ansible
         exit 1
@@ -104,6 +109,7 @@ test_operator() {
     if kubectl logs deployment/memcached-operator -c operator | grep -i error;
     then
         echo FAIL: the operator log includes errors
+        kubectl describe pods
         kubectl logs deployment/memcached-operator -c operator
         kubectl logs deployment/memcached-operator -c ansible
         exit 1
@@ -135,6 +141,7 @@ remove_operator
 if ! timeout 60s bash -c -- "until kubectl get pods -l name=memcached-operator |& grep \"No resources found\"; do sleep 2; done";
 then
     echo FAIL: memcached-operator Deployment did not get garbage collected
+    kubectl describe pods
     kubectl logs deployment/memcached-operator -c operator
     kubectl logs deployment/memcached-operator -c ansible
     exit 1

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -45,20 +45,7 @@ func (d *DockerfileHybrid) GetInput() (input.Input, error) {
 	return d.Input, nil
 }
 
-const dockerFileHybridAnsibleTmpl = `FROM ansible/ansible-runner:1.2
-
-RUN yum remove -y ansible python-idna
-RUN yum install -y inotify-tools && yum clean all
-RUN pip uninstall ansible-runner -y
-
-RUN pip install --upgrade setuptools==41.0.1
-RUN pip install "urllib3>=1.23,<1.25"
-RUN pip install ansible==2.7.10 \
-	ansible-runner==1.2 \
-	ansible-runner-http==1.0.0 \
-	idna==2.7 \
-	"kubernetes>=8.0.0,<9.0.0" \
-	openshift==0.8.8
+const dockerFileHybridAnsibleTmpl = `FROM registry.access.redhat.com/ubi7/ubi
 
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
@@ -71,23 +58,38 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
     USER_NAME=ansible-operator\
     HOME=/opt/ansible
 
-[[- if .Watches ]]
-COPY watches.yaml ${HOME}/watches.yaml[[ end ]]
+# Install python dependencies
+RUN yum install -y python-devel gcc \
+ && easy_install pip \
+ && pip install -U --no-cache-dir setuptools pip \
+ && pip install --no-cache-dir --ignore-installed ipaddress \
+      ansible-runner==1.2 \
+      ansible-runner-http==1.0.0 \
+      openshift==0.8.9 \
+ && yum remove -y gcc python-devel \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
-# install operator binary
 COPY build/_output/bin/[[.ProjectName]] ${OPERATOR}
-# install k8s_status Ansible Module
+COPY bin/ao-logs /usr/local/bin/ao-logs
 COPY library/k8s_status.py /usr/share/ansible/openshift/
 
-COPY bin /usr/local/bin
-RUN  /usr/local/bin/user_setup
+# Ensure directory permissions are properly set
+RUN mkdir -p ${HOME}/.ansible/tmp \
+ && chown -R ${USER_UID}:0 ${HOME} \
+ && chmod -R ug+rwx ${HOME}
 
+ADD https://github.com/krallin/tini/releases/latest/download/tini /tini
+RUN chmod +x /tini
+
+[[- if .Watches ]]
+COPY watches.yaml ${HOME}/watches.yaml[[ end ]]
 [[- if .Roles ]]
 COPY roles/ ${HOME}/roles/[[ end ]]
 [[- if .Playbook ]]
 COPY playbook.yml ${HOME}/playbook.yml[[ end ]]
 
-ENTRYPOINT ["/usr/local/bin/entrypoint"]
+ENTRYPOINT ["/tini", "--", "bash", "-c", "${OPERATOR} run ansible --watches-file=/opt/ansible/watches.yaml $@"]
 
 USER ${USER_UID}
 `

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -59,13 +59,16 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
     HOME=/opt/ansible
 
 # Install python dependencies
-RUN yum install -y python-devel gcc \
+
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+ && yum install -y python-devel gcc inotify-tools \
  && easy_install pip \
  && pip install -U --no-cache-dir setuptools pip \
  && pip install --no-cache-dir --ignore-installed ipaddress \
       ansible-runner==1.2 \
       ansible-runner-http==1.0.0 \
       openshift==0.8.9 \
+      ansible==2.8 \
  && yum remove -y gcc python-devel \
  && yum clean all \
  && rm -rf /var/cache/yum

--- a/internal/pkg/scaffold/ansible/molecule_default_molecule.go
+++ b/internal/pkg/scaffold/ansible/molecule_default_molecule.go
@@ -48,7 +48,7 @@ platforms:
 - name: kind-default
   groups:
   - k8s
-  image: bsycorp/kind:latest-1.12
+  image: bsycorp/kind:latest-1.14
   privileged: True
   override_command: no
   exposed_ports:

--- a/internal/pkg/scaffold/ansible/molecule_default_prepare.go
+++ b/internal/pkg/scaffold/ansible/molecule_default_prepare.go
@@ -65,7 +65,7 @@ const moleculeDefaultPrepareAnsibleTmpl = `---
 
     - name: Wait for the Kubernetes API to become available (this could take a minute)
       uri:
-        url: "https://localhost:8443/apis"
+        url: "https://localhost:8443/version"
         status_code: 200
         validate_certs: no
       register: result

--- a/internal/pkg/scaffold/ansible/molecule_test_local_molecule.go
+++ b/internal/pkg/scaffold/ansible/molecule_test_local_molecule.go
@@ -48,7 +48,7 @@ platforms:
 - name: kind-test-local
   groups:
   - k8s
-  image: bsycorp/kind:latest-1.12
+  image: bsycorp/kind:latest-1.14
   privileged: True
   override_command: no
   exposed_ports:

--- a/test/ansible-inventory/molecule/test-local/molecule.yml
+++ b/test/ansible-inventory/molecule/test-local/molecule.yml
@@ -10,7 +10,7 @@ platforms:
 - name: kind-test-local
   groups:
   - k8s
-  image: bsycorp/kind:latest-1.12
+  image: bsycorp/kind:latest-1.14
   privileged: True
   override_command: no
   exposed_ports:

--- a/test/ansible-inventory/molecule/test-local/prepare.yml
+++ b/test/ansible-inventory/molecule/test-local/prepare.yml
@@ -26,7 +26,7 @@
 
     - name: Wait for the Kubernetes API to become available (this could take a minute)
       uri:
-        url: "https://localhost:8443/apis"
+        url: "https://localhost:8443/version"
         status_code: 200
         validate_certs: no
       register: result

--- a/test/ansible-memcached/asserts.yml
+++ b/test/ansible-memcached/asserts.yml
@@ -142,7 +142,7 @@
           name: '{{ custom_resource.metadata.name }}'
         register: cr
         retries: 10
-        delay: 2
+        delay: 6
         until: not cr.resources
         failed_when: cr.resources
 

--- a/test/ansible-memcached/asserts.yml
+++ b/test/ansible-memcached/asserts.yml
@@ -23,7 +23,11 @@
       - name: Wait 2 minutes for memcached deployment
         debug:
           var: deploy
-        until: deploy and deploy.status and deploy.status.replicas == deploy.status.get("availableReplicas", 0)
+        until:
+        - deploy is defined
+        - deploy.status is defined
+        - deploy.status.replicas is defined
+        - deploy.status.replicas == deploy.status.get("availableReplicas", 0)
         retries: 12
         delay: 10
         vars:
@@ -83,7 +87,11 @@
         - name: Wait 2 minutes for operator deployment
           debug:
             var: deploy
-          until: deploy and deploy.status and deploy.status.replicas == deploy.status.get("availableReplicas", 0)
+          until:
+          - deploy is defined
+          - deploy.status is defined
+          - deploy.status.replicas is defined
+          - deploy.status.replicas == deploy.status.get("availableReplicas", 0)
           retries: 12
           delay: 10
           vars:

--- a/test/ansible-memcached/molecule.yml
+++ b/test/ansible-memcached/molecule.yml
@@ -10,7 +10,7 @@ platforms:
 - name: kind-test-local
   groups:
   - k8s
-  image: bsycorp/kind:latest-1.12
+  image: bsycorp/kind:latest-1.14
   privileged: True
   override_command: no
   exposed_ports:


### PR DESCRIPTION
**Description of the change:**
Replaces `ansible-runner` base image with `ubi7/ubi`.
Also installs and uses `tini` to reap zombie Ansible processes.
Currently python dependencies are installed via pip, but should move to using RPMs as soon as we determine what the proper practice for that on ubi is.

**Motivation for the change:**
Partners need a ubi-based image for certification, 

**Note**
Both this and https://github.com/openshift/release/pull/4302 will need to be merged for tests to pass

closes #1551