### PR TITLE
fix(code/gen) : Unsupported group names which do not match with ^[a-z]+$ (Issue 1812)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 ### Changed
 - The Helm operator now uses the CR name for the release name for newly created CRs. Existing CRs will continue to use their existing UID-based release name. When a release name collision occurs (when CRs of different types share the same name), the second CR will fail to install with an error about a duplicate name. ([#1818](https://github.com/operator-framework/operator-sdk/pull/1818))
 - Commands [`olm uninstall`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#uninstall) and [`olm status`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#status) no longer use a `--version` flag to specify OLM version. This information is now retrieved from the running cluster. ([#1634](https://github.com/operator-framework/operator-sdk/pull/1634))
+- **Breaking change:** Unsupported group names which do not match with `^[a-z]+$`.([#1826](https://github.com/operator-framework/operator-sdk/pull/1826)). Following a few options to solve it.
+    - **By operator-sdk(recommended):** Use the operator-sdk tool to recreate all CR/CRD's and API's then replace their implementations with the old ones. 
+    - **By manual edition:** Rename all files and paths which are written with the group which not not match with `^[a-z]+$`. See then in the `/<operator>/pkg/apis/` and `/<operator>/pkg/crds/` and fix all import paths in the files as well. 
+    
+    **NOTE**: To ensure that all was fixed as expected check if you are able to run the commands `operator-sdk generate k8s` and `operator-sdk generate openapi` as to build your project (`operator-sdk build <image:tag>`) successfully. 
 
 ### Deprecated
 

--- a/internal/pkg/scaffold/addtoscheme.go
+++ b/internal/pkg/scaffold/addtoscheme.go
@@ -33,7 +33,7 @@ type AddToScheme struct {
 func (s *AddToScheme) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		fileName := fmt.Sprintf("addtoscheme_%s_%s.go",
-			s.Resource.GoImportGroup,
+			strings.ToLower(s.Resource.Group),
 			strings.ToLower(s.Resource.Version))
 		s.Path = filepath.Join(ApisDir, fileName)
 	}
@@ -44,7 +44,7 @@ func (s *AddToScheme) GetInput() (input.Input, error) {
 const addToSchemeTemplate = `package apis
 
 import (
-	"{{ .Repo }}/pkg/apis/{{ .Resource.GoImportGroup}}/{{ .Resource.Version }}"
+	"{{ .Repo }}/pkg/apis/{{ .Resource.Group | lower }}/{{ .Resource.Version }}"
 )
 
 func init() {

--- a/internal/pkg/scaffold/controller_kind.go
+++ b/internal/pkg/scaffold/controller_kind.go
@@ -69,18 +69,18 @@ func (s *ControllerKind) setImports() (err error) {
 			return err
 		}
 	} else {
-		importPath = path.Join(s.Repo, "pkg", "apis", s.Resource.GoImportGroup, s.Resource.Version)
-		s.GoImportIdent = s.Resource.GoImportGroup + s.Resource.Version
+		importPath = path.Join(s.Repo, "pkg", "apis", s.Resource.Group, s.Resource.Version)
+		s.GoImportIdent =  s.Resource.Group + s.Resource.Version
 	}
 	// Import identifiers must be unique within a file.
 	for p, id := range s.ImportMap {
-		if s.GoImportIdent == id && importPath != p {
+		if  s.Resource.Group == id && importPath != p {
 			// Append "api" to the conflicting import identifier.
-			s.GoImportIdent = s.GoImportIdent + "api"
+			s.GoImportIdent =  s.Resource.Group + "api"
 			break
 		}
 	}
-	s.ImportMap[importPath] = s.GoImportIdent
+	s.ImportMap[importPath] =  s.Resource.Group
 	return nil
 }
 

--- a/internal/pkg/scaffold/cr.go
+++ b/internal/pkg/scaffold/cr.go
@@ -38,7 +38,7 @@ type CR struct {
 func (s *CR) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		fileName := fmt.Sprintf("%s_%s_%s_cr.yaml",
-			s.Resource.GoImportGroup,
+			strings.ToLower(s.Resource.Group),
 			strings.ToLower(s.Resource.Version),
 			s.Resource.LowerKind)
 		s.Path = filepath.Join(CRDsDir, fileName)

--- a/internal/pkg/scaffold/crd.go
+++ b/internal/pkg/scaffold/crd.go
@@ -59,7 +59,7 @@ func (s *CRD) getFS() afero.Fs {
 func (s *CRD) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		fileName := fmt.Sprintf("%s_%s_%s_crd.yaml",
-			s.Resource.GoImportGroup,
+			strings.ToLower(s.Resource.Group),
 			strings.ToLower(s.Resource.Version),
 			s.Resource.LowerKind)
 		s.Path = filepath.Join(CRDsDir, fileName)
@@ -110,7 +110,7 @@ func (s *CRD) CustomRender() ([]byte, error) {
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil, fmt.Errorf("no API exists for Group %s Version %s Kind %s",
-					s.Resource.GoImportGroup, s.Resource.Version, s.Resource.Kind)
+					s.Resource.Group, s.Resource.Version, s.Resource.Kind)
 			}
 			return nil, err
 		}

--- a/internal/pkg/scaffold/doc.go
+++ b/internal/pkg/scaffold/doc.go
@@ -34,7 +34,7 @@ type Doc struct {
 func (s *Doc) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		s.Path = filepath.Join(ApisDir,
-			s.Resource.GoImportGroup,
+			strings.ToLower(s.Resource.Group),
 			strings.ToLower(s.Resource.Version),
 			DocFile)
 	}

--- a/internal/pkg/scaffold/group.go
+++ b/internal/pkg/scaffold/group.go
@@ -15,9 +15,9 @@
 package scaffold
 
 import (
-	"path/filepath"
-
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/input"
+	"path/filepath"
+	"strings"
 )
 
 const GroupFile = "group.go"
@@ -32,16 +32,16 @@ var _ input.File = &Group{}
 
 func (s *Group) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		s.Path = filepath.Join(ApisDir, s.Resource.GoImportGroup, GroupFile)
+		s.Path = filepath.Join(ApisDir, strings.ToLower(s.Resource.Group), GroupFile)
 	}
 	s.TemplateBody = groupTmpl
 	return s.Input, nil
 }
 
-const groupTmpl = `// Package {{.Resource.GoImportGroup}} contains {{.Resource.GoImportGroup}} API versions.
+const groupTmpl = `// Package {{.Resource.Group}} contains {{ .Resource.Group }} API versions.
 //
-// This file ensures Go source parsers acknowledge the {{.Resource.GoImportGroup}} package
+// This file ensures Go source parsers acknowledge the {{.Resource.Group}} package
 // and any child packages. It can be removed if any other Go source files are
 // added to this package.
-package {{.Resource.GoImportGroup}}
+package {{.Resource.Group}}
 `

--- a/internal/pkg/scaffold/register.go
+++ b/internal/pkg/scaffold/register.go
@@ -34,7 +34,7 @@ type Register struct {
 func (s *Register) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		s.Path = filepath.Join(ApisDir,
-			s.Resource.GoImportGroup,
+			strings.ToLower(s.Resource.Group),
 			strings.ToLower(s.Resource.Version),
 			RegisterFile)
 	}

--- a/internal/pkg/scaffold/types.go
+++ b/internal/pkg/scaffold/types.go
@@ -32,7 +32,7 @@ type Types struct {
 func (s *Types) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		s.Path = filepath.Join(ApisDir,
-			s.Resource.GoImportGroup,
+			strings.ToLower(s.Resource.Group),
 			strings.ToLower(s.Resource.Version),
 			s.Resource.LowerKind+"_types.go")
 	}


### PR DESCRIPTION
**Description of the change:**
- Unsupported group names which do not match with `^[a-z]+$` in order to solve code gen issues. 

**Motivation for the change:**

- https://github.com/operator-framework/operator-sdk/issues/1812
- https://github.com/operator-framework/operator-sdk/issues/1368

**Locally test**

<img width="939" alt="Screenshot 2019-08-16 at 00 30 54" src="https://user-images.githubusercontent.com/7708031/63133436-214e1400-bfbd-11e9-9bcd-3d0060780e53.png">

