### PR TITLE
Update v0.1.0 migration guide

### DIFF
--- a/doc/migration/v0.1.0-migration-guide.md
+++ b/doc/migration/v0.1.0-migration-guide.md
@@ -18,7 +18,7 @@ operator-sdk version 0.1.0
 # Create new project
 $ cd $GOPATH/src/github.com/example-inc/
 $ mv memcached-operator old-memcached-operator
-$ operator-sdk new memcached-operator --skip-git-init
+$ operator-sdk new memcached-operator
 $ ls
 memcached-operator old-memcached-operator
 


### PR DESCRIPTION
`--skip-git-init` is not available in the latest release.
There's a `--git-init` flag, which defaults to `false`. So, we can omit that flag.