### PR TITLE
 ansible: Use operator-sdk's dynamic restmapper

### DIFF
--- a/pkg/ansible/run.go
+++ b/pkg/ansible/run.go
@@ -27,6 +27,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
+	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,6 +72,7 @@ func Run(flags *aoflags.AnsibleOperatorFlags) error {
 	// TODO: probably should expose the host & port as an environment variables
 	mgr, err := manager.New(cfg, manager.Options{
 		Namespace:          namespace,
+		MapperProvider:     restmapper.NewDynamicRESTMapper,
 		MetricsBindAddress: fmt.Sprintf("0.0.0.0:%d", metricsPort),
 	})
 	if err != nil {

--- a/pkg/ansible/watches/watches_test.go
+++ b/pkg/ansible/watches/watches_test.go
@@ -46,6 +46,7 @@ func TestLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create valid.yaml: %v", err)
 	}
+	defer os.Remove("testdata/valid.yaml")
 	err = tmpl.Execute(f, validTemplate)
 	if err != nil {
 		t.Fatalf("Unable to create valid.yaml: %v", err)


### PR DESCRIPTION
This makes it possible for ansible based operators to interact with CRDs
that didn't exist when the operator started.

fixes #1330