### PR TITLE
Ensure Ansible is installed in CI images

### DIFF
--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -28,6 +28,7 @@ RUN (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.
       ansible-runner==1.2 \
       ansible-runner-http==1.0.0 \
       openshift==0.8.9 \
+      ansible==2.8 \
  && yum remove -y gcc python-devel \
  && yum clean all \
  && rm -rf /var/cache/yum

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -27,6 +27,7 @@ RUN (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.
       ansible-runner==1.2 \
       ansible-runner-http==1.0.0 \
       openshift==0.8.9 \
+      ansible==2.8 \
  && yum remove -y gcc python-devel \
  && yum clean all \
  && rm -rf /var/cache/yum


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Ansible is now explicitly installed in the CI images, which should allow https://github.com/openshift/release/pull/4302 to pass

**Motivation for the change:**
The CI images when based on UBI don't actually have ansible installed, just ansible-runner.
