### PR TITLE
doc/user-guide.md: operator-sdk new requires --repo if outside of $GOPATH/src

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -24,9 +24,9 @@ Follow the steps in the [installation guide][install_guide] to learn how to inst
 Use the CLI to create a new memcached-operator project:
 
 ```sh
-$ mkdir -p $HOME/projects/example.com/
-$ cd $HOME/projects/example.com/
-$ operator-sdk new memcached-operator
+$ mkdir -p $HOME/projects
+$ cd $HOME/projects
+$ operator-sdk new memcached-operator --repo=github.com/example-inc/memcached-operator
 $ cd memcached-operator
 ```
 
@@ -34,7 +34,7 @@ To learn about the project directory structure, see [project layout][layout_doc]
 
 #### A note on dependency management
 
-By default, `operator-sdk new` generates a `go.mod` file to be used with [Go modules][go_mod_wiki]. If you'd like to use [`dep`][dep_tool], set `--dep-manager=dep` when initializing your project, which will create a `Gopkg.toml` file with the same dependency information.
+By default, `operator-sdk new` generates a `go.mod` file to be used with [Go modules][go_mod_wiki]. The `--repo=<path>` flag is required when creating a project outside of `$GOPATH/src`, as scaffolded files require a valid module path. If you'd like to use [`dep`][dep_tool], set `--dep-manager=dep` when initializing your project, which will create a `Gopkg.toml` file with the same dependency information.
 
 ##### Go modules
 
@@ -102,12 +102,12 @@ $ operator-sdk generate k8s
 ```
 
 ### OpenAPI validation
-To update the OpenAPI validation section in the CRD `deploy/crds/cache_v1alpha1_memcached_crd.yaml`, run the following command. 
+To update the OpenAPI validation section in the CRD `deploy/crds/cache_v1alpha1_memcached_crd.yaml`, run the following command.
 
 ```console
 $ operator-sdk generate openapi
 ```
-This validation section allows Kubernetes to validate the properties in a Memcached Custom Resource when it is created or updated. An example of the generated YAML is as follows: 
+This validation section allows Kubernetes to validate the properties in a Memcached Custom Resource when it is created or updated. An example of the generated YAML is as follows:
 
 ```YAML
 spec:


### PR DESCRIPTION
**Description of the change:** add `--repo` to user guide example.


**Motivation for the change:** see #1713 

