### PR TITLE
ansible Dockerfiles: ensure clean yum cache before installing packages

### DIFF
--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -20,7 +20,10 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
     HOME=/opt/ansible
 
 # Install python dependencies
-RUN (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true) \
+# Ensure fresh metadata rather than cached metadata in the base by running
+# yum clean all && rm -rf /var/yum/cache/* first
+RUN yum clean all && rm -rf /var/cache/yum/* \
+ && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true) \
  && yum install -y python-devel gcc inotify-tools \
  && easy_install pip \
  && pip install -U --no-cache-dir setuptools pip \

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -18,8 +18,10 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
     USER_NAME=ansible-operator\
     HOME=/opt/ansible
 
-# Install python dependencies
-RUN (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true) \
+# Ensure fresh metadata rather than cached metadata in the base by running
+# yum clean all && rm -rf /var/yum/cache/* first
+RUN yum clean all && rm -rf /var/cache/yum/* \
+ && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true) \
  && yum install -y python-devel gcc inotify-tools \
  && easy_install pip \
  && pip install -U --no-cache-dir setuptools pip \

--- a/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
+++ b/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
@@ -41,7 +41,10 @@ const buildTestFrameworkDockerfileAnsibleTmpl = `ARG BASEIMAGE
 FROM ${BASEIMAGE}
 USER 0
 
-RUN yum install -y python-devel gcc libffi-devel
+# Ensure fresh metadata rather than cached metadata in the base by running
+# yum clean all && rm -rf /var/yum/cache/* first
+RUN yum clean all && rm -rf /var/cache/yum/* \
+ && yum install -y python-devel gcc libffi-devel
 RUN pip install molecule==2.20.1
 
 ARG NAMESPACEDMAN

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -59,8 +59,10 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
     HOME=/opt/ansible
 
 # Install python dependencies
-
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+# Ensure fresh metadata rather than cached metadata in the base by running
+# yum clean all && rm -rf /var/yum/cache/* first
+RUN yum clean all && rm -rf /var/cache/yum/* \
+ && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
  && yum install -y python-devel gcc inotify-tools \
  && easy_install pip \
  && pip install -U --no-cache-dir setuptools pip \


### PR DESCRIPTION
**Description of the change:** add `yum clean all && rm -rf /var/cache/yum/*` to ansible dockerfiles.


**Motivation for the change:** yum repos can become stale and cause errors like:
```console
$ yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
...
 https://mirror.steadfastnet.com/epel/7/x86_64/repodata/59cd2d904711571ac63cfec0fec0641233dc027173c6667914bbcc2e10ea11dd-primary.sqlite.bz2: [Errno 14] HTTPS Error 404 - Not Found
Trying other mirror.
http://mirror.math.princeton.edu/pub/epel/7/x86_64/repodata/59cd2d904711571ac63cfec0fec0641233dc027173c6667914bbcc2e10ea11dd-primary.sqlite.bz2: [Errno 14] HTTP Error 404 - Not Found
Trying other mirror.
...
```
The accepted fix is to clean the yum cache on each build. See [this commit](https://github.com/operator-framework/operator-metering/commit/5a9ed03c4a7591412b5398eda05a177a2bb1de8b) for an example.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
