### PR TITLE
Put remote_tmp in /tmp to prevent errors writing to $HOME

### DIFF
--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -22,7 +22,8 @@ RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
     && echo '[defaults]' > /etc/ansible/ansible.cfg \
     && echo 'roles_path = /opt/ansible/roles' >> /etc/ansible/ansible.cfg \
-    && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg
+    && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg \
+    && echo 'remote_tmp = /tmp/.ansible-${USER}/tmp' >> /etc/ansible/ansible.cfg
 
 ENV OPERATOR=/usr/local/bin/ansible-operator \
     USER_UID=1001 \

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -21,7 +21,8 @@ RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
     && echo '[defaults]' > /etc/ansible/ansible.cfg \
     && echo 'roles_path = /opt/ansible/roles' >> /etc/ansible/ansible.cfg \
-    && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg
+    && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg \
+    && echo 'remote_tmp = /tmp/.ansible-${USER}/tmp' >> /etc/ansible/ansible.cfg
 
 ENV OPERATOR=/usr/local/bin/ansible-operator \
     USER_UID=1001 \

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -64,7 +64,8 @@ RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
     && echo '[defaults]' > /etc/ansible/ansible.cfg \
     && echo 'roles_path = /opt/ansible/roles' >> /etc/ansible/ansible.cfg \
-    && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg
+    && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg \
+    && echo 'remote_tmp = /tmp/.ansible-${USER}/tmp' >> /etc/ansible/ansible.cfg
 
 ENV OPERATOR=/usr/local/bin/ansible-operator \
     USER_UID=1001 \


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Sets `remote_tmp` which should work around https://bugzilla.redhat.com/show_bug.cgi?id=1726326 for the most part.

**Motivation for the change:**
Hopefully will get our CI working again, and there's not really a reason to put `remote_tmp` in `$HOME` instead of `/tmp`