### PR TITLE
feat(olm-catalog) : Generated alm-examples in a pretty format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 ### Added
+- The `operator-sdk olm-catalog gen-csv` command now produces indented JSON for the `alm-examples` annotation. ([#1793](https://github.com/operator-framework/operator-sdk/pull/1793))
 
 ### Changed
 

--- a/internal/pkg/scaffold/olm-catalog/csv_updaters.go
+++ b/internal/pkg/scaffold/olm-catalog/csv_updaters.go
@@ -343,16 +343,26 @@ func (u *ALMExamplesUpdate) Apply(csv *olmapiv1alpha1.ClusterServiceVersion) err
 	if csv.GetAnnotations() == nil {
 		csv.SetAnnotations(make(map[string]string))
 	}
-	sb := &strings.Builder{}
-	sb.WriteString(`[`)
+	buf := &bytes.Buffer{}
+	buf.WriteString(`[`)
 	for i, example := range u.crs {
-		sb.WriteString(example)
+		buf.WriteString(example)
 		if i < len(u.crs)-1 {
-			sb.WriteString(`,`)
+			buf.WriteString(`,`)
 		}
 	}
-	sb.WriteString(`]`)
-
-	csv.GetAnnotations()["alm-examples"] = sb.String()
+	buf.WriteString(`]`)
+	examplesJSON, err := prettyJSON(buf.Bytes())
+	if err != nil {
+		return err
+	}
+	csv.GetAnnotations()["alm-examples"] = examplesJSON
 	return nil
+}
+
+// prettyJSON returns a JSON in a pretty format
+func prettyJSON(b []byte) (string, error) {
+	var out bytes.Buffer
+	err := json.Indent(&out, b, "", "  ")
+	return out.String(), err
 }

--- a/test/test-framework/deploy/olm-catalog/memcached-operator/0.0.3/memcached-operator.v0.0.3.clusterserviceversion.yaml
+++ b/test/test-framework/deploy/olm-catalog/memcached-operator/0.0.3/memcached-operator.v0.0.3.clusterserviceversion.yaml
@@ -2,8 +2,20 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[{"apiVersion":"cache.example.com/v1alpha1","kind":"Memcached","metadata":{"name":"example-memcached"},"spec":{"size":3}}]'
-    capabilities: Basic Install
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "cache.example.com/v1alpha1",
+          "kind": "Memcached",
+          "metadata": {
+            "name": "example-memcached"
+          },
+          "spec": {
+            "size": 3
+          }
+        }
+      ]
+  capabilities: Basic Install
   name: memcachedoperator.v0.0.3
   namespace: placeholder
 spec:


### PR DESCRIPTION
**Description of the change:**
Generated `alm-examples` for olm in a pretty format. 

**Motivation for the change:**

* To improve the Maintenace ability and understatement.
* https://github.com/operator-framework/operator-sdk/issues/1708

**Tests performed locally:**

<img width="820" alt="Screenshot 2019-08-08 at 08 24 59" src="https://user-images.githubusercontent.com/7708031/62683647-db8abd80-b9b6-11e9-8b48-b769e6466fc4.png">
<img width="735" alt="Screenshot 2019-08-08 at 08 23 40" src="https://user-images.githubusercontent.com/7708031/62683684-eba29d00-b9b6-11e9-9b82-191006b52668.png">
