### PR TITLE
CHANGELOG.md,cmd,doc: update docs about --skip-generation flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- Added new flag `--skip-generation` to skip to run k8s codegen and openapi-gen to generate deepcopy and validation spec for new CRD. ([#1890](https://github.com/operator-framework/operator-sdk/pull/1890))
+- Added new `--skip-generation` flag to the `operator-sdk add api` command to support skipping generation of deepcopy and OpenAPI code and OpenAPI CRD specs. ([#1890](https://github.com/operator-framework/operator-sdk/pull/1890))
 - The `operator-sdk olm-catalog gen-csv` command now produces indented JSON for the `alm-examples` annotation. ([#1793](https://github.com/operator-framework/operator-sdk/pull/1793))
 - Added flag `--dep-manager` to command [`operator-sdk print-deps`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#print-deps) to specify the type of dependency manager file to print. The choice of dependency manager is inferred from top-level dependency manager files present if `--dep-manager` is not set. ([#1819](https://github.com/operator-framework/operator-sdk/pull/1819))
 - Ansible based operators now gather and serve metrics about each custom resource on port 8686 of the metrics service. ([#1723](https://github.com/operator-framework/operator-sdk/pull/1723))

--- a/cmd/operator-sdk/add/api.go
+++ b/cmd/operator-sdk/add/api.go
@@ -40,19 +40,19 @@ func newAddApiCmd() *cobra.Command {
 	apiCmd := &cobra.Command{
 		Use:   "api",
 		Short: "Adds a new api definition under pkg/apis",
-		Long: `operator-sdk add api --kind=<kind> --api-version=<group/version> --skip-generation=<true or false> creates the
+		Long: `operator-sdk add api --kind=<kind> --api-version=<group/version> creates the
 api definition for a new custom resource under pkg/apis. This command must be
 run from the project root directory. If the api already exists at
 pkg/apis/<group>/<version> then the command will not overwrite and return an
 error.
 
-This command runs Kubernetes deepcopy and OpenAPI V3 generators on tagged
-types in all paths under pkg/apis. Go code is generated under
+By default, this command runs Kubernetes deepcopy and OpenAPI V3 generators on
+tagged types in all paths under pkg/apis. Go code is generated under
 pkg/apis/<group>/<version>/zz_generated.{deepcopy,openapi}.go. CRD's are
 generated, or updated if they exist for a particular group + version + kind,
 under deploy/crds/<group>_<version>_<kind>_crd.yaml; OpenAPI V3 validation YAML
-is generated as a 'validation' object. But can disable this by setting flag
---skip-generation.
+is generated as a 'validation' object. Generation can be disabled with the
+--skip-generation flag.
 
 Example:
 	$ operator-sdk add api --api-version=app.example.com/v1alpha1 --kind=AppService
@@ -82,7 +82,7 @@ Example:
 	if err := apiCmd.MarkFlagRequired("kind"); err != nil {
 		log.Fatalf("Failed to mark `kind` flag for `add api` subcommand as required")
 	}
-	apiCmd.Flags().BoolVar(&skipGeneration, "skip-generation", false, "Skip to run k8s codegen and openapi-gen to generate deepcopy and validation spec for new CRD (default false)")
+	apiCmd.Flags().BoolVar(&skipGeneration, "skip-generation", false, "Skip generation of deepcopy and OpenAPI code and OpenAPI CRD specs")
 
 	return apiCmd
 }

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -332,8 +332,9 @@ Adds the API definition for a new custom resource under `pkg/apis` and generates
 
 #### Flags
 
-* `--api-version` string - CRD APIVersion in the format `$GROUP_NAME/$VERSION` (e.g app.example.com/v1alpha1)
-* `--kind` string - CRD Kind. (e.g AppService)
+* `--api-version` string - (required) CRD APIVersion in the format `$GROUP_NAME/$VERSION` (e.g app.example.com/v1alpha1)
+* `--kind` string - (required) CRD Kind. (e.g AppService)
+* `--skip-generation` - Skip generation of deepcopy and OpenAPI code and OpenAPI CRD specs.
 
 #### Example
 


### PR DESCRIPTION
**Description of the change:**
Improves documentation and CHANGELOG for `operator-sdk add api --skip-generation` flag.

**Motivation for the change:**
Add to SDK CLI Reference doc and improve wording.
