### PR TITLE
doc/user-guide: add docs for advanced controller configurations

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -175,7 +175,7 @@ There are a number of useful configurations that can be made when initialzing a 
   })
   ```
 - Filter watch events using [predicates][event_filtering]
-- Choose the type of [EventHandler][event_handler_godocs] to change how a watch event will translate to reconcile requests for the reconicle loop. For operator relationships that are more comlpex than primary and secondary resources, the [`EnqueueRequestsFromMapFunc`][enqueue_requests_from_map_func] handler can be used to transform a watch event into an arbitrary set of reconcile requests.
+- Choose the type of [EventHandler][event_handler_godocs] to change how a watch event will translate to reconcile requests for the reconcile loop. For operator relationships that are more complex than primary and secondary resources, the [`EnqueueRequestsFromMapFunc`][enqueue_requests_from_map_func] handler can be used to transform a watch event into an arbitrary set of reconcile requests.
 
 
 ### Reconcile loop

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -163,9 +163,20 @@ err := c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequest
   })
 ```
 
-**// TODO:** Doc on eventhandler, arbitrary mapping between watched and reconciled resource.
+#### Controller configurations
 
-**// TODO:** Doc on configuring a Controller: number of workers, predicates, watching channels,
+There are a number of useful configurations that can be made when initialzing a controller and declaring the watch parameters. For more details on these configurations consult the upstream [controller godocs][controller_godocs]. 
+
+- Set the max number of concurrent Reconciles for the controller via the [`MaxConcurrentReconciles`][controller_options]  option. Defaults to 1.
+  ```Go
+  _, err := controller.New("memcached-controller", mgr, controller.Options{
+	  MaxConcurrentReconciles: 2,
+	  ...
+  })
+  ```
+- Filter watch events using [predicates][event_filtering]
+- Choose the type of [EventHandler][event_handler_godocs] to change how a watch event will translate to reconcile requests for the reconicle loop. For operator relationships that are more comlpex than primary and secondary resources, the [`EnqueueRequestsFromMapFunc`][enqueue_requests_from_map_func] handler can be used to transform a watch event into an arbitrary set of reconcile requests.
+
 
 ### Reconcile loop
 
@@ -614,6 +625,11 @@ func main() {
 
 When the operator is not running in a cluster, the Manager will return an error on starting since it can't detect the operator's namespace in order to create the configmap for leader election. You can override this namespace by setting the Manager's `LeaderElectionNamespace` option.
 
+[enqueue_requests_from_map_func]: https://godoc.org/sigs.k8s.io/controller-runtime/pkg/handler#EnqueueRequestsFromMapFunc
+[event_handler_godocs]: https://godoc.org/sigs.k8s.io/controller-runtime/pkg/handler#hdr-EventHandlers
+[event_filtering]:./user/event-filtering.md
+[controller_options]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/controller#Options
+[controller_godocs]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/controller
 [operator_scope]:./operator-scope.md
 [install_guide]: ./user/install-operator-sdk.md
 [pod_eviction_timeout]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/#options


### PR DESCRIPTION
**Description of the change:**
Address the TODOs in the user-guide on the more common advanced controller configurations.
Fixes #1028 

**Motivation for the change:**
The upstream godocs for the [Controller](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/controller) and [EventHandler](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/handler) types are already detailed enough with examples so we can mostly point and defer to those docs.

The one example that can be improved is for the EnqueueRequestFromMapFunc handler. That should be worked on upstream.

The [Predicate godocs](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/predicate) are a little sparse and since we already have an in depth example for that we can just point to that.