### PR TITLE
docs(user dev guide) : replace make dep since it no longer exists

### DIFF
--- a/doc/dev/developer_guide.md
+++ b/doc/dev/developer_guide.md
@@ -9,16 +9,6 @@ This document explains how to setup your dev environment.
 ## Download Operator SDK
 
 Go to the [Operator SDK repo][repo-sdk] and follow the [fork guide][fork-guide] to fork, clone, and setup the local operator-sdk repository.
-
-## Vendor dependencies
-
-Run the following in the project root directory to update the vendored dependencies:
-
-```sh
-$ cd $GOPATH/src/github.com/operator-framework/operator-sdk
-$ make dep
-```
-
 ## Build the Operator SDK CLI
 
 Build the Operator SDK CLI `operator-sdk` binary:


### PR DESCRIPTION
**Description of the change:**
Just update the doc since `make dep` no longer exists

**Motivation for the change:**
https://github.com/operator-framework/operator-sdk/issues/1775
