### PR TITLE
example: Fix incorrect path of log package; Fix incorrect usage of me…

### DIFF
--- a/example/memcached-operator/memcached_controller.go.tmpl
+++ b/example/memcached-operator/memcached_controller.go.tmpl
@@ -3,6 +3,7 @@ package memcached
 import (
 	"context"
 	"reflect"
+	"k8s.io/apimachinery/pkg/labels"
 
 	cachev1alpha1 "github.com/example-inc/memcached-operator/pkg/apis/cache/v1alpha1"
 
@@ -16,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -141,11 +142,12 @@ func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Res
 	// Update the Memcached status with the pod names
 	// List the pods for this memcached's deployment
 	podList := &corev1.PodList{}
-	listOpts := []client.ListOption{
-		client.InNamespace(memcached.Namespace),
-		client.MatchingLabels(labelsForMemcached(memcached.Name)),
+	labelSelector := labels.SelectorFromSet(labelsForMemcached(memcached.Name))
+	listOpts := &client.ListOptions{
+		Namespace:     memcached.Namespace,
+		LabelSelector: labelSelector,
 	}
-	if err = r.client.List(context.TODO(), podList, listOpts...); err != nil {
+	if err = r.client.List(context.TODO(), listOpts, podList); err != nil {
 		reqLogger.Error(err, "Failed to list pods", "Memcached.Namespace", memcached.Namespace, "Memcached.Name", memcached.Name)
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
**Description of the change:**
1. Fix the incorrect package path: 
  - "sigs.k8s.io/controller-runtime/pkg/log" should be "sigs.k8s.io/controller-runtime/pkg/runtime/log"; 
  - Add package "k8s.io/apimachinery/pkg/labels" since it is used.
2. Fix some incorrect references of client object: 
  - client.ListOption should be client.ListOptions; 
  - the sequence of parameters in client.List is also incorrect before.

**Motivation for the change:**

Closes #1907 


