### PR TITLE
internal/pkg/scaffold/crd.go: remove CRD cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Generated CSV's that include a deployment install strategy will be checked for a reference to `metadata.annotations['olm.targetNamespaces']`, and if one is not found a reference will be added to the `WATCH_NAMESPACE` env var for all containers in the deployment. This is a bug because any other value that references the CSV's namespace is incorrect. ([#1396](https://github.com/operator-framework/operator-sdk/pull/1396))
 - Build `-trimpath` was not being respected. `$GOPATH` was not expanding because `exec.Cmd{}` is not executed in a shell environment. ([#1535](https://github.com/operator-framework/operator-sdk/pull/1535))
 - Running the [scorecard](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#up) with `--olm-deployed` will now only use the first CR set in either the `cr-manifest` config option or the CSV's `metadata.annotations['alm-examples']` as was intended, and access manifests correctly from the config. ([#1565](https://github.com/operator-framework/operator-sdk/pull/1565))
+- Use the correct domain names when generating CRD's instead that of the first CRD to be parsed. ([#1636](https://github.com/operator-framework/operator-sdk/pull/1636))
 
 ## v0.8.1
 

--- a/internal/pkg/scaffold/crd.go
+++ b/internal/pkg/scaffold/crd.go
@@ -64,29 +64,7 @@ func (s *CRD) GetInput() (input.Input, error) {
 			s.Resource.LowerKind)
 		s.Path = filepath.Join(CRDsDir, fileName)
 	}
-	initCache()
 	return s.Input, nil
-}
-
-type fsCache struct {
-	afero.Fs
-}
-
-func (c *fsCache) fileExists(path string) bool {
-	_, err := c.Stat(path)
-	return err == nil
-}
-
-var (
-	// Global cache so users can use new CRD structs.
-	cache *fsCache
-	once  sync.Once
-)
-
-func initCache() {
-	once.Do(func() {
-		cache = &fsCache{Fs: afero.NewMemMapFs()}
-	})
 }
 
 var _ CustomRenderer = &CRD{}
@@ -101,39 +79,34 @@ func (s *CRD) CustomRender() ([]byte, error) {
 
 	crd := &apiextv1beta1.CustomResourceDefinition{}
 	if s.IsOperatorGo {
+		// This sets domain as empty string when we can't extract it from FullGroup.
+		// In turn this defaults to extracting the domain from project root file
+		// in controller-tools.
+		fg := strings.SplitN(s.Resource.FullGroup, ".", 2)
+		domain := s.Resource.FullGroup
+		if len(fg) > 1 {
+			domain = fg[1]
+		}
+		fs := afero.NewMemMapFs()
+		g := &crdgenerator.Generator{
+			RootPath:          s.AbsProjectPath,
+			Domain:            domain,
+			Repo:              s.Repo,
+			OutputDir:         ".",
+			SkipMapValidation: false,
+			OutFs:             fs,
+		}
+		if err := g.ValidateAndInitFields(); err != nil {
+			return nil, err
+		}
+		if err := g.Do(); err != nil {
+			return nil, err
+		}
+
 		// controller-tools generates crd file names with no _crd.yaml suffix:
 		// <group>_<version>_<kind>.yaml.
 		path := strings.Replace(filepath.Base(i.Path), "_crd.yaml", ".yaml", 1)
-
-		// controller-tools' generators read and make crds for all apis in pkg/apis,
-		// so generate crds in a cached, in-memory fs to extract the data we need.
-		if !cache.fileExists(path) {
-			// This sets domain as empty string when we can't extract it from FullGroup.
-			// In turn this defaults to extracting the domain from project root file
-			// in controller-tools.
-			fg := strings.SplitN(s.Resource.FullGroup, ".", 2)
-			domain := s.Resource.FullGroup
-			if len(fg) > 1 {
-				domain = fg[1]
-			}
-
-			g := &crdgenerator.Generator{
-				RootPath:          s.AbsProjectPath,
-				Domain:            domain,
-				Repo:              s.Repo,
-				OutputDir:         ".",
-				SkipMapValidation: false,
-				OutFs:             cache,
-			}
-			if err := g.ValidateAndInitFields(); err != nil {
-				return nil, err
-			}
-			if err := g.Do(); err != nil {
-				return nil, err
-			}
-		}
-
-		b, err := afero.ReadFile(cache, path)
+		b, err := afero.ReadFile(fs, path)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil, fmt.Errorf("no API exists for Group %s Version %s Kind %s",
@@ -175,11 +148,11 @@ func (s *CRD) CustomRender() ([]byte, error) {
 func newCRDForResource(r *Resource) *apiextv1beta1.CustomResourceDefinition {
 	crd := &apiextv1beta1.CustomResourceDefinition{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apiextensions.k8s.io/v1beta1",
+			APIVersion: apiextv1beta1.SchemeGroupVersion.String(),
 			Kind:       "CustomResourceDefinition",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: r.Resource + "." + r.FullGroup,
+			Name: fmt.Sprintf("%s.%s", r.Resource, r.FullGroup),
 		},
 		Spec: apiextv1beta1.CustomResourceDefinitionSpec{
 			Group:   r.FullGroup,


### PR DESCRIPTION
**Description of the change:** remove CRD cache so manifests are generated with the correct [domain](https://github.com/operator-framework/operator-sdk/blob/db3a453bde93dc4bba13e5ace6dde08758b6dca0/internal/pkg/scaffold/crd.go#L122).


**Motivation for the change:** Fixes #1608. The cache didn't provide a big performance benefit anyway unless quite a few API's require parsing. This is also not an issue in controller-tools v0.2.0 CRD generator.

Closes #1608
