### PR TITLE
doc/test-framework: use correct manifest structure in docs

### DIFF
--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -280,14 +280,16 @@ in [MainEntry][main-entry-link] are declared, the tests will run correctly. Runn
 will result in undefined behavior. This is an example `go test` equivalent to the `operator-sdk test local` example above:
 
 ```shell
-# Combine service_account, rbac, operator manifest into namespaced manifest
+# Combine service_account, role, role_binding, and operator manifests into namespaced manifest
 $ cp deploy/service_account.yaml deploy/namespace-init.yaml
 $ echo -e "\n---\n" >> deploy/namespace-init.yaml
-$ cat deploy/rbac.yaml >> deploy/namespace-init.yaml
+$ cat deploy/role.yaml >> deploy/namespace-init.yaml
+$ echo -e "\n---\n" >> deploy/namespace-init.yaml
+$ cat deploy/role_binding.yaml >> deploy/namespace-init.yaml
 $ echo -e "\n---\n" >> deploy/namespace-init.yaml
 $ cat deploy/operator.yaml >> deploy/namespace-init.yaml
 # Run tests
-$ go test ./test/e2e/... -root=$(pwd) -kubeconfig=$HOME/.kube/config -globalMan deploy/crd.yaml -namespacedMan deploy/namespace-init.yaml -v -parallel=2
+$ go test ./test/e2e/... -root=$(pwd) -kubeconfig=$HOME/.kube/config -globalMan deploy/crds/example_v1alpha1_app_crd.yaml -namespacedMan deploy/namespace-init.yaml -v -parallel=2
 ```
 
 ## Manual Cleanup


### PR DESCRIPTION
**Description of the change:** Update old manifest structure used in part of the writing tests doc (was using the pre-v0.1.0 manifest structure)


**Motivation for the change:** Keep docs up to date