### PR TITLE
internal/pkg/scaffold/olm-catalog/csv_updaters.go: fix applying owned CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - In the Helm operator, skip owner reference injection for cluster-scoped resources in release manifests. The Helm operator only supports namespace-scoped CRs, and namespaced resources cannot own cluster-scoped resources. ([#1817](https://github.com/operator-framework/operator-sdk/pull/1817))
 - Package manifests generated with [`gen-csv`](https://github.com/operator-framework/operator-sdk/blob/master/doc/sdk-cli-reference.md#gen-csv) respect the `--operator-name` flag, channel names are checked for duplicates before (re-)generation. ([#1693](https://github.com/operator-framework/operator-sdk/pull/1693))
 - Generated inventory for Ansible-based Operators now sets the localhost's `ansible_python_interpreter` to `{{ ansible_playbook_python }}`, to properly match the [implicit localhost](https://docs.ansible.com/ansible/latest/inventory/implicit_localhost.html). ([#1952](https://github.com/operator-framework/operator-sdk/pull/1952))
+- Fixed an issue in `operator-sdk olm-catalog gen-csv` where the generated CSV is missing the expected set of owned CRDs. ([#2017](https://github.com/operator-framework/operator-sdk/pull/2017))
 
 ## v0.10.0
 

--- a/internal/pkg/scaffold/olm-catalog/csv_updaters.go
+++ b/internal/pkg/scaffold/olm-catalog/csv_updaters.go
@@ -305,12 +305,12 @@ func getGVKID(g, v, k string) string {
 // the CRD key is not in spec.customresourcedefinitions.owned already.
 func (u *CustomResourceDefinitionsUpdate) Apply(csv *olmapiv1alpha1.ClusterServiceVersion) error {
 	set := make(map[string]olmapiv1alpha1.CRDDescription)
-	for _, uDesc := range u.Owned {
-		set[crdDescID(uDesc)] = uDesc
+	for _, csvDesc := range csv.Spec.CustomResourceDefinitions.Owned {
+		set[crdDescID(csvDesc)] = csvDesc
 	}
 	newDescs := []olmapiv1alpha1.CRDDescription{}
-	for _, csvDesc := range csv.Spec.CustomResourceDefinitions.Owned {
-		if uDesc, ok := set[crdDescID(csvDesc)]; !ok {
+	for _, uDesc := range u.Owned {
+		if csvDesc, ok := set[crdDescID(uDesc)]; !ok {
 			newDescs = append(newDescs, uDesc)
 		} else {
 			newDescs = append(newDescs, csvDesc)


### PR DESCRIPTION
**Description of the change:**
This PR fixes an issue in `olm-catalog gen-csv` where the CSV's owned CRDs are not properly populated from CRD manifests in `deploy/crds`.

The current code has two issues:
1. For new CSVs (when `--from-version` is not used), no CRDs are populated.
2. For CSV updates (when `--from-version` is used), only CRDs that are in the original version will be carried forward to the new version, even if there are new CRDs present in `deploy/crds`

These issues stem from the fact that the CSV updater iterates the existing set of CRDs to build the new set. In case 1, the existing set is empty, since nothing exists, which explains why no CRDs are populated.

**Motivation for the change:**
Fixes the above described issue.
