### PR TITLE
k8s_status module: fix append issue, when condition was on 0 index

### DIFF
--- a/internal/pkg/scaffold/ansible/k8s_status.go
+++ b/internal/pkg/scaffold/ansible/k8s_status.go
@@ -367,7 +367,7 @@ class KubernetesAnsibleStatusModule(KubernetesAnsibleModule):
 
         for condition in new_conditions:
             idx = self.get_condition_idx(merged, condition['type'])
-            if idx:
+            if idx is not None:
                 merged[idx] = condition
             else:
                 merged.append(condition)
@@ -378,6 +378,7 @@ class KubernetesAnsibleStatusModule(KubernetesAnsibleModule):
         for i, condition in enumerate(conditions):
             if condition.get('type') == name:
                 return i
+        return None
 
     def object_contains(self, obj, subset):
         def dict_is_subset(obj, subset):


### PR DESCRIPTION
when old condition is on index 0, new condition with same type was always appended, instead of replaced.

**Description of the change:**
This PR fixes issue when old condition is on index 0 and new condition with the same type should replace old condition, but instead it is appended.

/cc @fabianvf @MarSik