### PR TITLE
doc/operator-scope: add scope tag for CRD generation

### DIFF
--- a/doc/operator-scope.md
+++ b/doc/operator-scope.md
@@ -24,6 +24,8 @@ For each CRD that needs to be cluster-scoped, update its manifest to be cluster-
 * `deploy/crds/<group>_<version>_<kind>_crd.yaml`
   * Set `spec.scope: Cluster`
 
+To ensure that the CRD is always generated with `scope: Cluster`, add the tag `// +genclient:nonNamespaced` above the CRD's Go type defintion in `pkg/apis/<group>/<version>/<kind>_types.go`.
+
 
 ### Example for cluster scoped operator
 
@@ -81,4 +83,19 @@ With the above changes the specified manifests should look as follows:
       group: cache.example.com
       ...
       scope: Cluster
+    ```
+* `pkg/apis/cache/v1alpha1/memcached_types.go`
+    ```Go
+    // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+    // Memcached is the Schema for the memcacheds API
+    // +k8s:openapi-gen=true
+    // +genclient:nonNamespaced
+    type Memcached struct {
+      metav1.TypeMeta   `json:",inline"`
+      metav1.ObjectMeta `json:"metadata,omitempty"`
+
+      Spec   MemcachedSpec   `json:"spec,omitempty"`
+      Status MemcachedStatus `json:"status,omitempty"`
+    }
     ```

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -75,6 +75,8 @@ By default this will be the namespace that the operator is running in. To watch 
 mgr, err := manager.New(cfg, manager.Options{Namespace: ""})
 ```
 
+By default the main program will set the manager's namespace using the value of `WATCH_NAMESPACE` env defined in `deploy/operator.yaml`.
+
 ## Add a new Custom Resource Definition
 
 Add a new Custom Resource Definition(CRD) API called Memcached, with APIVersion `cache.example.com/v1alpha1` and Kind `Memcached`.


### PR DESCRIPTION
**Description of the change:**
Document the tag `// +genclient:nonNamespaced` for generating CRDs as cluster-scoped in the operator scope document.
Also add a line clarifying the default usage of the `WATCH_NAMESPACE` env in the user guide. 

**Motivation for the change:**
Closes: #1650 