### PR TITLE
Makefile: remove test/ansible from ci-ansible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ test/e2e/ansible: image/build/ansible
 test/e2e/ansible2:
 	./ci/tests/e2e-ansible.sh
 
-test/e2e/ansible-molecule:
+test/e2e/ansible-molecule: image/build/ansible
 	./hack/tests/e2e-ansible-molecule.sh
 
 test/e2e/helm: image/build/helm

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ test-ci: test/markdown test/sanity test/unit install test/subcommand test/e2e
 
 test/ci-go: test/subcommand test/e2e/go
 
-test/ci-ansible: test/e2e/ansible test/e2e/ansible-molecule
+test/ci-ansible: test/e2e/ansible-molecule
 
 test/ci-helm: test/e2e/helm
 

--- a/doc/dev/testing/running-the-tests.md
+++ b/doc/dev/testing/running-the-tests.md
@@ -77,16 +77,17 @@ $ eval $(minikube docker-env)
 
 All the tests are run through the [`Makefile`][makefile]. This is a brief description of all makefile test instructions:
 
-- `test` - Installs `operator-sdk` by running `dep ensure` and `make install`, and then runs all tests. This is intended as a full test for developers.
-- `test/ci-go` - Runs all the tests that the Go job runs in CI (`sanity`, `unit`, `subcommand`, `e2e/go`).
-- `test/ci-ansible` - Runs all the tests that the Ansible job runs in CI (`e2e/ansible`).
-- `test/ci-helm` - Runs all the tests that the Helm job runs in CI (`e2e/helm`).
+- `test` - Runs `test/unit`
+- `test/ci-go` - Runs all the tests that the Go job runs in Travis CI (`test/sanity`, `test/unit`, `test/subcommand`, `test/e2e/go`).
+- `test/ci-ansible` - Runs all the tests that the Ansible job runs in Travis CI (`test/e2e/ansible-molecule`).
+- `test/ci-helm` - Runs all the tests that the Helm job runs in Travis CI (`test/e2e/helm`).
 - `test/sanity` - Runs sanity checks.
 - `test/unit` - Runs unit tests.
 - `test/subcommand` - Runs subcommand tests.
-- `test/e2e` - Runs all E2E tests (`e2e/go`, `e2e/ansible`, and `e2e/helm`).
+- `test/e2e` - Runs all E2E tests (`test/e2e/go`, `test/e2e/ansible`, `test/e2e/ansible-molecule`, and `e2e/helm`).
 - `test/e2e/go` - Runs the go E2E test.
 - `test/e2e/ansible` - Runs the ansible E2E test.
+- `test/e2e/ansible-molecule` - Runs the ansible molecule E2E test.
 - `test/e2e/helm` - Runs the helm E2E test.
 - `test/markdown` - Runs the markdown checks
 

--- a/doc/dev/testing/travis-build.md
+++ b/doc/dev/testing/travis-build.md
@@ -67,18 +67,11 @@ The Go, Ansible, and Helm tests then differ in what tests they run.
 
 ### Ansible tests
 
-1. Run [ansible e2e tests][ansible-e2e].
-    1. Create base ansible operator project by running [`hack/image/ansible/scaffold-ansible-image.go`][ansible-base].
-    2. Build base ansible operator image.
-    3. Create and configure a new ansible type memcached-operator.
-    4. Create cluster resources.
-    5. Wait for operator to be ready.
-    6. Create a memcached CR and wait for it to be ready.
-    7. Create a configmap that the memcached-operator is configured to delete using a finalizer.
-    8. Delete memcached CR and verify that the finalizer deleted the configmap.
-    9. Run `operator-sdk migrate` to add go source to the operator (see this [note][deps_mgmt] on dependency management first).
-    10. Run `operator-sdk build` to compile the new binary and build a new image.
-    11. Re-run steps 4-8 to test the migrated operator.
+1. Run [ansible molecule tests][ansible-molecule].
+    1. Create and configure a new ansible type memcached-operator.
+    2. Create cluster resources.
+    3. Run `operator-sdk test local` to run ansible molecule tests
+    4. Change directory to [`test/ansible-inventory`][ansible-inventory] and run `operator-sdk test local`
 
 **NOTE**: All created resources, including the namespace, are deleted using a bash trap when the test finishes
 
@@ -113,8 +106,8 @@ The markdown test does not create a new cluster and runs in a barebones Travis V
 [subcommand]: ../../../hack/tests/test-subcommand.sh
 [go-e2e]: ../../../hack/tests/e2e-go.sh
 [tls-tests]: ../../../test/e2e/tls_util_test.go
-[ansible-e2e]: ../../../hack/tests/e2e-ansible.sh
-[ansible-base]: ../../../hack/image/ansible/scaffold-ansible-image.go
+[ansible-molecule]: ../../../hack/tests/e2e-ansible-molecule.sh
+[ansible-inventory]: ../../../test/ansible-inventory
 [helm-e2e]: ../../../hack/tests/e2e-helm.sh
 [helm-base]: ../../../hack/image/helm/scaffold-helm-image.go
 [marker-github]: https://github.com/crawford/marker


### PR DESCRIPTION
**Description of the change:** Remove `test/ansible` target from the `ci-ansible` make target used by travis


**Motivation for the change:** The main ansible test is currently being tested in Openshift-CI