### PR TITLE
Allow using subset of endpoints when creating a ServiceMonitor

### DIFF
--- a/hack/tests/sanity-check.sh
+++ b/hack/tests/sanity-check.sh
@@ -2,6 +2,7 @@
 set -ex
 
 go vet ./...
+go fmt ./...
 ./hack/check_license.sh
 ./hack/check_error_log_msg_format.sh
 

--- a/pkg/metrics/service-monitor.go
+++ b/pkg/metrics/service-monitor.go
@@ -32,7 +32,7 @@ type ServiceMonitorUpdater func(*monitoringv1.ServiceMonitor) error
 
 // CreateServiceMonitors creates ServiceMonitors objects based on an array of Service objects.
 // If CR ServiceMonitor is not registered in the Cluster it will not attempt at creating resources.
-func CreateServiceMonitors(config *rest.Config, ns string, services []*v1.Service, updaters... ServiceMonitorUpdater) ([]*monitoringv1.ServiceMonitor, error) {
+func CreateServiceMonitors(config *rest.Config, ns string, services []*v1.Service, updaters ...ServiceMonitorUpdater) ([]*monitoringv1.ServiceMonitor, error) {
 	// check if we can even create ServiceMonitors
 	exists, err := hasServiceMonitor(config)
 	if err != nil {

--- a/pkg/metrics/service-monitor.go
+++ b/pkg/metrics/service-monitor.go
@@ -28,9 +28,11 @@ import (
 
 var ErrServiceMonitorNotPresent = fmt.Errorf("no ServiceMonitor registered with the API")
 
+type ServiceMonitorUpdater func(*monitoringv1.ServiceMonitor) error
+
 // CreateServiceMonitors creates ServiceMonitors objects based on an array of Service objects.
 // If CR ServiceMonitor is not registered in the Cluster it will not attempt at creating resources.
-func CreateServiceMonitors(config *rest.Config, ns string, services []*v1.Service) ([]*monitoringv1.ServiceMonitor, error) {
+func CreateServiceMonitors(config *rest.Config, ns string, services []*v1.Service, updaters... ServiceMonitorUpdater) ([]*monitoringv1.ServiceMonitor, error) {
 	// check if we can even create ServiceMonitors
 	exists, err := hasServiceMonitor(config)
 	if err != nil {
@@ -48,6 +50,12 @@ func CreateServiceMonitors(config *rest.Config, ns string, services []*v1.Servic
 			continue
 		}
 		sm := GenerateServiceMonitor(s)
+		for _, update := range updaters {
+			if err := update(sm); err != nil {
+				return nil, err
+			}
+		}
+
 		smc, err := mclient.ServiceMonitors(ns).Create(sm)
 		if err != nil {
 			return serviceMonitors, err


### PR DESCRIPTION
metrics: add an ability to create a ServiceMonitor with only a subset of ports, provided as a list of port names.

This change adds 2 additional calls for creating a ServiceMonitor: `CreateServiceMonitorWithPorts` and `GenerateServiceMonitorWithPorts`, they allow providing a list of ports to add as endpoints in the created ServiceMonitor object. The list is compared with the ports in the provided service and only adds the endpoints that already exist in the initial service.

Closes #1972 

Signed-off-by: Alex Lourie <djay.il@gmail.com>
