### PR TITLE
pkg/helm: deprecate UID-based release name, use CR name instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - The `operator-sdk olm-catalog gen-csv` command now produces indented JSON for the `alm-examples` annotation. ([#1793](https://github.com/operator-framework/operator-sdk/pull/1793))
 
 ### Changed
+- The Helm operator now uses the CR name for the release name for newly created CRs. Existing CRs will continue to use their existing UID-based release name. When a release name collision occurs (when CRs of different types share the same name), the second CR will fail to install with an error about a duplicate name. ([#1818](https://github.com/operator-framework/operator-sdk/pull/1818))
 
 ### Deprecated
 

--- a/pkg/helm/release/manager.go
+++ b/pkg/helm/release/manager.go
@@ -144,7 +144,7 @@ func (m *manager) Sync(ctx context.Context) error {
 }
 
 func notFoundErr(err error) bool {
-	return strings.Contains(err.Error(), "not found")
+	return err != nil && strings.Contains(err.Error(), "not found")
 }
 
 func (m manager) loadChartAndConfig() (*cpb.Chart, *cpb.Config, error) {

--- a/pkg/helm/release/manager_factory.go
+++ b/pkg/helm/release/manager_factory.go
@@ -166,7 +166,7 @@ func getReleaseName(storageBackend *storage.Storage, crChartName string, cr *uns
 	// If a release with the CR name does not exist, return the CR name.
 	releaseName := cr.GetName()
 	history, err := storageBackend.History(releaseName)
-	if notFoundErr(err) || len(history) == 0 {
+	if notFoundErr(err) || (err == nil && len(history) == 0) {
 		return releaseName, nil
 	} else if err != nil {
 		return "", err

--- a/pkg/helm/release/manager_factory.go
+++ b/pkg/helm/release/manager_factory.go
@@ -24,7 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/typed/core/v1"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/helm/pkg/chartutil"
 	helmengine "k8s.io/helm/pkg/engine"
 	"k8s.io/helm/pkg/kube"
 	"k8s.io/helm/pkg/storage"
@@ -66,9 +67,17 @@ func (f managerFactory) NewManager(cr *unstructured.Unstructured) (Manager, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client from manager: %s", err)
 	}
+	crChart, err := chartutil.LoadDir(f.chartDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load chart dir: %s", err)
+	}
 	releaseServer, err := getReleaseServer(cr, storageBackend, tillerKubeClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get helm release server: %s", err)
+	}
+	releaseName, err := getReleaseName(storageBackend, crChart.GetMetadata().GetName(), cr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get helm release name: %s", err)
 	}
 	return &manager{
 		storageBackend:   storageBackend,
@@ -76,7 +85,7 @@ func (f managerFactory) NewManager(cr *unstructured.Unstructured) (Manager, erro
 		chartDir:         f.chartDir,
 
 		tiller:      releaseServer,
-		releaseName: getReleaseName(cr),
+		releaseName: releaseName,
 		namespace:   cr.GetNamespace(),
 
 		spec:   cr.Object["spec"],
@@ -113,8 +122,66 @@ func getReleaseServer(cr *unstructured.Unstructured, storageBackend *storage.Sto
 	return tiller.NewReleaseServer(env, cs, false), nil
 }
 
-func getReleaseName(cr *unstructured.Unstructured) string {
-	return fmt.Sprintf("%s-%s", cr.GetName(), shortenUID(cr.GetUID()))
+// getReleaseName returns a release name for the CR. If a release for the
+// legacy name exists, the legacy name is returned. This ensures
+// backwards-compatibility for pre-existing CRs.
+//
+// If no releases are found with the legacy name, getReleaseName searches for
+// a release using the CR name. If a release cannot be found, or if it is found
+// and was created by the chart managed by this manager, the CR name is
+// returned.
+//
+// If a release is found but it was created by another chart, that means we
+// have a release name collision, so return an error. This case is possible
+// because Kubernetes allows instances of different types to have the same name
+// in the same namespace.
+//
+//     NOTE: The motivation for including the CR's UID was to prevent any
+//     possibility of a collision between release names of CRs of different
+//     types, so we now have to take extra precautions.
+//
+// The reason for this change is based on an interaction between the Kubernetes
+// constraint that limits label values to 63 characters and the Helm convention
+// of including the release name as a label on release resources.
+//
+// Since the legacy release name includes a 25-character value based on the
+// parent CR's UID, it leaves little extra space for the CR name and any other
+// identifying names or characters added by templates.
+//
+// TODO(jlanford): As noted above, using the CR name as the release name raises
+// the possibility of collision. We should move this logic to a validating
+// admission webhook so that the CR owner receives immediate feedback of the
+// collision. As is, the only indication of collision will be in the CR status
+// and operator logs.
+func getReleaseName(storageBackend *storage.Storage, crChartName string, cr *unstructured.Unstructured) (string, error) {
+	// If a release with the legacy name exists, return the legacy name.
+	legacyName := fmt.Sprintf("%s-%s", cr.GetName(), shortenUID(cr.GetUID()))
+	_, err := storageBackend.History(legacyName)
+	if err == nil {
+		return legacyName, nil
+	} else if !notFoundErr(err) {
+		return "", err
+	}
+
+	// If a release with the CR name does not exist, return the CR name.
+	releaseName := cr.GetName()
+	history, err := storageBackend.History(releaseName)
+	if notFoundErr(err) || len(history) == 0 {
+		return releaseName, nil
+	} else if err != nil {
+		return "", err
+	}
+
+	// If a release name with the CR name exists, only return the CR name when
+	// the release's chart is the same as the chart managed by this operator.
+	existingChartName := history[0].GetChart().GetMetadata().GetName()
+	if existingChartName == "" || existingChartName == crChartName {
+		return releaseName, nil
+	}
+
+	// If another chart created the release, return an error about the duplicate
+	// release name.
+	return "", fmt.Errorf("duplicate release name: found existing release with name %q for chart %q", releaseName, existingChartName)
 }
 
 func shortenUID(uid apitypes.UID) string {


### PR DESCRIPTION
**Description of the change:**
This changes the release name for new CRs to be the CR name. Releases for existing CRs will continue to use the legacy name. If a CR is created, and a release already exists with the same name from a CR of a different kind, an error is returned, indicating a duplicate name.

**Motivation for the change:**
The reason for this change is based on an interaction between the Kubernetes constraint that limits label values to 63 characters and the Helm convention of including the release name as a label on release resources.

Since the legacy release name includes a 25-character value based on the parent CR's UID, it leaves little extra space for the CR name and any other identifying names or characters added by templates.

Also including a random string in the release name means that the release name is no longer predicable (see #1094)

Closes #1094 

/cc @dmesser 