### PR TITLE
hack/tests: remove tty setup in e2e usage of kubectl run

### DIFF
--- a/ci/tests/e2e-ansible.sh
+++ b/ci/tests/e2e-ansible.sh
@@ -50,6 +50,8 @@ remove_operator() {
 }
 
 test_operator() {
+    local metrics_test_image="registry.access.redhat.com/ubi8/ubi-minimal:latest"
+
     # wait for operator pod to run
     if ! timeout 1m kubectl rollout status deployment/memcached-operator;
     then
@@ -71,7 +73,7 @@ test_operator() {
     fi
 
     # verify that the metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8383/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run --attach --rm --restart=Never test-metrics --image=$metrics_test_image -- curl -sfo /dev/null http://memcached-operator-metrics:8383/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
         kubectl describe pods
@@ -81,7 +83,7 @@ test_operator() {
     fi
 
     # verify that the operator metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8686/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run --attach --rm --restart=Never test-metrics --image=$metrics_test_image -- curl -sfo /dev/null http://memcached-operator-metrics:8686/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
         kubectl describe pods
@@ -102,7 +104,7 @@ test_operator() {
     fi
 
     # verify that metrics reflect cr creation
-    if ! bash -c -- 'kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached';
+    if ! bash -c -- "kubectl run --attach --rm --restart=Never test-metrics --image=$metrics_test_image -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached";
     then
         echo "Failed to verify custom resource metrics"
         kubectl describe pods


### PR DESCRIPTION
**Description of the change:**
Remove `-t` flag, which unnecessarily enables a TTY for `kubectl run` commands that test metrics endpoints in ansible and helm e2e tests.

**Motivation for the change:**
Following up from #1864, making similar changes to e2e scripts used in Travis, this should fix some flakes that happen periodically with helm and ansible e2e tests.
