### PR TITLE
ci/tests: remove `-t` from kubectl commands in scripts

### DIFF
--- a/ci/tests/e2e-ansible.sh
+++ b/ci/tests/e2e-ansible.sh
@@ -64,23 +64,29 @@ test_operator() {
     if ! timeout 20s bash -c -- "until kubectl get service/memcached-operator-metrics > /dev/null 2>&1; do sleep 1; done";
     then
         echo "Failed to get metrics service"
-        kubectl logs deployment/memcached-operator
+        kubectl describe pods
+        kubectl logs deployment/memcached-operator -c operator
+        kubectl logs deployment/memcached-operator -c ansible
         exit 1
     fi
 
     # verify that the metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8383/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8383/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
-        kubectl logs deployment/memcached-operator
+        kubectl describe pods
+        kubectl logs deployment/memcached-operator -c operator
+        kubectl logs deployment/memcached-operator -c ansible
         exit 1
     fi
 
     # verify that the operator metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8686/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8686/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
-        kubectl logs deployment/memcached-operator
+        kubectl describe pods
+        kubectl logs deployment/memcached-operator -c operator
+        kubectl logs deployment/memcached-operator -c ansible
         exit 1
     fi
 
@@ -96,10 +102,12 @@ test_operator() {
     fi
 
     # verify that metrics reflect cr creation
-    if ! bash -c -- 'kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached';
+    if ! bash -c -- 'kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached';
     then
         echo "Failed to verify custom resource metrics"
-        kubectl logs deployment/memcached-operator
+        kubectl describe pods
+        kubectl logs deployment/memcached-operator -c operator
+        kubectl logs deployment/memcached-operator -c ansible
         exit 1
     fi
 

--- a/ci/tests/e2e-helm.sh
+++ b/ci/tests/e2e-helm.sh
@@ -61,7 +61,7 @@ test_operator() {
     fi
 
     # verify that the metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator-metrics:8383/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator-metrics:8383/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
         kubectl logs deployment/nginx-operator


### PR DESCRIPTION
**Description of the change:** Remove the `-t` flag from `kubectl` calls in out scripts, as that causes a lot of failures during openshift-ci tests. This also updates the `kubectl logs` calls for the ansible operator so they output correctly.


**Motivation for the change:** Allow tests to pass consistently.