### PR TITLE
Version flag

### DIFF
--- a/cmd/operator-sdk/scorecard/cmd.go
+++ b/cmd/operator-sdk/scorecard/cmd.go
@@ -37,7 +37,7 @@ func NewCmd() *cobra.Command {
 	scorecardCmd.Flags().String(scorecard.ConfigOpt, "", fmt.Sprintf("config file (default is '<project_dir>/%s'; the config file's extension and format can be .yaml, .json, or .toml)", scorecard.DefaultConfigFile))
 	scorecardCmd.Flags().String(scplugins.KubeconfigOpt, "", "Path to kubeconfig of custom resource created in cluster")
 	scorecardCmd.Flags().StringP(scorecard.OutputFormatOpt, "o", scorecard.TextOutputFormat, fmt.Sprintf("Output format for results. Valid values: %s, %s", scorecard.TextOutputFormat, scorecard.JSONOutputFormat))
-	scorecardCmd.Flags().String(schelpers.VersionOpt, schelpers.DefaultScorecardVersion, fmt.Sprintf("scorecard version (experimental version is '%s'", schelpers.LatestScorecardVersion))
+	scorecardCmd.Flags().String(schelpers.VersionOpt, schelpers.DefaultScorecardVersion, fmt.Sprintf("scorecard version (tech preview version is '%s'", schelpers.LatestScorecardVersion))
 
 	// TODO: make config file global and make this a top level flag
 	viper.BindPFlag(scorecard.ConfigOpt, scorecardCmd.Flags().Lookup(scorecard.ConfigOpt))

--- a/cmd/operator-sdk/scorecard/cmd.go
+++ b/cmd/operator-sdk/scorecard/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/operator-framework/operator-sdk/internal/pkg/scorecard"
+	schelpers "github.com/operator-framework/operator-sdk/internal/pkg/scorecard/helpers"
 	scplugins "github.com/operator-framework/operator-sdk/internal/pkg/scorecard/plugins"
 
 	"github.com/spf13/cobra"
@@ -36,12 +37,14 @@ func NewCmd() *cobra.Command {
 	scorecardCmd.Flags().String(scorecard.ConfigOpt, "", fmt.Sprintf("config file (default is '<project_dir>/%s'; the config file's extension and format can be .yaml, .json, or .toml)", scorecard.DefaultConfigFile))
 	scorecardCmd.Flags().String(scplugins.KubeconfigOpt, "", "Path to kubeconfig of custom resource created in cluster")
 	scorecardCmd.Flags().StringP(scorecard.OutputFormatOpt, "o", scorecard.TextOutputFormat, fmt.Sprintf("Output format for results. Valid values: %s, %s", scorecard.TextOutputFormat, scorecard.JSONOutputFormat))
+	scorecardCmd.Flags().String(schelpers.VersionOpt, schelpers.DefaultScorecardVersion, fmt.Sprintf("scorecard version (experimental version is '%s'", schelpers.LatestScorecardVersion))
 
 	// TODO: make config file global and make this a top level flag
 	viper.BindPFlag(scorecard.ConfigOpt, scorecardCmd.Flags().Lookup(scorecard.ConfigOpt))
 
 	viper.BindPFlag("scorecard."+scplugins.KubeconfigOpt, scorecardCmd.Flags().Lookup(scplugins.KubeconfigOpt))
 	viper.BindPFlag("scorecard."+scorecard.OutputFormatOpt, scorecardCmd.Flags().Lookup(scorecard.OutputFormatOpt))
+	viper.BindPFlag("scorecard."+schelpers.VersionOpt, scorecardCmd.Flags().Lookup(schelpers.VersionOpt))
 
 	return scorecardCmd
 }

--- a/go.mod
+++ b/go.mod
@@ -113,5 +113,3 @@ replace (
 )
 
 replace github.com/operator-framework/operator-lifecycle-manager => github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190605231540-b8a4faf68e36
-
-replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -113,3 +113,5 @@ replace (
 )
 
 replace github.com/operator-framework/operator-lifecycle-manager => github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190605231540-b8a4faf68e36
+
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0

--- a/internal/pkg/scorecard/helpers/versions.go
+++ b/internal/pkg/scorecard/helpers/versions.go
@@ -1,0 +1,58 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schelpers
+
+import (
+	"fmt"
+	"github.com/spf13/viper"
+	"strings"
+)
+
+const V1alpha1 = "v1alpha1"
+const V1alpha2 = "v1alpha2"
+const DefaultScorecardVersion = V1alpha1
+const LatestScorecardVersion = V1alpha2
+const VersionOpt = "version"
+
+var ScorecardVersions = []string{DefaultScorecardVersion, LatestScorecardVersion}
+
+func ValidateVersion(version string) error {
+	validVersion := false
+	for _, a := range ScorecardVersions {
+		if a == version {
+			validVersion = true
+			break
+		}
+	}
+	if !validVersion {
+		return fmt.Errorf("invalid scorecard version (%s); valid values: %s", version, strings.Join(ScorecardVersions, ", "))
+	}
+	return nil
+
+}
+
+func IsV1alpha2() bool {
+	if viper.Sub("scorecard").GetString(VersionOpt) == V1alpha2 {
+		return true
+	}
+	return false
+}
+
+func IsLatestVersion() bool {
+	if viper.Sub("scorecard").GetString(VersionOpt) == LatestScorecardVersion {
+		return true
+	}
+	return false
+}

--- a/internal/pkg/scorecard/helpers/versions.go
+++ b/internal/pkg/scorecard/helpers/versions.go
@@ -20,31 +20,26 @@ import (
 	"strings"
 )
 
-const V1alpha1 = "v1alpha1"
-const V1alpha2 = "v1alpha2"
-const DefaultScorecardVersion = V1alpha1
-const LatestScorecardVersion = V1alpha2
+const v1alpha1 = "v1alpha1"
+const v1alpha2 = "v1alpha2"
+const DefaultScorecardVersion = v1alpha1
+const LatestScorecardVersion = v1alpha2
 const VersionOpt = "version"
 
 var ScorecardVersions = []string{DefaultScorecardVersion, LatestScorecardVersion}
 
 func ValidateVersion(version string) error {
-	validVersion := false
 	for _, a := range ScorecardVersions {
 		if a == version {
-			validVersion = true
-			break
+			return nil
 		}
 	}
-	if !validVersion {
-		return fmt.Errorf("invalid scorecard version (%s); valid values: %s", version, strings.Join(ScorecardVersions, ", "))
-	}
-	return nil
+	return fmt.Errorf("invalid scorecard version (%s); valid values: %s", version, strings.Join(ScorecardVersions, ", "))
 
 }
 
 func IsV1alpha2() bool {
-	if viper.Sub("scorecard").GetString(VersionOpt) == V1alpha2 {
+	if viper.Sub("scorecard").GetString(VersionOpt) == v1alpha2 {
 		return true
 	}
 	return false

--- a/internal/pkg/scorecard/helpers/versions_test.go
+++ b/internal/pkg/scorecard/helpers/versions_test.go
@@ -1,0 +1,44 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schelpers
+
+import (
+	"testing"
+)
+
+func TestValidateVersions(t *testing.T) {
+	cases := []struct {
+		name      string
+		version   string
+		result    []string
+		wantError bool
+	}{
+		{"empty", "", nil, true},
+		{"invalidVersion", "invalidVersion", nil, true},
+		{"v1alpha1", V1alpha1, nil, false},
+		{"v1alpha2", V1alpha2, nil, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateVersion(c.version)
+			if err != nil && !c.wantError {
+				t.Errorf("Wanted result %+q, got error: %v", c.result, err)
+			} else if err == nil && c.wantError {
+				t.Errorf("Wanted error, got nil")
+			}
+		})
+	}
+}

--- a/internal/pkg/scorecard/helpers/versions_test.go
+++ b/internal/pkg/scorecard/helpers/versions_test.go
@@ -27,8 +27,8 @@ func TestValidateVersions(t *testing.T) {
 	}{
 		{"empty", "", nil, true},
 		{"invalidVersion", "invalidVersion", nil, true},
-		{"v1alpha1", V1alpha1, nil, false},
-		{"v1alpha2", V1alpha2, nil, false},
+		{"v1alpha1", v1alpha1, nil, false},
+		{"v1alpha2", v1alpha2, nil, false},
 	}
 
 	for _, c := range cases {

--- a/internal/pkg/scorecard/plugins/basic_tests.go
+++ b/internal/pkg/scorecard/plugins/basic_tests.go
@@ -162,6 +162,13 @@ func (t *WritingIntoCRsHasEffectTest) Run(ctx context.Context) *schelpers.TestRe
 			break
 		}
 	}
+
+	if schelpers.IsV1alpha2() {
+		fmt.Println("jeff version is v1alpha2 in basic tests")
+	} else {
+		fmt.Println("jeff version is NOT v1alpha2 in basic tests")
+	}
+
 	if res.EarnedPoints != 1 {
 		res.Suggestions = append(res.Suggestions, "The operator should write into objects to update state. No PUT or POST requests from the operator were recorded by the scorecard.")
 	}

--- a/internal/pkg/scorecard/plugins/basic_tests.go
+++ b/internal/pkg/scorecard/plugins/basic_tests.go
@@ -163,12 +163,6 @@ func (t *WritingIntoCRsHasEffectTest) Run(ctx context.Context) *schelpers.TestRe
 		}
 	}
 
-	if schelpers.IsV1alpha2() {
-		fmt.Println("jeff version is v1alpha2 in basic tests")
-	} else {
-		fmt.Println("jeff version is NOT v1alpha2 in basic tests")
-	}
-
 	if res.EarnedPoints != 1 {
 		res.Suggestions = append(res.Suggestions, "The operator should write into objects to update state. No PUT or POST requests from the operator were recorded by the scorecard.")
 	}

--- a/internal/pkg/scorecard/plugins/resource_handler.go
+++ b/internal/pkg/scorecard/plugins/resource_handler.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"time"
 
+	schelpers "github.com/operator-framework/operator-sdk/internal/pkg/scorecard/helpers"
 	"github.com/operator-framework/operator-sdk/internal/util/yamlutil"
 	proxyConf "github.com/operator-framework/operator-sdk/pkg/ansible/proxy/kubeconfig"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -169,6 +170,13 @@ func getPodFromDeployment(depName, namespace string) (pod *v1.Pod, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get newly created deployment: %v", err)
 	}
+
+	if schelpers.IsV1alpha2() {
+		fmt.Println("jeff version is v1alpha2 in resource handler")
+	} else {
+		fmt.Println("jeff version is NOT v1alpha2 in resource handler")
+	}
+
 	// In some cases, the pod from the old deployment will be picked up
 	// instead of the new one.
 	err = wait.PollImmediate(time.Second*1, time.Second*60, func() (bool, error) {

--- a/internal/pkg/scorecard/plugins/resource_handler.go
+++ b/internal/pkg/scorecard/plugins/resource_handler.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"time"
 
-	schelpers "github.com/operator-framework/operator-sdk/internal/pkg/scorecard/helpers"
 	"github.com/operator-framework/operator-sdk/internal/util/yamlutil"
 	proxyConf "github.com/operator-framework/operator-sdk/pkg/ansible/proxy/kubeconfig"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -169,12 +168,6 @@ func getPodFromDeployment(depName, namespace string) (pod *v1.Pod, err error) {
 	err = runtimeClient.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: depName}, dep)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get newly created deployment: %v", err)
-	}
-
-	if schelpers.IsV1alpha2() {
-		fmt.Println("jeff version is v1alpha2 in resource handler")
-	} else {
-		fmt.Println("jeff version is NOT v1alpha2 in resource handler")
 	}
 
 	// In some cases, the pod from the old deployment will be picked up

--- a/internal/pkg/scorecard/scorecard.go
+++ b/internal/pkg/scorecard/scorecard.go
@@ -111,6 +111,14 @@ func ScorecardTests(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	if schelpers.IsV1alpha2() {
+		fmt.Println("jeff in scorecard.go with v1alpha2")
+	}
+	if schelpers.IsLatestVersion() {
+		fmt.Println("jeff in scorecard.go with latest scorecard version")
+	}
+
 	var pluginOutputs []scapiv1alpha1.ScorecardOutput
 	for _, plugin := range plugins {
 		pluginOutputs = append(pluginOutputs, plugin.Run())
@@ -223,7 +231,9 @@ func validateScorecardConfig() error {
 	if outputFormat != TextOutputFormat && outputFormat != JSONOutputFormat {
 		return fmt.Errorf("invalid output format (%s); valid values: %s, %s", outputFormat, TextOutputFormat, JSONOutputFormat)
 	}
-	return nil
+
+	return schelpers.ValidateVersion(scViper.GetString(schelpers.VersionOpt))
+
 }
 
 func makeSCViper() {
@@ -231,6 +241,8 @@ func makeSCViper() {
 	// this is a workaround for the fact that nested flags don't persist on viper.Sub
 	scViper.Set(OutputFormatOpt, viper.GetString("scorecard."+OutputFormatOpt))
 	scViper.Set(scplugins.KubeconfigOpt, viper.GetString("scorecard."+scplugins.KubeconfigOpt))
+	scViper.Set(schelpers.VersionOpt, viper.GetString("scorecard."+schelpers.VersionOpt))
+
 }
 
 func configDocLink() string {

--- a/internal/pkg/scorecard/scorecard.go
+++ b/internal/pkg/scorecard/scorecard.go
@@ -112,13 +112,6 @@ func ScorecardTests(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if schelpers.IsV1alpha2() {
-		fmt.Println("jeff in scorecard.go with v1alpha2")
-	}
-	if schelpers.IsLatestVersion() {
-		fmt.Println("jeff in scorecard.go with latest scorecard version")
-	}
-
 	var pluginOutputs []scapiv1alpha1.ScorecardOutput
 	for _, plugin := range plugins {
 		pluginOutputs = append(pluginOutputs, plugin.Run())


### PR DESCRIPTION


**Description of the change:**
This PR adds a version flag to the operator-sdk scorecard subcommand which will support
the ability of the end user to specify which version of the scorecard they want to run.

With this flag added, typical usage in code looks like:

        if schelpers.IsV1alpha2() {
                // v1alpha2 logic
        }

The version command option is allowed on the scorecard CLI command line or
within the scorecard configuration file.

If not set, the version value is v1alpha1 which represents the current scorecard implementation.

This PR includes code to validate the version:  v1alpha1, v1alpha2 being the valid choices

When a user specifies an invalid version an error is reported as follows:

        $ operator-sdk scorecard --version foomatic
        Error: invalid scorecard version (foomatic); valid values: v1alpha1, v1alpha2
        Usage:
          operator-sdk scorecard [flags]


This PR provides the version implementation within the schelpers package can can imported within the scorecard and scplugins packages when needed.

The PR includes a unit test which tests the version validation logic.


**Motivation for the change:**

This PR supports a future scorecard implementation and allows the scorecard to support different implementations by switching upon the requested version.

