### PR TITLE
test/test-framework: update manifests to pass registry/OLM validation

### DIFF
--- a/test/test-framework/deploy/olm-catalog/memcached-operator/0.0.2/memcached-operator.v0.0.2.clusterserviceversion.yaml
+++ b/test/test-framework/deploy/olm-catalog/memcached-operator/0.0.2/memcached-operator.v0.0.2.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     alm-examples: '[{"apiVersion":"cache.example.com/v1alpha1","kind":"Memcached","metadata":{"name":"example-memcached"},"spec":{"size":3}}]'
     capabilities: Basic Install
-  name: memcachedoperator.v0.0.2
+  name: memcached-operator.v0.0.2
   namespace: placeholder
 spec:
   installModes:
@@ -131,7 +131,6 @@ spec:
     url: www.example.com
   maturity: alpha
   version: 0.0.2
-  replaces: memcachedoperator.v0.0.1
   maintainers:
   - email: corp@example.com
     name: Some Corp

--- a/test/test-framework/deploy/olm-catalog/memcached-operator/0.0.3/memcached-operator.v0.0.3.clusterserviceversion.yaml
+++ b/test/test-framework/deploy/olm-catalog/memcached-operator/0.0.3/memcached-operator.v0.0.3.clusterserviceversion.yaml
@@ -15,8 +15,8 @@ metadata:
           }
         }
       ]
-  capabilities: Basic Install
-  name: memcachedoperator.v0.0.3
+    capabilities: Basic Install
+  name: memcached-operator.v0.0.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -54,7 +54,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.phase:reason
       version: v1alpha1
-    - kind: MemcachedRS
+    - description: Represents a cluster of MemcachedRS apps
+      displayName: MemcachedRS App
+      kind: MemcachedRS
       name: memcachedrs.cache.example.com
       version: v1alpha1
       statusDescriptors:

--- a/test/test-framework/deploy/olm-catalog/memcached-operator/memcached-operator.package.yaml
+++ b/test/test-framework/deploy/olm-catalog/memcached-operator/memcached-operator.package.yaml
@@ -1,0 +1,7 @@
+packageName: memcached-operator
+channels:
+- currentCSV: memcached-operator.v0.0.2
+  name: alpha
+- currentCSV: memcached-operator.v0.0.3
+  name: beta
+defaultChannel: beta


### PR DESCRIPTION
**Description of the change:** make names uniform, add package manifest


**Motivation for the change:** currently test framework CSV's do not pass registry/OLM validation, and don't have a package manifest that describes them.
