### PR TITLE
add template arg to add commands to provide custom type and controller template

### DIFF
--- a/cmd/operator-sdk/add/get.go
+++ b/cmd/operator-sdk/add/get.go
@@ -1,0 +1,47 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package add
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+// GetTemplate reads a template file from the url
+func GetTemplate(template string) (string, error) {
+	var templateBody []byte
+	urlString, err := url.Parse(template)
+	if err != nil {
+		return "", err
+	}
+	if urlString.Scheme == "file" {
+		templateBody, err = ioutil.ReadFile(urlString.Path)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		resp, err := http.Get(template)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		templateBody, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+	}
+	return string(templateBody), nil
+}

--- a/internal/pkg/scaffold/controller_kind.go
+++ b/internal/pkg/scaffold/controller_kind.go
@@ -51,7 +51,9 @@ func (s *ControllerKind) GetInput() (input.Input, error) {
 	}
 	// Error if this file exists.
 	s.IfExistsAction = input.Error
-	s.TemplateBody = controllerKindTemplate
+	if s.TemplateBody == "" {
+		s.TemplateBody = controllerKindTemplate
+	}
 
 	// Set imports.
 	if err := s.setImports(); err != nil {

--- a/internal/pkg/scaffold/types.go
+++ b/internal/pkg/scaffold/types.go
@@ -38,7 +38,9 @@ func (s *Types) GetInput() (input.Input, error) {
 	}
 	// Error if this file exists.
 	s.IfExistsAction = input.Error
-	s.TemplateBody = typesTemplate
+	if s.TemplateBody == "" {
+		s.TemplateBody = typesTemplate
+	}
 	return s.Input, nil
 }
 


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This change adds a template arg to the api|controller add commands:

operator-sdk add api and controller can be called with
--template arg and a uri scheme such as
http://domain/file.tmpl
https://domain/file.tmpl
file:///pathto/file.tmpl

Instead of the hardcoded templates, the custom templates
will be used to generate the type and controller.

**Motivation for the change:**
In larger organizations where multiple units work on the same operator, each unit providing their own controller, it is beneficial to define a custom template for the type and controller. Whenever a unit adds a new controller, it will be pre-created with the defined standards.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
