### PR TITLE
ServiceMonitor fixes

### DIFF
--- a/pkg/metrics/service-monitor.go
+++ b/pkg/metrics/service-monitor.go
@@ -96,7 +96,7 @@ func GenerateServiceMonitor(s *v1.Service) *monitoringv1.ServiceMonitor {
 func populateEndpointsFromServicePorts(s *v1.Service) []monitoringv1.Endpoint {
 	var endpoints []monitoringv1.Endpoint
 	for _, port := range s.Spec.Ports {
-		endpoints = append(endpoints, monitoringv1.Endpoint{Port: port.Name})
+		endpoints = append(endpoints, monitoringv1.Endpoint{Port: port.Name, Path: "/metrics"})
 	}
 	return endpoints
 }


### PR DESCRIPTION
Without this, while the ServiceMonitor gets created fine, Prometheus
looks in the wrong place, and doesn't pick up on any metrics.

I've also tried to add the ability to set additional labels on the ServiceMonitor here.

When provisioning a Prometheus server with a Prometheus CR, one often
specifies a ServiceMonitorSelector. In this case, this Prometheus will only
scrape metrics from endpoints that are specified in ServiceMonitors
that are selected based on the labels specified in the
ServiceMonitorSelector.

Without the ability to set a label on the ServiceMonitor, then many
people would have to either not use the utility function from here, or
update the resource after creation.