### PR TITLE
internal/: use operator-registry's PackageManifest type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190128024246-5eb7ae5bdb7a
+	github.com/operator-framework/operator-registry v1.1.1
 	github.com/pborman/uuid v1.2.0
 	github.com/pelletier/go-toml v1.3.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -351,6 +351,7 @@ github.com/operator-framework/go-appr v0.0.0-20180917210448-f2aef88446f2/go.mod 
 github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190605231540-b8a4faf68e36 h1:zQykXcFkA+wZm5//RKB7BEzEH7Q0Hwvp8+3HJrG5BD0=
 github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190605231540-b8a4faf68e36/go.mod h1:HKV3ZB9aOUxRyfM53shoBRtIMP4lg8QRmkW+dmZy+kI=
 github.com/operator-framework/operator-marketplace v0.0.0-20190216021216-57300a3ef3ba/go.mod h1:msZSL8pXwzQjB+hU+awVrZQw94IwJi3sNZVD3NoESIs=
+github.com/operator-framework/operator-registry v1.1.1 h1:oDIevJvKXFsp7BEb7iJHuLvuhPZYBtIx5oZQ7iSISAs=
 github.com/operator-framework/operator-registry v1.1.1/go.mod h1:7D4WEwL+EKti5npUh4/u64DQhawCBRugp8Ql20duUb4=
 github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=

--- a/internal/pkg/scaffold/olm-catalog/package_manifest.go
+++ b/internal/pkg/scaffold/olm-catalog/package_manifest.go
@@ -26,7 +26,7 @@ import (
 	registryutil "github.com/operator-framework/operator-sdk/internal/util/operator-registry"
 
 	"github.com/ghodss/yaml"
-	olmregistry "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+	"github.com/operator-framework/operator-registry/pkg/registry"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -77,7 +77,7 @@ func (s *PackageManifest) CustomRender() ([]byte, error) {
 	}
 	path := filepath.Join(s.AbsProjectPath, i.Path)
 
-	pm := &olmregistry.PackageManifest{}
+	pm := &registry.PackageManifest{}
 	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
 		pm = s.newPackageManifest()
 	} else if err == nil {
@@ -112,7 +112,7 @@ func (s *PackageManifest) CustomRender() ([]byte, error) {
 	return yaml.Marshal(pm)
 }
 
-func (s *PackageManifest) newPackageManifest() *olmregistry.PackageManifest {
+func (s *PackageManifest) newPackageManifest() *registry.PackageManifest {
 	// Take the current CSV version to be the "alpha" channel, as an operator
 	// should only be designated anything more stable than "alpha" by a human.
 	channel := "alpha"
@@ -120,9 +120,9 @@ func (s *PackageManifest) newPackageManifest() *olmregistry.PackageManifest {
 		channel = s.Channel
 	}
 	lowerOperatorName := strings.ToLower(s.OperatorName)
-	pm := &olmregistry.PackageManifest{
+	pm := &registry.PackageManifest{
 		PackageName: lowerOperatorName,
-		Channels: []olmregistry.PackageChannel{
+		Channels: []registry.PackageChannel{
 			{Name: channel, CurrentCSVName: getCSVName(lowerOperatorName, s.CSVVersion)},
 		},
 		DefaultChannelName: channel,
@@ -132,7 +132,7 @@ func (s *PackageManifest) newPackageManifest() *olmregistry.PackageManifest {
 
 // setChannels checks for duplicate channels in pm and sets the default
 // channel if possible.
-func (s *PackageManifest) setChannels(pm *olmregistry.PackageManifest) error {
+func (s *PackageManifest) setChannels(pm *registry.PackageManifest) error {
 	if s.Channel != "" {
 		channelIdx := -1
 		for i, channel := range pm.Channels {
@@ -143,7 +143,7 @@ func (s *PackageManifest) setChannels(pm *olmregistry.PackageManifest) error {
 		}
 		lowerOperatorName := strings.ToLower(s.OperatorName)
 		if channelIdx == -1 {
-			pm.Channels = append(pm.Channels, olmregistry.PackageChannel{
+			pm.Channels = append(pm.Channels, registry.PackageChannel{
 				Name:           s.Channel,
 				CurrentCSVName: getCSVName(lowerOperatorName, s.CSVVersion),
 			})

--- a/internal/util/operator-registry/package_manifest.go
+++ b/internal/util/operator-registry/package_manifest.go
@@ -17,12 +17,11 @@ package registry
 import (
 	"fmt"
 
+	"github.com/operator-framework/operator-registry/pkg/registry"
 	"github.com/pkg/errors"
-
-	olmregistry "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
 )
 
-func ValidatePackageManifest(pm *olmregistry.PackageManifest) error {
+func ValidatePackageManifest(pm *registry.PackageManifest) error {
 	if pm.PackageName == "" {
 		return errors.New("package name cannot be empty")
 	}

--- a/internal/util/operator-registry/package_manifest_test.go
+++ b/internal/util/operator-registry/package_manifest_test.go
@@ -17,14 +17,14 @@ package registry
 import (
 	"testing"
 
-	olmregistry "github.com/operator-framework/operator-lifecycle-manager/pkg/controller/registry"
+	"github.com/operator-framework/operator-registry/pkg/registry"
 )
 
 func TestValidatePackageManifest(t *testing.T) {
-	channels := []olmregistry.PackageChannel{
+	channels := []registry.PackageChannel{
 		{Name: "foo", CurrentCSVName: "bar"},
 	}
-	pm := &olmregistry.PackageManifest{
+	pm := &registry.PackageManifest{
 		Channels:           channels,
 		DefaultChannelName: "baz",
 		PackageName:        "test-package",
@@ -34,7 +34,7 @@ func TestValidatePackageManifest(t *testing.T) {
 		description string
 		wantErr     bool
 		errMsg      string
-		operation   func(*olmregistry.PackageManifest)
+		operation   func(*registry.PackageManifest)
 	}{
 		{
 			"default channel does not exist",
@@ -43,22 +43,22 @@ func TestValidatePackageManifest(t *testing.T) {
 		{
 			"successful validation",
 			false, "",
-			func(pm *olmregistry.PackageManifest) {
+			func(pm *registry.PackageManifest) {
 				pm.DefaultChannelName = pm.Channels[0].Name
 			},
 		},
 		{
 			"channels are empty",
 			true, "channels cannot be empty",
-			func(pm *olmregistry.PackageManifest) {
+			func(pm *registry.PackageManifest) {
 				pm.Channels = nil
 			},
 		},
 		{
 			"one channel's CSVName is empty",
 			true, "channel foo currentCSV cannot be empty",
-			func(pm *olmregistry.PackageManifest) {
-				pm.Channels = make([]olmregistry.PackageChannel, 1)
+			func(pm *registry.PackageManifest) {
+				pm.Channels = make([]registry.PackageChannel, 1)
 				copy(pm.Channels, channels)
 				pm.Channels[0].CurrentCSVName = ""
 			},
@@ -66,7 +66,7 @@ func TestValidatePackageManifest(t *testing.T) {
 		{
 			"duplicate channel name",
 			true, "duplicate package manifest channel name foo; channel names must be unique",
-			func(pm *olmregistry.PackageManifest) {
+			func(pm *registry.PackageManifest) {
 				pm.Channels = append(channels, channels...)
 			},
 		},


### PR DESCRIPTION
**Description of the change:** use [`operator-registry`](https://github.com/operator-framework/operator-registry/blob/master/pkg/registry/types.go#L29)'s `PackageManifest` type over [OLM](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/pkg/controller/registry/types.go#L18)'s.


**Motivation for the change:** OLM's `PackageManifest` type is used for display purposes, while `operator-registry`'s is used for (un)marshalling package manifests.