### PR TITLE
pkg/ready: Make set/unset idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - **Breaking change:** CSV config field `role-path` is now `role-paths` and takes a list of strings. Users can now specify multiple `Role` and `ClusterRole` manifests using `role-paths`. ([#1704](https://github.com/operator-framework/operator-sdk/pull/1704))
+- Make `ready` package idempotent. Now, a user can call `Set()` or `Unset()` to set the operator's readiness without knowing the current state. ([#1761](https://github.com/operator-framework/operator-sdk/pull/1761))
 
 ### Deprecated
 

--- a/pkg/ready/ready.go
+++ b/pkg/ready/ready.go
@@ -18,6 +18,7 @@ import (
 	"os"
 )
 
+// FileName represent the full path to the file for determining ready status
 const FileName = "/tmp/operator-sdk-ready"
 
 // Ready holds state about whether the operator is ready and communicates that
@@ -46,7 +47,7 @@ type fileReady struct{}
 // to determine that the operator is ready.
 func (r fileReady) Set() error {
 	f, err := os.Create(FileName)
-	if err != nil {
+	if err != nil && err != os.ErrExist {
 		return err
 	}
 	return f.Close()
@@ -54,5 +55,12 @@ func (r fileReady) Set() error {
 
 // Unset removes the file on disk that was created by Set().
 func (r fileReady) Unset() error {
-	return os.Remove(FileName)
+	if _, err := os.Stat(FileName); os.IsNotExist(err) {
+		return nil
+	}
+	err := os.Remove(FileName)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/ready/ready.go
+++ b/pkg/ready/ready.go
@@ -47,7 +47,10 @@ type fileReady struct{}
 // to determine that the operator is ready.
 func (r fileReady) Set() error {
 	f, err := os.Create(FileName)
-	if err != nil && err != os.ErrExist {
+	if err != nil {
+		if os.IsExist(err) {
+			return nil
+		}
 		return err
 	}
 	return f.Close()
@@ -58,9 +61,5 @@ func (r fileReady) Unset() error {
 	if _, err := os.Stat(FileName); os.IsNotExist(err) {
 		return nil
 	}
-	err := os.Remove(FileName)
-	if err != nil {
-		return err
-	}
-	return nil
+	return os.Remove(FileName)
 }

--- a/pkg/ready/ready_test.go
+++ b/pkg/ready/ready_test.go
@@ -31,6 +31,12 @@ func TestFileReady(t *testing.T) {
 		t.Errorf("Did not find expected file at %s: %v", FileName, err)
 	}
 
+	// Should be safe to set multiple times
+	err = r.Set()
+	if err != nil {
+		t.Errorf("Failed to set ready file when it already exists: %v", err)
+	}
+
 	err = r.Unset()
 	if err != nil {
 		t.Errorf("Could not unset ready file: %v", err)
@@ -42,5 +48,10 @@ func TestFileReady(t *testing.T) {
 	}
 	if !os.IsNotExist(err) {
 		t.Errorf("Error determining if file still exists at %s: %v", FileName, err)
+	}
+
+	err = r.Unset()
+	if err != nil {
+		t.Errorf("Could not unset ready file when already removed: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #1760

**Description of the change:**

Make the ready package idempotent.

**Motivation for the change:**

As a user, I would expect the cases where I set the operator as ready or unset the operator's readiness to be a no-op in the cases that the operator is already in said state.