### PR TITLE
[WIP] pkg/restmapper: use exponential backoff with DynamicRESTMapper calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 // indirect
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a // indirect
 	golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 // indirect
-	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	golang.org/x/tools v0.0.0-20190408170212-12dd9f86f350
 	google.golang.org/appengine v1.5.0 // indirect
 	google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107 // indirect


### PR DESCRIPTION
**Description of the change:** add exponential backoff to `DynamicRESTMapper.reloadOnErr()` calls.


**Motivation for the change:** see [this discussion](https://github.com/operator-framework/operator-sdk/pull/1329#discussion_r275966907) from #1329.