### PR TITLE
Display simple installation first

### DIFF
--- a/doc/user/install-operator-sdk.md
+++ b/doc/user/install-operator-sdk.md
@@ -1,5 +1,13 @@
 # Install the Operator SDK CLI
 
+## Install from Homebrew (MacOS)
+
+Alternatively, if you are using [Homebrew][homebrew_tool], you can install the SDK CLI tool with the following command:
+
+```sh
+$ brew install operator-sdk
+```
+
 ## Install from GitHub release
 
 ### Download the release binary
@@ -63,14 +71,6 @@ Now you should be able to verify the binary.
 $ chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu && sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk && rm operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
 # macOS
 $ chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin && sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin /usr/local/bin/operator-sdk && rm operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin
-```
-
-## Install from Homebrew
-
-Alternatively, if you are using [Homebrew][homebrew_tool], you can install the SDK CLI tool with the following command:
-
-```sh
-$ brew install operator-sdk
 ```
 
 ## Compile and install from master

--- a/doc/user/install-operator-sdk.md
+++ b/doc/user/install-operator-sdk.md
@@ -1,6 +1,6 @@
 # Install the Operator SDK CLI
 
-- [Install from Homebrew (macOS)](#install-from-homebrew-(macOS))
+- [Install from Homebrew (macOS)](#install-from-homebrew-macos)
 - [Install from GitHub release](#install-from-github-release)
 - [Compile and install from master](#compile-and-install-from-master)
 

--- a/doc/user/install-operator-sdk.md
+++ b/doc/user/install-operator-sdk.md
@@ -2,7 +2,7 @@
 
 ## Install from Homebrew (MacOS)
 
-Alternatively, if you are using [Homebrew][homebrew_tool], you can install the SDK CLI tool with the following command:
+If you are using [Homebrew][homebrew_tool], you can install the SDK CLI tool with the following command:
 
 ```sh
 $ brew install operator-sdk

--- a/doc/user/install-operator-sdk.md
+++ b/doc/user/install-operator-sdk.md
@@ -1,6 +1,6 @@
 # Install the Operator SDK CLI
 
-## Install from Homebrew (MacOS)
+## Install from Homebrew (macOS)
 
 If you are using [Homebrew][homebrew_tool], you can install the SDK CLI tool with the following command:
 


### PR DESCRIPTION
**Description of the change:**
operator-sdk installation documentation update.
Moved `brew install operator-sdk` to the top since it's the simplest installation method.

**Motivation for the change:**
Visitors only see `brew install operator-sdk` after downloading from Github method.