### PR TITLE
docs: make directories clear, escape less than

### DIFF
--- a/doc/ansible/project_layout.md
+++ b/doc/ansible/project_layout.md
@@ -6,7 +6,7 @@ After creating a new operator project using
 
 | File/Folders   | Purpose                           |
 | :---           | :--- |
-| deploy | Contains a generic set of Kubernetes manifests for deploying this operator on a Kubernetes cluster. |
-| roles/<kind> | Contains an Ansible Role initialized using [Ansible Galaxy](https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html) |
-| build | Contains scripts that the operator-sdk uses for build and initialization. |
-| watches.yaml | Contains Group, Version, Kind, and Ansible invocation method. |
+| deploy/ | Contains a generic set of Kubernetes manifests for deploying this operator on a Kubernetes cluster. |
+| roles/\<kind> | Contains an Ansible Role initialized using [Ansible Galaxy](https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html) |
+| build/ | Contains scripts that the `operator-sdk` uses for build and initialization. |
+| watches.yaml | Contains Group, Version, Kind, and the Ansible invocation method. |


### PR DESCRIPTION
**Description of the change:**
Add the `/` to make the directory name more clear that it is a directory. Escape the less than symbol so that it does not get eaten by markdown.

**Motivation for the change:**
OCD?