### PR TITLE
Update writing-e2e-tests doc

### DIFF
--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -250,9 +250,10 @@ $ operator-sdk test local ./test/e2e --namespace operator-test
 
 To run the operator itself locally during the tests instead of starting a deployment in the cluster, you can use the
 `--up-local` flag. This mode will still create global resources, but by default will not create any in-cluster namespaced
-resources unless the user specifies one through the `--namespaced-manifest` flag. (**NOTE**: The `--up-local` flag requires
-the `--namespace` flag,
-and the command will NOT create the `namespace`, then, be sure that you are specifying a valid namespace). 
+resources unless the user specifies one through the `--namespaced-manifest` flag.
+
+**NOTE**: The --up-local flag requires the `--namespace` flag and the command will NOT create the namespace. Then, be sure that you are specifying a valid namespace.
+
 ```shell
 $ kubectl create namespace operator-test
 $ operator-sdk test local ./test/e2e --namespace operator-test --up-local

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -252,7 +252,7 @@ To run the operator itself locally during the tests instead of starting a deploy
 `--up-local` flag. This mode will still create global resources, but by default will not create any in-cluster namespaced
 resources unless the user specifies one through the `--namespaced-manifest` flag. (Note: the `--up-local` flag requires
 the `--namespace` flag:
-
+**NOTE**: The command will NOT create the `--namespace`.  Then, be sure that you are specifying a valid namespace. 
 ```shell
 $ kubectl create namespace operator-test
 $ operator-sdk test local ./test/e2e --namespace operator-test --up-local

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -251,7 +251,7 @@ $ operator-sdk test local ./test/e2e --namespace operator-test
 To run the operator itself locally during the tests instead of starting a deployment in the cluster, you can use the
 `--up-local` flag. This mode will still create global resources, but by default will not create any in-cluster namespaced
 resources unless the user specifies one through the `--namespaced-manifest` flag. (Note: the `--up-local` flag requires
-the `--namespace` flag):
+the `--namespace` flag, be sure to specify the existing namespace that it should watch for changes in):
 
 ```shell
 $ kubectl create namespace operator-test

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -251,7 +251,7 @@ $ operator-sdk test local ./test/e2e --namespace operator-test
 To run the operator itself locally during the tests instead of starting a deployment in the cluster, you can use the
 `--up-local` flag. This mode will still create global resources, but by default will not create any in-cluster namespaced
 resources unless the user specifies one through the `--namespaced-manifest` flag. (Note: the `--up-local` flag requires
-the `--namespace` flag, be sure to specify the existing namespace that it should watch for changes in):
+the `--namespace` flag:
 
 ```shell
 $ kubectl create namespace operator-test

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -252,7 +252,7 @@ To run the operator itself locally during the tests instead of starting a deploy
 `--up-local` flag. This mode will still create global resources, but by default will not create any in-cluster namespaced
 resources unless the user specifies one through the `--namespaced-manifest` flag.
 
-**NOTE**: The --up-local flag requires the `--namespace` flag and the command will NOT create the namespace. Then, be sure that you are specifying a valid namespace.
+**NOTE**: The `--up-local` flag requires the `--namespace` flag and the command will NOT create the namespace. Then, be sure that you are specifying a valid namespace.
 
 ```shell
 $ kubectl create namespace operator-test

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -250,9 +250,9 @@ $ operator-sdk test local ./test/e2e --namespace operator-test
 
 To run the operator itself locally during the tests instead of starting a deployment in the cluster, you can use the
 `--up-local` flag. This mode will still create global resources, but by default will not create any in-cluster namespaced
-resources unless the user specifies one through the `--namespaced-manifest` flag. (Note: the `--up-local` flag requires
-the `--namespace` flag:
-**NOTE**: The command will NOT create the `--namespace`.  Then, be sure that you are specifying a valid namespace. 
+resources unless the user specifies one through the `--namespaced-manifest` flag. (**NOTE**: The `--up-local` flag requires
+the `--namespace` flag,
+and the command will NOT create the `namespace`, then, be sure that you are specifying a valid namespace). 
 ```shell
 $ kubectl create namespace operator-test
 $ operator-sdk test local ./test/e2e --namespace operator-test --up-local


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adding one-liner information about `--namespace` flag.

**Motivation for the change:**
I was under the impression that `operator-sdk test local ./test/e2e --up-local --namespace=memcached`  will create `namespece=memcached` and when I tried the command it was failing due to  `namespaces "memcached" not found` and for this, I raised an issue #2014. But later I got to know that it won't create any namespace but we need to specify the namespace that it should watch for changes in. So I thought it's a good piece of information and should have a place in the doc.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
