### PR TITLE
internal/pkg/scaffold: fix versions for go mod proxy

### DIFF
--- a/internal/pkg/scaffold/ansible/go_mod.go
+++ b/internal/pkg/scaffold/ansible/go_mod.go
@@ -97,8 +97,8 @@ require (
 
 // Pinned to kubernetes-1.13.4
 replace (
-	k8s.io/api => k8s.io/api v0.0.0-20190222131558-5cb15d344471
-	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190221124651-86fb29eff628
+	k8s.io/api => k8s.io/api v0.0.0-20190222213804-5cb15d344471
+	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
 	k8s.io/client-go => k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4
 	k8s.io/kubernetes => k8s.io/kubernetes v1.13.4
 )

--- a/internal/pkg/scaffold/go_mod.go
+++ b/internal/pkg/scaffold/go_mod.go
@@ -76,9 +76,9 @@ require (
 
 // Pinned to kubernetes-1.13.4
 replace (
-	k8s.io/api => k8s.io/api v0.0.0-20190222131558-5cb15d344471
+	k8s.io/api => k8s.io/api v0.0.0-20190222213804-5cb15d344471
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190228180357-d002e88f6236
-	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190221124651-86fb29eff628
+	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
 	k8s.io/client-go => k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4
 )
 

--- a/internal/pkg/scaffold/go_mod_test.go
+++ b/internal/pkg/scaffold/go_mod_test.go
@@ -77,9 +77,9 @@ require (
 
 // Pinned to kubernetes-1.13.4
 replace (
-	k8s.io/api => k8s.io/api v0.0.0-20190222131558-5cb15d344471
+	k8s.io/api => k8s.io/api v0.0.0-20190222213804-5cb15d344471
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190228180357-d002e88f6236
-	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190221124651-86fb29eff628
+	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
 	k8s.io/client-go => k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4
 )
 

--- a/internal/pkg/scaffold/helm/go_mod.go
+++ b/internal/pkg/scaffold/helm/go_mod.go
@@ -151,9 +151,9 @@ require (
 
 // Pinned to kubernetes-1.13.4
 replace (
-	k8s.io/api => k8s.io/api v0.0.0-20190222131558-5cb15d344471
+	k8s.io/api => k8s.io/api v0.0.0-20190222213804-5cb15d344471
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190228180357-d002e88f6236
-	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190221124651-86fb29eff628
+	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
 	k8s.io/apiserver => k8s.io/apiserver v0.0.0-20190228174905-79427f02047f
 	k8s.io/cli-runtime => k8s.io/cli-runtime v0.0.0-20190228180923-a9e421a79326
 	k8s.io/client-go => k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4


### PR DESCRIPTION
**Description of the change:**
As a follow on to #1612, this PR changes the timestamps in the go mod scaffolds for `k8s.io/api` and `k8s.io/apimachinery` so that GOPROXY can be used when building scaffolded projects.

**Motivation for the change:**
Oddly, when `GOPROXY=https://proxy.golang.org` the e2e tests on master fail with an error about an invalid module version:

```
build github.com/example-inc/nginx-operator/cmd/manager: cannot load k8s.io/api/admission/v1beta1: unexpected status (https://proxy.golang.org/k8s.io/api/@v/v0.0.0-20190222131558-5cb15d344471.zip): 400 Bad Request
```

For some reason, without GOPROXY set, `go build` accepts both old and new version strings.
