### PR TITLE
bugfix: error in Do will never return to outer scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bug Fixes
 
+- OLM internal manager is not returning errors in the initialization. ([#1976](https://github.com/operator-framework/operator-sdk/pull/1976))
+
 ## v0.11.0
 
 ### Added

--- a/internal/olm/manager.go
+++ b/internal/olm/manager.go
@@ -42,15 +42,15 @@ type Manager struct {
 func (m *Manager) initialize() (err error) {
 	m.once.Do(func() {
 		if m.Client == nil {
-			cfg, err := config.GetConfig()
-			if err != nil {
-				err = errors.Wrapf(err, "failed to get Kubernetes config")
+			cfg, cerr := config.GetConfig()
+			if cerr != nil {
+				err = errors.Wrapf(cerr, "failed to get Kubernetes config")
 				return
 			}
 
-			client, err := ClientForConfig(cfg)
-			if err != nil {
-				err = errors.Wrapf(err, "failed to create manager client")
+			client, cerr := ClientForConfig(cfg)
+			if cerr != nil {
+				err = errors.Wrapf(cerr, "failed to create manager client")
 				return
 			}
 			m.Client = client


### PR DESCRIPTION

**Description of the change:**
func in `Do` declared a new local err, it will never be return to outer scope.

**Motivation for the change:**
fix this bug
