### PR TITLE
internal/olm/client{,.go}: refactor Client to its own package

### DIFF
--- a/internal/olm/client.go
+++ b/internal/olm/client.go
@@ -18,33 +18,25 @@
 package olm
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"sync"
-	"text/tabwriter"
 	"time"
 
-	"github.com/operator-framework/operator-sdk/pkg/restmapper"
+	olmresourceclient "github.com/operator-framework/operator-sdk/internal/olm/client"
 
 	olmapiv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	appsv1 "k8s.io/api/apps/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -57,66 +49,55 @@ var (
 	packageServerKey   = types.NamespacedName{Namespace: olmNamespace, Name: "packageserver"}
 )
 
+var ErrOLMNotInstalled = errors.New("no existing installation found")
+
 type Client struct {
-	KubeClient      client.Client
+	*olmresourceclient.Client
 	HTTPClient      http.Client
 	BaseDownloadURL string
 }
 
 func ClientForConfig(cfg *rest.Config) (*Client, error) {
-	rm, err := restmapper.NewDynamicRESTMapper(cfg)
+	cl, err := olmresourceclient.ClientForConfig(cfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create dynamic rest mapper")
+		return nil, errors.Wrap(err, "failed to get OLM resource client")
 	}
-
-	sch := scheme.Scheme
-	if err := olmapiv1alpha1.AddToScheme(sch); err != nil {
-		return nil, errors.Wrap(err, "failed to add OLM types to scheme")
-	}
-
-	cl, err := client.New(cfg, client.Options{
-		Scheme: sch,
-		Mapper: rm,
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create client")
-	}
-
 	c := &Client{
-		KubeClient:      cl,
+		Client:          cl,
 		HTTPClient:      *http.DefaultClient,
 		BaseDownloadURL: "https://github.com/operator-framework/operator-lifecycle-manager/releases",
 	}
 	return c, nil
 }
 
-func (c Client) InstallVersion(ctx context.Context, version string) (*Status, error) {
+func (c Client) InstallVersion(ctx context.Context, version string) (*olmresourceclient.Status, error) {
 	resources, err := c.getResources(ctx, version)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get resources")
 	}
+	objs := toObjects(resources...)
 
-	status := c.getStatus(ctx, resources)
+	status := c.GetObjectsStatus(ctx, objs...)
 	if status.HasExistingResources() {
 		return nil, errors.New("detected existing OLM resources: OLM must be completely uninstalled before installation")
 	}
 
 	log.Print("Creating CRDs and resources")
-	if err := c.doCreate(ctx, resources); err != nil {
+	if err := c.DoCreate(ctx, objs...); err != nil {
 		return nil, errors.Wrap(err, "failed to create CRDs and resources")
 	}
 
 	log.Print("Waiting for deployment/olm-operator rollout to complete")
-	if err := c.doRolloutWait(ctx, olmOperatorKey); err != nil {
+	if err := c.DoRolloutWait(ctx, olmOperatorKey); err != nil {
 		return nil, errors.Wrapf(err, "deployment/%s failed to rollout", olmOperatorKey.Name)
 	}
 
 	log.Print("Waiting for deployment/catalog-operator rollout to complete")
-	if err := c.doRolloutWait(ctx, catalogOperatorKey); err != nil {
+	if err := c.DoRolloutWait(ctx, catalogOperatorKey); err != nil {
 		return nil, errors.Wrapf(err, "deployment/%s failed to rollout", catalogOperatorKey.Name)
 	}
 
-	subscriptions := filterResources(resources, func(r unstructured.Unstructured) bool {
+	subscriptions := filterResources(resources, func(r *unstructured.Unstructured) bool {
 		return r.GroupVersionKind() == schema.GroupVersionKind{
 			Group:   olmapiv1alpha1.GroupName,
 			Version: olmapiv1alpha1.GroupVersion,
@@ -132,17 +113,17 @@ func (c Client) InstallVersion(ctx context.Context, version string) (*Status, er
 			return nil, errors.Wrapf(err, "subscription/%s failed to install CSV", subscriptionKey.Name)
 		}
 		log.Printf("Waiting for clusterserviceversion/%s to reach 'Succeeded' phase", csvKey.Name)
-		if err := c.doCSVWait(ctx, *csvKey); err != nil {
+		if err := c.DoCSVWait(ctx, csvKey); err != nil {
 			return nil, errors.Wrapf(err, "clusterserviceversion/%s failed to reach 'Succeeded' phase", csvKey.Name)
 		}
 	}
 
 	log.Printf("Waiting for deployment/%s rollout to complete", packageServerKey.Name)
-	if err := c.doRolloutWait(ctx, packageServerKey); err != nil {
+	if err := c.DoRolloutWait(ctx, packageServerKey); err != nil {
 		return nil, errors.Wrapf(err, "deployment/%s failed to rollout", packageServerKey.Name)
 	}
 
-	status = c.getStatus(ctx, resources)
+	status = c.GetObjectsStatus(ctx, objs...)
 	return &status, nil
 }
 
@@ -151,33 +132,35 @@ func (c Client) UninstallVersion(ctx context.Context, version string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get resources")
 	}
+	objs := toObjects(resources...)
 
-	status := c.getStatus(ctx, resources)
+	status := c.GetObjectsStatus(ctx, objs...)
 	if !status.HasExistingResources() {
-		return errors.New("no existing installation found")
+		return ErrOLMNotInstalled
 	}
 
 	log.Infof("Uninstalling resources for version %q", version)
-	if err := c.doDelete(ctx, resources); err != nil {
+	if err := c.DoDelete(ctx, objs...); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (c Client) GetStatus(ctx context.Context, version string) (*Status, error) {
+func (c Client) GetStatus(ctx context.Context, version string) (*olmresourceclient.Status, error) {
 	resources, err := c.getResources(ctx, version)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get resources")
 	}
+	objs := toObjects(resources...)
 
-	status := c.getStatus(ctx, resources)
+	status := c.GetObjectsStatus(ctx, objs...)
 	if !status.HasExistingResources() {
-		return nil, errors.New("no existing installation found")
+		return nil, ErrOLMNotInstalled
 	}
 	return &status, nil
 }
 
-func (c Client) getResources(ctx context.Context, version string) ([]unstructured.Unstructured, error) {
+func (c Client) getResources(ctx context.Context, version string) ([]*unstructured.Unstructured, error) {
 	log.Infof("Fetching CRDs for version %q", version)
 	crdResources, err := c.getCRDs(ctx, version)
 	if err != nil {
@@ -194,7 +177,7 @@ func (c Client) getResources(ctx context.Context, version string) ([]unstructure
 	return resources, nil
 }
 
-func (c Client) getCRDs(ctx context.Context, version string) ([]unstructured.Unstructured, error) {
+func (c Client) getCRDs(ctx context.Context, version string) ([]*unstructured.Unstructured, error) {
 	resp, err := c.doRequest(ctx, c.crdsURL(version))
 	if err != nil {
 		return nil, errors.Wrap(err, "request failed")
@@ -203,7 +186,7 @@ func (c Client) getCRDs(ctx context.Context, version string) ([]unstructured.Uns
 	return decodeResources(resp.Body)
 }
 
-func (c Client) getOLM(ctx context.Context, version string) ([]unstructured.Unstructured, error) {
+func (c Client) getOLM(ctx context.Context, version string) ([]*unstructured.Unstructured, error) {
 	resp, err := c.doRequest(ctx, c.olmURL(version))
 	if err != nil {
 		return nil, errors.Wrap(err, "request failed")
@@ -249,135 +232,31 @@ func (c Client) doRequest(ctx context.Context, url string) (*http.Response, erro
 	return resp, nil
 }
 
-func decodeResources(rds ...io.Reader) ([]unstructured.Unstructured, error) {
-	var objs []unstructured.Unstructured
+func toObjects(us ...*unstructured.Unstructured) (objs []runtime.Object) {
+	for _, u := range us {
+		objs = append(objs, u)
+	}
+	return objs
+}
+
+func decodeResources(rds ...io.Reader) (objs []*unstructured.Unstructured, err error) {
 	for _, r := range rds {
 		dec := yaml.NewYAMLOrJSONDecoder(r, 8)
 		for {
 			var u unstructured.Unstructured
-			err := dec.Decode(&u)
+			err = dec.Decode(&u)
 			if err == io.EOF {
 				break
 			} else if err != nil {
 				return nil, err
 			}
-			objs = append(objs, u)
+			objs = append(objs, &u)
 		}
 	}
 	return objs, nil
 }
 
-func (c Client) getStatus(ctx context.Context, objs []unstructured.Unstructured) Status {
-	var rss []ResourceStatus
-	for _, obj := range objs {
-		nn := types.NamespacedName{
-			Namespace: obj.GetNamespace(),
-			Name:      obj.GetName(),
-		}
-		u := unstructured.Unstructured{}
-		u.SetGroupVersionKind(obj.GroupVersionKind())
-		err := c.KubeClient.Get(ctx, nn, &u)
-		rs := ResourceStatus{
-			NamespacedName: nn,
-			GVK:            obj.GroupVersionKind(),
-		}
-		if err != nil {
-			rs.Error = err
-		} else {
-			rs.Resource = &u
-		}
-		rss = append(rss, rs)
-	}
-
-	return Status{Resources: rss}
-}
-
-func (c Client) doCreate(ctx context.Context, objs []unstructured.Unstructured) error {
-	for _, obj := range objs {
-		log.Infof("  Creating %s %q", obj.GroupVersionKind().Kind, getName(obj.GetNamespace(), obj.GetName()))
-		err := c.KubeClient.Create(ctx, &obj)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (c Client) doDelete(ctx context.Context, objs []unstructured.Unstructured) error {
-	for _, obj := range objs {
-		log.Infof("  Removing %s %q", obj.GroupVersionKind().Kind, getName(obj.GetNamespace(), obj.GetName()))
-		err := c.KubeClient.Delete(ctx, &obj, client.PropagationPolicy(metav1.DeletePropagationForeground))
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-			return err
-		}
-	}
-
-	log.Infof("  Waiting for deleted resources to disappear")
-	wait.PollImmediateUntil(time.Second, func() (bool, error) {
-		s := c.getStatus(ctx, objs)
-		return !s.HasExistingResources(), nil
-	}, ctx.Done())
-
-	return nil
-}
-
-func getName(namespace, name string) string {
-	if namespace != "" {
-		name = fmt.Sprintf("%s/%s", namespace, name)
-	}
-	return name
-}
-
-func (c Client) doRolloutWait(ctx context.Context, key types.NamespacedName) error {
-	onceReplicasUpdated := sync.Once{}
-	oncePendingTermination := sync.Once{}
-	onceNotAvailable := sync.Once{}
-	onceSpecUpdate := sync.Once{}
-
-	rolloutComplete := func() (bool, error) {
-		deployment := appsv1.Deployment{}
-		err := c.KubeClient.Get(ctx, key, &deployment)
-		if err != nil {
-			return false, err
-		}
-		if deployment.Generation <= deployment.Status.ObservedGeneration {
-			cond := deploymentutil.GetDeploymentCondition(deployment.Status, appsv1.DeploymentProgressing)
-			if cond != nil && cond.Reason == deploymentutil.TimedOutReason {
-				return false, errors.New("progress deadline exceeded")
-			}
-			if deployment.Spec.Replicas != nil && deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
-				onceReplicasUpdated.Do(func() {
-					log.Printf("  Waiting for deployment %q to rollout: %d out of %d new replicas have been updated", deployment.Name, deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas)
-				})
-				return false, nil
-			}
-			if deployment.Status.Replicas > deployment.Status.UpdatedReplicas {
-				oncePendingTermination.Do(func() {
-					log.Printf("  Waiting for deployment %q to rollout: %d old replicas are pending termination", deployment.Name, deployment.Status.Replicas-deployment.Status.UpdatedReplicas)
-				})
-				return false, nil
-			}
-			if deployment.Status.AvailableReplicas < deployment.Status.UpdatedReplicas {
-				onceNotAvailable.Do(func() {
-					log.Printf("  Waiting for deployment %q to rollout: %d of %d updated replicas are available", deployment.Name, deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas)
-				})
-				return false, nil
-			}
-			log.Printf("  Deployment %q successfully rolled out", deployment.Name)
-			return true, nil
-		}
-		onceSpecUpdate.Do(func() {
-			log.Printf("  Waiting for deployment %q to rollout: waiting for deployment spec update to be observed", deployment.Name)
-		})
-		return false, nil
-	}
-	return wait.PollImmediateUntil(time.Second, rolloutComplete, ctx.Done())
-}
-
-func filterResources(resources []unstructured.Unstructured, filter func(unstructured.Unstructured) bool) (filtered []unstructured.Unstructured) {
+func filterResources(resources []*unstructured.Unstructured, filter func(*unstructured.Unstructured) bool) (filtered []*unstructured.Unstructured) {
 	for _, r := range resources {
 		if filter(r) {
 			filtered = append(filtered, r)
@@ -386,7 +265,7 @@ func filterResources(resources []unstructured.Unstructured, filter func(unstruct
 	return filtered
 }
 
-func (c Client) getSubscriptionCSV(ctx context.Context, subKey types.NamespacedName) (*types.NamespacedName, error) {
+func (c Client) getSubscriptionCSV(ctx context.Context, subKey types.NamespacedName) (types.NamespacedName, error) {
 	var csvKey *types.NamespacedName
 	subscriptionInstalledCSV := func() (bool, error) {
 		sub := olmapiv1alpha1.Subscription{}
@@ -406,77 +285,5 @@ func (c Client) getSubscriptionCSV(ctx context.Context, subKey types.NamespacedN
 		return true, nil
 	}
 
-	return csvKey, wait.PollImmediateUntil(time.Second, subscriptionInstalledCSV, ctx.Done())
-}
-
-func (c Client) doCSVWait(ctx context.Context, key types.NamespacedName) error {
-	var (
-		curPhase olmapiv1alpha1.ClusterServiceVersionPhase
-		newPhase olmapiv1alpha1.ClusterServiceVersionPhase
-	)
-	once := sync.Once{}
-
-	csvPhaseSucceeded := func() (bool, error) {
-		csv := olmapiv1alpha1.ClusterServiceVersion{}
-		err := c.KubeClient.Get(ctx, key, &csv)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				once.Do(func() {
-					log.Printf("  Waiting for clusterserviceversion %q to appear", key.Name)
-				})
-				return false, nil
-			}
-			return false, err
-		}
-		newPhase = csv.Status.Phase
-		if newPhase != curPhase {
-			curPhase = newPhase
-			log.Printf("  Found clusterserviceversion %q phase: %s", key.Name, curPhase)
-		}
-		return curPhase == olmapiv1alpha1.CSVPhaseSucceeded, nil
-	}
-
-	return wait.PollImmediateUntil(time.Second, csvPhaseSucceeded, ctx.Done())
-}
-
-type Status struct {
-	Resources []ResourceStatus
-}
-
-type ResourceStatus struct {
-	NamespacedName types.NamespacedName
-	Resource       *unstructured.Unstructured
-	GVK            schema.GroupVersionKind
-	Error          error
-}
-
-func (s Status) HasExistingResources() bool {
-	for _, r := range s.Resources {
-		if r.Resource != nil {
-			return true
-		}
-	}
-	return false
-}
-
-func (s Status) String() string {
-	out := &bytes.Buffer{}
-	tw := tabwriter.NewWriter(out, 8, 4, 4, ' ', 0)
-	fmt.Fprintf(tw, "NAME\tNAMESPACE\tKIND\tSTATUS\n")
-	for _, r := range s.Resources {
-		nn := r.NamespacedName
-		kind := r.GVK.Kind
-		var status string
-		if r.Resource != nil {
-			status = "Installed"
-		} else if r.Error != nil {
-			status = r.Error.Error()
-		} else {
-			status = "Unknown"
-		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", nn.Name, nn.Namespace, kind, status)
-	}
-	tw.Flush()
-
-	return out.String()
+	return *csvKey, wait.PollImmediateUntil(time.Second, subscriptionInstalledCSV, ctx.Done())
 }

--- a/internal/olm/client/client.go
+++ b/internal/olm/client/client.go
@@ -1,0 +1,204 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package olm provides an API to install, uninstall, and check the
+// status of an Operator Lifecycle Manager installation.
+// TODO: move to OLM repository?
+package olm
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/operator-framework/operator-sdk/pkg/restmapper"
+
+	olmapiv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var Scheme = scheme.Scheme
+
+func init() {
+	if err := olmapiv1alpha1.AddToScheme(Scheme); err != nil {
+		log.Fatalf("Failed to add OLM operator API v1alpha1 types to scheme: %v", err)
+	}
+}
+
+type Client struct {
+	KubeClient client.Client
+}
+
+func ClientForConfig(cfg *rest.Config) (*Client, error) {
+	rm, err := restmapper.NewDynamicRESTMapper(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create dynamic rest mapper")
+	}
+
+	cl, err := client.New(cfg, client.Options{
+		Scheme: Scheme,
+		Mapper: rm,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create client")
+	}
+
+	c := &Client{
+		KubeClient: cl,
+	}
+	return c, nil
+}
+
+func (c Client) DoCreate(ctx context.Context, objs ...runtime.Object) error {
+	for _, obj := range objs {
+		a, err := meta.Accessor(obj)
+		if err != nil {
+			return err
+		}
+		kind := obj.GetObjectKind().GroupVersionKind().Kind
+		log.Infof("  Creating %s %q", kind, getName(a.GetNamespace(), a.GetName()))
+		err = c.KubeClient.Create(ctx, obj)
+		if err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				log.Infof("    %s %q already exists", kind, getName(a.GetNamespace(), a.GetName()))
+				return nil
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func (c Client) DoDelete(ctx context.Context, objs ...runtime.Object) error {
+	for _, obj := range objs {
+		a, err := meta.Accessor(obj)
+		if err != nil {
+			return err
+		}
+		kind := obj.GetObjectKind().GroupVersionKind().Kind
+		log.Infof("  Deleting %s %q", kind, getName(a.GetNamespace(), a.GetName()))
+		err = c.KubeClient.Delete(ctx, obj, client.PropagationPolicy(metav1.DeletePropagationForeground))
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Infof("    %s %q does not exist", kind, getName(a.GetNamespace(), a.GetName()))
+				continue
+			}
+			return err
+		}
+	}
+
+	log.Infof("  Waiting for deleted resources to disappear")
+	wait.PollImmediateUntil(time.Second, func() (bool, error) {
+		s := c.GetObjectsStatus(ctx, objs...)
+		return !s.HasExistingResources(), nil
+	}, ctx.Done())
+
+	return nil
+}
+
+func getName(namespace, name string) string {
+	if namespace != "" {
+		name = fmt.Sprintf("%s/%s", namespace, name)
+	}
+	return name
+}
+
+func (c Client) DoRolloutWait(ctx context.Context, key types.NamespacedName) error {
+	onceReplicasUpdated := sync.Once{}
+	oncePendingTermination := sync.Once{}
+	onceNotAvailable := sync.Once{}
+	onceSpecUpdate := sync.Once{}
+
+	rolloutComplete := func() (bool, error) {
+		deployment := appsv1.Deployment{}
+		err := c.KubeClient.Get(ctx, key, &deployment)
+		if err != nil {
+			return false, err
+		}
+		if deployment.Generation <= deployment.Status.ObservedGeneration {
+			cond := deploymentutil.GetDeploymentCondition(deployment.Status, appsv1.DeploymentProgressing)
+			if cond != nil && cond.Reason == deploymentutil.TimedOutReason {
+				return false, errors.New("progress deadline exceeded")
+			}
+			if deployment.Spec.Replicas != nil && deployment.Status.UpdatedReplicas < *deployment.Spec.Replicas {
+				onceReplicasUpdated.Do(func() {
+					log.Printf("  Waiting for deployment %q to rollout: %d out of %d new replicas have been updated", deployment.Name, deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas)
+				})
+				return false, nil
+			}
+			if deployment.Status.Replicas > deployment.Status.UpdatedReplicas {
+				oncePendingTermination.Do(func() {
+					log.Printf("  Waiting for deployment %q to rollout: %d old replicas are pending termination", deployment.Name, deployment.Status.Replicas-deployment.Status.UpdatedReplicas)
+				})
+				return false, nil
+			}
+			if deployment.Status.AvailableReplicas < deployment.Status.UpdatedReplicas {
+				onceNotAvailable.Do(func() {
+					log.Printf("  Waiting for deployment %q to rollout: %d of %d updated replicas are available", deployment.Name, deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas)
+				})
+				return false, nil
+			}
+			log.Printf("  Deployment %q successfully rolled out", deployment.Name)
+			return true, nil
+		}
+		onceSpecUpdate.Do(func() {
+			log.Printf("  Waiting for deployment %q to rollout: waiting for deployment spec update to be observed", deployment.Name)
+		})
+		return false, nil
+	}
+	return wait.PollImmediateUntil(time.Second, rolloutComplete, ctx.Done())
+}
+
+func (c Client) DoCSVWait(ctx context.Context, key types.NamespacedName) error {
+	var (
+		curPhase olmapiv1alpha1.ClusterServiceVersionPhase
+		newPhase olmapiv1alpha1.ClusterServiceVersionPhase
+	)
+	once := sync.Once{}
+
+	csvPhaseSucceeded := func() (bool, error) {
+		csv := olmapiv1alpha1.ClusterServiceVersion{}
+		err := c.KubeClient.Get(ctx, key, &csv)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				once.Do(func() {
+					log.Printf("  Waiting for clusterserviceversion %q to appear", key.Name)
+				})
+				return false, nil
+			}
+			return false, err
+		}
+		newPhase = csv.Status.Phase
+		if newPhase != curPhase {
+			curPhase = newPhase
+			log.Printf("  Found clusterserviceversion %q phase: %s", key.Name, curPhase)
+		}
+		return curPhase == olmapiv1alpha1.CSVPhaseSucceeded, nil
+	}
+
+	return wait.PollImmediateUntil(time.Second, csvPhaseSucceeded, ctx.Done())
+}

--- a/internal/olm/client/status.go
+++ b/internal/olm/client/status.go
@@ -1,0 +1,103 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package olm provides an API to install, uninstall, and check the
+// status of an Operator Lifecycle Manager installation.
+// TODO: move to OLM repository?
+package olm
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"text/tabwriter"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type Status struct {
+	Resources []ResourceStatus
+}
+
+type ResourceStatus struct {
+	NamespacedName types.NamespacedName
+	Resource       *unstructured.Unstructured
+	GVK            schema.GroupVersionKind
+	Error          error
+}
+
+func (c Client) GetObjectsStatus(ctx context.Context, objs ...runtime.Object) Status {
+	var rss []ResourceStatus
+	for _, obj := range objs {
+		a, aerr := meta.Accessor(obj)
+		if aerr != nil {
+			log.Fatalf("Object %s: %v", obj.GetObjectKind().GroupVersionKind(), aerr)
+		}
+		nn := types.NamespacedName{
+			Namespace: a.GetNamespace(),
+			Name:      a.GetName(),
+		}
+		u := unstructured.Unstructured{}
+		u.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
+		err := c.KubeClient.Get(ctx, nn, &u)
+		rs := ResourceStatus{
+			NamespacedName: nn,
+			GVK:            obj.GetObjectKind().GroupVersionKind(),
+		}
+		if err != nil {
+			rs.Error = err
+		} else {
+			rs.Resource = &u
+		}
+		rss = append(rss, rs)
+	}
+
+	return Status{Resources: rss}
+}
+
+func (s Status) HasExistingResources() bool {
+	for _, r := range s.Resources {
+		if r.Resource != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (s Status) String() string {
+	out := &bytes.Buffer{}
+	tw := tabwriter.NewWriter(out, 8, 4, 4, ' ', 0)
+	fmt.Fprintf(tw, "NAME\tNAMESPACE\tKIND\tSTATUS\n")
+	for _, r := range s.Resources {
+		nn := r.NamespacedName
+		kind := r.GVK.Kind
+		var status string
+		if r.Resource != nil {
+			status = "Installed"
+		} else if r.Error != nil {
+			status = r.Error.Error()
+		} else {
+			status = "Unknown"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", nn.Name, nn.Namespace, kind, status)
+	}
+	tw.Flush()
+
+	return out.String()
+}


### PR DESCRIPTION
**Description of the change:** move functions that use `sigs.k8s.io/controller-runtime/pkg/client.Client` directly to `internal/olm/client`.


**Motivation for the change:** future packages that use OLM API's should be able to share a client.

**Note:** this PR mostly refactors code as-is except for `Do{Create,Delete}`.