### PR TITLE
internal/pkg/scorecard/plugins: return an error if no CRs exist in alm-examples w/o cr-manifest set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Bug Fixes
 
+- Check if `metadata.annotations['alm-examples']` is non-empty before creating contained CR manifests in the scorecard. ([#1789](https://github.com/operator-framework/operator-sdk/pull/1789))
+
 ## v0.9.0
 
 ### Added

--- a/internal/pkg/scorecard/plugins/plugin_runner.go
+++ b/internal/pkg/scorecard/plugins/plugin_runner.go
@@ -159,7 +159,10 @@ func RunInternalPlugin(plugin PluginType, config *viper.Viper, logFile io.ReadWr
 			if crJSONStr, ok := csv.ObjectMeta.Annotations["alm-examples"]; ok {
 				var crs []interface{}
 				if err = json.Unmarshal([]byte(crJSONStr), &crs); err != nil {
-					return scapiv1alpha1.ScorecardOutput{}, err
+					return scapiv1alpha1.ScorecardOutput{}, errors.Wrapf(err, "metadata.annotations['alm-examples'] in CSV %s incorrectly formatted", csv.GetName())
+				}
+				if len(crs) == 0 {
+					return scapiv1alpha1.ScorecardOutput{}, errors.Errorf("no CRs found in metadata.annotations['alm-examples'] in CSV %s and cr-manifest config option not set", csv.GetName())
 				}
 				// TODO: run scorecard against all CR's in CSV.
 				cr := crs[0]


### PR DESCRIPTION
**Description of the change:** check if CRs are present when parsing `metadata.annotations['alm-examples']`.


**Motivation for the change:** see #1780 

Closes #1780
