### PR TITLE
Fix log message so it doesn't cause an error

### DIFF
--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -115,7 +115,7 @@ func main() {
 		log.Error(err, "")
 		os.Exit(1)
 	}
-	
+
 	ctx := context.TODO()
 	// Become the leader before proceeding
 	err = leader.Become(ctx, "{{ .ProjectName }}-lock")
@@ -129,7 +129,7 @@ func main() {
 		Namespace:          namespace,
 		MapperProvider:     restmapper.NewDynamicRESTMapper,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
-	})	
+	})
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)
@@ -150,9 +150,9 @@ func main() {
 	}
 
 	if err = serveCRMetrics(cfg); err != nil {
-		log.Info("Could not generate and serve custom resource metrics: ", err.Error())
+		log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
 	}
-	
+
 	// Add to the below struct any other metrics ports you want to expose.
 	servicePorts := []v1.ServicePort{
 		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -149,7 +149,7 @@ func main() {
 	}
 
 	if err = serveCRMetrics(cfg); err != nil {
-		log.Info("Could not generate and serve custom resource metrics: ", err.Error())
+		log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
 	}
 
 	// Add to the below struct any other metrics ports you want to expose.

--- a/pkg/helm/run.go
+++ b/pkg/helm/run.go
@@ -127,7 +127,7 @@ func Run(flags *hoflags.HelmOperatorFlags) error {
 	// It serves those metrics on "http://metricsHost:operatorMetricsPort".
 	err = kubemetrics.GenerateAndServeCRMetrics(cfg, []string{namespace}, gvks, metricsHost, operatorMetricsPort)
 	if err != nil {
-		log.Info("Could not generate and serve custom resource metrics: ", err.Error())
+		log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
 	}
 
 	servicePorts := []v1.ServicePort{


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Without this change, I get an error about "odd number of arguments
passed as key-value pairs for logging" in the case where this code is
invoked (I hit it when running the operator with `operator-sdk up local`).

I only hit it in the cmd.go for my Go operator, but I presume the same
thing is needed for the cmd_test.go and helm/run.go.

I'm also not sure if this is absolutely the best solution (I'm not
that experienced with Go), but it fixed the issue for me.


**Motivation for the change:**

I think the previous behaviour was unintentional.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
