### PR TITLE
pkg/metrics: CreateMetricsService should return latest service

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -88,8 +88,8 @@ func createOrUpdateService(ctx context.Context, client crclient.Client, s *v1.Se
 		if err != nil {
 			return nil, err
 		}
-		log.V(1).Info("Metrics Service object updated", "Service.Name", s.Name, "Service.Namespace", s.Namespace)
-		return existingService, nil
+		log.Info("Metrics Service object updated", "Service.Name", s.Name, "Service.Namespace", s.Namespace)
+		return s, nil
 	}
 
 	log.Info("Metrics Service object created", "Service.Name", s.Name, "Service.Namespace", s.Namespace)


### PR DESCRIPTION
**Description of the change:**
createOrUpdateService should return latest service not the existing service.
log should use the INFO level log as like “Metrics Service object created”.

**Motivation for the change:**
CreateMetricsService should return latest service, so createOrUpdateService should return latest service not the existing service.
log should use the INFO level log as like “Metrics Service object created”.