### PR TITLE
WIP: upgrade images from ubi7 to ubi8 and python version from 2 which is deprecated to 3 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ sudo: required
 
 # go modules require xenial for mercurial TLS 1.2 support
 dist: xenial
-python:
-  - "3.6"
-
 env:
   global:
     - PATH=/opt/python/3.6.7/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ sudo: required
 dist: xenial
 python:
   - "3.6"
+
 env:
   global:
     - PATH=/opt/python/3.6.7/bin:$PATH
+
 
 # Install python userspace utilities dependencies
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ jobs:
     # Build and test ansible
     - <<: *test
       name: Ansible on OpenShift
-      before_script: sudo pip install ansible
+      before_script: pip3 install --user ansible
       script: make test/ci-ansible
 
     # Build and test helm

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,25 @@ sudo: required
 
 # go modules require xenial for mercurial TLS 1.2 support
 dist: xenial
+python:
+  - "3.6"
+env:
+  global:
+    - PATH=/opt/python/3.6.7/bin:$PATH
+
+# Install python userspace utilities dependencies
+addons:
+  apt:
+    packages:
+      - "python3"
+      - "python3-pip"
 
 cache:
   directories:
     - $HOME/.cache/go-build
 
 go:
-- 1.12.x
+  - "1.12.x"
 
 # The `x_base_steps` top-level key is unknown to travis,
 # so we can use it to create a bunch of common build step
@@ -26,6 +38,11 @@ x_base_steps:
     before_install:
       - travis_retry make tidy
 
+  # before_install for jobs that require pip upgrade it
+  - &pip3_before_install
+    before_install:
+      - pip3 install --upgrade pip
+  
   # before_install for jobs that require go builds and do not run for doc-only changes
   - &go_before_install
     before_install:
@@ -78,6 +95,7 @@ jobs:
     # Build and test ansible
     - <<: *test
       name: Ansible on OpenShift
+      <<: *pip3_before_install
       before_script: pip3 install --user ansible
       script: make test/ci-ansible
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,8 +94,7 @@ jobs:
     # Build and test ansible
     - <<: *test
       name: Ansible on OpenShift
-      <<: *pip3_before_install
-      before_script: pip3 install --user ansible
+      before_script: pip3 install --upgrade pip && pip3 install --user ansible
       script: make test/ci-ansible
 
     # Build and test helm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
       ```
 - [`pkg/test.FrameworkClient`](https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/client.go#L33) methods `List()` and `Delete()` have new signatures corresponding to the homonymous methods of `sigs.k8s.io/controller-runtime/pkg/client.Client`. ([#1876](https://github.com/operator-framework/operator-sdk/pull/1876))
 - CRD file names were previously of the form `<group>_<version>_<kind>_crd.yaml`. Now that CRD manifest `spec.version` is deprecated in favor of `spec.versions`, i.e. multiple versions can be specified in one CRD, CRD file names have the form `<full group>_<resource>_crd.yaml`. `<full group>` is the full group name of your CRD while `<group>` is the last subdomain of `<full group>`, ex. `foo.bar.com` vs `foo`. `<resource>` is the plural lower-case CRD Kind found at `spec.names.plural`. ([#1876](https://github.com/operator-framework/operator-sdk/pull/1876))
+- Upgrade image used for Go ad Helm operators and scorecard proxy from `registry.access.redhat.com/ubi7/ubi-minimal:latest` to `Use `registry.access.redhat.com/ubi8/ubi-minimal:latest`. [#1895](https://github.com/operator-framework/operator-sdk/pull/1895)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
       ```
 - [`pkg/test.FrameworkClient`](https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/client.go#L33) methods `List()` and `Delete()` have new signatures corresponding to the homonymous methods of `sigs.k8s.io/controller-runtime/pkg/client.Client`. ([#1876](https://github.com/operator-framework/operator-sdk/pull/1876))
 - CRD file names were previously of the form `<group>_<version>_<kind>_crd.yaml`. Now that CRD manifest `spec.version` is deprecated in favor of `spec.versions`, i.e. multiple versions can be specified in one CRD, CRD file names have the form `<full group>_<resource>_crd.yaml`. `<full group>` is the full group name of your CRD while `<group>` is the last subdomain of `<full group>`, ex. `foo.bar.com` vs `foo`. `<resource>` is the plural lower-case CRD Kind found at `spec.names.plural`. ([#1876](https://github.com/operator-framework/operator-sdk/pull/1876))
-- Upgrade image used for Go ad Helm operators and scorecard proxy from `registry.access.redhat.com/ubi7/ubi-minimal:latest` to `Use `registry.access.redhat.com/ubi8/ubi-minimal:latest`. [#1895](https://github.com/operator-framework/operator-sdk/pull/1895)
+- Upgrade base image for Go, Ansible, Helm, and scorecard proxy from `registry.access.redhat.com/ubi7/ubi-minimal:latest` to `registry.access.redhat.com/ubi8/ubi-minimal:latest`. ([#1895](https://github.com/operator-framework/operator-sdk/pull/1895))
 
 ### Deprecated
 

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -21,16 +21,21 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 
 # Install python dependencies
 # Ensure fresh metadata rather than cached metadata in the base by running
-# sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/yum/cache/* first
-RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/cache/yum/* \
+# yum clean all && rm -rf /var/yum/cache/* first
+RUN yum clean all && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
  && yum install -y python36-devel.x86_64 gcc \
- && pip3 install --user --no-cache-dir --ignore-installed ipaddress \
-      ansible-runner==1.2 \
-      ansible-runner-http==1.0.0 \
-      openshift==0.8.9 \
-      ansible==2.8 \
- && yum remove -y gcc python36-devel.x86_64 \
+ # Install inotify-tools
+ && yum install -y epel-release && yum update \
+ && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
+ && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
+ && yum --enablerepo=epel install inotify-tools.x86_64 \
+ && pip3 install --no-cache-dir --ignore-installed ipaddress \
+           ansible-runner==1.3.4 \
+           ansible-runner-http==1.0.0 \
+           openshift==0.8.9 \
+           ansible==2.8 \
+ && yum remove -y gcc \
  && yum clean all \
  && rm -rf /var/cache/yum
 

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -23,8 +23,8 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 # Ensure fresh metadata rather than cached metadata in the base by running
 # sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/yum/cache/* first
 RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/cache/yum/* \
- && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true) \
- && yum install -y python36-devel.x86_64 gcc inotify-tools \
+ && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
+ && yum install -y python36-devel.x86_64 gcc \
  && pip3 install --user --no-cache-dir --ignore-installed ipaddress \
       ansible-runner==1.2 \
       ansible-runner-http==1.0.0 \

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -29,8 +29,10 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
  && yum install -y epel-release \
  && (yum update || true) \
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
- && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \ # -> it installs the rpm to be used by the yum
- && yum --enablerepo=epel install inotify-tools.x86_64 \ # -> it will install the inotify-tools.x86_64 in the SO
+ # Installing the rpm to be used by the yum
+ && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
+ # Installing the inotify-tools.x86_64 in the SO
+ && yum --enablerepo=epel install inotify-tools.x86_64 \
  && (yum install python3-setuptools || true) \
  && pip3 install --no-cache-dir --ignore-installed ipaddress \
            ansible-runner==1.3.4 \

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -25,12 +25,12 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 RUN yum clean all && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
  && yum install -y python36-devel.x86_64 gcc \
- # Install inotify-tools
+ # Installing inotify-tools since it is no longer added in the rhel by default ...
  && yum install -y epel-release \
  && (yum update || true) \
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
- && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
- && yum --enablerepo=epel install inotify-tools.x86_64 \
+ && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \ # -> it installs the rpm to be used by the yum
+ && yum --enablerepo=epel install inotify-tools.x86_64 \ # -> it will install the inotify-tools.x86_64 in the SO
  && (yum install python3-setuptools || true) \
  && pip3 install --no-cache-dir --ignore-installed ipaddress \
            ansible-runner==1.3.4 \

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -26,10 +26,12 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
  && yum install -y python36-devel.x86_64 gcc \
  # Install inotify-tools
- && yum install -y epel-release && yum update \
+ && yum install -y epel-release \
+ && (yum update || true) \
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
  && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
  && yum --enablerepo=epel install inotify-tools.x86_64 \
+ && (yum install python3-setuptools || true) \
  && pip3 install --no-cache-dir --ignore-installed ipaddress \
            ansible-runner==1.3.4 \
            ansible-runner-http==1.0.0 \

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -25,9 +25,7 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true) \
  && yum install -y python36-devel.x86_64 gcc inotify-tools \
- && easy_install pip \
- && pip install -U --no-cache-dir setuptools pip \
- && pip install --no-cache-dir --ignore-installed ipaddress \
+ && pip3 install --user --no-cache-dir --ignore-installed ipaddress \
       ansible-runner==1.2 \
       ansible-runner-http==1.0.0 \
       openshift==0.8.9 \

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -37,7 +37,7 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
            ansible-runner-http==1.0.0 \
            openshift==0.8.9 \
            ansible==2.8 \
- && yum remove -y gcc \
+ && yum remove -y python36-devel.x86_64 gcc \
  && yum clean all \
  && rm -rf /var/cache/yum
 

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -24,7 +24,7 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 # yum clean all && rm -rf /var/yum/cache/* first
 RUN yum clean all && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
- && yum install -y python36-devel.x86_64 gcc \
+ && yum install -y python36-devel gcc \
  # Installing inotify-tools since it is no longer added in the rhel by default ...
  && yum install -y epel-release \
  && (yum update || true) \
@@ -37,7 +37,7 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
            ansible-runner-http==1.0.0 \
            openshift==0.8.9 \
            ansible==2.8 \
- && yum remove -y python36-devel.x86_64 gcc \
+ && yum remove -y python36-devel gcc \
  && yum clean all \
  && rm -rf /var/cache/yum
 

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -3,7 +3,7 @@ FROM osdk-builder as builder
 RUN make image/scaffold/ansible
 RUN ci/tests/e2e-ansible-scaffold-hybrid.sh
 
-FROM registry.access.redhat.com/ubi7/ubi
+FROM registry.access.redhat.com/ubi8/ubi
 
 # Temporary for CI, reset /etc/passwd
 RUN chmod 0644 /etc/passwd

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -3,7 +3,7 @@ FROM osdk-builder as builder
 RUN make image/scaffold/ansible
 RUN ci/tests/e2e-ansible-scaffold-hybrid.sh
 
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi:latest
 
 # Temporary for CI, reset /etc/passwd
 RUN chmod 0644 /etc/passwd
@@ -21,10 +21,10 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 
 # Install python dependencies
 # Ensure fresh metadata rather than cached metadata in the base by running
-# yum clean all && rm -rf /var/yum/cache/* first
-RUN yum clean all && rm -rf /var/cache/yum/* \
+# sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/yum/cache/* first
+RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true) \
- && yum install -y python-devel gcc inotify-tools \
+ && yum install -y python36-devel.x86_64 gcc inotify-tools \
  && easy_install pip \
  && pip install -U --no-cache-dir setuptools pip \
  && pip install --no-cache-dir --ignore-installed ipaddress \
@@ -32,7 +32,7 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
       ansible-runner-http==1.0.0 \
       openshift==0.8.9 \
       ansible==2.8 \
- && yum remove -y gcc python-devel \
+ && yum remove -y gcc python36-devel.x86_64 \
  && yum clean all \
  && rm -rf /var/cache/yum
 

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -21,8 +21,8 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 # Ensure fresh metadata rather than cached metadata in the base by running
 # sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/yum/cache/* first
 RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/cache/yum/* \
- && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true) \
- && yum install -y python36-devel.x86_64 gcc inotify-tools \
+ && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
+ && yum install -y python36-devel.x86_64 gcc \
  && pip3 install --user --no-cache-dir --ignore-installed ipaddress \
       ansible-runner==1.2 \
       ansible-runner-http==1.0.0 \

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -2,7 +2,7 @@ FROM osdk-builder as builder
 
 RUN make image/scaffold/ansible
 
-FROM registry.access.redhat.com/ubi7/ubi
+FROM registry.access.redhat.com/ubi8/ubi
 
 # Temporary for CI, reset /etc/passwd
 RUN chmod 0644 /etc/passwd

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -18,17 +18,23 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
     USER_NAME=ansible-operator\
     HOME=/opt/ansible
 
+# Install python dependencies
 # Ensure fresh metadata rather than cached metadata in the base by running
-# sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/yum/cache/* first
-RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/cache/yum/* \
+# yum clean all && rm -rf /var/yum/cache/* first
+RUN yum clean all && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
  && yum install -y python36-devel.x86_64 gcc \
- && pip3 install --user --no-cache-dir --ignore-installed ipaddress \
-      ansible-runner==1.2 \
-      ansible-runner-http==1.0.0 \
-      openshift==0.8.9 \
-      ansible==2.8 \
- && yum remove -y gcc python36-devel.x86_64 \
+ # Install inotify-tools
+ && yum install -y epel-release && yum update \
+ && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
+ && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
+ && yum --enablerepo=epel install inotify-tools.x86_64 \
+ && pip3 install --no-cache-dir --ignore-installed ipaddress \
+           ansible-runner==1.3.4 \
+           ansible-runner-http==1.0.0 \
+           openshift==0.8.9 \
+           ansible==2.8 \
+ && yum remove -y gcc \
  && yum clean all \
  && rm -rf /var/cache/yum
 

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -2,7 +2,7 @@ FROM osdk-builder as builder
 
 RUN make image/scaffold/ansible
 
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi:latest
 
 # Temporary for CI, reset /etc/passwd
 RUN chmod 0644 /etc/passwd
@@ -19,10 +19,10 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
     HOME=/opt/ansible
 
 # Ensure fresh metadata rather than cached metadata in the base by running
-# yum clean all && rm -rf /var/yum/cache/* first
-RUN yum clean all && rm -rf /var/cache/yum/* \
+# sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/yum/cache/* first
+RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true) \
- && yum install -y python-devel gcc inotify-tools \
+ && yum install -y python36-devel.x86_64 gcc inotify-tools \
  && easy_install pip \
  && pip install -U --no-cache-dir setuptools pip \
  && pip install --no-cache-dir --ignore-installed ipaddress \
@@ -30,7 +30,7 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
       ansible-runner-http==1.0.0 \
       openshift==0.8.9 \
       ansible==2.8 \
- && yum remove -y gcc python-devel \
+ && yum remove -y gcc python36-devel.x86_64 \
  && yum clean all \
  && rm -rf /var/cache/yum
 

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -28,8 +28,10 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
  && yum install -y epel-release \
  && (yum update || true) \
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
- && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \ # -> it installs the rpm to be used by the yum
- && yum --enablerepo=epel install inotify-tools.x86_64 \ # -> it will install the inotify-tools.x86_64 in the SO
+ # Installing the rpm to be used by the yum
+ && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
+ # Installing the inotify-tools.x86_64 in the SO
+ && yum --enablerepo=epel install inotify-tools.x86_64 \
  && (yum install python3-setuptools || true) \
  && pip3 install --no-cache-dir --ignore-installed ipaddress \
            ansible-runner==1.3.4 \

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -23,9 +23,7 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true) \
  && yum install -y python36-devel.x86_64 gcc inotify-tools \
- && easy_install pip \
- && pip install -U --no-cache-dir setuptools pip \
- && pip install --no-cache-dir --ignore-installed ipaddress \
+ && pip3 install --user --no-cache-dir --ignore-installed ipaddress \
       ansible-runner==1.2 \
       ansible-runner-http==1.0.0 \
       openshift==0.8.9 \

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -36,7 +36,7 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
            ansible-runner-http==1.0.0 \
            openshift==0.8.9 \
            ansible==2.8 \
- && yum remove -y gcc \
+ && yum remove -y python36-devel.x86_64 gcc \
  && yum clean all \
  && rm -rf /var/cache/yum
 

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -25,10 +25,12 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
  && yum install -y python36-devel.x86_64 gcc \
  # Install inotify-tools
- && yum install -y epel-release && yum update \
+ && yum install -y epel-release \
+ && (yum update || true) \
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
  && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
  && yum --enablerepo=epel install inotify-tools.x86_64 \
+ && (yum install python3-setuptools || true) \
  && pip3 install --no-cache-dir --ignore-installed ipaddress \
            ansible-runner==1.3.4 \
            ansible-runner-http==1.0.0 \

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -24,12 +24,12 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 RUN yum clean all && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
  && yum install -y python36-devel.x86_64 gcc \
- # Install inotify-tools
+ # Installing inotify-tools since it is no longer added in the rhel by default ...
  && yum install -y epel-release \
  && (yum update || true) \
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
- && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
- && yum --enablerepo=epel install inotify-tools.x86_64 \
+ && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \ # -> it installs the rpm to be used by the yum
+ && yum --enablerepo=epel install inotify-tools.x86_64 \ # -> it will install the inotify-tools.x86_64 in the SO
  && (yum install python3-setuptools || true) \
  && pip3 install --no-cache-dir --ignore-installed ipaddress \
            ansible-runner==1.3.4 \

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -23,7 +23,7 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 # yum clean all && rm -rf /var/yum/cache/* first
 RUN yum clean all && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
- && yum install -y python36-devel.x86_64 gcc \
+ && yum install -y python36-devel gcc \
  # Installing inotify-tools since it is no longer added in the rhel by default ...
  && yum install -y epel-release \
  && (yum update || true) \
@@ -36,7 +36,7 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
            ansible-runner-http==1.0.0 \
            openshift==0.8.9 \
            ansible==2.8 \
- && yum remove -y python36-devel.x86_64 gcc \
+ && yum remove -y python36-devel gcc \
  && yum clean all \
  && rm -rf /var/cache/yum
 

--- a/ci/dockerfiles/go-e2e.Dockerfile
+++ b/ci/dockerfiles/go-e2e.Dockerfile
@@ -2,7 +2,7 @@ FROM osdk-builder as builder
 
 RUN ci/tests/e2e-go-scaffold.sh
 
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/memcached-operator \
     USER_UID=1001 \

--- a/ci/dockerfiles/helm-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/helm-e2e-hybrid.Dockerfile
@@ -3,7 +3,7 @@ FROM osdk-builder as builder
 RUN make image/scaffold/helm
 RUN ci/tests/e2e-helm-scaffold-hybrid.sh
 
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/helm-operator \
     USER_UID=1001 \

--- a/ci/dockerfiles/helm.Dockerfile
+++ b/ci/dockerfiles/helm.Dockerfile
@@ -2,7 +2,7 @@ FROM osdk-builder as builder
 
 RUN make image/scaffold/helm
 
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/helm-operator \
     USER_UID=1001 \

--- a/ci/dockerfiles/scorecard-proxy.Dockerfile
+++ b/ci/dockerfiles/scorecard-proxy.Dockerfile
@@ -2,7 +2,7 @@ FROM osdk-builder as builder
 
 RUN ci/tests/scorecard-proxy-scaffold.sh
 
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV PROXY=/usr/local/bin/scorecard-proxy \
     USER_UID=1001 \

--- a/ci/tests/e2e-ansible.sh
+++ b/ci/tests/e2e-ansible.sh
@@ -71,7 +71,7 @@ test_operator() {
     fi
 
     # verify that the metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8383/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8383/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
         kubectl describe pods
@@ -81,7 +81,7 @@ test_operator() {
     fi
 
     # verify that the operator metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8686/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8686/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
         kubectl describe pods
@@ -102,7 +102,7 @@ test_operator() {
     fi
 
     # verify that metrics reflect cr creation
-    if ! bash -c -- 'kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached';
+    if ! bash -c -- 'kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached';
     then
         echo "Failed to verify custom resource metrics"
         kubectl describe pods

--- a/ci/tests/e2e-helm.sh
+++ b/ci/tests/e2e-helm.sh
@@ -61,7 +61,7 @@ test_operator() {
     fi
 
     # verify that the metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator-metrics:8383/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator-metrics:8383/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
         kubectl logs deployment/nginx-operator

--- a/doc/ansible/dev/apb_migration_guide.md
+++ b/doc/ansible/dev/apb_migration_guide.md
@@ -189,7 +189,7 @@ The `k8s` module takes normal kubernetes manifests, so if you currently rely on 
 # convert.py
 The `convert.py` script should be run from inside the APB directory, next to the `apb.yml`
 ```python
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import yaml
 

--- a/doc/ansible/dev/apb_migration_guide.md
+++ b/doc/ansible/dev/apb_migration_guide.md
@@ -189,7 +189,7 @@ The `k8s` module takes normal kubernetes manifests, so if you currently rely on 
 # convert.py
 The `convert.py` script should be run from inside the APB directory, next to the `apb.yml`
 ```python
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import yaml
 

--- a/doc/ansible/dev/developer_guide.md
+++ b/doc/ansible/dev/developer_guide.md
@@ -28,7 +28,7 @@ $ sudo dnf install ansible
 In addition to Ansible, a user must install the [OpenShift Restclient
 Python][openshift_restclient_python] package. This can be installed from pip:
 ```bash
-$ pip install openshift
+$ pip3 install openshift
 ```
 
 ### Testing the k8s Ansible modules locally

--- a/doc/ansible/dev/testing_guide.md
+++ b/doc/ansible/dev/testing_guide.md
@@ -7,7 +7,7 @@ To begin, you sould have:
 - The latest version of the [operator-sdk](https://github.com/operator-framework/operator-sdk) installed.
 - Docker installed and running
 - [Molecule](https://github.com/ansible/molecule) >= v2.20
-- [Ansible](https://github.com/ansible/ansible) >= v2.7
+- [Ansible](https://github.com/ansible/ansible) >= v3
 - [jmespath](https://pypi.org/project/jmespath/)
 - [The OpenShift Python client](https://github.com/openshift/openshift-restclient-python) >= v0.8
 - An initialized Ansible Operator project, with the molecule directory present. If you initialized a project with a previous

--- a/doc/dev/testing/travis-build.md
+++ b/doc/dev/testing/travis-build.md
@@ -20,7 +20,7 @@ For the Go, Ansible, and Helm tests, the `before_install` and `install` stages a
     - If only documentation has been updated, skip these tests.
 2. Run `make tidy` to ensure `go.mod` and `go.sum` are up-to-date.
 3. Build and install the sdk using `make install`.
-4. Install ansible using `sudo pip install ansible`.
+4. Install ansible using `pip3 install ansible`.
 5. Run the [`hack/ci/setup-openshift`][script] script, which spins up an openshift cluster by configuring docker and then downloading the `oc` v3.11 binary and running `oc cluster up`.
 
 The Go, Ansible, and Helm tests then differ in what tests they run.

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -36,7 +36,7 @@ building example-operator...
 
 building container quay.io/example/operator:v0.0.1...
 Sending build context to Docker daemon  163.9MB
-Step 1/4 : FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+Step 1/4 : FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
  ---> 77144d8c6bdc
 Step 2/4 : ADD tmp/_output/bin/example-operator /usr/local/bin/example-operator
  ---> 2ada0d6ca93c

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -7,9 +7,9 @@ set -eux
 ROOTDIR="$(pwd)"
 GOTMP="$(mktemp -d)"
 trap_add 'rm -rf $GOTMP' EXIT
-pip install --user pyasn1==0.4.5 pyasn1-modules==0.2.5 idna==2.7 ipaddress==1.0.22
-pip install --user molecule==2.20.2
-pip install --user docker openshift jmespath
+pip3 install --user pyasn1==0.4.5 pyasn1-modules==0.2.5 idna==2.7 ipaddress==1.0.22
+pip3 install --user molecule==2.20.2
+pip3 install --user docker openshift jmespath
 
 deploy_prereqs() {
     kubectl create -f "$OPERATORDIR/deploy/service_account.yaml"

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -7,7 +7,7 @@ set -eux
 ROOTDIR="$(pwd)"
 GOTMP="$(mktemp -d)"
 trap_add 'rm -rf $GOTMP' EXIT
-pip3 install --user pyasn1==0.4.5 pyasn1-modules==0.2.6 idna==2.7 ipaddress==1.0.22
+pip3 install --user pyasn1==0.4.7 pyasn1-modules==0.2.6 idna==2.7 ipaddress==1.0.22
 pip3 install -U git+https://github.com/ansible/molecule
 pip3 install --user docker openshift jmespath
 

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -8,7 +8,7 @@ ROOTDIR="$(pwd)"
 GOTMP="$(mktemp -d)"
 trap_add 'rm -rf $GOTMP' EXIT
 pip3 install --user pyasn1==0.4.7 pyasn1-modules==0.2.6 idna==2.7 ipaddress==1.0.22
-pip3 install -U git+https://github.com/ansible/molecule
+pip3 install molecule==2.22
 pip3 install --user docker openshift jmespath
 
 deploy_prereqs() {

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -7,8 +7,8 @@ set -eux
 ROOTDIR="$(pwd)"
 GOTMP="$(mktemp -d)"
 trap_add 'rm -rf $GOTMP' EXIT
-pip3 install --user pyasn1==0.4.5 pyasn1-modules==0.2.5 idna==2.7 ipaddress==1.0.22
-pip3 install --user molecule==2.20.2
+pip3 install --user pyasn1==0.4.5 pyasn1-modules==0.2.6 idna==2.7 ipaddress==1.0.22
+pip3 install -U git+https://github.com/ansible/molecule
 pip3 install --user docker openshift jmespath
 
 deploy_prereqs() {
@@ -42,8 +42,6 @@ cat "$ROOTDIR/test/ansible-memcached/watches-finalizer.yaml" >> memcached-operat
 cat "$ROOTDIR/test/ansible-memcached/prepare-test-image.yml" >> memcached-operator/molecule/test-local/prepare.yml
 # Append v1 kind to watches to test watching already registered GVK
 cat "$ROOTDIR/test/ansible-memcached/watches-v1-kind.yaml" >> memcached-operator/watches.yaml
-
-
 
 # Test local
 pushd memcached-operator

--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -50,7 +50,7 @@ test_operator() {
     fi
 
     # verify that the metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8383/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8383/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
         kubectl logs deployment/memcached-operator
@@ -58,7 +58,7 @@ test_operator() {
     fi
 
     # verify that the operator metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8686/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8686/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
         kubectl logs deployment/memcached-operator
@@ -76,7 +76,7 @@ test_operator() {
     fi
 
     # verify that metrics reflect cr creation
-    if ! bash -c -- 'kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached';
+    if ! bash -c -- 'kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached';
     then
         echo "Failed to verify custom resource metrics"
         kubectl logs deployment/memcached-operator

--- a/hack/tests/e2e-helm.sh
+++ b/hack/tests/e2e-helm.sh
@@ -42,7 +42,7 @@ test_operator() {
     fi
 
     # verify that the metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator-metrics:8383/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator-metrics:8383/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
         kubectl logs deployment/nginx-operator
@@ -59,7 +59,7 @@ test_operator() {
     fi
 
     # verify that the custom resource metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-cr-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator-metrics:8686/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-cr-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator-metrics:8686/metrics; do sleep 1; done";
     then
         echo "Failed to verify that custom resource metrics endpoint exists"
         kubectl logs deployment/nginx-operator

--- a/images/scorecard-proxy/Dockerfile
+++ b/images/scorecard-proxy/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV PROXY=/usr/local/bin/scorecard-proxy \
     USER_UID=1001 \

--- a/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
+++ b/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
@@ -42,10 +42,10 @@ FROM ${BASEIMAGE}
 USER 0
 
 # Ensure fresh metadata rather than cached metadata in the base by running
-# yum clean all && rm -rf /var/yum/cache/* first
-RUN yum clean all && rm -rf /var/cache/yum/* \
- && yum install -y python-devel gcc libffi-devel
-RUN pip install molecule==2.20.1
+# sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/yum/cache/* first
+RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/cache/yum/* \
+ && yum install -y python36-devel.x86_64 gcc inotify-tools gcc libffi-devel
+RUN pip3 install molecule==2.20.1
 
 ARG NAMESPACEDMAN
 ADD $NAMESPACEDMAN /namespaced.yaml

--- a/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
+++ b/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
@@ -44,7 +44,7 @@ USER 0
 # Ensure fresh metadata rather than cached metadata in the base by running
 # sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/yum/cache/* first
 RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/cache/yum/* \
- && yum install -y python36-devel.x86_64 gcc inotify-tools gcc libffi-devel
+ && yum install -y python36-devel.x86_64 gcc libffi-devel
 RUN pip3 install molecule==2.20.1
 
 ARG NAMESPACEDMAN

--- a/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
+++ b/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
@@ -42,10 +42,10 @@ FROM ${BASEIMAGE}
 USER 0
 
 # Ensure fresh metadata rather than cached metadata in the base by running
-# sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/yum/cache/* first
-RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/cache/yum/* \
- && yum install -y python36-devel.x86_64 gcc libffi-devel
-RUN pip3 install molecule==2.20.1
+# yum clean all && rm -rf /var/yum/cache/* first
+RUN yum clean all && rm -rf /var/cache/yum/* \
+ && yum install -y python36-devel gcc libffi-devel
+RUN pip3 install molecule==2.22
 
 ARG NAMESPACEDMAN
 ADD $NAMESPACEDMAN /namespaced.yaml

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -68,15 +68,15 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
  && yum install -y epel-release \
  && (yum update || true) \
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
- && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \ # -> it installs the rpm to be used by the yum 
- && yum --enablerepo=epel install inotify-tools.x86_64 \ # -> it will install the inotify-tools.x86_64 in the SO 
+ && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \ # -> it installs the rpm to be used by the yum
+ && yum --enablerepo=epel install inotify-tools.x86_64 \ # -> it will install the inotify-tools.x86_64 in the SO
  && (yum install python3-setuptools || true) \
  && pip3 install --no-cache-dir --ignore-installed ipaddress \
            ansible-runner==1.3.4 \
            ansible-runner-http==1.0.0 \
            openshift==0.8.9 \
            ansible==2.8 \
- && yum remove -y gcc \
+ && yum remove -y python36-devel.x86_64 gcc \
  && yum clean all \
  && rm -rf /var/cache/yum
 

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -64,12 +64,12 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 RUN yum clean all && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
  && yum install -y python36-devel.x86_64 gcc \
- # Install inotify-tools
+ # Installing inotify-tools since it is no longer added in the rhel by default ...
  && yum install -y epel-release \
  && (yum update || true) \
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
- && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
- && yum --enablerepo=epel install inotify-tools.x86_64 \
+ && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \ # -> it installs the rpm to be used by the yum 
+ && yum --enablerepo=epel install inotify-tools.x86_64 \ # -> it will install the inotify-tools.x86_64 in the SO 
  && (yum install python3-setuptools || true) \
  && pip3 install --no-cache-dir --ignore-installed ipaddress \
            ansible-runner==1.3.4 \

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -62,8 +62,8 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 # Ensure fresh metadata rather than cached metadata in the base by running
 # sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/yum/cache/* first
 RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/cache/yum/* \
- && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
- && yum install -y python36-devel.x86_64 gcc inotify-tools \
+ && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+ && yum install -y python36-devel.x86_64 gcc \
  && pip3 install --user --no-cache-dir --ignore-installed ipaddress \
     ansible-runner==1.2 \
     ansible-runner-http==1.0.0 \

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -45,7 +45,7 @@ func (d *DockerfileHybrid) GetInput() (input.Input, error) {
 	return d.Input, nil
 }
 
-const dockerFileHybridAnsibleTmpl = `FROM registry.access.redhat.com/ubi8/ubi
+const dockerFileHybridAnsibleTmpl = `FROM registry.access.redhat.com/ubi8/ubi:latest
 
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
@@ -60,10 +60,10 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 
 # Install python dependencies
 # Ensure fresh metadata rather than cached metadata in the base by running
-# yum clean all && rm -rf /var/yum/cache/* first
-RUN yum clean all && rm -rf /var/cache/yum/* \
+# sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/yum/cache/* first
+RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/cache/yum/* \
  && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
- && yum install -y python-devel gcc inotify-tools \
+ && yum install -y python36-devel.x86_64 gcc inotify-tools \
  && easy_install pip \
  && pip install -U --no-cache-dir setuptools pip \
  && pip install --no-cache-dir --ignore-installed ipaddress \
@@ -71,7 +71,7 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
       ansible-runner-http==1.0.0 \
       openshift==0.8.9 \
       ansible==2.8 \
- && yum remove -y gcc python-devel \
+ && yum remove -y gcc python36-devel.x86_64 \
  && yum clean all \
  && rm -rf /var/cache/yum
 

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -68,8 +68,10 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
  && yum install -y epel-release \
  && (yum update || true) \
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
- && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \ # -> it installs the rpm to be used by the yum
- && yum --enablerepo=epel install inotify-tools.x86_64 \ # -> it will install the inotify-tools.x86_64 in the SO
+ # Installing the rpm to be used by the yum
+ && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
+ # Installing the inotify-tools.x86_64 in the SO
+ && yum --enablerepo=epel install inotify-tools.x86_64 \
  && (yum install python3-setuptools || true) \
  && pip3 install --no-cache-dir --ignore-installed ipaddress \
            ansible-runner==1.3.4 \

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -60,16 +60,21 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 
 # Install python dependencies
 # Ensure fresh metadata rather than cached metadata in the base by running
-# sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/yum/cache/* first
-RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/cache/yum/* \
- && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+# yum clean all && rm -rf /var/yum/cache/* first
+RUN yum clean all && rm -rf /var/cache/yum/* \
+ && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
  && yum install -y python36-devel.x86_64 gcc \
- && pip3 install --user --no-cache-dir --ignore-installed ipaddress \
-    ansible-runner==1.2 \
-    ansible-runner-http==1.0.0 \
-    openshift==0.8.9 \
-	ansible==2.8 \
- && yum remove -y gcc python36-devel.x86_64 \
+ # Install inotify-tools
+ && yum install -y epel-release && yum update \
+ && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
+ && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
+ && yum --enablerepo=epel install inotify-tools.x86_64 \
+ && pip3 install --no-cache-dir --ignore-installed ipaddress \
+           ansible-runner==1.3.4 \
+           ansible-runner-http==1.0.0 \
+           openshift==0.8.9 \
+           ansible==2.8 \
+ && yum remove -y gcc \
  && yum clean all \
  && rm -rf /var/cache/yum
 

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -64,13 +64,11 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 RUN sed -i 's|enabled=1|enabled=0|g' /etc/yum/pluginconf.d/product-id.conf && rm -rf /var/cache/yum/* \
  && yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
  && yum install -y python36-devel.x86_64 gcc inotify-tools \
- && easy_install pip \
- && pip install -U --no-cache-dir setuptools pip \
- && pip install --no-cache-dir --ignore-installed ipaddress \
-      ansible-runner==1.2 \
-      ansible-runner-http==1.0.0 \
-      openshift==0.8.9 \
-      ansible==2.8 \
+ && pip3 install --user --no-cache-dir --ignore-installed ipaddress \
+    ansible-runner==1.2 \
+    ansible-runner-http==1.0.0 \
+    openshift==0.8.9 \
+	ansible==2.8 \
  && yum remove -y gcc python36-devel.x86_64 \
  && yum clean all \
  && rm -rf /var/cache/yum

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -45,7 +45,7 @@ func (d *DockerfileHybrid) GetInput() (input.Input, error) {
 	return d.Input, nil
 }
 
-const dockerFileHybridAnsibleTmpl = `FROM registry.access.redhat.com/ubi7/ubi
+const dockerFileHybridAnsibleTmpl = `FROM registry.access.redhat.com/ubi8/ubi
 
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -65,10 +65,12 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
  && yum install -y python36-devel.x86_64 gcc \
  # Install inotify-tools
- && yum install -y epel-release && yum update \
+ && yum install -y epel-release \
+ && (yum update || true) \
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
  && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
  && yum --enablerepo=epel install inotify-tools.x86_64 \
+ && (yum install python3-setuptools || true) \
  && pip3 install --no-cache-dir --ignore-installed ipaddress \
            ansible-runner==1.3.4 \
            ansible-runner-http==1.0.0 \

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -63,7 +63,7 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 # yum clean all && rm -rf /var/yum/cache/* first
 RUN yum clean all && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
- && yum install -y python36-devel.x86_64 gcc \
+ && yum install -y python36-devel gcc \
  # Installing inotify-tools since it is no longer added in the rhel by default ...
  && yum install -y epel-release \
  && (yum update || true) \
@@ -76,7 +76,7 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
            ansible-runner-http==1.0.0 \
            openshift==0.8.9 \
            ansible==2.8 \
- && yum remove -y python36-devel.x86_64 gcc \
+ && yum remove -y python36-devel gcc \
  && yum clean all \
  && rm -rf /var/cache/yum
 

--- a/internal/pkg/scaffold/ansible/k8s_status.go
+++ b/internal/pkg/scaffold/ansible/k8s_status.go
@@ -36,7 +36,7 @@ func (k *K8sStatus) GetInput() (input.Input, error) {
 	return k.Input, nil
 }
 
-const k8sStatusTmpl = `#!/usr/bin/python
+const k8sStatusTmpl = `#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function
@@ -65,7 +65,7 @@ module: k8s_status
 
 short_description: Update the status for a Kubernetes API resource
 
-version_added: "2.7"
+version_added: "3.6.7"
 
 author: "Fabian von Feilitzsch (@fabianvf)"
 
@@ -163,7 +163,7 @@ options:
     type: bool
 
 requirements:
-    - "python >= 2.7"
+    - "python >= 3.6.7"
     - "openshift >= 0.8.1"
     - "PyYAML >= 3.11"
 '''

--- a/internal/pkg/scaffold/ansible/k8s_status.go
+++ b/internal/pkg/scaffold/ansible/k8s_status.go
@@ -36,7 +36,7 @@ func (k *K8sStatus) GetInput() (input.Input, error) {
 	return k.Input, nil
 }
 
-const k8sStatusTmpl = `#!/usr/bin/python3
+const k8sStatusTmpl = `#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function
@@ -65,7 +65,7 @@ module: k8s_status
 
 short_description: Update the status for a Kubernetes API resource
 
-version_added: "3.6.7"
+version_added: "3.6"
 
 author: "Fabian von Feilitzsch (@fabianvf)"
 
@@ -163,7 +163,7 @@ options:
     type: bool
 
 requirements:
-    - "python >= 3.6.7"
+    - "python >= 3.6"
     - "openshift >= 0.8.1"
     - "PyYAML >= 3.11"
 '''

--- a/internal/pkg/scaffold/ansible/k8s_status.go
+++ b/internal/pkg/scaffold/ansible/k8s_status.go
@@ -65,7 +65,7 @@ module: k8s_status
 
 short_description: Update the status for a Kubernetes API resource
 
-version_added: "3.6"
+version_added: "2.7"
 
 author: "Fabian von Feilitzsch (@fabianvf)"
 
@@ -163,7 +163,7 @@ options:
     type: bool
 
 requirements:
-    - "python >= 3.6"
+    - "python >= 2.7"
     - "openshift >= 0.8.1"
     - "PyYAML >= 3.11"
 '''

--- a/internal/pkg/scaffold/ansible/molecule_test_cluster_playbook.go
+++ b/internal/pkg/scaffold/ansible/molecule_test_cluster_playbook.go
@@ -59,7 +59,7 @@ const moleculeTestClusterPlaybookAnsibleTmpl = `---
     debug:
       msg: "{{ lookup('k8s', group='[[.Resource.FullGroup]]', api_version='[[.Resource.Version]]', kind='[[.Resource.Kind]]', namespace=namespace, resource_name=custom_resource.metadata.name) }}"
 
-  - name: Wait 60s for reconciliation to run
+  - name: Wait 2m for reconciliation to run
     k8s_facts:
       api_version: '[[.Resource.Version]]'
       kind: '[[.Resource.Kind]]'
@@ -68,7 +68,7 @@ const moleculeTestClusterPlaybookAnsibleTmpl = `---
     register: reconcile_cr
     until:
     - "'Successful' in (reconcile_cr | json_query('resources[].status.conditions[].reason'))"
-    delay: 6
+    delay: 12
     retries: 10
 
 - import_playbook: '{{ playbook_dir }}/../default/asserts.yml'

--- a/internal/pkg/scaffold/ansible/molecule_test_local_playbook.go
+++ b/internal/pkg/scaffold/ansible/molecule_test_local_playbook.go
@@ -101,7 +101,7 @@ const moleculeTestLocalPlaybookAnsibleTmpl = `---
         namespace: '{{ namespace }}'
         definition: '{{ custom_resource }}'
 
-    - name: Wait 60s for reconciliation to run
+    - name: Wait 2m for reconciliation to run
       k8s_facts:
         api_version: '{{ custom_resource.apiVersion }}'
         kind: '{{ custom_resource.kind }}'
@@ -110,7 +110,7 @@ const moleculeTestLocalPlaybookAnsibleTmpl = `---
       register: cr
       until:
       - "'Successful' in (cr | json_query('resources[].status.conditions[].reason'))"
-      delay: 6
+      delay: 12
       retries: 10
     rescue:
     - name: debug cr

--- a/internal/pkg/scaffold/ansible/travis.go
+++ b/internal/pkg/scaffold/ansible/travis.go
@@ -36,7 +36,7 @@ const travisAnsibleTmpl = `sudo: required
 services: docker
 language: python
 python:
-  - "3.6.7"
+  - "3.6"
 install:
   - pip3 install docker molecule openshift
 script:

--- a/internal/pkg/scaffold/ansible/travis.go
+++ b/internal/pkg/scaffold/ansible/travis.go
@@ -35,8 +35,10 @@ func (t *Travis) GetInput() (input.Input, error) {
 const travisAnsibleTmpl = `sudo: required
 services: docker
 language: python
+python:
+  - "3.6.7"
 install:
-  - pip install docker molecule openshift
+  - pip3 install docker molecule openshift
 script:
   - molecule test -s test-local
 `

--- a/internal/pkg/scaffold/build_dockerfile.go
+++ b/internal/pkg/scaffold/build_dockerfile.go
@@ -34,7 +34,7 @@ func (s *Dockerfile) GetInput() (input.Input, error) {
 	return s.Input, nil
 }
 
-const dockerfileTmpl = `FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+const dockerfileTmpl = `FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/{{.ProjectName}} \
     USER_UID=1001 \

--- a/internal/pkg/scaffold/build_dockerfile_test.go
+++ b/internal/pkg/scaffold/build_dockerfile_test.go
@@ -33,7 +33,7 @@ func TestDockerfile(t *testing.T) {
 	}
 }
 
-const dockerfileExp = `FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+const dockerfileExp = `FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/app-operator \
     USER_UID=1001 \

--- a/internal/pkg/scaffold/helm/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/helm/dockerfilehybrid.go
@@ -41,7 +41,7 @@ func (d *DockerfileHybrid) GetInput() (input.Input, error) {
 	return d.Input, nil
 }
 
-const dockerFileHybridHelmTmpl = `FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+const dockerFileHybridHelmTmpl = `FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/helm-operator \
     USER_UID=1001 \


### PR DESCRIPTION
**Description of the change:**
- Upgrade image `registry.access.redhat.com/ubi7/ubi-minimal:latest` to `registry.access.redhat.com/ubi8/ubi-minimal:latest`
- Upgrade epel7 to epel8 in docker images
- Upgrade the python version 2 which is deprecated to 3.

**Motivation for the change:**

- https://github.com/operator-framework/operator-sdk/issues/1884
- https://github.com/operator-framework/operator-sdk/issues/1656
- https://jira.coreos.com/browse/OSDK-512
- Keep the images and versions updated ( solve technical debts )

**Progress**

- [ ] Merge the PR and check if the tests in the prow will be executed with success*
- [x] Pass in the trevis tests -  Fix issue with ansible molecule test `operator-framework/operator-sdk/hack/tests/e2e-ansible-molecule.sh` which is not working after upgrade it to python3. (`Error: failed to exec []string{"molecule", "test", "-s", "test-local"}: exit status 1` `Failed on action: converge`). To reproduce run `make test/e2e/ansible-molecule` .  

PS.* To fix the ci/prow tests shows that we need to update the ubi images. See the PR for it: https://github.com/openshift/release/pull/4995/files