### PR TITLE
e2e: better method of adding SDK repo replace directive to operator's go.mod (#1574)

### DIFF
--- a/hack/lib/test_lib.sh
+++ b/hack/lib/test_lib.sh
@@ -48,3 +48,37 @@ function trap_add() {
                 fatal "unable to add to trap ${trap_add_name}"
     done
 }
+
+# add_go_mod_replace adds a "replace" directive from $1 to $2 with an
+# optional version version $3 to the current working directory's go.mod file.
+function add_go_mod_replace() {
+	local from_path="${1:?first path in replace statement is required}"
+	local to_path="${2:?second path in replace statement is required}"
+	local version="${3:-}"
+
+	if [[ ! -d "$to_path" && -z "$version" ]]; then
+		echo "second replace path $to_path requires a version be set because it is not a directory"
+		exit 1
+	fi
+	if [[ ! -e go.mod ]]; then
+		echo "go.mod file not found in $(pwd)"
+		exit 1
+	fi
+
+	# If $to_path is a directory, it needs a `go.mod` file that specifies the
+	# module name to make the go toolchain happy.
+	#
+	# TODO: remove the below if statement once
+	# https://github.com/operator-framework/operator-sdk/pull/1566 is merged,
+	# which updates the SDK to use go modules.
+	if [[ -d "${to_path}" && ! -e "${to_path}/go.mod" ]]; then
+		echo "module ${from_path}" > "${to_path}/go.mod"
+		trap_add "rm ${to_path}/go.mod" EXIT
+	fi
+	# Do not use "go mod edit" so formatting stays the same.
+	local replace="replace ${from_path} => ${to_path}"
+	if [[ -n "$version" ]]; then
+		replace="$replace $version"
+	fi
+	echo "$replace" >> go.mod
+}

--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -133,17 +133,8 @@ then
     exit 1
 fi
 
-# Right now, SDK projects still need a vendor directory, so run `go mod vendor`
-# to pull down the deps specified by the scaffolded `go.mod` file.
+add_go_mod_replace "github.com/operator-framework/operator-sdk" "$ROOTDIR"
 go mod vendor
-
-# Use the local operator-sdk directory as the repo. To make the go toolchain
-# happy, the directory needs a `go.mod` file that specifies the module name,
-# so we need this temporary hack until we update the SDK repo itself to use
-# go modules.
-echo "module github.com/operator-framework/operator-sdk" > $ROOTDIR/go.mod
-trap_add 'rm $ROOTDIR/go.mod' EXIT
-go mod edit -replace=github.com/operator-framework/operator-sdk=$ROOTDIR
 
 operator-sdk build "$DEST_IMAGE"
 

--- a/hack/tests/e2e-helm.sh
+++ b/hack/tests/e2e-helm.sh
@@ -128,17 +128,8 @@ then
     exit 1
 fi
 
-# Right now, SDK projects still need a vendor directory, so run `go mod vendor`
-# to pull down the deps specified by the scaffolded `go.mod` file.
+add_go_mod_replace "github.com/operator-framework/operator-sdk" "$ROOTDIR"
 go mod vendor
-
-# Use the local operator-sdk directory as the repo. To make the go toolchain
-# happy, the directory needs a `go.mod` file that specifies the module name,
-# so we need this temporary hack until we update the SDK repo itself to use
-# go modules.
-echo "module github.com/operator-framework/operator-sdk" > $ROOTDIR/go.mod
-trap_add 'rm $ROOTDIR/go.mod' EXIT
-go mod edit -replace=github.com/operator-framework/operator-sdk=$ROOTDIR
 
 operator-sdk build "$DEST_IMAGE"
 


### PR DESCRIPTION
**Description of the change:** see #1574


**Motivation for the change:** necessary to pass CI on release PR's.
