### PR TITLE
Fixes #1748: Ansible molecule test preparation should not rely on anonymous access to K8s API.

### DIFF
--- a/test/ansible-inventory/molecule/test-local/prepare.yml
+++ b/test/ansible-inventory/molecule/test-local/prepare.yml
@@ -25,12 +25,9 @@
       delegate_to: localhost
 
     - name: Wait for the Kubernetes API to become available (this could take a minute)
-      uri:
-        url: "https://localhost:8443/version"
-        status_code: 200
-        validate_certs: no
+      command: kubectl cluster-info
       register: result
-      until: (result.status|default(-1)) == 200
+      until: result.stdout is regex("Kubernetes master.* is running")
       retries: 60
       delay: 5
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Fixes #1748: Ansible's molecule test preparation should not rely on anonymous access to the K8s API, but instead should use kubectl cluster-info.

**Motivation for the change:**
Closes #1748. Ensures the molecule test scaffold works with Kubernetes 1.15 and later.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->