### PR TITLE
Revert "Operator developers gets UBI8 based images (for all less Ansible) (#1952)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 - Commands [`olm uninstall`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#uninstall) and [`olm status`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#status) no longer use a `--version` flag to specify OLM version. This information is now retrieved from the running cluster. ([#1634](https://github.com/operator-framework/operator-sdk/pull/1634))
 - The Helm operator no longer prints manifest diffs in the operator log at verbosity levels lower than INFO ([#1857](https://github.com/operator-framework/operator-sdk/pull/1857))
 - CRD manifest `spec.version` is still supported, but users will see a warning message if `spec.versions` is not present and an error if `spec.versions` is populated but the version in `spec.version` is not in `spec.versions`. ([#1876](https://github.com/operator-framework/operator-sdk/pull/1876))
-- Upgrade base image for Go, Helm, and scorecard proxy from `registry.access.redhat.com/ubi7/ubi-minimal:latest` to `registry.access.redhat.com/ubi8/ubi-minimal:latest`. ([#1952](https://github.com/operator-framework/operator-sdk/pull/1952))
 
 ### Breaking changes
 

--- a/ci/dockerfiles/go-e2e.Dockerfile
+++ b/ci/dockerfiles/go-e2e.Dockerfile
@@ -2,7 +2,7 @@ FROM osdk-builder as builder
 
 RUN ci/tests/e2e-go-scaffold.sh
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/memcached-operator \
     USER_UID=1001 \

--- a/ci/dockerfiles/helm-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/helm-e2e-hybrid.Dockerfile
@@ -3,7 +3,7 @@ FROM osdk-builder as builder
 RUN make image/scaffold/helm
 RUN ci/tests/e2e-helm-scaffold-hybrid.sh
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/helm-operator \
     USER_UID=1001 \

--- a/ci/dockerfiles/helm.Dockerfile
+++ b/ci/dockerfiles/helm.Dockerfile
@@ -2,7 +2,7 @@ FROM osdk-builder as builder
 
 RUN make image/scaffold/helm
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/helm-operator \
     USER_UID=1001 \

--- a/ci/dockerfiles/scorecard-proxy.Dockerfile
+++ b/ci/dockerfiles/scorecard-proxy.Dockerfile
@@ -2,7 +2,7 @@ FROM osdk-builder as builder
 
 RUN ci/tests/scorecard-proxy-scaffold.sh
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 ENV PROXY=/usr/local/bin/scorecard-proxy \
     USER_UID=1001 \

--- a/ci/tests/e2e-helm.sh
+++ b/ci/tests/e2e-helm.sh
@@ -61,7 +61,7 @@ test_operator() {
     fi
 
     # verify that the metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator-metrics:8383/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator-metrics:8383/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
         kubectl logs deployment/nginx-operator

--- a/hack/tests/e2e-helm.sh
+++ b/hack/tests/e2e-helm.sh
@@ -42,7 +42,7 @@ test_operator() {
     fi
 
     # verify that the metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator-metrics:8383/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator-metrics:8383/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
         kubectl logs deployment/nginx-operator
@@ -59,7 +59,7 @@ test_operator() {
     fi
 
     # verify that the custom resource metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-cr-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator-metrics:8686/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-cr-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://nginx-operator-metrics:8686/metrics; do sleep 1; done";
     then
         echo "Failed to verify that custom resource metrics endpoint exists"
         kubectl logs deployment/nginx-operator

--- a/images/scorecard-proxy/Dockerfile
+++ b/images/scorecard-proxy/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 ENV PROXY=/usr/local/bin/scorecard-proxy \
     USER_UID=1001 \

--- a/internal/pkg/scaffold/build_dockerfile.go
+++ b/internal/pkg/scaffold/build_dockerfile.go
@@ -34,7 +34,7 @@ func (s *Dockerfile) GetInput() (input.Input, error) {
 	return s.Input, nil
 }
 
-const dockerfileTmpl = `FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+const dockerfileTmpl = `FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/{{.ProjectName}} \
     USER_UID=1001 \

--- a/internal/pkg/scaffold/build_dockerfile_test.go
+++ b/internal/pkg/scaffold/build_dockerfile_test.go
@@ -33,7 +33,7 @@ func TestDockerfile(t *testing.T) {
 	}
 }
 
-const dockerfileExp = `FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+const dockerfileExp = `FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/app-operator \
     USER_UID=1001 \

--- a/internal/pkg/scaffold/helm/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/helm/dockerfilehybrid.go
@@ -41,7 +41,7 @@ func (d *DockerfileHybrid) GetInput() (input.Input, error) {
 	return d.Input, nil
 }
 
-const dockerFileHybridHelmTmpl = `FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+const dockerFileHybridHelmTmpl = `FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/helm-operator \
     USER_UID=1001 \


### PR DESCRIPTION
This reverts commit bef05f974012ea6698fc9292e8c34ebee7e99690.

Need to make sure ansible python3 bump happens at the same time as ubi8 bump.