### PR TITLE
internal/olm: move GetInstalledVersion() to internal/olm/client

### DIFF
--- a/internal/olm/client.go
+++ b/internal/olm/client.go
@@ -23,17 +23,13 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"time"
 
 	olmresourceclient "github.com/operator-framework/operator-sdk/internal/olm/client"
 
-	"github.com/blang/semver"
 	olmapiv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -41,20 +37,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	olmNamespace = "olm"
 )
 
 var (
-	olmOperatorKey     = types.NamespacedName{Namespace: olmNamespace, Name: "olm-operator"}
-	catalogOperatorKey = types.NamespacedName{Namespace: olmNamespace, Name: "catalog-operator"}
-	packageServerKey   = types.NamespacedName{Namespace: olmNamespace, Name: "packageserver"}
+	olmOperatorKey     = types.NamespacedName{Namespace: olmresourceclient.OLMNamespace, Name: "olm-operator"}
+	catalogOperatorKey = types.NamespacedName{Namespace: olmresourceclient.OLMNamespace, Name: "catalog-operator"}
+	packageServerKey   = types.NamespacedName{Namespace: olmresourceclient.OLMNamespace, Name: "packageserver"}
 )
-
-var ErrOLMNotInstalled = errors.New("no existing installation found")
 
 type Client struct {
 	*olmresourceclient.Client
@@ -141,7 +130,7 @@ func (c Client) UninstallVersion(ctx context.Context, version string) error {
 
 	status := c.GetObjectsStatus(ctx, objs...)
 	if !status.HasExistingResources() {
-		return ErrOLMNotInstalled
+		return olmresourceclient.ErrOLMNotInstalled
 	}
 
 	log.Infof("Uninstalling resources for version %q", version)
@@ -149,63 +138,6 @@ func (c Client) UninstallVersion(ctx context.Context, version string) error {
 		return err
 	}
 	return nil
-}
-
-func (c Client) GetInstalledVersion(ctx context.Context) (string, error) {
-	opts := client.InNamespace(olmNamespace)
-	csvs := &olmapiv1alpha1.ClusterServiceVersionList{}
-	if err := c.KubeClient.List(ctx, opts, csvs); err != nil {
-		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
-			return "", ErrOLMNotInstalled
-		}
-		return "", errors.Wrap(err, "failed to get OLM version from CSVs")
-	}
-	var pkgServerCSV *olmapiv1alpha1.ClusterServiceVersion
-	for _, csv := range csvs.Items {
-		name := csv.GetName()
-		// Check old and new name possibilities.
-		if name == pkgServerCSVNewName || strings.HasPrefix(name, pkgServerCSVOldNamePrefix) {
-			// There is more than one version of OLM installed in the cluster,
-			// so we can't resolve the version being used.
-			if pkgServerCSV != nil {
-				return "", errors.New("failed to get OLM version: more than one OLM version installed")
-			}
-			pkgServerCSV = &csv
-		}
-	}
-	if pkgServerCSV == nil {
-		return "", ErrOLMNotInstalled
-	}
-	return getOLMVersionFromPackageServerCSV(pkgServerCSV)
-}
-
-const (
-	// Versions pre-0.11 have a versioned name.
-	pkgServerCSVOldNamePrefix = "packageserver."
-	// Versions 0.11+ have a fixed name.
-	pkgServerCSVNewName      = "packageserver"
-	pkgServerOLMVersionLabel = "olm.version"
-)
-
-func getOLMVersionFromPackageServerCSV(csv *olmapiv1alpha1.ClusterServiceVersion) (string, error) {
-	// Package server CSV's from OLM versions > 0.10.1 have a label containing
-	// the OLM version.
-	if labels := csv.GetLabels(); labels != nil {
-		if ver, ok := labels[pkgServerOLMVersionLabel]; ok {
-			return ver, nil
-		}
-	}
-	// Fall back to getting OLM version from package server CSV name. Versions
-	// of OLM <= 0.10.1 are not labelled with pkgServerOLMVersionLabel.
-	ver := strings.TrimPrefix(csv.GetName(), pkgServerCSVOldNamePrefix)
-	// OLM releases do not have a "v" prefix but CSV versions do.
-	ver = strings.TrimPrefix(ver, "v")
-	// Check if a valid semver. Ignore non-nil errors as they are not related
-	// to the reason OLM version can't be found.
-	if _, err := semver.Parse(ver); err == nil {
-		return ver, nil
-	}
-	return "", errors.Errorf("no OLM version found in %s CSV spec", csv.GetName())
 }
 
 func (c Client) GetStatus(ctx context.Context, version string) (*olmresourceclient.Status, error) {
@@ -217,7 +149,7 @@ func (c Client) GetStatus(ctx context.Context, version string) (*olmresourceclie
 
 	status := c.GetObjectsStatus(ctx, objs...)
 	if !status.HasExistingResources() {
-		return nil, ErrOLMNotInstalled
+		return nil, olmresourceclient.ErrOLMNotInstalled
 	}
 	return &status, nil
 }

--- a/internal/olm/client/client.go
+++ b/internal/olm/client/client.go
@@ -20,11 +20,13 @@ package olm
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 
+	"github.com/blang/semver"
 	olmapiv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -40,6 +42,10 @@ import (
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const OLMNamespace = "olm"
+
+var ErrOLMNotInstalled = errors.New("no existing installation found")
 
 var Scheme = scheme.Scheme
 
@@ -201,4 +207,61 @@ func (c Client) DoCSVWait(ctx context.Context, key types.NamespacedName) error {
 	}
 
 	return wait.PollImmediateUntil(time.Second, csvPhaseSucceeded, ctx.Done())
+}
+
+func (c Client) GetInstalledVersion(ctx context.Context) (string, error) {
+	opts := client.InNamespace(OLMNamespace)
+	csvs := &olmapiv1alpha1.ClusterServiceVersionList{}
+	if err := c.KubeClient.List(ctx, opts, csvs); err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return "", ErrOLMNotInstalled
+		}
+		return "", errors.Wrap(err, "failed to get OLM version from CSVs")
+	}
+	var pkgServerCSV *olmapiv1alpha1.ClusterServiceVersion
+	for _, csv := range csvs.Items {
+		name := csv.GetName()
+		// Check old and new name possibilities.
+		if name == pkgServerCSVNewName || strings.HasPrefix(name, pkgServerCSVOldNamePrefix) {
+			// There is more than one version of OLM installed in the cluster,
+			// so we can't resolve the version being used.
+			if pkgServerCSV != nil {
+				return "", errors.New("failed to get OLM version: more than one OLM version installed")
+			}
+			pkgServerCSV = &csv
+		}
+	}
+	if pkgServerCSV == nil {
+		return "", ErrOLMNotInstalled
+	}
+	return getOLMVersionFromPackageServerCSV(pkgServerCSV)
+}
+
+const (
+	// Versions pre-0.11 have a versioned name.
+	pkgServerCSVOldNamePrefix = "packageserver."
+	// Versions 0.11+ have a fixed name.
+	pkgServerCSVNewName      = "packageserver"
+	pkgServerOLMVersionLabel = "olm.version"
+)
+
+func getOLMVersionFromPackageServerCSV(csv *olmapiv1alpha1.ClusterServiceVersion) (string, error) {
+	// Package server CSV's from OLM versions > 0.10.1 have a label containing
+	// the OLM version.
+	if labels := csv.GetLabels(); labels != nil {
+		if ver, ok := labels[pkgServerOLMVersionLabel]; ok {
+			return ver, nil
+		}
+	}
+	// Fall back to getting OLM version from package server CSV name. Versions
+	// of OLM <= 0.10.1 are not labelled with pkgServerOLMVersionLabel.
+	ver := strings.TrimPrefix(csv.GetName(), pkgServerCSVOldNamePrefix)
+	// OLM releases do not have a "v" prefix but CSV versions do.
+	ver = strings.TrimPrefix(ver, "v")
+	// Check if a valid semver. Ignore non-nil errors as they are not related
+	// to the reason OLM version can't be found.
+	if _, err := semver.Parse(ver); err == nil {
+		return ver, nil
+	}
+	return "", errors.Errorf("no OLM version found in %s CSV spec", csv.GetName())
 }

--- a/internal/olm/client/client.go
+++ b/internal/olm/client/client.go
@@ -216,7 +216,7 @@ func (c Client) GetInstalledVersion(ctx context.Context) (string, error) {
 		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 			return "", ErrOLMNotInstalled
 		}
-		return "", errors.Wrap(err, "failed to get OLM version from CSVs")
+		return "", errors.Wrapf(err, "failed to list CSVs in namespace %q", OLMNamespace)
 	}
 	var pkgServerCSV *olmapiv1alpha1.ClusterServiceVersion
 	for _, csv := range csvs.Items {
@@ -226,7 +226,7 @@ func (c Client) GetInstalledVersion(ctx context.Context) (string, error) {
 			// There is more than one version of OLM installed in the cluster,
 			// so we can't resolve the version being used.
 			if pkgServerCSV != nil {
-				return "", errors.New("failed to get OLM version: more than one OLM version installed")
+				return "", errors.Errorf("more than one OLM (package server) version installed: %q and %q", pkgServerCSV.GetName(), name)
 			}
 			pkgServerCSV = &csv
 		}
@@ -263,5 +263,5 @@ func getOLMVersionFromPackageServerCSV(csv *olmapiv1alpha1.ClusterServiceVersion
 	if _, err := semver.Parse(ver); err == nil {
 		return ver, nil
 	}
-	return "", errors.Errorf("no OLM version found in %s CSV spec", csv.GetName())
+	return "", errors.Errorf("no OLM version found in CSV %q spec", csv.GetName())
 }


### PR DESCRIPTION
**Description of the change:** copy `Client.GetInstalledVersion()`, `olmNamespace`, and `ErrOLMNotInstalled` from `internal/olm` to `internal/olm/client`.


**Motivation for the change:** Each of these pieces of code can be used by various parts of code interacting with OLM, in the present and future. They should therefore be accessible to code which leverages `internal/olm/client.Client`.
