### PR TITLE
cmd: add option 'k8s-codegen' and 'openapi-gen' for command 'operator-sdk add api'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- Added new flag `--skip-generation` to skip to run k8s codegen and openapi-gen to generate deepcopy and validation spec for new CRD. ([#1878](https://github.com/operator-framework/operator-sdk/pull/1878))
 - The `operator-sdk olm-catalog gen-csv` command now produces indented JSON for the `alm-examples` annotation. ([#1793](https://github.com/operator-framework/operator-sdk/pull/1793))
 - Added flag `--dep-manager` to command [`operator-sdk print-deps`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#print-deps) to specify the type of dependency manager file to print. The choice of dependency manager is inferred from top-level dependency manager files present if `--dep-manager` is not set. ([#1819](https://github.com/operator-framework/operator-sdk/pull/1819))
 - Ansible based operators now gather and serve metrics about each custom resource on port 8686 of the metrics service. ([#1723](https://github.com/operator-framework/operator-sdk/pull/1723))

--- a/cmd/operator-sdk/add/api.go
+++ b/cmd/operator-sdk/add/api.go
@@ -31,26 +31,28 @@ import (
 )
 
 var (
-	apiVersion string
-	kind       string
+	apiVersion     string
+	kind           string
+	skipGeneration bool
 )
 
 func newAddApiCmd() *cobra.Command {
 	apiCmd := &cobra.Command{
 		Use:   "api",
 		Short: "Adds a new api definition under pkg/apis",
-		Long: `operator-sdk add api --kind=<kind> --api-version=<group/version> creates the
+		Long: `operator-sdk add api --kind=<kind> --api-version=<group/version> --skip-generation=<true or false> creates the
 api definition for a new custom resource under pkg/apis. This command must be
 run from the project root directory. If the api already exists at
 pkg/apis/<group>/<version> then the command will not overwrite and return an
 error.
 
 This command runs Kubernetes deepcopy and OpenAPI V3 generators on tagged
-types in all paths under pkg/apis. Go code is generated under
+types in all paths under pkg/apis by default. Go code is generated under
 pkg/apis/<group>/<version>/zz_generated.{deepcopy,openapi}.go. CRD's are
 generated, or updated if they exist for a particular group + version + kind,
 under deploy/crds/<group>_<version>_<kind>_crd.yaml; OpenAPI V3 validation YAML
-is generated as a 'validation' object.
+is generated as a 'validation' object. But can disable this by setting flag
+--skip-generation
 
 Example:
 	$ operator-sdk add api --api-version=app.example.com/v1alpha1 --kind=AppService
@@ -80,6 +82,7 @@ Example:
 	if err := apiCmd.MarkFlagRequired("kind"); err != nil {
 		log.Fatalf("Failed to mark `kind` flag for `add api` subcommand as required")
 	}
+	apiCmd.Flags().BoolVar(&skipGeneration, "skip-generation", false, "Skip to run k8s codegen and openapi-gen to generate deepcopy and validation spec for new CRD (default false)")
 
 	return apiCmd
 }
@@ -132,14 +135,16 @@ func apiRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to update the RBAC manifest for the resource (%v, %v): (%v)", r.APIVersion, r.Kind, err)
 	}
 
-	// Run k8s codegen for deepcopy
-	if err := genutil.K8sCodegen(); err != nil {
-		return err
-	}
+	if !skipGeneration {
+		// Run k8s codegen for deepcopy
+		if err := genutil.K8sCodegen(); err != nil {
+			return err
+		}
 
-	// Generate a validation spec for the new CRD.
-	if err := genutil.OpenAPIGen(); err != nil {
-		return err
+		// Generate a validation spec for the new CRD.
+		if err := genutil.OpenAPIGen(); err != nil {
+			return err
+		}
 	}
 
 	log.Info("API generation complete.")


### PR DESCRIPTION
To disable to run k8s codegen for deepcopy and generate a validation spec for the new CRD when adding new API.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Add two options `k8s-codegen` and `openapi-gen` to be able to disable to run k8s codegen for deepcopy and generate a validation spec for the new CRD each time

**Motivation for the change:**
Sometimes there possible lots of CRDs will be added, since each time  execute`operator-sdk add api --api-version=xx --kind=xx` will re-run deepcopy code-generation and OpenAPI code-generation for all added CRDs and new CRD to generate `zz_generated.deepcopy.go` and update CRDs YAML definition, it's time-consuming. So, this PR is to make controller developers have an optional way to disable to run k8s codegen for deepcopy and generate a validation spec for the new CRD, then will save much time.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
