### PR TITLE
docs: add links in install doc

### DIFF
--- a/doc/user/install-operator-sdk.md
+++ b/doc/user/install-operator-sdk.md
@@ -1,5 +1,10 @@
 # Install the Operator SDK CLI
 
+- [Install from GitHub release](#install-from-github-release)
+- [Install from Homebrew](#install-from-homebrew)
+- [Compile and install from master](#compile-and-install-from-master)
+
+
 ## Install from GitHub release
 
 ### Download the release binary


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adds some links to the top of the install guide.

**Motivation for the change:**
I didn't realize there was a homebrew option until really late.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
