### PR TITLE
Refactor e2e framework to remove globals

### DIFF
--- a/cmd/operator-sdk/test/local.go
+++ b/cmd/operator-sdk/test/local.go
@@ -15,6 +15,7 @@
 package test
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -225,9 +226,9 @@ func testLocalGoFunc(cmd *cobra.Command, args []string) error {
 		TestBinaryArgs: testArgs,
 	}
 	if err := projutil.GoTest(opts); err != nil {
-		osErr, ok := err.(*exec.ExitError)
-		if ok {
-			os.Exit(osErr.ExitCode())
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.ExitCode())
 		}
 		return fmt.Errorf("failed to build test binary: (%v)", err)
 	}

--- a/cmd/operator-sdk/test/local.go
+++ b/cmd/operator-sdk/test/local.go
@@ -225,6 +225,10 @@ func testLocalGoFunc(cmd *cobra.Command, args []string) error {
 		TestBinaryArgs: testArgs,
 	}
 	if err := projutil.GoTest(opts); err != nil {
+		osErr, ok := err.(*exec.ExitError)
+		if ok {
+			os.Exit(osErr.ExitCode())
+		}
 		return fmt.Errorf("failed to build test binary: (%v)", err)
 	}
 	log.Info("Local operator test successfully completed.")

--- a/internal/util/projutil/exec.go
+++ b/internal/util/projutil/exec.go
@@ -29,7 +29,7 @@ func ExecCmd(cmd *exec.Cmd) error {
 	cmd.Stderr = os.Stderr
 	log.Debugf("Running %#v", cmd.Args)
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to exec %#v: %v", cmd.Args, err)
+		return fmt.Errorf("failed to exec %#v: %w", cmd.Args, err)
 	}
 	return nil
 }
@@ -82,17 +82,7 @@ func GoTest(opts GoTestOptions) error {
 	bargs = append(bargs, opts.TestBinaryArgs...)
 	c := exec.Command("go", bargs...)
 	opts.setCmdFields(c)
-
-	// TODO(joelanford): Don't use ExecCmd because it
-	// wraps the error, making os.ExitError unrecoverable.
-	// ExecCmd can be updated in Go 1.13 to wrap the error
-	// with %w, at which point we can use it again.
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
-	if err := c.Run(); err != nil {
-		return err
-	}
-	return nil
+	return ExecCmd(c)
 }
 
 // GoCmd runs "go {cmd}".

--- a/internal/util/projutil/exec.go
+++ b/internal/util/projutil/exec.go
@@ -82,7 +82,17 @@ func GoTest(opts GoTestOptions) error {
 	bargs = append(bargs, opts.TestBinaryArgs...)
 	c := exec.Command("go", bargs...)
 	opts.setCmdFields(c)
-	return ExecCmd(c)
+
+	// TODO(joelanford): Don't use ExecCmd because it
+	// wraps the error, making os.ExitError unrecoverable.
+	// ExecCmd can be updated in Go 1.13 to wrap the error
+	// with %w, at which point we can use it again.
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // GoCmd runs "go {cmd}".

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -74,6 +74,7 @@ func (f *Framework) newTestCtx(t *testing.T) *TestCtx {
 		namespace:         namespace,
 		namespacedManPath: *f.NamespacedManPath,
 		client:            f.Client,
+		kubeclient:        f.KubeClient,
 		restMapper:        f.restMapper,
 	}
 }

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/restmapper"
 )
 
 type TestCtx struct {
@@ -28,6 +30,11 @@ type TestCtx struct {
 	cleanupFns []cleanupFn
 	namespace  string
 	t          *testing.T
+
+	namespacedManPath string
+	client            *frameworkClient
+	kubeclient        kubernetes.Interface
+	restMapper        *restmapper.DeferredDiscoveryRESTMapper
 }
 
 type CleanupOptions struct {
@@ -38,7 +45,7 @@ type CleanupOptions struct {
 
 type cleanupFn func() error
 
-func NewTestCtx(t *testing.T) *TestCtx {
+func (f *Framework) newTestCtx(t *testing.T) *TestCtx {
 	var prefix string
 	if t != nil {
 		// TestCtx is used among others for namespace names where '/' is forbidden
@@ -56,10 +63,23 @@ func NewTestCtx(t *testing.T) *TestCtx {
 	}
 
 	id := prefix + "-" + strconv.FormatInt(time.Now().Unix(), 10)
-	return &TestCtx{
-		id: id,
-		t:  t,
+
+	var namespace string
+	if f.singleNamespaceMode {
+		namespace = f.Namespace
 	}
+	return &TestCtx{
+		id:                id,
+		t:                 t,
+		namespace:         namespace,
+		namespacedManPath: *f.NamespacedManPath,
+		client:            f.Client,
+		restMapper:        f.restMapper,
+	}
+}
+
+func NewTestCtx(t *testing.T) *TestCtx {
+	return Global.newTestCtx(t)
 }
 
 func (ctx *TestCtx) GetID() string {

--- a/pkg/test/main_entry.go
+++ b/pkg/test/main_entry.go
@@ -15,125 +15,28 @@
 package test
 
 import (
-	"bytes"
 	"flag"
-	"fmt"
-	"io/ioutil"
 	"os"
-	"os/exec"
-	"os/signal"
-	"path/filepath"
-	"strings"
-	"syscall"
 	"testing"
 
-	"github.com/operator-framework/operator-sdk/internal/scaffold"
-	"github.com/operator-framework/operator-sdk/internal/util/projutil"
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-
 	log "github.com/sirupsen/logrus"
-	"k8s.io/client-go/tools/clientcmd"
-)
-
-const (
-	ProjRootFlag          = "root"
-	KubeConfigFlag        = "kubeconfig"
-	NamespacedManPathFlag = "namespacedMan"
-	GlobalManPathFlag     = "globalMan"
-	SingleNamespaceFlag   = "singleNamespace"
-	TestNamespaceEnv      = "TEST_NAMESPACE"
-	LocalOperatorFlag     = "localOperator"
-	LocalOperatorArgs     = "localOperatorArgs"
 )
 
 func MainEntry(m *testing.M) {
-	projRoot := flag.String(ProjRootFlag, "", "path to project root")
-	kubeconfigPath := flag.String(KubeConfigFlag, "", "path to kubeconfig")
-	globalManPath := flag.String(GlobalManPathFlag, "", "path to operator manifest")
-	namespacedManPath := flag.String(NamespacedManPathFlag, "", "path to rbac manifest")
-	singleNamespace = flag.Bool(SingleNamespaceFlag, false, "enable single namespace mode")
-	localOperator := flag.Bool(LocalOperatorFlag, false, "enable if operator is running locally (not in cluster)")
-	localOperatorArgs := flag.String(LocalOperatorArgs, "", "flags that the operator needs (while using --up-local). example: \"--flag1 value1 --flag2=value2\"")
+	fopts := &frameworkOpts{}
+	fopts.addToFlagSet(flag.CommandLine)
 	flag.Parse()
-	// go test always runs from the test directory; change to project root
-	err := os.Chdir(*projRoot)
+
+	f, err := newFramework(fopts)
 	if err != nil {
-		log.Fatalf("Failed to change directory to project root: %v", err)
+		log.Fatalf("Failed to create framework: %v", err)
 	}
-	if err := setup(kubeconfigPath, namespacedManPath, *localOperator); err != nil {
-		log.Fatalf("Failed to set up framework: %v", err)
-	}
-	// setup local operator command, but don't start it yet
-	var localCmd *exec.Cmd
-	var localCmdOutBuf, localCmdErrBuf bytes.Buffer
-	if *localOperator {
-		projectName := filepath.Base(projutil.MustGetwd())
-		outputBinName := filepath.Join(scaffold.BuildBinDir, projectName+"-local")
-		opts := projutil.GoCmdOptions{
-			BinName:     outputBinName,
-			PackagePath: filepath.Join(scaffold.ManagerDir, scaffold.CmdFile),
-		}
-		if err := projutil.GoBuild(opts); err != nil {
-			log.Fatalf("Failed to build local operator binary: %s", err)
-		}
-		args := []string{}
-		if *localOperatorArgs != "" {
-			args = append(args, strings.Split(*localOperatorArgs, " ")...)
-		}
-		localCmd = exec.Command(outputBinName, args...)
-		localCmd.Stdout = &localCmdOutBuf
-		localCmd.Stderr = &localCmdErrBuf
-		c := make(chan os.Signal)
-		signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-		go func() {
-			<-c
-			err := localCmd.Process.Signal(os.Interrupt)
-			if err != nil {
-				log.Fatalf("Failed to terminate the operator: (%v)", err)
-			}
-			os.Exit(0)
-		}()
-		if *kubeconfigPath != "" {
-			localCmd.Env = append(os.Environ(), fmt.Sprintf("%v=%v", k8sutil.KubeConfigEnvVar, *kubeconfigPath))
-		} else {
-			// we can hardcode index 0 as that is the highest priority kubeconfig to be loaded and will always
-			// be populated by NewDefaultClientConfigLoadingRules()
-			localCmd.Env = append(os.Environ(), fmt.Sprintf("%v=%v", k8sutil.KubeConfigEnvVar, clientcmd.NewDefaultClientConfigLoadingRules().Precedence[0]))
-		}
-		localCmd.Env = append(localCmd.Env, fmt.Sprintf("%v=%v", k8sutil.WatchNamespaceEnvVar, Global.Namespace))
-	}
-	// setup context to use when setting up crd
-	ctx := NewTestCtx(nil)
-	// os.Exit stops the program before the deferred functions run
-	// to fix this, we put the exit in the defer as well
-	defer func() {
-		// start local operator before running tests
-		if *localOperator {
-			err := localCmd.Start()
-			if err != nil {
-				log.Fatalf("Failed to run operator locally: (%v)", err)
-			}
-			log.Info("Started local operator")
-		}
-		exitCode := m.Run()
-		if *localOperator {
-			err := localCmd.Process.Kill()
-			if err != nil {
-				log.Warn("Failed to stop local operator process")
-			}
-			log.Infof("Local operator stdout: %s", string(localCmdOutBuf.Bytes()))
-			log.Infof("Local operator stderr: %s", string(localCmdErrBuf.Bytes()))
-		}
-		ctx.Cleanup()
-		os.Exit(exitCode)
-	}()
-	// create crd
-	globalYAML, err := ioutil.ReadFile(*globalManPath)
+
+	Global = f
+
+	exitCode, err := f.runM(m)
 	if err != nil {
-		log.Fatalf("Failed to read global resource manifest: %v", err)
+		log.Fatal(err)
 	}
-	err = ctx.createFromYAML(globalYAML, true, &CleanupOptions{TestContext: ctx})
-	if err != nil {
-		log.Fatalf("Failed to create resource(s) in global resource manifest: %v", err)
-	}
+	os.Exit(exitCode)
 }


### PR DESCRIPTION
**Description of the change:**
This PR refactors the e2e framework to remove unnecessary global variables.

**Motivation for the change:**
[Global Variables Are Bad](http://wiki.c2.com/?GlobalVariablesAreBad)
