### PR TITLE
upgrade info to tell users how to how hack/tests/e2e-ansible-molecule…

### DIFF
--- a/doc/dev/testing/travis-build.md
+++ b/doc/dev/testing/travis-build.md
@@ -75,13 +75,23 @@ The Go, Ansible, and Helm tests then differ in what tests they run.
 
 ### Ansible tests
 
-1. Run [ansible molecule tests][ansible-molecule].
+1. Run [ansible molecule tests][ansible-molecule]. (`make test/e2e/ansible-molecule)
     1. Create and configure a new ansible type memcached-operator.
     2. Create cluster resources.
     3. Run `operator-sdk test local` to run ansible molecule tests
     4. Change directory to [`test/ansible-inventory`][ansible-inventory] and run `operator-sdk test local`
 
 **NOTE**: All created resources, including the namespace, are deleted using a bash trap when the test finishes
+
+**NOTE** If you are using a MacOSX SO then will be required replace the sed command in the `hack/tests/e2e-ansible-molecule.sh` as the following example. 
+
+```sh
+# Use the following sed command to check it on macOsX. 
+# More info: https://www.mkyong.com/mac/sed-command-hits-undefined-label-error-on-mac-os-x/
+sed -i "" 's|\(FROM quay.io/operator-framework/ansible-operator\)\(:.*\)\?|\1:dev|g' build/Dockerfile
+# The following code is the default used (Not valid for MacOSX)
+# sed -i 's|\(FROM quay.io/operator-framework/ansible-operator\)\(:.*\)\?|\1:dev|g' build/Dockerfile
+```
 
 ### Helm Tests
 

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -47,6 +47,10 @@ cat "$ROOTDIR/test/ansible-memcached/watches-v1-kind.yaml" >> memcached-operator
 
 # Test local
 pushd memcached-operator
+# Use the following sed command to check it on macOsX.
+# More info: https://www.mkyong.com/mac/sed-command-hits-undefined-label-error-on-mac-os-x/
+# sed -i "" 's|\(FROM quay.io/operator-framework/ansible-operator\)\(:.*\)\?|\1:dev|g' build/Dockerfile
+# The following code is the default used (Not valid for MacOSX)
 sed -i 's|\(FROM quay.io/operator-framework/ansible-operator\)\(:.*\)\?|\1:dev|g' build/Dockerfile
 OPERATORDIR="$(pwd)"
 TEST_CLUSTER_PORT=24443 operator-sdk test local --namespace default
@@ -57,7 +61,10 @@ popd
 popd
 
 pushd "${ROOTDIR}/test/ansible-inventory"
-
+# Use the following sed command to check it on macOsX.
+# More info: https://www.mkyong.com/mac/sed-command-hits-undefined-label-error-on-mac-os-x/
+# sed -i "" 's|\(FROM quay.io/operator-framework/ansible-operator\)\(:.*\)\?|\1:dev|g' build/Dockerfile
+# The following code is the default used (Not valid for MacOSX)
 sed -i 's|\(FROM quay.io/operator-framework/ansible-operator\)\(:.*\)\?|\1:dev|g' build/Dockerfile
 TEST_CLUSTER_PORT=24443 operator-sdk test local --namespace default
 


### PR DESCRIPTION
**Description of the change:**
Just add info over how to run it on Mac. 

**Motivation for the change:**
Issues faced when I was trying to run it locally because of `https://github.com/operator-framework/operator-sdk/pull/1895`