### PR TITLE
hack/check_error_log_msg_format.sh: correctly check "errors." functions

### DIFF
--- a/hack/check_error_log_msg_format.sh
+++ b/hack/check_error_log_msg_format.sh
@@ -7,7 +7,7 @@ source "hack/lib/test_lib.sh"
 
 echo "Checking format of error and log messages..."
 allfiles=$(listFiles)
-log_case_output=$(grep -PRn '(Error\((.*[Ee]rr|nil), |^(?!.*fmt).+\.Error(f)?\(|Fatal(f)?\(|Info(f)?\(|Warn(f)?\()"[[:lower:]]' $allfiles | sort -u)
+log_case_output=$(grep -PRn '(Error\((.*[Ee]rr|nil), |^(?!.*(fmt|errors)).+\.Error(f)?\(|Fatal(f)?\(|Info(f)?\(|Warn(f)?\()"[[:lower:]]' $allfiles | sort -u)
 if [ -n "${log_case_output}" ]; then
   echo -e "Log messages do not begin with upper case:\n${log_case_output}"
 fi


### PR DESCRIPTION
**Description of the change:** correctly check functions with the form `errors.Function(...)`.

**Motivation for the change:** functions like `github.com/pkg/errors.Errorf()` should not be assessed as log messages.
