### PR TITLE
internal/pkg/scaffold: move some utility functions to internal/util/k8sutil

### DIFF
--- a/internal/pkg/scaffold/crd.go
+++ b/internal/pkg/scaffold/crd.go
@@ -169,7 +169,7 @@ func (s *CRD) CustomRender() ([]byte, error) {
 	}
 
 	setCRDVersions(crd)
-	return k8sutil.GetObjectBytes(crd)
+	return k8sutil.GetObjectBytes(crd, yaml.Marshal)
 }
 
 func newCRDForResource(r *Resource) *apiextv1beta1.CustomResourceDefinition {

--- a/internal/pkg/scaffold/olm-catalog/csv.go
+++ b/internal/pkg/scaffold/olm-catalog/csv.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"unicode"
 
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/input"
@@ -138,7 +137,7 @@ func (s *CSV) CustomRender() ([]byte, error) {
 		}
 	}
 
-	return k8sutil.GetObjectBytes(csv)
+	return k8sutil.GetObjectBytes(csv, yaml.Marshal)
 }
 
 func (s *CSV) getBaseCSVIfExists() (*olmapiv1alpha1.ClusterServiceVersion, bool, error) {
@@ -190,41 +189,6 @@ func (s *CSV) getCSVPath(ver string) string {
 	return filepath.Join(s.pathPrefix, OLMCatalogDir, lowerProjName, ver, name)
 }
 
-// getDisplayName turns a project dir name in any of {snake, chain, camel}
-// cases, hierarchical dot structure, or space-delimited into a
-// space-delimited, title'd display name.
-// Ex. "another-_AppOperator_againTwiceThrice More"
-// ->  "Another App Operator Again Twice Thrice More"
-func getDisplayName(name string) string {
-	for _, sep := range ".-_ " {
-		splitName := strings.Split(name, string(sep))
-		for i := 0; i < len(splitName); i++ {
-			if splitName[i] == "" {
-				splitName = append(splitName[:i], splitName[i+1:]...)
-				i--
-			} else {
-				splitName[i] = strings.TrimSpace(splitName[i])
-			}
-		}
-		name = strings.Join(splitName, " ")
-	}
-	splitName := strings.Split(name, " ")
-	for i, word := range splitName {
-		temp := word
-		o := 0
-		for j, r := range word {
-			if unicode.IsUpper(r) {
-				if j > 0 && !unicode.IsUpper(rune(word[j-1])) {
-					temp = temp[0:j+o] + " " + temp[j+o:len(temp)]
-					o++
-				}
-			}
-		}
-		splitName[i] = temp
-	}
-	return strings.TrimSpace(strings.Title(strings.Join(splitName, " ")))
-}
-
 // initCSVFields initializes all csv fields that should be populated by a user
 // with sane defaults. initCSVFields should only be called for new csv's.
 func (s *CSV) initCSVFields(csv *olmapiv1alpha1.ClusterServiceVersion) {
@@ -237,7 +201,7 @@ func (s *CSV) initCSVFields(csv *olmapiv1alpha1.ClusterServiceVersion) {
 
 	// Spec fields
 	csv.Spec.Version = *semver.New(s.CSVVersion)
-	csv.Spec.DisplayName = getDisplayName(s.OperatorName)
+	csv.Spec.DisplayName = k8sutil.GetDisplayName(s.OperatorName)
 	csv.Spec.Description = "Placeholder description"
 	csv.Spec.Maturity = "alpha"
 	csv.Spec.Provider = olmapiv1alpha1.AppLink{}
@@ -371,7 +335,7 @@ func (s *CSV) updateCSVFromManifestFiles(cfg *CSVConfig, csv *olmapiv1alpha1.Clu
 		scanner := yamlutil.NewYAMLScanner(yamlData)
 		for scanner.Scan() {
 			yamlSpec := scanner.Bytes()
-			kind, err := getKindfromYAML(yamlSpec)
+			kind, err := k8sutil.GetKindfromYAML(yamlSpec)
 			if err != nil {
 				return fmt.Errorf("%s: %v", f, err)
 			}

--- a/internal/pkg/scaffold/olm-catalog/csv_test.go
+++ b/internal/pkg/scaffold/olm-catalog/csv_test.go
@@ -167,33 +167,6 @@ func TestUpdateVersion(t *testing.T) {
 	}
 }
 
-func TestGetDisplayName(t *testing.T) {
-	cases := []struct {
-		input, wanted string
-	}{
-		{"Appoperator", "Appoperator"},
-		{"appoperator", "Appoperator"},
-		{"appoperatoR", "Appoperato R"},
-		{"AppOperator", "App Operator"},
-		{"appOperator", "App Operator"},
-		{"app-operator", "App Operator"},
-		{"app-_operator", "App Operator"},
-		{"App-operator", "App Operator"},
-		{"app-_Operator", "App Operator"},
-		{"app--Operator", "App Operator"},
-		{"app--_Operator", "App Operator"},
-		{"APP", "APP"},
-		{"another-AppOperator_againTwiceThrice More", "Another App Operator Again Twice Thrice More"},
-	}
-
-	for _, c := range cases {
-		dn := getDisplayName(c.input)
-		if dn != c.wanted {
-			t.Errorf("Wanted %s, got %s", c.wanted, dn)
-		}
-	}
-}
-
 func TestSetAndCheckOLMNamespaces(t *testing.T) {
 	depBytes, err := ioutil.ReadFile(filepath.Join(testDeployDir, "operator.yaml"))
 	if err != nil {

--- a/internal/pkg/scaffold/olm-catalog/csv_updaters.go
+++ b/internal/pkg/scaffold/olm-catalog/csv_updaters.go
@@ -69,16 +69,6 @@ func (s *updaterStore) Apply(csv *olmapiv1alpha1.ClusterServiceVersion) error {
 	return nil
 }
 
-func getKindfromYAML(yamlData []byte) (string, error) {
-	var temp struct {
-		Kind string
-	}
-	if err := yaml.Unmarshal(yamlData, &temp); err != nil {
-		return "", err
-	}
-	return temp.Kind, nil
-}
-
 func (s *updaterStore) AddToUpdater(yamlSpec []byte, kind string) (found bool, err error) {
 	found = true
 	switch kind {

--- a/internal/pkg/scaffold/olm-catalog/package_manifest.go
+++ b/internal/pkg/scaffold/olm-catalog/package_manifest.go
@@ -95,7 +95,7 @@ func (s *PackageManifest) CustomRender() ([]byte, error) {
 		return nil, errors.Wrapf(err, "package manifest %s", path)
 	}
 
-	if err := validatePackageManifest(pm); err != nil {
+	if err := ValidatePackageManifest(pm); err != nil {
 		return nil, errors.Wrapf(err, "failed to validate package manifest %s", pm.PackageName)
 	}
 
@@ -127,7 +127,7 @@ func (s *PackageManifest) newPackageManifest() *olmregistry.PackageManifest {
 	return pm
 }
 
-func validatePackageManifest(pm *olmregistry.PackageManifest) error {
+func ValidatePackageManifest(pm *olmregistry.PackageManifest) error {
 	if pm.PackageName == "" {
 		return fmt.Errorf("package name cannot be empty")
 	}

--- a/internal/pkg/scaffold/olm-catalog/package_manifest.go
+++ b/internal/pkg/scaffold/olm-catalog/package_manifest.go
@@ -15,7 +15,6 @@
 package catalog
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -24,6 +23,7 @@ import (
 
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/input"
+	registryutil "github.com/operator-framework/operator-sdk/internal/util/operator-registry"
 
 	"github.com/ghodss/yaml"
 	olmregistry "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
@@ -95,7 +95,7 @@ func (s *PackageManifest) CustomRender() ([]byte, error) {
 		return nil, errors.Wrapf(err, "package manifest %s", path)
 	}
 
-	if err := ValidatePackageManifest(pm); err != nil {
+	if err := registryutil.ValidatePackageManifest(pm); err != nil {
 		return nil, errors.Wrapf(err, "failed to validate package manifest %s", pm.PackageName)
 	}
 
@@ -125,37 +125,6 @@ func (s *PackageManifest) newPackageManifest() *olmregistry.PackageManifest {
 		DefaultChannelName: channel,
 	}
 	return pm
-}
-
-func ValidatePackageManifest(pm *olmregistry.PackageManifest) error {
-	if pm.PackageName == "" {
-		return fmt.Errorf("package name cannot be empty")
-	}
-	if len(pm.Channels) == 0 {
-		return fmt.Errorf("channels cannot be empty")
-	}
-	if pm.DefaultChannelName == "" {
-		return fmt.Errorf("default channel cannot be empty")
-	}
-
-	seen := map[string]struct{}{}
-	for i, c := range pm.Channels {
-		if c.Name == "" {
-			return fmt.Errorf("channel %d name cannot be empty", i)
-		}
-		if c.CurrentCSVName == "" {
-			return fmt.Errorf("channel %s currentCSV cannot be empty", c.Name)
-		}
-		if _, ok := seen[c.Name]; ok {
-			return fmt.Errorf("duplicate package manifest channel name %s; channel names must be unique", c.Name)
-		}
-		seen[c.Name] = struct{}{}
-	}
-	if _, ok := seen[pm.DefaultChannelName]; !ok {
-		return fmt.Errorf("default channel %s does not exist in channels", pm.DefaultChannelName)
-	}
-
-	return nil
 }
 
 // setChannels checks for duplicate channels in pm and sets the default

--- a/internal/pkg/scaffold/olm-catalog/package_manifest_test.go
+++ b/internal/pkg/scaffold/olm-catalog/package_manifest_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/input"
 	"github.com/operator-framework/operator-sdk/internal/util/diffutil"
-
-	olmregistry "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 )
 
 func TestPackageManifest(t *testing.T) {
@@ -70,74 +68,3 @@ const packageManifestExp = `channels:
 defaultChannel: stable
 packageName: app-operator
 `
-
-func TestValidatePackageManifest(t *testing.T) {
-	channels := []olmregistry.PackageChannel{
-		{Name: "foo", CurrentCSVName: "bar"},
-	}
-	pm := &olmregistry.PackageManifest{
-		Channels:           channels,
-		DefaultChannelName: "baz",
-		PackageName:        "test-package",
-	}
-
-	cases := []struct {
-		description string
-		wantErr     bool
-		errMsg      string
-		operation   func(*olmregistry.PackageManifest)
-	}{
-		{
-			"default channel does not exist",
-			true, "default channel baz does not exist in channels", nil,
-		},
-		{
-			"successful validation",
-			false, "",
-			func(pm *olmregistry.PackageManifest) {
-				pm.DefaultChannelName = pm.Channels[0].Name
-			},
-		},
-		{
-			"channels are empty",
-			true, "channels cannot be empty",
-			func(pm *olmregistry.PackageManifest) {
-				pm.Channels = nil
-			},
-		},
-		{
-			"one channel's CSVName is empty",
-			true, "channel foo currentCSV cannot be empty",
-			func(pm *olmregistry.PackageManifest) {
-				pm.Channels = make([]olmregistry.PackageChannel, 1)
-				copy(pm.Channels, channels)
-				pm.Channels[0].CurrentCSVName = ""
-			},
-		},
-		{
-			"duplicate channel name",
-			true, "duplicate package manifest channel name foo; channel names must be unique",
-			func(pm *olmregistry.PackageManifest) {
-				pm.Channels = append(channels, channels...)
-			},
-		},
-	}
-
-	for _, c := range cases {
-		if c.operation != nil {
-			c.operation(pm)
-		}
-		err := ValidatePackageManifest(pm)
-		if c.wantErr {
-			if err == nil {
-				t.Errorf(`%s: expected error "%s", got none`, c.description, c.errMsg)
-			} else if err.Error() != c.errMsg {
-				t.Errorf(`%s: expected error message "%s", got "%s"`, c.description, c.errMsg, err)
-			}
-		} else {
-			if err != nil {
-				t.Errorf(`%s: expected no error, got error "%s"`, c.description, err)
-			}
-		}
-	}
-}

--- a/internal/pkg/scaffold/olm-catalog/package_manifest_test.go
+++ b/internal/pkg/scaffold/olm-catalog/package_manifest_test.go
@@ -127,7 +127,7 @@ func TestValidatePackageManifest(t *testing.T) {
 		if c.operation != nil {
 			c.operation(pm)
 		}
-		err := validatePackageManifest(pm)
+		err := ValidatePackageManifest(pm)
 		if c.wantErr {
 			if err == nil {
 				t.Errorf(`%s: expected error "%s", got none`, c.description, c.errMsg)

--- a/internal/util/k8sutil/k8sutil.go
+++ b/internal/util/k8sutil/k8sutil.go
@@ -16,7 +16,10 @@ package k8sutil
 
 import (
 	"fmt"
+	"strings"
+	"unicode"
 
+	"github.com/ghodss/yaml"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -50,4 +53,49 @@ func GetKubeconfigAndNamespace(configPath string) (*rest.Config, string, error) 
 		return nil, "", err
 	}
 	return kubeconfig, namespace, nil
+}
+
+func GetKindfromYAML(yamlData []byte) (string, error) {
+	var temp struct {
+		Kind string
+	}
+	if err := yaml.Unmarshal(yamlData, &temp); err != nil {
+		return "", err
+	}
+	return temp.Kind, nil
+}
+
+// GetDisplayName turns a project dir name in any of {snake, chain, camel}
+// cases, hierarchical dot structure, or space-delimited into a
+// space-delimited, title'd display name.
+// Ex. "another-_AppOperator_againTwiceThrice More"
+// ->  "Another App Operator Again Twice Thrice More"
+func GetDisplayName(name string) string {
+	for _, sep := range ".-_ " {
+		splitName := strings.Split(name, string(sep))
+		for i := 0; i < len(splitName); i++ {
+			if splitName[i] == "" {
+				splitName = append(splitName[:i], splitName[i+1:]...)
+				i--
+			} else {
+				splitName[i] = strings.TrimSpace(splitName[i])
+			}
+		}
+		name = strings.Join(splitName, " ")
+	}
+	splitName := strings.Split(name, " ")
+	for i, word := range splitName {
+		temp := word
+		o := 0
+		for j, r := range word {
+			if unicode.IsUpper(r) {
+				if j > 0 && !unicode.IsUpper(rune(word[j-1])) {
+					temp = temp[0:j+o] + " " + temp[j+o:len(temp)]
+					o++
+				}
+			}
+		}
+		splitName[i] = temp
+	}
+	return strings.TrimSpace(strings.Title(strings.Join(splitName, " ")))
 }

--- a/internal/util/k8sutil/k8sutil_test.go
+++ b/internal/util/k8sutil/k8sutil_test.go
@@ -1,0 +1,44 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sutil
+
+import "testing"
+
+func TestGetDisplayName(t *testing.T) {
+	cases := []struct {
+		input, wanted string
+	}{
+		{"Appoperator", "Appoperator"},
+		{"appoperator", "Appoperator"},
+		{"appoperatoR", "Appoperato R"},
+		{"AppOperator", "App Operator"},
+		{"appOperator", "App Operator"},
+		{"app-operator", "App Operator"},
+		{"app-_operator", "App Operator"},
+		{"App-operator", "App Operator"},
+		{"app-_Operator", "App Operator"},
+		{"app--Operator", "App Operator"},
+		{"app--_Operator", "App Operator"},
+		{"APP", "APP"},
+		{"another-AppOperator_againTwiceThrice More", "Another App Operator Again Twice Thrice More"},
+	}
+
+	for _, c := range cases {
+		dn := GetDisplayName(c.input)
+		if dn != c.wanted {
+			t.Errorf("Wanted %s, got %s", c.wanted, dn)
+		}
+	}
+}

--- a/internal/util/k8sutil/object.go
+++ b/internal/util/k8sutil/object.go
@@ -15,13 +15,14 @@
 package k8sutil
 
 import (
-	yaml "github.com/ghodss/yaml"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// GetObjectBytes marshalls an object and removes runtime-managed fields:
+type MarshalFunc func(interface{}) ([]byte, error)
+
+// GetObjectBytes marshalls an object with m and removes runtime-managed fields:
 // 'status', 'creationTimestamp'
-func GetObjectBytes(obj interface{}) ([]byte, error) {
+func GetObjectBytes(obj interface{}, m MarshalFunc) ([]byte, error) {
 	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {
 		return nil, err
@@ -30,7 +31,7 @@ func GetObjectBytes(obj interface{}) ([]byte, error) {
 	for _, dk := range deleteKeys {
 		deleteKeyFromUnstructured(u, dk)
 	}
-	return yaml.Marshal(u)
+	return m(u)
 }
 
 func deleteKeyFromUnstructured(u map[string]interface{}, key string) {

--- a/internal/util/operator-registry/package_manifest.go
+++ b/internal/util/operator-registry/package_manifest.go
@@ -17,18 +17,20 @@ package registry
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	olmregistry "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 )
 
 func ValidatePackageManifest(pm *olmregistry.PackageManifest) error {
 	if pm.PackageName == "" {
-		return fmt.Errorf("package name cannot be empty")
+		return errors.New("package name cannot be empty")
 	}
 	if len(pm.Channels) == 0 {
-		return fmt.Errorf("channels cannot be empty")
+		return errors.New("channels cannot be empty")
 	}
 	if pm.DefaultChannelName == "" {
-		return fmt.Errorf("default channel cannot be empty")
+		return errors.New("default channel cannot be empty")
 	}
 
 	seen := map[string]struct{}{}

--- a/internal/util/operator-registry/package_manifest.go
+++ b/internal/util/operator-registry/package_manifest.go
@@ -1,0 +1,52 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"fmt"
+
+	olmregistry "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+)
+
+func ValidatePackageManifest(pm *olmregistry.PackageManifest) error {
+	if pm.PackageName == "" {
+		return fmt.Errorf("package name cannot be empty")
+	}
+	if len(pm.Channels) == 0 {
+		return fmt.Errorf("channels cannot be empty")
+	}
+	if pm.DefaultChannelName == "" {
+		return fmt.Errorf("default channel cannot be empty")
+	}
+
+	seen := map[string]struct{}{}
+	for i, c := range pm.Channels {
+		if c.Name == "" {
+			return fmt.Errorf("channel %d name cannot be empty", i)
+		}
+		if c.CurrentCSVName == "" {
+			return fmt.Errorf("channel %s currentCSV cannot be empty", c.Name)
+		}
+		if _, ok := seen[c.Name]; ok {
+			return fmt.Errorf("duplicate package manifest channel name %s; channel names must be unique", c.Name)
+		}
+		seen[c.Name] = struct{}{}
+	}
+	if _, ok := seen[pm.DefaultChannelName]; !ok {
+		return fmt.Errorf("default channel %s does not exist in channels", pm.DefaultChannelName)
+	}
+
+	return nil
+}

--- a/internal/util/operator-registry/package_manifest_test.go
+++ b/internal/util/operator-registry/package_manifest_test.go
@@ -1,0 +1,92 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"testing"
+
+	olmregistry "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+)
+
+func TestValidatePackageManifest(t *testing.T) {
+	channels := []olmregistry.PackageChannel{
+		{Name: "foo", CurrentCSVName: "bar"},
+	}
+	pm := &olmregistry.PackageManifest{
+		Channels:           channels,
+		DefaultChannelName: "baz",
+		PackageName:        "test-package",
+	}
+
+	cases := []struct {
+		description string
+		wantErr     bool
+		errMsg      string
+		operation   func(*olmregistry.PackageManifest)
+	}{
+		{
+			"default channel does not exist",
+			true, "default channel baz does not exist in channels", nil,
+		},
+		{
+			"successful validation",
+			false, "",
+			func(pm *olmregistry.PackageManifest) {
+				pm.DefaultChannelName = pm.Channels[0].Name
+			},
+		},
+		{
+			"channels are empty",
+			true, "channels cannot be empty",
+			func(pm *olmregistry.PackageManifest) {
+				pm.Channels = nil
+			},
+		},
+		{
+			"one channel's CSVName is empty",
+			true, "channel foo currentCSV cannot be empty",
+			func(pm *olmregistry.PackageManifest) {
+				pm.Channels = make([]olmregistry.PackageChannel, 1)
+				copy(pm.Channels, channels)
+				pm.Channels[0].CurrentCSVName = ""
+			},
+		},
+		{
+			"duplicate channel name",
+			true, "duplicate package manifest channel name foo; channel names must be unique",
+			func(pm *olmregistry.PackageManifest) {
+				pm.Channels = append(channels, channels...)
+			},
+		},
+	}
+
+	for _, c := range cases {
+		if c.operation != nil {
+			c.operation(pm)
+		}
+		err := ValidatePackageManifest(pm)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf(`%s: expected error "%s", got none`, c.description, c.errMsg)
+			} else if err.Error() != c.errMsg {
+				t.Errorf(`%s: expected error message "%s", got "%s"`, c.description, c.errMsg, err)
+			}
+		} else {
+			if err != nil {
+				t.Errorf(`%s: expected no error, got error "%s"`, c.description, err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
**Description of the change:** export `getDisplayName()`, `getKindFromYAML()`, and `validatePackageManifest()` and move to `internal/util/k8sutil`.

**Motivation for the change:** these functions are useful elsewhere when dealing with k8s and OLM resources. See #1552 for an example.