### PR TITLE
snap

### DIFF
--- a/pkg/snap/snapcraft.yaml
+++ b/pkg/snap/snapcraft.yaml
@@ -1,0 +1,54 @@
+name: operator-sdk
+summary: SDK for Kubernetes.
+description: SDK for building Kubernetes applications. Provides high level APIs, useful abstractions, and project scaffolding.
+  
+confinement: devmode
+base: core18
+
+architectures:
+  - build-on: i386
+  - build-on: amd64
+  - build-on: armhf
+  - build-on: arm64
+
+apps:
+  operator-sdk:
+    command: bin/operator-sdk
+    plugs:
+      - home
+      - network
+      - removable-media
+      - docker
+      
+
+parts:
+  operator-sdk:
+    plugin: godeps
+    source: https://github.com/operator-framework/operator-sdk.git
+    source-type: git
+    override-pull: |
+      git clone https://github.com/operator-framework/operator-sdk.git src/github.com/operator-framework/operator-sdk
+      cd src/github.com/operator-framework/operator-sdk
+      last_committed_tag="$(git describe --tags --abbrev=0)"
+      last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/v//')"
+      last_released_tag="$(snap info $SNAPCRAFT_PROJECT_NAME | awk '$1 == "beta:" { print $2 }')"
+      # If the latest tag from the upstream project has not been released to
+      # beta, build that tag instead of master.
+      if [ "${last_committed_tag_ver}" != "${last_released_tag}" ]; then
+        git fetch
+        git checkout "${last_committed_tag}"
+      fi
+      snapcraftctl set-version "$(git describe --tags | sed 's/v//')"
+    override-build: |
+      export GOPATH=$PWD
+      cd src/github.com/operator-framework/operator-sdk
+      env CGO_ENABLED=0 GOOS=linux \
+      go build --ldflags "-s -w \
+        -X 'github.com/operator-framework/operator-sdk/version.GitCommit=$(git rev-list -1 HEAD)' \
+        -X 'github.com/operator-framework/operator-sdk/version.Version=$(git describe --tags --abbrev=0)'" \
+        -a -installsuffix cgo -o $SNAPCRAFT_PART_INSTALL/bin/operator-sdk
+    build-snaps:
+      - go
+    build-packages:
+      - git
+      - sed


### PR DESCRIPTION
Added snapcraft.yaml to build a [snap](https://snapcraft.io/).

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Added snapcraft.yaml to build a snap package to install operator-sdk on Linux.

**Motivation for the change:**
Snap package's support installing applications across 41 Linux distributions.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
