### PR TITLE
Makefile: add help to major targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,20 +30,29 @@ export CGO_ENABLED:=0
 export GO111MODULE:=on
 export GOPROXY?=https://proxy.golang.org/
 
-all: format test build/operator-sdk
+all: format test build/operator-sdk ## Test and Build the Operator SDK
 
-format:
+format: ## Format the source code
 	$(Q)go fmt $(PKGS)
 
-tidy:
+tidy: ## Update dependencies
 	$(Q)go mod tidy -v
 
-clean:
+clean: ## Clean up the build artifacts
 	$(Q)rm -rf build
 
-.PHONY: all test format tidy clean
+help: ## Show this help screen
+	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
+	@echo ''
+	@echo 'Available targets are:'
+	@echo ''
+	@grep -E '^[ a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@echo ''
 
-install:
+.PHONY: all test format tidy clean help
+
+install: ## Build & install the Operator SDK CLI binary
 	$(Q)go install \
 		-gcflags "all=-trimpath=${GOPATH}" \
 		-asmflags "all=-trimpath=${GOPATH}" \
@@ -63,7 +72,7 @@ release_builds := \
 	build/operator-sdk-$(VERSION)-x86_64-apple-darwin \
 	build/operator-sdk-$(VERSION)-ppc64le-linux-gnu
 
-release: clean $(release_builds) $(release_builds:=.asc)
+release: clean $(release_builds) $(release_builds:=.asc) ## Release the Operator SDK
 
 build/operator-sdk-%-x86_64-linux-gnu: GOARGS = GOOS=linux GOARCH=amd64
 build/operator-sdk-%-x86_64-apple-darwin: GOARGS = GOOS=darwin GOARCH=amd64
@@ -95,9 +104,9 @@ build/%.asc:
 
 .PHONY: install release_builds release
 
-test: test/unit
+test: test/unit ## Run the tests
 
-test-ci: test/markdown test/sanity test/unit install test/subcommand test/e2e
+test-ci: test/markdown test/sanity test/unit install test/subcommand test/e2e ## Run the CI test suite
 
 test/ci-go: test/subcommand test/e2e/go
 
@@ -108,7 +117,7 @@ test/ci-helm: test/e2e/helm
 test/sanity: tidy
 	./hack/tests/sanity-check.sh
 
-test/unit:
+test/unit: ## Run the unit tests
 	$(Q)go test -count=1 -short ./cmd/...
 	$(Q)go test -count=1 -short ./pkg/...
 	$(Q)go test -count=1 -short ./internal/...
@@ -130,7 +139,7 @@ test/subcommand/scorecard2:
 test/subcommand/alpha-olm:
 	./hack/tests/alpha-olm-subcommands.sh
 
-test/e2e: test/e2e/go test/e2e/ansible test/e2e/ansible-molecule test/e2e/helm
+test/e2e: test/e2e/go test/e2e/ansible test/e2e/ansible-molecule test/e2e/helm ## Run the e2e tests
 
 test/e2e/go:
 	./hack/tests/e2e-go.sh $(ARGS)
@@ -158,7 +167,7 @@ test/markdown:
 
 .PHONY: test test-ci test/sanity test/unit test/subcommand test/subcommand/test-local test/subcommand/scorecard test/subcommand/alpha-olm test/e2e test/e2e/go test/e2e/ansible test/e2e/ansible-molecule test/e2e/helm test/ci-go test/ci-ansible test/ci-helm test/markdown
 
-image: image/build image/push
+image: image/build image/push ## Build and push all images
 
 image/scaffold/ansible:
 	go run ./hack/image/ansible/scaffold-ansible-image.go
@@ -166,7 +175,7 @@ image/scaffold/ansible:
 image/scaffold/helm:
 	go run ./hack/image/helm/scaffold-helm-image.go
 
-image/build: image/build/ansible image/build/helm image/build/scorecard-proxy
+image/build: image/build/ansible image/build/helm image/build/scorecard-proxy ## Build all images
 
 image/build/ansible: build/operator-sdk-dev-x86_64-linux-gnu
 	./hack/image/build-ansible-image.sh $(ANSIBLE_BASE_IMAGE):dev
@@ -177,7 +186,7 @@ image/build/helm: build/operator-sdk-dev
 image/build/scorecard-proxy:
 	./hack/image/build-scorecard-proxy-image.sh $(SCORECARD_PROXY_BASE_IMAGE):dev
 
-image/push: image/push/ansible image/push/helm image/push/scorecard-proxy
+image/push: image/push/ansible image/push/helm image/push/scorecard-proxy ## Push all images
 
 image/push/ansible:
 	./hack/image/push-image-tags.sh $(ANSIBLE_BASE_IMAGE):dev $(ANSIBLE_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ HELM_ARCHES:="amd64" "ppc64le"
 export CGO_ENABLED:=0
 export GO111MODULE:=on
 export GOPROXY?=https://proxy.golang.org/
+.DEFAULT_GOAL:=help
 
 all: format test build/operator-sdk ## Test and Build the Operator SDK
 


### PR DESCRIPTION
Makefiles can sometimes be cumbersome to read. This little patch allows
you to run `make help` and see what targets do and what's available.

Right now I didn't document all the ones with / in them but we can certainly
add support for that. I hope I got the help messages right.

Closes: #1950