### PR TITLE
go.mod,go.sum,internal/pkg/scaffold: use git.apache.org mirror

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -112,7 +112,13 @@ replace (
 	k8s.io/kubernetes => k8s.io/kubernetes v1.14.1
 )
 
-replace github.com/operator-framework/operator-lifecycle-manager => github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190605231540-b8a4faf68e36
+replace (
+	// Indirect operator-sdk dependencies use git.apache.org, which is frequently
+	// down. The github mirror should be used instead.
+	// Locking to a specific version (from 'go mod graph'):
+	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
+	github.com/operator-framework/operator-lifecycle-manager => github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190605231540-b8a4faf68e36
+)
 
 // Remove when controller-tools v0.2.2 is released
 // Required for the bugfix https://github.com/kubernetes-sigs/controller-tools/pull/322

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,6 @@ cloud.google.com/go v0.37.2 h1:4y4L7BdHenTfZL0HervofNTHh9Ad6mNX72cQvl+5eH0=
 cloud.google.com/go v0.37.2/go.mod h1:H8IAquKe2L30IxoupDgqTaQvKSwF/c8prYHynGIWQbA=
 contrib.go.opencensus.io/exporter/ocagent v0.4.12 h1:jGFvw3l57ViIVEPKKEUXPcLYIXJmQxLUh6ey1eJhwyc=
 contrib.go.opencensus.io/exporter/ocagent v0.4.12/go.mod h1:450APlNTSR6FrvC3CTRqYosuDstRB9un7SOx2k/9ckA=
-git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-git.apache.org/thrift.git v0.12.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v11.1.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
@@ -41,6 +39,7 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=

--- a/internal/pkg/scaffold/ansible/go_mod.go
+++ b/internal/pkg/scaffold/ansible/go_mod.go
@@ -57,9 +57,15 @@ replace (
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver kubernetes-1.14.1
 )
 
-// Pinned to v2.10.0 (kubernetes-1.14.1) so https://proxy.golang.org can
-// resolve it correctly.
-replace github.com/prometheus/prometheus => github.com/prometheus/prometheus d20e84d0fb64aff2f62a977adc8cfb656da4e286
+replace (
+	// Indirect operator-sdk dependencies use git.apache.org, which is frequently
+	// down. The github mirror should be used instead.
+	// Locking to a specific version (from 'go mod graph'):
+	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
+	// Pinned to v2.10.0 (kubernetes-1.14.1) so https://proxy.golang.org can
+	// resolve it correctly.
+	github.com/prometheus/prometheus => github.com/prometheus/prometheus d20e84d0fb64aff2f62a977adc8cfb656da4e286
+)
 `
 
 func PrintGoMod() error {

--- a/internal/pkg/scaffold/go_mod.go
+++ b/internal/pkg/scaffold/go_mod.go
@@ -38,13 +38,11 @@ func (s *GoMod) GetInput() (input.Input, error) {
 const goModTmpl = `module {{ .Repo }}
 
 require (
-	github.com/coreos/prometheus-operator v0.31.1 // indirect
 	github.com/operator-framework/operator-sdk master
 	github.com/spf13/pflag v1.0.3
 	k8s.io/api v0.0.0-20190612125737-db0771252981
 	k8s.io/apimachinery v0.0.0-20190612125636-6a5db36e93ad
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
-	k8s.io/kube-openapi v0.0.0-20190603182131-db7b694dc208 // indirect
 	sigs.k8s.io/controller-runtime v0.2.0
 )
 
@@ -58,6 +56,10 @@ replace (
 )
 
 replace (
+	// Indirect operator-sdk dependencies use git.apache.org, which is frequently
+	// down. The github mirror should be used instead.
+	// Locking to a specific version (from 'go mod graph'):
+	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 	github.com/coreos/prometheus-operator => github.com/coreos/prometheus-operator v0.31.1
 	// Pinned to v2.10.0 (kubernetes-1.14.1) so https://proxy.golang.org can
 	// resolve it correctly.

--- a/internal/pkg/scaffold/helm/go_mod.go
+++ b/internal/pkg/scaffold/helm/go_mod.go
@@ -61,7 +61,6 @@ require (
 	gotest.tools v2.2.0+incompatible // indirect
 	k8s.io/apiserver v0.0.0-20181213151703-3ccfe8365421 // indirect
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
-	k8s.io/helm v2.14.1+incompatible // indirect
 	k8s.io/kube-openapi v0.0.0-20190603182131-db7b694dc208 // indirect
 	sigs.k8s.io/controller-runtime v0.2.0
 )
@@ -79,6 +78,10 @@ replace (
 )
 
 replace (
+	// Indirect operator-sdk dependencies use git.apache.org, which is frequently
+	// down. The github mirror should be used instead.
+	// Locking to a specific version (from 'go mod graph'):
+	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 	github.com/coreos/prometheus-operator => github.com/coreos/prometheus-operator v0.31.1
 	// Pinned to v2.10.0 (kubernetes-1.14.1) so https://proxy.golang.org can
 	// resolve it correctly.


### PR DESCRIPTION
**Description of the change:** use github.com/apache/thrift mirror instead of git.apache.org directly.


**Motivation for the change:** see #1873 for details.

Closes #1873