### PR TITLE
ci/tests,test/e2e: log up local errors better

### DIFF
--- a/ci/tests/e2e-go.sh
+++ b/ci/tests/e2e-go.sh
@@ -9,7 +9,7 @@ set -- "--image-name=$IMAGE --local-image=false"
 source ./hack/tests/scaffolding/e2e-go-scaffold.sh
 
 pushd $BASEPROJECTDIR/memcached-operator
-operator-sdk test local ./test/e2e
+operator-sdk test local ./test/e2e --verbose
 popd
 
 go test ./test/e2e/... -root=. -globalMan=testdata/empty.yaml

--- a/test/e2e/_incluster-test-code/memcached_test.go
+++ b/test/e2e/_incluster-test-code/memcached_test.go
@@ -257,7 +257,7 @@ func MemcachedLocal(t *testing.T) {
 	if err = memcachedScaleTest(t, framework.Global, ctx, 3, 4); err != nil {
 		file, fileErr := ioutil.ReadFile("stderr.txt")
 		if fileErr != nil {
-			t.Logf("Failed to read operator logs after test failure")
+			t.Logf("Failed to read operator logs after test failure: %v", fileErr)
 		} else {
 			t.Logf("Operator Logs: %s", string(file))
 		}

--- a/test/e2e/_incluster-test-code/memcached_test.go
+++ b/test/e2e/_incluster-test-code/memcached_test.go
@@ -255,6 +255,12 @@ func MemcachedLocal(t *testing.T) {
 	}
 
 	if err = memcachedScaleTest(t, framework.Global, ctx, 3, 4); err != nil {
+		file, fileErr := ioutil.ReadFile("stderr.txt")
+		if fileErr != nil {
+			t.Logf("Failed to read operator logs after test failure")
+		} else {
+			t.Logf("Operator Logs: %s", string(file))
+		}
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
**Description of the change:** Print out operator logs if local operator fails


**Motivation for the change:** It is difficult to identify what caused an error if we don't have proper logs