### PR TITLE
cmd/.../genutil: fix typo in comment

### DIFF
--- a/cmd/operator-sdk/internal/genutil/genutil.go
+++ b/cmd/operator-sdk/internal/genutil/genutil.go
@@ -23,7 +23,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// generateWithHeaderFile runs f with a header file path as an arguemnt.
+// generateWithHeaderFile runs f with a header file path as an argument.
 // If there is no project boilerplate.go.txt file, an empty header file is
 // created and its path passed as the argument.
 // generateWithHeaderFile is meant to be used with Kubernetes code generators.


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Fix typo in the `generateWithHeaderFile` comment.

**Motivation for the change:**

"arguemnt" isn't a valid English word.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
