### PR TITLE
cmd/operator-sdk/build: expand env in go build (#1535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 - Fixes header file content validation when the content contains empty lines or centered text. ([#1544](https://github.com/operator-framework/operator-sdk/pull/1544))
+- Build `-trimpath` was not being respected. `$GOPATH` was not expanding because `exec.Cmd{}` is not executed in a shell environment. ([#1535](https://github.com/operator-framework/operator-sdk/pull/1535))
 
 ## v0.8.1
 

--- a/cmd/operator-sdk/build/cmd.go
+++ b/cmd/operator-sdk/build/cmd.go
@@ -92,7 +92,8 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 		goBuildEnv = append(goBuildEnv, "CGO_ENABLED=0")
 	}
 
-	goTrimFlags := []string{"-gcflags", "all=-trimpath=${GOPATH}", "-asmflags", "all=-trimpath=${GOPATH}"}
+	trimPath := os.ExpandEnv("all=-trimpath=${GOPATH}")
+	goTrimFlags := []string{"-gcflags", trimPath, "-asmflags", trimPath}
 	absProjectPath := projutil.MustGetwd()
 	projectName := filepath.Base(absProjectPath)
 

--- a/internal/util/projutil/exec.go
+++ b/internal/util/projutil/exec.go
@@ -113,8 +113,9 @@ func getGeneralArgs(cmd string, opts GoCmdOptions) ([]string, error) {
 }
 
 func setCommandFields(c *exec.Cmd, opts GoCmdOptions) {
+	c.Env = append(c.Env, os.Environ()...)
 	if len(opts.Env) != 0 {
-		c.Env = append(os.Environ(), opts.Env...)
+		c.Env = append(c.Env, opts.Env...)
 	}
 	if opts.Dir != "" {
 		c.Dir = opts.Dir


### PR DESCRIPTION
**Description of the change:** see #1535


**Motivation for the change:** cherry-pick for v0.8.2

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
