### PR TITLE
Add openshift subcommand to generate

### DIFF
--- a/cmd/operator-sdk/generate/cmd.go
+++ b/cmd/operator-sdk/generate/cmd.go
@@ -26,5 +26,6 @@ func NewCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newGenerateK8SCmd())
 	cmd.AddCommand(newGenerateOpenAPICmd())
+	cmd.AddCommand(newGenerateOpenshiftCmd())
 	return cmd
 }

--- a/cmd/operator-sdk/generate/openshift.go
+++ b/cmd/operator-sdk/generate/openshift.go
@@ -1,0 +1,57 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"fmt"
+
+	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/internal/genutil"
+
+	"github.com/spf13/cobra"
+)
+
+func newGenerateOpenshiftCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "openshift",
+		Short: "Generates Openshift operator specific manifest files",
+		Long: `openshift generator generates the needed manifest files for 
+the operator to be deployed on Openshift. 
+Example:
+	$ operator-sdk generate openshift
+	$ tree deploy/openshift/
+		deploy/openshift/
+		├── crds
+		│   ├── app_v1alpha1_memcached_cr.yaml
+		│   └── app_v1alpha1_memcached_crd.yaml
+		├── metrics
+		│   ├── service-monitor.yaml
+		│   └── service.yaml
+		├── operator.yaml
+		└── rbac
+			├── role.yaml
+			├── role_binding.yaml
+			└── service_account.yaml
+`,
+		RunE: openshiftFunc,
+	}
+}
+
+func openshiftFunc(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return fmt.Errorf("command %s doesn't accept any arguments", cmd.CommandPath())
+	}
+
+	return genutil.OpenshiftGen()
+}

--- a/cmd/operator-sdk/internal/genutil/openshift.go
+++ b/cmd/operator-sdk/internal/genutil/openshift.go
@@ -1,0 +1,136 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package genutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold"
+	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/input"
+	"github.com/operator-framework/operator-sdk/internal/util/projutil"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+// OpenshiftGen generates all the dirs and manifest that are openshift specifc under deploy/openshift.
+func OpenshiftGen() error {
+	projutil.MustInProjectRoot()
+	absProjectPath := projutil.MustGetwd()
+	openshiftAbsPath := fmt.Sprintf("%s/deploy/openshift", absProjectPath)
+	repo := projutil.GetGoPkg()
+	deployDir := fmt.Sprintf("%s/deploy/", absProjectPath)
+
+	// check if dir openshift already exists
+	if _, err := os.Stat(openshiftAbsPath); err == nil || os.IsExist(err) {
+		log.Info("The deploy/openshift directory already exists, remove it first to continue")
+		return err
+	}
+
+	// create directories
+	if err := makeDirs([]string{openshiftAbsPath,
+		fmt.Sprintf("%s/crds", openshiftAbsPath),
+		fmt.Sprintf("%s/metrics", openshiftAbsPath),
+		fmt.Sprintf("%s/rbac", openshiftAbsPath)}); err != nil {
+		return fmt.Errorf("failed to create directory: %s", err)
+	}
+
+	// copy over crds dir files to openshift/crds/ dir
+	fs := afero.NewOsFs()
+	if err := copyDirs(fs, fmt.Sprintf("%scrds", deployDir),
+		fmt.Sprintf("%s/crds", openshiftAbsPath)); err != nil {
+		return fmt.Errorf("failed to create openshift/crds directory: %s", err)
+	}
+	if err := copyFiles(fmt.Sprintf("%srole.yaml", deployDir),
+		deployDir, fmt.Sprintf("%s/rbac/", openshiftAbsPath), fs); err != nil {
+		return err
+	}
+	if err := copyFiles(fmt.Sprintf("%srole_binding.yaml", deployDir),
+		deployDir, fmt.Sprintf("%s/rbac/", openshiftAbsPath), fs); err != nil {
+		return err
+	}
+	if err := copyFiles(fmt.Sprintf("%sservice_account.yaml", deployDir),
+		deployDir, fmt.Sprintf("%s/rbac/", openshiftAbsPath), fs); err != nil {
+		return err
+	}
+
+	// create service.yaml, service-monitor.yaml and operator.yaml
+	s := &scaffold.Scaffold{}
+	cfg := &input.Config{
+		Repo:           repo,
+		AbsProjectPath: absProjectPath,
+		ProjectName:    filepath.Base(absProjectPath),
+	}
+	if err := s.Execute(cfg,
+		&scaffold.Service{},
+		&scaffold.ServiceMonitor{},
+		&scaffold.OpenshiftOperator{},
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func makeDirs(dirs []string) error {
+	for _, dir := range dirs {
+		err := os.MkdirAll(dir, os.ModePerm)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyDirs(fs afero.Fs, src string, dst string) error {
+	return afero.Walk(fs, src,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			fullDst := strings.Replace(path, src, dst, 1)
+			if info.IsDir() {
+				if err = fs.MkdirAll(fullDst, info.Mode()); err != nil {
+					return err
+				}
+			} else {
+				if err = copyFiles(path, src, dst, fs); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+}
+
+func copyFiles(path, src, dst string, fs afero.Fs) error {
+	f, err := fs.Open(path)
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	fullDst := strings.Replace(path, src, dst, 1)
+	if err != nil {
+		return err
+	}
+	if err = afero.WriteReader(fs, fullDst, f); err != nil {
+		return err
+	}
+	if err = fs.Chmod(fullDst, info.Mode()); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/pkg/scaffold/openshift_operator.go
+++ b/internal/pkg/scaffold/openshift_operator.go
@@ -1,0 +1,119 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scaffold
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/input"
+)
+
+const OpenshiftOperatorYamlFile = "operator.yaml"
+
+type OpenshiftOperator struct {
+	input.Input
+}
+
+func (s *OpenshiftOperator) GetInput() (input.Input, error) {
+	if s.Path == "" {
+		s.Path = filepath.Join(fmt.Sprintf("%s/openshift/", DeployDir), OpenshiftOperatorYamlFile)
+	}
+	s.TemplateBody = openshiftOperatorTemplate
+	return s.Input, nil
+}
+
+const openshiftOperatorTemplate = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.ProjectName}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{.ProjectName}}
+  template:
+    metadata:
+      labels:
+        name: {{.ProjectName}}
+    spec:
+      serviceAccountName: {{.ProjectName}}
+      volumes:
+      - name: {{.ProjectName}}
+        secret:
+          secretName: {{.ProjectName}}
+      - emptyDir: {}
+        name: volume-directive-shadow
+      containers:
+        - name: {{.ProjectName}}
+          # Replace this with the built image name
+          image: REPLACE_IMAGE
+          command:
+          - {{.ProjectName}}
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "{{.ProjectName}}"
+        - args:
+          - --logtostderr
+          - -v=8
+          - --secure-listen-address=:9393
+          - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+          - --upstream=http://127.0.0.1:8383/
+          - --tls-cert-file=/etc/tls/private/tls.crt
+          - --tls-private-key-file=/etc/tls/private/tls.key
+          image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+          name: kube-rbac-proxy-https
+          ports:
+          - containerPort: 9393
+            name: https-metrics
+          resources:
+            requests:
+              cpu: 10m
+              memory: 40Mi
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: {{.ProjectName}}
+            readOnly: false
+        - args:
+          - --logtostderr
+          - -v=8
+          - --secure-listen-address=:9696
+          - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+          - --upstream=http://127.0.0.1:8686/
+          - --tls-cert-file=/etc/tls/private/tls.crt
+          - --tls-private-key-file=/etc/tls/private/tls.key
+          image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+          name: kube-rbac-proxy-cr
+          ports:
+          - containerPort: 9696
+            name: cr-metrics
+          resources:
+            requests:
+              cpu: 10m
+              memory: 40Mi
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: {{.ProjectName}}
+            readOnly: false
+`

--- a/internal/pkg/scaffold/openshift_operator_test.go
+++ b/internal/pkg/scaffold/openshift_operator_test.go
@@ -1,0 +1,117 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scaffold
+
+import (
+	"testing"
+
+	"github.com/operator-framework/operator-sdk/internal/util/diffutil"
+)
+
+func TestOpenshiftOperator(t *testing.T) {
+	s, buf := setupScaffoldAndWriter()
+	err := s.Execute(appConfig, &OpenshiftOperator{})
+	if err != nil {
+		t.Fatalf("Failed to execute the scaffold: (%v)", err)
+	}
+
+	if openshiftOperatorExp != buf.String() {
+		diffs := diffutil.Diff(openshiftOperatorExp, buf.String())
+		t.Fatalf("Expected vs actual differs.\n%v", diffs)
+	}
+}
+
+const openshiftOperatorExp = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: app-operator
+  template:
+    metadata:
+      labels:
+        name: app-operator
+    spec:
+      serviceAccountName: app-operator
+      volumes:
+      - name: app-operator
+        secret:
+          secretName: app-operator
+      - emptyDir: {}
+        name: volume-directive-shadow
+      containers:
+        - name: app-operator
+          # Replace this with the built image name
+          image: REPLACE_IMAGE
+          command:
+          - app-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "app-operator"
+        - args:
+          - --logtostderr
+          - -v=8
+          - --secure-listen-address=:9393
+          - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+          - --upstream=http://127.0.0.1:8383/
+          - --tls-cert-file=/etc/tls/private/tls.crt
+          - --tls-private-key-file=/etc/tls/private/tls.key
+          image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+          name: kube-rbac-proxy-https
+          ports:
+          - containerPort: 9393
+            name: https-metrics
+          resources:
+            requests:
+              cpu: 10m
+              memory: 40Mi
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: app-operator
+            readOnly: false
+        - args:
+          - --logtostderr
+          - -v=8
+          - --secure-listen-address=:9696
+          - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+          - --upstream=http://127.0.0.1:8686/
+          - --tls-cert-file=/etc/tls/private/tls.crt
+          - --tls-private-key-file=/etc/tls/private/tls.key
+          image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+          name: kube-rbac-proxy-cr
+          ports:
+          - containerPort: 9696
+            name: cr-metrics
+          resources:
+            requests:
+              cpu: 10m
+              memory: 40Mi
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: app-operator
+            readOnly: false
+`

--- a/internal/pkg/scaffold/service.go
+++ b/internal/pkg/scaffold/service.go
@@ -1,0 +1,58 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scaffold
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/input"
+)
+
+const ServiceFile = "service.yaml"
+
+type Service struct {
+	input.Input
+}
+
+func (s *Service) GetInput() (input.Input, error) {
+	if s.Path == "" {
+		s.Path = filepath.Join(fmt.Sprintf("%s/openshift/metrics/", DeployDir), ServiceFile)
+	}
+	s.TemplateBody = serviceTemplate
+
+	return s.Input, nil
+}
+
+const serviceTemplate = `apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: {{.ProjectName}}
+  labels:
+    name: {{.ProjectName}}
+  name: {{.ProjectName}}
+spec:
+  ports:
+  - name: cr-metrics
+    port: 9696
+    targetPort: cr-metrics
+  - name: https-metrics
+    port: 9393
+    targetPort: https-metrics
+  selector:
+    name: {{.ProjectName}}
+  type: ClusterIP
+`

--- a/internal/pkg/scaffold/service_monitor.go
+++ b/internal/pkg/scaffold/service_monitor.go
@@ -1,0 +1,67 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scaffold
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/input"
+)
+
+const ServiceMonitorYamlFile = "service-monitor.yaml"
+
+type ServiceMonitor struct {
+	input.Input
+}
+
+func (s *ServiceMonitor) GetInput() (input.Input, error) {
+	if s.Path == "" {
+		s.Path = filepath.Join(fmt.Sprintf("%s/openshift/metrics/", DeployDir), ServiceMonitorYamlFile)
+	}
+	s.TemplateBody = serviceMonitorTemplate
+	return s.Input, nil
+}
+
+const serviceMonitorTemplate = `apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: {{.ProjectName}}
+  name: {{.ProjectName}}
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 2m
+    port: cr-metrics
+    scheme: https
+    scrapeTimeout: 2m
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: {{.ProjectName}}.default.svc
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    interval: 2m
+    port: https-metrics
+    scheme: https
+    scrapeTimeout: 2m
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: {{.ProjectName}}.default.svc
+  jobLabel: {{.ProjectName}}
+  selector:
+    matchLabels:
+        name: {{.ProjectName}}
+`

--- a/internal/pkg/scaffold/service_monitor_test.go
+++ b/internal/pkg/scaffold/service_monitor_test.go
@@ -1,0 +1,65 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scaffold
+
+import (
+	"testing"
+
+	"github.com/operator-framework/operator-sdk/internal/util/diffutil"
+)
+
+func TestServiceMonitor(t *testing.T) {
+	s, buf := setupScaffoldAndWriter()
+	err := s.Execute(appConfig, &ServiceMonitor{})
+	if err != nil {
+		t.Fatalf("Failed to execute the scaffold: (%v)", err)
+	}
+
+	if serviceMonitorExp != buf.String() {
+		diffs := diffutil.Diff(serviceMonitorExp, buf.String())
+		t.Fatalf("Expected vs actual differs.\n%v", diffs)
+	}
+}
+
+const serviceMonitorExp = `apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: app-operator
+  name: app-operator
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 2m
+    port: cr-metrics
+    scheme: https
+    scrapeTimeout: 2m
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: app-operator.default.svc
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    interval: 2m
+    port: https-metrics
+    scheme: https
+    scrapeTimeout: 2m
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: app-operator.default.svc
+  jobLabel: app-operator
+  selector:
+    matchLabels:
+        name: app-operator
+`

--- a/internal/pkg/scaffold/service_test.go
+++ b/internal/pkg/scaffold/service_test.go
@@ -1,0 +1,55 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scaffold
+
+import (
+	"testing"
+
+	"github.com/operator-framework/operator-sdk/internal/util/diffutil"
+)
+
+func TestService(t *testing.T) {
+	s, buf := setupScaffoldAndWriter()
+	err := s.Execute(appConfig, &Service{})
+	if err != nil {
+		t.Fatalf("Failed to execute the scaffold: (%v)", err)
+	}
+
+	if serviceExp != buf.String() {
+		diffs := diffutil.Diff(serviceExp, buf.String())
+		t.Fatalf("Expected vs actual differs.\n%v", diffs)
+	}
+}
+
+const serviceExp = `apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: app-operator
+  labels:
+    name: app-operator
+  name: app-operator
+spec:
+  ports:
+  - name: cr-metrics
+    port: 9696
+    targetPort: cr-metrics
+  - name: https-metrics
+    port: 9393
+    targetPort: https-metrics
+  selector:
+    name: app-operator
+  type: ClusterIP
+`


### PR DESCRIPTION
This currently generates openshift specific manifest files, but the
command can be reused later on for any openshift specif generation.

The manifest that are generated only work in openshift clusters as they
have specific annotations to generate TLS certs and secure the metrics
endpoints that are exposed by the operator.

Issue detailing design -> https://github.com/operator-framework/operator-sdk/issues/396#issuecomment-510035291

Closes https://github.com/operator-framework/operator-sdk/issues/396