### PR TITLE
Default ansible fact gathering to explicit

### DIFF
--- a/internal/pkg/scaffold/ansible/deploy_operator.go
+++ b/internal/pkg/scaffold/ansible/deploy_operator.go
@@ -84,6 +84,8 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "[[.ProjectName]]"
+            - name: ANSIBLE_GATHERING
+              value: explicit
       volumes:
         - name: runner
           emptyDir: {}


### PR DESCRIPTION
**Description of the change:**
Defaults fact gathering to explicit, which means you need to add `gather_facts: yes` or run the setup task to make ansible gather facts about your hosts.

**Motivation for the change:**
This should help us avoid a class of error related to certain facts not necessarily being discoverable on any arbitrary image.

closes #1677 
