### PR TITLE
*: document mercurial dependency for v0.9+ operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- Document new compile-time dependency `mercurial` in user-facing documentation. ([#1683](https://github.com/operator-framework/operator-sdk/pull/1683))
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The following workflow is for a new **Helm** operator:
 
 - [git][git_tool]
 - [go][go_tool] version v1.12+.
+- [mercurial][mercurial_tool] version 3.9+
 - [docker][docker_tool] version 17.03+.
   - Alternatively [podman][podman_tool] `v1.2.0+` or [buildah][buildah_tool] `v1.7+`
 - [kubectl][kubectl_tool] version v1.11.3+.
@@ -172,6 +173,7 @@ Operator SDK is under Apache 2.0 license. See the [LICENSE][license_file] file f
 [dep_tool]:https://golang.github.io/dep/docs/installation.html
 [git_tool]:https://git-scm.com/downloads
 [go_tool]:https://golang.org/dl/
+[mercurial_tool]:https://www.mercurial-scm.org/downloads
 [docker_tool]:https://docs.docker.com/install/
 [podman_tool]:https://github.com/containers/libpod/blob/master/install.md
 [buildah_tool]:https://github.com/containers/buildah/blob/master/install.md

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -7,6 +7,7 @@ This guide walks through an example of building a simple memcached-operator usin
 
 - [git][git_tool]
 - [go][go_tool] version v1.12+.
+- [mercurial][mercurial_tool] version 3.9+
 - [docker][docker_tool] version 17.03+.
 - [kubectl][kubectl_tool] version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.
@@ -609,6 +610,7 @@ When the operator is not running in a cluster, the Manager will return an error 
 [git_tool]:https://git-scm.com/downloads
 [go_tool]:https://golang.org/dl/
 [docker_tool]:https://docs.docker.com/install/
+[mercurial_tool]:https://www.mercurial-scm.org/downloads
 [kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [minikube_tool]:https://github.com/kubernetes/minikube#installation
 [scheme_package]:https://github.com/kubernetes/client-go/blob/master/kubernetes/scheme/register.go


### PR DESCRIPTION
**Description of the change:** document new mercurial compile-time dependency for new operators.


**Motivation for the change:** new operators require mercurial be installed as of v0.9.0.


Closes #1681 
