### PR TITLE
README.md: Add missing --repo flag in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ mkdir -p $HOME/projects/example-inc/
 # Create a new app-operator project
 $ cd $HOME/projects/example-inc/
 $ export GO111MODULE=on
-$ operator-sdk new app-operator
+$ operator-sdk new app-operator --repo github.com/example-inc/app-operator
 $ cd app-operator
 
 # Add a new API for the custom resource AppService


### PR DESCRIPTION
In 757f7a0b9 the `--repo` flag was added to the `operator-sdk new` command, which is required when running with `--dep-manager modules`. This breaks the Go quickstart since `--repo` isn't mentioned there.

Closes https://github.com/operator-framework/operator-sdk/issues/1688.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Include the `--repo` flag in the Go quickstart.

**Motivation for the change:**

Docs should be accurate.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
