### PR TITLE
Ansible ubi upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - The Helm operator no longer prints manifest diffs in the operator log at verbosity levels lower than INFO ([#1857](https://github.com/operator-framework/operator-sdk/pull/1857))
 - CRD manifest `spec.version` is still supported, but users will see a warning message if `spec.versions` is not present and an error if `spec.versions` is populated but the version in `spec.version` is not in `spec.versions`. ([#1876](https://github.com/operator-framework/operator-sdk/pull/1876))
 - Upgrade base image for Go, Helm, and scorecard proxy from `registry.access.redhat.com/ubi7/ubi-minimal:latest` to `registry.access.redhat.com/ubi8/ubi-minimal:latest`. ([#1952](https://github.com/operator-framework/operator-sdk/pull/1952))
+- Upgrade base image for Ansbile from `registry.access.redhat.com/ubi7/ubi:latest` to `registry.access.redhat.com/ubi8/ubi:latest`. ([#1990](https://github.com/operator-framework/operator-sdk/pull/1990))
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - The Helm operator no longer prints manifest diffs in the operator log at verbosity levels lower than INFO ([#1857](https://github.com/operator-framework/operator-sdk/pull/1857))
 - CRD manifest `spec.version` is still supported, but users will see a warning message if `spec.versions` is not present and an error if `spec.versions` is populated but the version in `spec.version` is not in `spec.versions`. ([#1876](https://github.com/operator-framework/operator-sdk/pull/1876))
 - Upgrade base image for Go, Helm, and scorecard proxy from `registry.access.redhat.com/ubi7/ubi-minimal:latest` to `registry.access.redhat.com/ubi8/ubi-minimal:latest`. ([#1952](https://github.com/operator-framework/operator-sdk/pull/1952))
-- Upgrade base image for Ansbile from `registry.access.redhat.com/ubi7/ubi:latest` to `registry.access.redhat.com/ubi8/ubi:latest`. ([#1990](https://github.com/operator-framework/operator-sdk/pull/1990))
+- Upgrade base image for Ansible from `registry.access.redhat.com/ubi7/ubi:latest` to `registry.access.redhat.com/ubi8/ubi:latest`. ([#1990](https://github.com/operator-framework/operator-sdk/pull/1990))
 
 ### Breaking changes
 

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -25,7 +25,7 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 RUN yum clean all && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
  && yum -y update \
- && yum install -y python36-devel gcc \
+ && yum install -y python36-devel python3-pip gcc \
  # Install inotify-tools. Note: rpm -i will install the rpm in the registry for allow yum install it.
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
  && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -23,9 +23,9 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 # Ensure fresh metadata rather than cached metadata in the base by running
 # yum clean all && rm -rf /var/yum/cache/* first
 RUN yum clean all && rm -rf /var/cache/yum/* \
- && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true) \
+ && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
  && yum -y update \
- && yum install -y python36-devel python36-pip gcc \
+ && yum install -y python36-devel gcc \
  # Install inotify-tools. Note: rpm -i will install the rpm in the registry for allow yum install it.
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
  && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -3,7 +3,7 @@ FROM osdk-builder as builder
 RUN make image/scaffold/ansible
 RUN ci/tests/e2e-ansible-scaffold-hybrid.sh
 
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi7/ubi
 
 # Temporary for CI, reset /etc/passwd
 RUN chmod 0644 /etc/passwd
@@ -22,12 +22,24 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 # Install python dependencies
 # Ensure fresh metadata rather than cached metadata in the base by running
 # yum clean all && rm -rf /var/yum/cache/* first
-RUN yum clean all && rm -rf /var/cache/yum/* \
- && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
- && yum -y update \
- && yum install -y python36-devel python3-pip gcc \
- # Install inotify-tools. Note: rpm -i will install the rpm in the registry for allow yum install it.
- && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
+RUN yum clean all && rm -rf /var/cache/yum/*
+
+# todo; remove ubi7 after CI be updated with images
+# ubi7
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 7'); then (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true); fi
+# ubi8
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 8'); then (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true); fi
+
+RUN yum -y update \
+ && yum install -y python36-devel gcc
+
+# ubi7
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 7'); then (yum install -y python36-pip || true); fi
+# ubi8
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 8'); then (yum install -y python3-pip || true); fi
+
+# Install inotify-tools. Note: rpm -i will install the rpm in the registry for allow yum install it.
+RUN curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
  && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
  && yum install inotify-tools \
  && pip3 install --upgrade setuptools pip \

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -27,22 +27,16 @@ RUN yum clean all && rm -rf /var/cache/yum/*
 # todo; remove ubi7 after CI be updated with images
 # ubi7
 RUN if $(cat /etc/redhat-release | grep --quiet 'release 7'); then (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true); fi
-# ubi8
-RUN if $(cat /etc/redhat-release | grep --quiet 'release 8'); then (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true); fi
 
 RUN yum -y update \
  && yum install -y python36-devel gcc
 
 # ubi7
-RUN if $(cat /etc/redhat-release | grep --quiet 'release 7'); then (yum install -y python36-pip || true); fi
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 7'); then (yum install -y python36-pip inotify-tools || true); fi
 # ubi8
-RUN if $(cat /etc/redhat-release | grep --quiet 'release 8'); then (yum install -y python3-pip || true); fi
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 8'); then (yum install -y python3-pip inotify3-tools || true); fi
 
-# Install inotify-tools. Note: rpm -i will install the rpm in the registry for allow yum install it.
-RUN curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
- && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
- && yum install inotify-tools \
- && pip3 install --upgrade setuptools pip \
+RUN pip3 install --upgrade setuptools pip \
  && pip install --no-cache-dir --ignore-installed ipaddress \
       ansible-runner==1.3.4 \
       ansible-runner-http==1.0.0 \

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -3,7 +3,7 @@ FROM osdk-builder as builder
 RUN make image/scaffold/ansible
 RUN ci/tests/e2e-ansible-scaffold-hybrid.sh
 
-FROM registry.access.redhat.com/ubi7/ubi
+FROM registry.access.redhat.com/ubi8/ubi
 
 # Temporary for CI, reset /etc/passwd
 RUN chmod 0644 /etc/passwd

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -2,7 +2,7 @@ FROM osdk-builder as builder
 
 RUN make image/scaffold/ansible
 
-FROM registry.access.redhat.com/ubi7/ubi
+FROM registry.access.redhat.com/ubi8/ubi
 
 # Temporary for CI, reset /etc/passwd
 RUN chmod 0644 /etc/passwd

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -26,22 +26,16 @@ RUN yum clean all && rm -rf /var/cache/yum/*
 # todo; remove ubi7 after CI be updated with images
 # ubi7
 RUN if $(cat /etc/redhat-release | grep --quiet 'release 7'); then (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true); fi
-# ubi8
-RUN if $(cat /etc/redhat-release | grep --quiet 'release 8'); then (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true); fi
 
 RUN yum -y update \
  && yum install -y python36-devel gcc
 
 # ubi7
-RUN if $(cat /etc/redhat-release | grep --quiet 'release 7'); then (yum install -y python36-pip || true); fi
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 7'); then (yum install -y python36-pip inotify-tools || true); fi
 # ubi8
-RUN if $(cat /etc/redhat-release | grep --quiet 'release 8'); then (yum install -y python3-pip || true); fi
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 8'); then (yum install -y python3-pip inotify3-tools || true); fi
 
-# Install inotify-tools. Note: rpm -i will install the rpm in the registry for allow yum install it.
-RUN curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
- && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
- && yum install inotify-tools \
- && pip3 install --upgrade setuptools pip \
+RUN pip3 install --upgrade setuptools pip \
  && pip install --no-cache-dir --ignore-installed ipaddress \
       ansible-runner==1.3.4 \
       ansible-runner-http==1.0.0 \

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -22,9 +22,9 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 # Ensure fresh metadata rather than cached metadata in the base by running
 # yum clean all && rm -rf /var/yum/cache/* first
 RUN yum clean all && rm -rf /var/cache/yum/* \
- && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true) \
+ && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
  && yum -y update \
- && yum install -y python36-devel python36-pip gcc \
+ && yum install -y python36-devel gcc \
  # Install inotify-tools. Note: rpm -i will install the rpm in the registry for allow yum install it.
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
  && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -24,7 +24,7 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 RUN yum clean all && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
  && yum -y update \
- && yum install -y python36-devel gcc \
+ && yum install -y python36-devel python3-pip gcc \
  # Install inotify-tools. Note: rpm -i will install the rpm in the registry for allow yum install it.
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
  && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -2,7 +2,7 @@ FROM osdk-builder as builder
 
 RUN make image/scaffold/ansible
 
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi7/ubi
 
 # Temporary for CI, reset /etc/passwd
 RUN chmod 0644 /etc/passwd
@@ -21,12 +21,24 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 # Install python dependencies
 # Ensure fresh metadata rather than cached metadata in the base by running
 # yum clean all && rm -rf /var/yum/cache/* first
-RUN yum clean all && rm -rf /var/cache/yum/* \
- && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
- && yum -y update \
- && yum install -y python36-devel python3-pip gcc \
- # Install inotify-tools. Note: rpm -i will install the rpm in the registry for allow yum install it.
- && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
+RUN yum clean all && rm -rf /var/cache/yum/*
+
+# todo; remove ubi7 after CI be updated with images
+# ubi7
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 7'); then (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true); fi
+# ubi8
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 8'); then (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true); fi
+
+RUN yum -y update \
+ && yum install -y python36-devel gcc
+
+# ubi7
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 7'); then (yum install -y python36-pip || true); fi
+# ubi8
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 8'); then (yum install -y python3-pip || true); fi
+
+# Install inotify-tools. Note: rpm -i will install the rpm in the registry for allow yum install it.
+RUN curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
  && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
  && yum install inotify-tools \
  && pip3 install --upgrade setuptools pip \

--- a/ci/tests/e2e-ansible.sh
+++ b/ci/tests/e2e-ansible.sh
@@ -71,7 +71,7 @@ test_operator() {
     fi
 
     # verify that the metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8383/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8383/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
         kubectl describe pods
@@ -81,7 +81,7 @@ test_operator() {
     fi
 
     # verify that the operator metrics endpoint exists
-    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8686/metrics; do sleep 1; done";
+    if ! timeout 1m bash -c -- "until kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl -sfo /dev/null http://memcached-operator-metrics:8686/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
         kubectl describe pods
@@ -102,7 +102,7 @@ test_operator() {
     fi
 
     # verify that metrics reflect cr creation
-    if ! bash -c -- 'kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi7/ubi-minimal:latest -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached';
+    if ! bash -c -- 'kubectl run -i --rm --restart=Never test-metrics --image=registry.access.redhat.com/ubi8/ubi-minimal:latest -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached';
     then
         echo "Failed to verify custom resource metrics"
         kubectl describe pods

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -36,7 +36,7 @@ building example-operator...
 
 building container quay.io/example/operator:v0.0.1...
 Sending build context to Docker daemon  163.9MB
-Step 1/4 : FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+Step 1/4 : FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
  ---> 77144d8c6bdc
 Step 2/4 : ADD tmp/_output/bin/example-operator /usr/local/bin/example-operator
  ---> 2ada0d6ca93c

--- a/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
+++ b/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
@@ -45,7 +45,7 @@ USER 0
 # yum clean all && rm -rf /var/yum/cache/* first
 RUN yum clean all && rm -rf /var/cache/yum/* \
  && yum -y update \ 
- && yum install -y python36-devel gcc libffi-devel
+ && yum install -y python36-devel python3-pip gcc libffi-devel
 RUN pip3 install --user molecule==2.22
 
 ARG NAMESPACEDMAN

--- a/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
+++ b/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
@@ -45,7 +45,13 @@ USER 0
 # yum clean all && rm -rf /var/yum/cache/* first
 RUN yum clean all && rm -rf /var/cache/yum/* \
  && yum -y update \ 
- && yum install -y python36-devel python3-pip gcc libffi-devel
+ && yum install -y python36-devel gcc libffi-devel
+
+# ubi7
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 7'); then (yum install -y python36-pip || true); fi
+# ubi8
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 8'); then (yum install -y python3-pip || true); fi
+
 RUN pip3 install --user molecule==2.22
 
 ARG NAMESPACEDMAN

--- a/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
+++ b/internal/pkg/scaffold/ansible/build_test_framework_dockerfile.go
@@ -45,7 +45,7 @@ USER 0
 # yum clean all && rm -rf /var/yum/cache/* first
 RUN yum clean all && rm -rf /var/cache/yum/* \
  && yum -y update \ 
- && yum install -y python36-devel python36-pip gcc libffi-devel
+ && yum install -y python36-devel gcc libffi-devel
 RUN pip3 install --user molecule==2.22
 
 ARG NAMESPACEDMAN

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -64,7 +64,7 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 RUN yum clean all && rm -rf /var/cache/yum/* \
  && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
  && yum -y update \
- && yum install -y python36-devel gcc \
+ && yum install -y python36-devel python3-pip gcc \
  # Install inotify-tools. Note: rpm -i will install the rpm in the registry for allow yum install it.
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
  && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -45,7 +45,7 @@ func (d *DockerfileHybrid) GetInput() (input.Input, error) {
 	return d.Input, nil
 }
 
-const dockerFileHybridAnsibleTmpl = `FROM registry.access.redhat.com/ubi7/ubi
+const dockerFileHybridAnsibleTmpl = `FROM registry.access.redhat.com/ubi8/ubi
 
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts \

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -66,22 +66,16 @@ RUN yum clean all && rm -rf /var/cache/yum/*
 # todo; remove ubi7 after CI be updated with images
 # ubi7
 RUN if $(cat /etc/redhat-release | grep --quiet 'release 7'); then (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true); fi
-# ubi8
-RUN if $(cat /etc/redhat-release | grep --quiet 'release 8'); then (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true); fi
 
 RUN yum -y update \
  && yum install -y python36-devel gcc
 
 # ubi7
-RUN if $(cat /etc/redhat-release | grep --quiet 'release 7'); then (yum install -y python36-pip || true); fi
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 7'); then (yum install -y python36-pip inotify-tools || true); fi
 # ubi8
-RUN if $(cat /etc/redhat-release | grep --quiet 'release 8'); then (yum install -y python3-pip || true); fi
+RUN if $(cat /etc/redhat-release | grep --quiet 'release 8'); then (yum install -y python3-pip inotify3-tools || true); fi
 
-# Install inotify-tools. Note: rpm -i will install the rpm in the registry for allow yum install it.
-RUN curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
- && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \
- && yum install inotify-tools \
- && pip3 install --upgrade setuptools pip \
+RUN pip3 install --upgrade setuptools pip \
  && pip install --no-cache-dir --ignore-installed ipaddress \
       ansible-runner==1.3.4 \
       ansible-runner-http==1.0.0 \

--- a/internal/pkg/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/pkg/scaffold/ansible/dockerfilehybrid.go
@@ -62,9 +62,9 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 # Ensure fresh metadata rather than cached metadata in the base by running
 # yum clean all && rm -rf /var/yum/cache/* first
 RUN yum clean all && rm -rf /var/cache/yum/* \
- && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true) \
+ && (yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm || true) \
  && yum -y update \
- && yum install -y python36-devel python36-pip gcc \
+ && yum install -y python36-devel gcc \
  # Install inotify-tools. Note: rpm -i will install the rpm in the registry for allow yum install it.
  && curl -O https://rpmfind.net/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/i/inotify-tools-3.14-16.fc30.x86_64.rpm \
  && rpm -i inotify-tools-3.14-16.fc30.x86_64.rpm \


### PR DESCRIPTION
**Description of the change:**
- Upgrade ansible images to use ubi8 instead of 7 (for now it has the conditionals to pass in both)

**NOTE:**
To use ubi8 is required:
-to upgrade epel from 7 to 8 as well.
-python3-pip instead of python36-pip

**Motivation**
https://github.com/operator-framework/operator-sdk/issues/1656