### PR TITLE
Issue #1905: Add type of guide to user guide documentation.

### DIFF
--- a/doc/ansible/dev/developer_guide.md
+++ b/doc/ansible/dev/developer_guide.md
@@ -1,4 +1,4 @@
-# Developer guide
+# Ansible Developer Guide for Operator SDK
 
 This document provides some useful information and tips for a developer
 creating an operator powered by Ansible.

--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -1,4 +1,4 @@
-# User Guide
+# Ansible User Guide for Operator SDK
 
 This guide walks through an example of building a simple memcached-operator powered by Ansible using tools and libraries provided by the Operator SDK.
 

--- a/doc/dev/developer_guide.md
+++ b/doc/dev/developer_guide.md
@@ -1,4 +1,4 @@
-# Developer guide
+# Operator SDK Developer guide
 
 This document explains how to setup your dev environment.
 

--- a/doc/helm/user-guide.md
+++ b/doc/helm/user-guide.md
@@ -1,4 +1,4 @@
-# User Guide
+# Helm User Guide for Operator SDK
 
 This guide walks through an example of building a simple nginx-operator powered by Helm using tools and libraries provided by the Operator SDK.
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -1,4 +1,4 @@
-# User Guide
+# Operator SDK User Guide
 
 This guide walks through an example of building a simple memcached-operator using the operator-sdk CLI tool and controller-runtime library API. To learn how to use Ansible or Helm to create an operator, see the [Ansible Operator User Guide][ansible_user_guide] or the [Helm Operator User Guide][helm_user_guide]. The rest of this document will show how to program an operator in Go.
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adds context to titles of user guides for easier searchability.

**Motivation for the change:**
See issue #1905.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #1905

-->