### PR TITLE
doc: add OpenAPI validation info to user guide

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -106,7 +106,12 @@ After modifying the `*_types.go` file always run the following command to update
 $ operator-sdk generate k8s
 ```
 
-Update the Open API validation section in the CRD at `deploy/crds/cache_v1alpha1_memcached_crd.yaml` so that Kubernetes can validate the properties in a Memcached Custom Resource when it is created or updated.
+To update the Open API validation section in the CRD `deploy/crds/cache_v1alpha1_memcached_crd.yaml`, run the following command. 
+
+```console
+$ operator-sdk generate openapi
+```
+This validation section allows Kubernetes to validate the properties in a Memcached Custom Resource when it is created or updated. An example of the generated YAML is as follows: 
 
 ```YAML
 spec:
@@ -116,6 +121,7 @@ spec:
         spec:
           properties:
             size:
+              format: int32
               type: integer
 ```
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -106,6 +106,22 @@ After modifying the `*_types.go` file always run the following command to update
 $ operator-sdk generate k8s
 ```
 
+Update the Open API validation section in the CRD at `deploy/crds/cache_v1alpha1_memcached_crd.yaml` so that Kubernetes can validate the properties in a Memcached Custom Resource when it is created or updated.
+
+```YAML
+spec:
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            size:
+              type: integer
+```
+
+To learn more about OpenAPI v3.0 validation schemas in Custom Resource Definitions, refer to the [Kubernetes Documentation][doc_validation_schema].
+
+
 ## Add a new Controller
 
 Add a new [Controller][controller-go-doc] to the project that will watch and reconcile the Memcached resource:
@@ -619,3 +635,4 @@ When the operator is not running in a cluster, the Manager will return an error 
 [result_go_doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Result
 [metrics_doc]: ./user/metrics/README.md
 [quay_link]: https://quay.io
+[doc_validation_schema]: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#specifying-a-structural-schema

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -106,7 +106,8 @@ After modifying the `*_types.go` file always run the following command to update
 $ operator-sdk generate k8s
 ```
 
-To update the Open API validation section in the CRD `deploy/crds/cache_v1alpha1_memcached_crd.yaml`, run the following command. 
+### OpenAPI validation
+To update the OpenAPI validation section in the CRD `deploy/crds/cache_v1alpha1_memcached_crd.yaml`, run the following command. 
 
 ```console
 $ operator-sdk generate openapi


### PR DESCRIPTION
**Description of the change:**

The generated YAML CRD created when running `operator-sdk add api ...`
includes an OpenAPI v3.0 validation section. E.g.

```YAML
  validation:
    openAPIV3Schema:
      properties:
        apiVersion:
          description: 'APIVersion defines the versioned schema of this representation
            of an object. Servers should convert recognized schemas to the latest
            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
          type: string
        kind:
          description: 'Kind is a string value representing the REST resource this
            object represents. Servers may infer this from the endpoint the client
            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
          type: string
        metadata:
          type: object
        spec:
          type: object
        status:
          type: object
```

The properties for a CRD should be specified here for validation.
In the case of the Memcached example, a `size` property should be
added to the generated CRD. This change documents that process in
the user guide.


**Motivation for the change:**

I got hung up on this when going through the tutorial. I thought I was missing a step or something wasn't right when examining the generated CRD files and following the user guide. Perhaps this will make it a little clearer for people just starting out.
