### PR TITLE
pkg/ansible/controller/reconcile.go: fix invalid logger.Info usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Fixed an issue in `operator-sdk olm-catalog gen-csv` where the generated CSV is missing the expected set of owned CRDs. ([#2017](https://github.com/operator-framework/operator-sdk/pull/2017))
 - The command `operator-sdk olm-catalog gen-csv --csv-version=<version> --update-crds` would fail to copy over CRD manifests into `deploy/olm-catalog` for manifests whose name didn't end with a `_crd.yaml` suffix. This has been fixed so `gen-csv` now copies all CRD manifests specified by `deploy/olm-catalog/csv_config.yaml` by checking the type of the manifest rather than the filename suffix. ([#2015](https://github.com/operator-framework/operator-sdk/pull/2015))
 - Added missing `jmespath` dependency to Ansible-based Operator .travis.yml file template. ([#2027](https://github.com/operator-framework/operator-sdk/pull/2027))
+- Fixed invalid usage of `logr.Logger.Info()` in the Ansible-based operator implementation, which caused unnecessary operator panics. ([#2031](https://github.com/operator-framework/operator-sdk/pull/2031))
 
 ## v0.10.0
 

--- a/pkg/ansible/controller/reconcile.go
+++ b/pkg/ansible/controller/reconcile.go
@@ -271,7 +271,7 @@ func (r *AnsibleOperatorReconciler) markError(u *unstructured.Unstructured, name
 	// Get the latest resource to prevent updating a stale status
 	err := r.Client.Get(context.TODO(), namespacedName, u)
 	if apierrors.IsNotFound(err) {
-		logger.Info("Resource not found, assuming it was deleted", err)
+		logger.Info("Resource not found, assuming it was deleted")
 		return nil
 	}
 	if err != nil {
@@ -310,7 +310,7 @@ func (r *AnsibleOperatorReconciler) markDone(u *unstructured.Unstructured, names
 	// Get the latest resource to prevent updating a stale status
 	err := r.Client.Get(context.TODO(), namespacedName, u)
 	if apierrors.IsNotFound(err) {
-		logger.Info("Resource not found, assuming it was deleted", err)
+		logger.Info("Resource not found, assuming it was deleted")
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
**Description of the change:**
This PR fixes invalid usages of `logger.Info` in `pkg/ansible/controller/reconcile.go` that cause a panic due to an invalid number of arguments passed to the function.

`logger.Info` requires an odd number of arguments, consisting of a mandatory message and an optional list of `key1, value1, key2, value2, ..., keyN, valueN` pairs.

**Motivation for the change:**
See https://github.com/operator-framework/operator-sdk/issues/2025

Closes #2025 
