### PR TITLE
hack/: remove existing replace lines in go.mod for the SDK repo first

### DIFF
--- a/hack/lib/test_lib.sh
+++ b/hack/lib/test_lib.sh
@@ -58,6 +58,10 @@ function add_go_mod_replace() {
 		exit 1
 	fi
 
+	# Check if a replace line already exists. If it does, remove. If not, append.
+	if grep -q "${from_path} =>" go.mod; then
+		sed -E -i 's|^.+'"${from_path} =>"'.+$||g' go.mod
+	fi
 	# Do not use "go mod edit" so formatting stays the same.
 	local replace="replace ${from_path} => ${to_path}"
 	if [[ -n "$version" ]]; then

--- a/hack/tests/scaffolding/scaffold-memcached.go
+++ b/hack/tests/scaffolding/scaffold-memcached.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
@@ -271,6 +272,10 @@ func insertGoModReplace(repo, path, sha string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read go.mod")
 	}
+	// Remove all replace lines in go.mod.
+	replaceRe := regexp.MustCompile(fmt.Sprintf("(replace )?%s =>.+", repo))
+	modBytes = replaceRe.ReplaceAll(modBytes, nil)
+	// Append the desired replace to the end of go.mod's bytes.
 	sdkReplace := fmt.Sprintf("replace %s => %s", repo, path)
 	if sha != "" {
 		sdkReplace = fmt.Sprintf("%s %s", sdkReplace, sha)


### PR DESCRIPTION
**Description of the change:** remove existing replace lines in go.mod for the SDK repo before appending one in e2e tests


**Motivation for the change:** e2e code will not pass release PR's otherwise.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
