### PR TITLE
doc/dev/release.md: add statement ppcle64 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added flag `--dep-manager` to command [`operator-sdk print-deps`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#print-deps) to specify the type of dependency manager file to print. The choice of dependency manager is inferred from top-level dependency manager files present if `--dep-manager` is not set. ([#1819](https://github.com/operator-framework/operator-sdk/pull/1819))
 - Ansible based operators now gather and serve metrics about each custom resource on port 8686 of the metrics service. ([#1723](https://github.com/operator-framework/operator-sdk/pull/1723))
 - Added the Go version, OS, and architecture to the output of `operator-sdk version` ([#1863](https://github.com/operator-framework/operator-sdk/pull/1863))
+- Added support for `ppc64le-linux` for the `operator-sdk` binary and the Helm operator base image. ([#1533](https://github.com/operator-framework/operator-sdk/pull/1533))
 
 ### Changed
 

--- a/doc/dev/release.md
+++ b/doc/dev/release.md
@@ -22,9 +22,11 @@ As the Operator SDK interacts directly with the Kubernetes API, certain API feat
 
 ### Operating systems and architectures
 
-Release binaries will be built for the `x86_64` architecture for both GNU Linux and MacOS Darwin platforms.
+Release binaries will be built for the `x86_64` architecture for both GNU Linux and MacOS Darwin platforms and for the `ppc64le` architecture for GNU Linux.
 
-Support for the Windows platform or any architecture other than `x86_64` is not on the roadmap at this time.
+Base images for ansible-operator, helm-operator, and scorecard-proxy will be built for the `x86_64` architecture for GNU Linux. Base images for the `ppc64le` architecture for GNU Linux are a work-in-progress.
+
+Support for the Windows platform is not on the roadmap at this time.
 
 ## Binaries and signatures
 


### PR DESCRIPTION
**Description of the change:**
- As a follow-up to #1533, updates the developer release documentation to include the new support for the `ppc64le` binary and helm-operator base image.
- Add a line to the CHANGELOG for #1533.

**Motivation for the change:**
To ensure that SDK developers are aware of the new support for `ppc64le`.
