### PR TITLE
*: fix gen-csv to copy CRD manifests with any name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Bug Fixes
+
+- The command `operator-sdk olm-catalog gen-csv --csv-version=<version> --update-crds` would fail to copy over CRD manifests into `deploy/olm-catalog` for manifests whose name didn't end with a `_crd.yaml` suffix. This has been fixed so `gen-csv` now copies all CRD manifests specified by `deploy/olm-catalog/csv_config.yaml` by checking the type of the manifest rather than the filename suffix. ([#2015](https://github.com/operator-framework/operator-sdk/pull/2015))
+
 ### Added
 
 - Added new `--skip-generation` flag to the `operator-sdk add api` command to support skipping generation of deepcopy and OpenAPI code and OpenAPI CRD specs. ([#1890](https://github.com/operator-framework/operator-sdk/pull/1890))

--- a/cmd/operator-sdk/olmcatalog/gen-csv.go
+++ b/cmd/operator-sdk/olmcatalog/gen-csv.go
@@ -18,12 +18,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/input"
 	catalog "github.com/operator-framework/operator-sdk/internal/pkg/scaffold/olm-catalog"
 	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
+	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 
 	"github.com/coreos/go-semver/semver"
@@ -168,13 +168,18 @@ func verifyCSVVersion(version string) error {
 
 func writeCRDsToDir(crdPaths []string, toDir string) error {
 	for _, p := range crdPaths {
-		if !strings.HasSuffix(p, "crd.yaml") {
-			continue
-		}
 		b, err := ioutil.ReadFile(p)
 		if err != nil {
 			return err
 		}
+		typeMeta, err := k8sutil.GetTypeMetaFromBytes(b)
+		if err != nil {
+			return err
+		}
+		if typeMeta.Kind != "CustomResourceDefinition" {
+			continue
+		}
+
 		path := filepath.Join(toDir, filepath.Base(p))
 		err = ioutil.WriteFile(path, b, fileutil.DefaultFileMode)
 		if err != nil {

--- a/internal/util/k8sutil/k8sutil.go
+++ b/internal/util/k8sutil/k8sutil.go
@@ -104,7 +104,7 @@ func GetTypeMetaFromBytes(b []byte) (t metav1.TypeMeta, err error) {
 	// There is only one YAML doc if there are no more bytes to be read or EOF
 	// is hit.
 	if err := dec.Decode(&u); err == nil && r.Len() != 0 {
-		return t, errors.New("error getting TypeMeta from bytes: more than one manifest in b")
+		return t, errors.New("error getting TypeMeta from bytes: more than one manifest in file")
 	} else if err != nil && err != io.EOF {
 		return t, errors.Wrap(err, "error getting TypeMeta from bytes")
 	}


### PR DESCRIPTION
**Description of the change:**
Relax `_crd.yaml` suffix check when copying over CRD manifests for `operator-sdk olm-catalog gen-csv --update-crds`

**Motivation for the change:**
Fixes #1980 
