### PR TITLE
Makefile: Use hyphen instead of slash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -160,7 +160,7 @@ jobs:
     - <<: *deploy
       name: Docker image for ansible-operator
       script:
-        - make image/build/ansible
+        - make image-build-ansible
         - make image/push/ansible
 
     # Build and deploy amd64 helm-operator docker image
@@ -168,7 +168,7 @@ jobs:
       name: Docker image for helm-operator (amd64)
       os: linux
       script:
-        - make image/build/helm
+        - make image-build-helm
         - make image/push/helm
 
     # Build and deploy ppc64le helm-operator docker image
@@ -176,14 +176,14 @@ jobs:
       name: Docker image for helm-operator (ppc64le)
       os: linux-ppc64le
       script:
-        - make image/build/helm
+        - make image-build-helm
         - make image/push/helm
 
     # Build and deploy scorecard-proxy docker image
     - <<: *deploy
       name: Docker image for scorecard-proxy
       script:
-        - make image/build/scorecard-proxy
+        - make image-build-scorecard-proxy
         - make image/push/scorecard-proxy
 
     # Build and deploy helm multi-arch manifest list

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,7 +152,7 @@ jobs:
       # Currently, prow/api-ci tests all PRs that target master; use travis for post merge testing and non-master PRs
       if: type != pull_request OR branch != master
       <<: *dep_before_install
-      script: make test/sanity test-unit test/markdown
+      script: make test/sanity test-unit test-markdown
       after_success: echo 'Tests Passed'
       after_failure: echo 'Failure in unit, sanity, or markdown test'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,13 +132,13 @@ jobs:
     - if: tag IS present OR branch != master
       <<: *test
       name: Subcommands on Kubernetes
-      script: make test/subcommand
+      script: make test-subcommand
 
     # Test olm install/uninstall subcommands on master, as these cannot be tested in prow/api-ci.
     - if: tag IS NOT present AND branch = master
       <<: *test
       name: OLM Install/Uninstall on Kubernetes
-      script: make test/subcommand/olm-install
+      script: make test-subcommand-olm-install
 
     # Build and test ansible using molecule, as this cannot be tested in prow/api-ci.
     - if: tag IS NOT present AND branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -161,7 +161,7 @@ jobs:
       name: Docker image for ansible-operator
       script:
         - make image-build-ansible
-        - make image/push/ansible
+        - make image-push-ansible
 
     # Build and deploy amd64 helm-operator docker image
     - <<: *deploy
@@ -169,7 +169,7 @@ jobs:
       os: linux
       script:
         - make image-build-helm
-        - make image/push/helm
+        - make image-push-helm
 
     # Build and deploy ppc64le helm-operator docker image
     - <<: *deploy
@@ -177,17 +177,17 @@ jobs:
       os: linux-ppc64le
       script:
         - make image-build-helm
-        - make image/push/helm
+        - make image-push-helm
 
     # Build and deploy scorecard-proxy docker image
     - <<: *deploy
       name: Docker image for scorecard-proxy
       script:
         - make image-build-scorecard-proxy
-        - make image/push/scorecard-proxy
+        - make image-push-scorecard-proxy
 
     # Build and deploy helm multi-arch manifest list
     - <<: *manifest-deploy
       name: Manifest list for helm-operator
       script:
-        - make image/push/helm-multiarch
+        - make image-push-helm-multiarch

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ jobs:
     - if: tag IS present OR branch != master
       <<: *test
       name: Go on Kubernetes
-      script: make test/e2e/go
+      script: make test-e2e-go
 
     # Build and test ansible and test ansible using molecule in non-master PRs
     - if: tag IS present OR branch != master
@@ -119,14 +119,14 @@ jobs:
         - pip3 install --upgrade setuptools pip
         - pip install --user ansible
       script:
-        - make test/e2e/ansible
-        - make test/e2e/ansible-molecule
+        - make test-e2e-ansible
+        - make test-e2e-ansible-molecule
 
     # Build and test helm in non-master PRs
     - if: tag IS present OR branch != master
       <<: *test
       name: Helm on Kubernetes
-      script: make test/e2e/helm
+      script: make test-e2e-helm
 
     # Test subcommands in non-master PRs
     - if: tag IS present OR branch != master
@@ -144,7 +144,7 @@ jobs:
     - if: tag IS NOT present AND branch = master
       <<: *test
       name: Ansible Molecule on Kubernetes
-      script: make test/e2e/ansible-molecule
+      script: make test-e2e-ansible-molecule
 
     # Run the unit, sanity, and markdown tests
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,7 +152,7 @@ jobs:
       # Currently, prow/api-ci tests all PRs that target master; use travis for post merge testing and non-master PRs
       if: type != pull_request OR branch != master
       <<: *dep_before_install
-      script: make test/sanity test/unit test/markdown
+      script: make test/sanity test-unit test/markdown
       after_success: echo 'Tests Passed'
       after_failure: echo 'Failure in unit, sanity, or markdown test'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,7 +152,7 @@ jobs:
       # Currently, prow/api-ci tests all PRs that target master; use travis for post merge testing and non-master PRs
       if: type != pull_request OR branch != master
       <<: *dep_before_install
-      script: make test/sanity test-unit test-markdown
+      script: make test-sanity test-unit test-markdown
       after_success: echo 'Tests Passed'
       after_failure: echo 'Failure in unit, sanity, or markdown test'
 

--- a/Makefile
+++ b/Makefile
@@ -146,19 +146,19 @@ test-e2e: test-e2e-go test-e2e-ansible test-e2e-ansible-molecule test-e2e-helm #
 test-e2e-go:
 	./hack/tests/e2e-go.sh $(ARGS)
 
-test-e2e-ansible: image/build/ansible
+test-e2e-ansible: image-build-ansible
 	./hack/tests/e2e-ansible.sh
 
-test-e2e-ansible-molecule: image/build/ansible
+test-e2e-ansible-molecule: image-build-ansible
 	./hack/tests/e2e-ansible-molecule.sh
 
-test-e2e-helm: image/build/helm
+test-e2e-helm: image-build-helm
 	./hack/tests/e2e-helm.sh
 
 # Image scaffold/build/push.
-.PHONY: image image/scaffold/ansible image/scaffold/helm image/build image/build/ansible image/build/helm image/push image/push/ansible image/push/helm
+.PHONY: image image/scaffold/ansible image/scaffold/helm image-build image-build-ansible image-build-helm image/push image/push/ansible image/push/helm
 
-image: image/build image/push ## Build and push all images
+image: image-build image/push ## Build and push all images
 
 image/scaffold/ansible:
 	go run ./hack/image/ansible/scaffold-ansible-image.go
@@ -166,15 +166,15 @@ image/scaffold/ansible:
 image/scaffold/helm:
 	go run ./hack/image/helm/scaffold-helm-image.go
 
-image/build: image/build/ansible image/build/helm image/build/scorecard-proxy ## Build all images
+image-build: image-build-ansible image-build-helm image-build-scorecard-proxy ## Build all images
 
-image/build/ansible: build/operator-sdk-dev-x86_64-linux-gnu
+image-build-ansible: build/operator-sdk-dev-x86_64-linux-gnu
 	./hack/image/build-ansible-image.sh $(ANSIBLE_BASE_IMAGE):dev
 
-image/build/helm: build/operator-sdk-dev
+image-build-helm: build/operator-sdk-dev
 	./hack/image/build-helm-image.sh $(HELM_BASE_IMAGE):dev
 
-image/build/scorecard-proxy:
+image-build-scorecard-proxy:
 	./hack/image/build-scorecard-proxy-image.sh $(SCORECARD_PROXY_BASE_IMAGE):dev
 
 image/push: image/push/ansible image/push/helm image/push/scorecard-proxy ## Push all images

--- a/Makefile
+++ b/Makefile
@@ -156,9 +156,9 @@ test-e2e-helm: image-build-helm
 	./hack/tests/e2e-helm.sh
 
 # Image scaffold/build/push.
-.PHONY: image image-scaffold-ansible image-scaffold-helm image-build image-build-ansible image-build-helm image/push image/push/ansible image/push/helm
+.PHONY: image image-scaffold-ansible image-scaffold-helm image-build image-build-ansible image-build-helm image-push image-push-ansible image-push-helm
 
-image: image-build image/push ## Build and push all images
+image: image-build image-push ## Build and push all images
 
 image-scaffold-ansible:
 	go run ./hack/image/ansible/scaffold-ansible-image.go
@@ -177,16 +177,16 @@ image-build-helm: build/operator-sdk-dev
 image-build-scorecard-proxy:
 	./hack/image/build-scorecard-proxy-image.sh $(SCORECARD_PROXY_BASE_IMAGE):dev
 
-image/push: image/push/ansible image/push/helm image/push/scorecard-proxy ## Push all images
+image-push: image-push-ansible image-push-helm image-push-scorecard-proxy ## Push all images
 
-image/push/ansible:
+image-push-ansible:
 	./hack/image/push-image-tags.sh $(ANSIBLE_BASE_IMAGE):dev $(ANSIBLE_IMAGE)
 
-image/push/helm:
+image-push-helm:
 	./hack/image/push-image-tags.sh $(HELM_BASE_IMAGE):dev $(HELM_IMAGE)-$(shell go env GOARCH)
 
-image/push/helm-multiarch:
+image-push-helm-multiarch:
 	./hack/image/push-manifest-list.sh $(HELM_IMAGE) ${HELM_ARCHES}
 
-image/push/scorecard-proxy:
+image-push-scorecard-proxy:
 	./hack/image/push-image-tags.sh $(SCORECARD_PROXY_BASE_IMAGE):dev $(SCORECARD_PROXY_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -122,20 +122,20 @@ test-unit: ## Run the unit tests
 # CI tests.
 .PHONY: test-ci
 
-test-ci: test-markdown test-sanity test-unit install test/subcommand test/e2e ## Run the CI test suite
+test-ci: test-markdown test-sanity test-unit install test-subcommand test/e2e ## Run the CI test suite
 
 # Subcommand tests.
-.PHONY: test/subcommand test/subcommand/test-local test/subcommand/scorecard test/subcommand/olm-install
+.PHONY: test-subcommand test-subcommand-local test-subcommand-scorecard test-subcommand-olm-install
 
-test/subcommand: test/subcommand/test-local test/subcommand/scorecard test/subcommand/olm-install
+test-subcommand: test-subcommand-local test-subcommand-scorecard test-subcommand-olm-install
 
-test/subcommand/test-local:
+test-subcommand-local:
 	./hack/tests/subcommand.sh
 
-test/subcommand/scorecard:
+test-subcommand-scorecard:
 	./hack/tests/subcommand-scorecard.sh
 
-test/subcommand/olm-install:
+test-subcommand-olm-install:
 	./hack/tests/subcommand-olm-install.sh
 
 # E2E tests.

--- a/Makefile
+++ b/Makefile
@@ -104,11 +104,11 @@ build/%.asc:
 	}
 
 # Static tests.
-.PHONY: test test/markdown test/sanity test-unit
+.PHONY: test test-markdown test/sanity test-unit
 
 test: test-unit ## Run the tests
 
-test/markdown:
+test-markdown:
 	./hack/ci/marker --root=doc
 
 test/sanity: tidy
@@ -122,7 +122,7 @@ test-unit: ## Run the unit tests
 # CI tests.
 .PHONY: test/ci
 
-test/ci: test/markdown test/sanity test-unit install test/subcommand test/e2e ## Run the CI test suite
+test/ci: test-markdown test/sanity test-unit install test/subcommand test/e2e ## Run the CI test suite
 
 # Subcommand tests.
 .PHONY: test/subcommand test/subcommand/test-local test/subcommand/scorecard test/subcommand/olm-install

--- a/Makefile
+++ b/Makefile
@@ -156,14 +156,14 @@ test-e2e-helm: image-build-helm
 	./hack/tests/e2e-helm.sh
 
 # Image scaffold/build/push.
-.PHONY: image image/scaffold/ansible image/scaffold/helm image-build image-build-ansible image-build-helm image/push image/push/ansible image/push/helm
+.PHONY: image image-scaffold-ansible image-scaffold-helm image-build image-build-ansible image-build-helm image/push image/push/ansible image/push/helm
 
 image: image-build image/push ## Build and push all images
 
-image/scaffold/ansible:
+image-scaffold-ansible:
 	go run ./hack/image/ansible/scaffold-ansible-image.go
 
-image/scaffold/helm:
+image-scaffold-helm:
 	go run ./hack/image/helm/scaffold-helm-image.go
 
 image-build: image-build-ansible image-build-helm image-build-scorecard-proxy ## Build all images

--- a/Makefile
+++ b/Makefile
@@ -104,14 +104,14 @@ build/%.asc:
 	}
 
 # Static tests.
-.PHONY: test test-markdown test/sanity test-unit
+.PHONY: test test-markdown test-sanity test-unit
 
 test: test-unit ## Run the tests
 
 test-markdown:
 	./hack/ci/marker --root=doc
 
-test/sanity: tidy
+test-sanity: tidy
 	./hack/tests/sanity-check.sh
 
 test-unit: ## Run the unit tests
@@ -122,7 +122,7 @@ test-unit: ## Run the unit tests
 # CI tests.
 .PHONY: test/ci
 
-test/ci: test-markdown test/sanity test-unit install test/subcommand test/e2e ## Run the CI test suite
+test/ci: test-markdown test-sanity test-unit install test/subcommand test/e2e ## Run the CI test suite
 
 # Subcommand tests.
 .PHONY: test/subcommand test/subcommand/test-local test/subcommand/scorecard test/subcommand/olm-install

--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,9 @@ build/%.asc:
 	}
 
 # Static tests.
-.PHONY: test test/markdown test/sanity test/unit
+.PHONY: test test/markdown test/sanity test-unit
 
-test: test/unit ## Run the tests
+test: test-unit ## Run the tests
 
 test/markdown:
 	./hack/ci/marker --root=doc
@@ -114,7 +114,7 @@ test/markdown:
 test/sanity: tidy
 	./hack/tests/sanity-check.sh
 
-test/unit: ## Run the unit tests
+test-unit: ## Run the unit tests
 	$(Q)go test -count=1 -short ./cmd/...
 	$(Q)go test -count=1 -short ./pkg/...
 	$(Q)go test -count=1 -short ./internal/...
@@ -122,7 +122,7 @@ test/unit: ## Run the unit tests
 # CI tests.
 .PHONY: test/ci
 
-test/ci: test/markdown test/sanity test/unit install test/subcommand test/e2e ## Run the CI test suite
+test/ci: test/markdown test/sanity test-unit install test/subcommand test/e2e ## Run the CI test suite
 
 # Subcommand tests.
 .PHONY: test/subcommand test/subcommand/test-local test/subcommand/scorecard test/subcommand/olm-install

--- a/Makefile
+++ b/Makefile
@@ -120,9 +120,9 @@ test-unit: ## Run the unit tests
 	$(Q)go test -count=1 -short ./internal/...
 
 # CI tests.
-.PHONY: test/ci
+.PHONY: test-ci
 
-test/ci: test-markdown test-sanity test-unit install test/subcommand test/e2e ## Run the CI test suite
+test-ci: test-markdown test-sanity test-unit install test/subcommand test/e2e ## Run the CI test suite
 
 # Subcommand tests.
 .PHONY: test/subcommand test/subcommand/test-local test/subcommand/scorecard test/subcommand/olm-install

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ test-unit: ## Run the unit tests
 # CI tests.
 .PHONY: test-ci
 
-test-ci: test-markdown test-sanity test-unit install test-subcommand test/e2e ## Run the CI test suite
+test-ci: test-markdown test-sanity test-unit install test-subcommand test-e2e ## Run the CI test suite
 
 # Subcommand tests.
 .PHONY: test-subcommand test-subcommand-local test-subcommand-scorecard test-subcommand-olm-install
@@ -139,20 +139,20 @@ test-subcommand-olm-install:
 	./hack/tests/subcommand-olm-install.sh
 
 # E2E tests.
-.PHONY: test/e2e test/e2e/go test/e2e/ansible test/e2e/ansible-molecule test/e2e/helm
+.PHONY: test-e2e test-e2e-go test-e2e-ansible test-e2e-ansible-molecule test-e2e-helm
 
-test/e2e: test/e2e/go test/e2e/ansible test/e2e/ansible-molecule test/e2e/helm ## Run the e2e tests
+test-e2e: test-e2e-go test-e2e-ansible test-e2e-ansible-molecule test-e2e-helm ## Run the e2e tests
 
-test/e2e/go:
+test-e2e-go:
 	./hack/tests/e2e-go.sh $(ARGS)
 
-test/e2e/ansible: image/build/ansible
+test-e2e-ansible: image/build/ansible
 	./hack/tests/e2e-ansible.sh
 
-test/e2e/ansible-molecule: image/build/ansible
+test-e2e-ansible-molecule: image/build/ansible
 	./hack/tests/e2e-ansible-molecule.sh
 
-test/e2e/helm: image/build/helm
+test-e2e-helm: image/build/helm
 	./hack/tests/e2e-helm.sh
 
 # Image scaffold/build/push.

--- a/Makefile
+++ b/Makefile
@@ -108,13 +108,13 @@ build/%.asc:
 
 test: test-unit ## Run the tests
 
-test-markdown:
+test-markdown test/markdown:
 	./hack/ci/marker --root=doc
 
-test-sanity: tidy
+test-sanity test/sanity: tidy
 	./hack/tests/sanity-check.sh
 
-test-unit: ## Run the unit tests
+test-unit test/unit: ## Run the unit tests
 	$(Q)go test -count=1 -short ./cmd/...
 	$(Q)go test -count=1 -short ./pkg/...
 	$(Q)go test -count=1 -short ./internal/...

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -1,6 +1,6 @@
 FROM osdk-builder as builder
 
-RUN make image/scaffold/ansible
+RUN make image-scaffold-ansible
 RUN ci/tests/scaffolding/e2e-ansible-scaffold-hybrid.sh
 
 FROM registry.access.redhat.com/ubi8/ubi

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -1,6 +1,6 @@
 FROM osdk-builder as builder
 
-RUN make image/scaffold/ansible
+RUN make image-scaffold-ansible
 
 FROM registry.access.redhat.com/ubi8/ubi
 

--- a/ci/dockerfiles/helm-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/helm-e2e-hybrid.Dockerfile
@@ -1,6 +1,6 @@
 FROM osdk-builder as builder
 
-RUN make image/scaffold/helm
+RUN make image-scaffold-helm
 RUN ci/tests/scaffolding/e2e-helm-scaffold-hybrid.sh
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/ci/dockerfiles/helm.Dockerfile
+++ b/ci/dockerfiles/helm.Dockerfile
@@ -1,6 +1,6 @@
 FROM osdk-builder as builder
 
-RUN make image/scaffold/helm
+RUN make image-scaffold-helm
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 

--- a/ci/prow.Makefile
+++ b/ci/prow.Makefile
@@ -7,13 +7,13 @@ export GOPROXY ?= https://proxy.golang.org/
 build:
 	$(MAKE) -f Makefile build/operator-sdk
 
-test/e2e/go:
+test-e2e-go:
 	./ci/tests/e2e-go.sh $(ARGS)
 
-test/e2e/ansible:
+test-e2e-ansible:
 	./ci/tests/e2e-ansible.sh
 
-test/e2e/helm:
+test-e2e-helm:
 	./ci/tests/e2e-helm.sh
 
 test-subcommand:

--- a/ci/prow.Makefile
+++ b/ci/prow.Makefile
@@ -16,5 +16,5 @@ test/e2e/ansible:
 test/e2e/helm:
 	./ci/tests/e2e-helm.sh
 
-test/subcommand:
+test-subcommand:
 	./ci/tests/subcommand.sh

--- a/ci/prow.Makefile
+++ b/ci/prow.Makefile
@@ -7,14 +7,14 @@ export GOPROXY ?= https://proxy.golang.org/
 build:
 	$(MAKE) -f Makefile build/operator-sdk
 
-test-e2e-go:
+test-e2e-go test/e2e/go:
 	./ci/tests/e2e-go.sh $(ARGS)
 
-test-e2e-ansible:
+test-e2e-ansible test/e2e/ansible:
 	./ci/tests/e2e-ansible.sh
 
-test-e2e-helm:
+test-e2e-helm test/e2e/helm:
 	./ci/tests/e2e-helm.sh
 
-test-subcommand:
+test-subcommand test/subcommand:
 	./ci/tests/subcommand.sh

--- a/doc/dev/developer_guide.md
+++ b/doc/dev/developer_guide.md
@@ -24,7 +24,7 @@ To build the binary and run all tests (assuming you have a correctly configured 
 you can simple run:
 
 ```sh
-$ make test/ci
+$ make test-ci
 ```
 
 If you simply want to run the unit tests, you can run:

--- a/doc/dev/testing/running-the-tests.md
+++ b/doc/dev/testing/running-the-tests.md
@@ -53,10 +53,10 @@ $ export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
 
 All the tests are run through the [`Makefile`][makefile]. This is a brief description of all makefile test instructions:
 
-- `test` - Runs the unit tests (`test/unit`).
+- `test` - Runs the unit tests (`test-unit`).
 - `test/ci` - Runs markdown, sanity, and unit tests, installs the SDK binary, and runs the SDK subcommand and all E2E tests.
 - `test/sanity` - Runs sanity checks.
-- `test/unit` - Runs unit tests.
+- `test-unit` - Runs unit tests.
 - `test/subcommand` - Runs subcommand tests.
 - `test/e2e` - Runs all E2E tests (`test/e2e/go`, `test/e2e/ansible`, `test/e2e/ansible-molecule`, and `e2e/helm`).
 - `test/e2e/go` - Runs the go E2E test.

--- a/doc/dev/testing/running-the-tests.md
+++ b/doc/dev/testing/running-the-tests.md
@@ -57,7 +57,7 @@ All the tests are run through the [`Makefile`][makefile]. This is a brief descri
 - `test-ci` - Runs markdown, sanity, and unit tests, installs the SDK binary, and runs the SDK subcommand and all E2E tests.
 - `test-sanity` - Runs sanity checks.
 - `test-unit` - Runs unit tests.
-- `test/subcommand` - Runs subcommand tests.
+- `test-subcommand` - Runs subcommand tests.
 - `test/e2e` - Runs all E2E tests (`test/e2e/go`, `test/e2e/ansible`, `test/e2e/ansible-molecule`, and `e2e/helm`).
 - `test/e2e/go` - Runs the go E2E test.
 - `test/e2e/ansible` - Runs the ansible E2E test.

--- a/doc/dev/testing/running-the-tests.md
+++ b/doc/dev/testing/running-the-tests.md
@@ -54,7 +54,7 @@ $ export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
 All the tests are run through the [`Makefile`][makefile]. This is a brief description of all makefile test instructions:
 
 - `test` - Runs the unit tests (`test-unit`).
-- `test/ci` - Runs markdown, sanity, and unit tests, installs the SDK binary, and runs the SDK subcommand and all E2E tests.
+- `test-ci` - Runs markdown, sanity, and unit tests, installs the SDK binary, and runs the SDK subcommand and all E2E tests.
 - `test-sanity` - Runs sanity checks.
 - `test-unit` - Runs unit tests.
 - `test/subcommand` - Runs subcommand tests.

--- a/doc/dev/testing/running-the-tests.md
+++ b/doc/dev/testing/running-the-tests.md
@@ -58,11 +58,11 @@ All the tests are run through the [`Makefile`][makefile]. This is a brief descri
 - `test-sanity` - Runs sanity checks.
 - `test-unit` - Runs unit tests.
 - `test-subcommand` - Runs subcommand tests.
-- `test/e2e` - Runs all E2E tests (`test/e2e/go`, `test/e2e/ansible`, `test/e2e/ansible-molecule`, and `e2e/helm`).
-- `test/e2e/go` - Runs the go E2E test.
-- `test/e2e/ansible` - Runs the ansible E2E test.
-- `test/e2e/ansible-molecule` - Runs the ansible molecule E2E test.
-- `test/e2e/helm` - Runs the helm E2E test.
+- `test-e2e` - Runs all E2E tests (`test-e2e-go`, `test-e2e-ansible`, `test-e2e-ansible-molecule`, and `test-e2e-helm`).
+- `test-e2e-go` - Runs the go E2E test.
+- `test-e2e-ansible` - Runs the ansible E2E test.
+- `test-e2e-ansible-molecule` - Runs the ansible molecule E2E test.
+- `test-e2e-helm` - Runs the helm E2E test.
 - `test-markdown` - Runs the markdown checks
 
 For more info on what these tests actually do, please see the [Travis Build][travis] doc.
@@ -72,14 +72,14 @@ and the operator images will be built and stored in you local docker registry.
 
 ### Go E2E test flags
 
-The `make test/e2e/go` command accepts an `ARGS` variable containing flags that will be passed to `go test`:
+The `make test-e2e-go` command accepts an `ARGS` variable containing flags that will be passed to `go test`:
 
 - `-image-name` string - Sets the operator test image tag to be built and used in testing. Defaults to "quay.io/example/memcached-operator:v0.0.1"
 - `-local-repo` string - Sets the path to the local SDK repo being tested. Defaults to the path of the SDK repo containing e2e tests. This is useful for testing customized e2e code.
 
 An example of using `ARGS` is in the note below.
 
-**NOTE**: Some of these tests, specifically the ansible (`test/e2e/ansible`), helm (`test/e2e/helm`), and Go (`test/e2e/go`) tests,
+**NOTE**: Some of these tests, specifically the ansible (`test-e2e-ansible`), helm (`test-e2e-helm`), and Go (`test-e2e-go`) tests,
 only work when the cluster shares the local docker registry, as is the case with `oc cluster up` and `minikube` after running `eval $(minikube docker-env)`.
 
 ```sh

--- a/doc/dev/testing/running-the-tests.md
+++ b/doc/dev/testing/running-the-tests.md
@@ -63,7 +63,7 @@ All the tests are run through the [`Makefile`][makefile]. This is a brief descri
 - `test/e2e/ansible` - Runs the ansible E2E test.
 - `test/e2e/ansible-molecule` - Runs the ansible molecule E2E test.
 - `test/e2e/helm` - Runs the helm E2E test.
-- `test/markdown` - Runs the markdown checks
+- `test-markdown` - Runs the markdown checks
 
 For more info on what these tests actually do, please see the [Travis Build][travis] doc.
 

--- a/doc/dev/testing/running-the-tests.md
+++ b/doc/dev/testing/running-the-tests.md
@@ -55,7 +55,7 @@ All the tests are run through the [`Makefile`][makefile]. This is a brief descri
 
 - `test` - Runs the unit tests (`test-unit`).
 - `test/ci` - Runs markdown, sanity, and unit tests, installs the SDK binary, and runs the SDK subcommand and all E2E tests.
-- `test/sanity` - Runs sanity checks.
+- `test-sanity` - Runs sanity checks.
 - `test-unit` - Runs unit tests.
 - `test/subcommand` - Runs subcommand tests.
 - `test/e2e` - Runs all E2E tests (`test/e2e/go`, `test/e2e/ansible`, `test/e2e/ansible-molecule`, and `e2e/helm`).

--- a/doc/dev/testing/travis-build.md
+++ b/doc/dev/testing/travis-build.md
@@ -75,7 +75,7 @@ The Go, Ansible, and Helm tests then differ in what tests they run.
 
 ### Ansible tests
 
-1. Run [ansible molecule tests][ansible-molecule]. (`make test/e2e/ansible-molecule)
+1. Run [ansible molecule tests][ansible-molecule]. (`make test-e2e-ansible-molecule)
     1. Create and configure a new ansible type memcached-operator.
     2. Create cluster resources.
     3. Run `operator-sdk test local` to run ansible molecule tests


### PR DESCRIPTION
Switch to using `-` instead of `/` for the targets. This came up in a comment of Issue #1950, kubebuilder uses `-` as well.