### PR TITLE
add regex validation in the group names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Added flag `--dep-manager` to command [`operator-sdk print-deps`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#print-deps) to specify the type of dependency manager file to print. The choice of dependency manager is inferred from top-level dependency manager files present if `--dep-manager` is not set. ([#1819](https://github.com/operator-framework/operator-sdk/pull/1819))
 - Ansible based operators now gather and serve metrics about each custom resource on port 8686 of the metrics service. ([#1723](https://github.com/operator-framework/operator-sdk/pull/1723))
 - Added the Go version, OS, and architecture to the output of `operator-sdk version` ([#1863](https://github.com/operator-framework/operator-sdk/pull/1863))
-
+- Added Resource Group validation with the regex `^[a-z-]+$`. ([#1951](https://github.com/operator-framework/operator-sdk/pull/1951))
+ 
 ### Changed
 
 - The Helm operator now uses the CR name for the release name for newly created CRs. Existing CRs will continue to use their existing UID-based release name. When a release name collision occurs (when CRs of different types share the same name), the second CR will fail to install with an error about a duplicate name. ([#1818](https://github.com/operator-framework/operator-sdk/pull/1818))

--- a/internal/pkg/scaffold/resource.go
+++ b/internal/pkg/scaffold/resource.go
@@ -32,6 +32,8 @@ var (
 	ResourceVersionRegexp = regexp.MustCompile("^v[1-9][0-9]*((alpha|beta)[1-9][0-9]*)?$")
 	// ResourceKindRegexp matches Kubernetes API Kind's.
 	ResourceKindRegexp = regexp.MustCompile("^[A-Z]{1}[a-zA-Z0-9]+$")
+	// GroupRegexp matches Kubernetes API Kind's.
+	ResourceGroupRegexp = regexp.MustCompile("^[a-z-]+$")
 )
 
 // Resource contains the information required to scaffold files for a resource.
@@ -126,6 +128,10 @@ func (r *Resource) checkAndSetGroups() error {
 	if len(g) == 0 || len(g[0]) == 0 {
 		return errors.New("group cannot be empty")
 	}
+	if !ResourceGroupRegexp.MatchString(g[0]) {
+		return fmt.Errorf("group must match %s (was %s)", ResourceGroupRegexp, g[0])
+	}
+
 	r.FullGroup = fg[0]
 	r.Group = g[0]
 


### PR DESCRIPTION
**Description of the change:**
I as Operator user would like to not be able to create resources with invalid group names

**Motivation for the change:**
- https://jira.coreos.com/browse/OSDK-554
- https://github.com/operator-framework/operator-sdk/issues/1812
- https://github.com/operator-framework/operator-sdk/issues/1368

