### PR TITLE
Use the old setup logic to work around failing builds

### DIFF
--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -39,18 +39,15 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
 # install operator binary
 COPY --from=builder /memcached-operator ${OPERATOR}
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/library/k8s_status.py /usr/share/ansible/openshift/
-COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/bin/ao-logs /usr/local/bin/ao-logs
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/bin/* /usr/local/bin/
 COPY --from=builder /ansible/memcached-operator/watches.yaml ${HOME}/watches.yaml
 COPY --from=builder /ansible/memcached-operator/roles/ ${HOME}/roles/
 
-# Ensure directory permissions are properly set
-RUN mkdir -p ${HOME}/.ansible/tmp \
- && chown -R ${USER_UID}:0 ${HOME} \
- && chmod -R ug+rwx ${HOME}
+RUN /usr/local/bin/user_setup
 
 ADD https://github.com/krallin/tini/releases/latest/download/tini /tini
 RUN chmod +x /tini
 
-ENTRYPOINT ["/tini", "--", "bash", "-c", "${OPERATOR} run ansible --watches-file=/opt/ansible/watches.yaml $@"]
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/entrypoint"]
 
 USER ${USER_UID}

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -36,16 +36,13 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
 
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/build/operator-sdk ${OPERATOR}
 COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/library/k8s_status.py /usr/share/ansible/openshift/
-COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/bin/ao-logs /usr/local/bin/ao-logs
+COPY --from=builder /go/src/github.com/operator-framework/operator-sdk/bin/* /usr/local/bin/
 
-# Ensure directory permissions are properly set
-RUN mkdir -p ${HOME}/.ansible/tmp \
- && chown -R ${USER_UID}:0 ${HOME} \
- && chmod -R ug+rwx ${HOME}
+RUN /usr/local/bin/user_setup
 
 ADD https://github.com/krallin/tini/releases/latest/download/tini /tini
 RUN chmod +x /tini
 
-ENTRYPOINT ["/tini", "--", "bash", "-c", "${OPERATOR} run ansible --watches-file=/opt/ansible/watches.yaml $@"]
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/entrypoint"]
 
 USER ${USER_UID}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Move back to manual set up of /etc/passwd


**Motivation for the change:**
/etc/passwd is no longer being properly created

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
