### PR TITLE
Revert "Allow some commands to generate k8s, without requiring build …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 - Upgrade base image for Go, Helm, and scorecard proxy from `registry.access.redhat.com/ubi7/ubi-minimal:latest` to `registry.access.redhat.com/ubi8/ubi-minimal:latest`. ([#1952](https://github.com/operator-framework/operator-sdk/pull/1952))
 - Upgrade base image for Ansible from `registry.access.redhat.com/ubi7/ubi:latest` to `registry.access.redhat.com/ubi8/ubi:latest`. ([#1990](https://github.com/operator-framework/operator-sdk/pull/1990) and [#2004](https://github.com/operator-framework/operator-sdk/pull/2004))
 - Updated kube-state-metrics dependency from `v1.6.0` to `v1.7.2`. ([#1943](https://github.com/operator-framework/operator-sdk/pull/1943))
-- Change the structure used by sub-commands to check the type and the root dir of the projects for no longer relay in the `Dockerfile` and `main.go` files. ([#1966](https://github.com/operator-framework/operator-sdk/pull/1966)) 
 
 ### Breaking changes
 

--- a/cmd/operator-sdk/main.go
+++ b/cmd/operator-sdk/main.go
@@ -57,8 +57,7 @@ func main() {
 				log.Debug("Debug logging is set")
 			}
 			if err := checkDepManagerForCmd(cmd); err != nil {
-				// Allow cases where subcommands do not require deps files
-				log.Warnf("Operator type %s and the %s. Please, review the structure of your project.", projutil.GetOperatorType(), err)
+				log.Fatal(err)
 			}
 		},
 	}

--- a/cmd/operator-sdk/printdeps/cmd.go
+++ b/cmd/operator-sdk/printdeps/cmd.go
@@ -16,12 +16,13 @@ package printdeps
 
 import (
 	"fmt"
+
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/ansible"
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/helm"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
+
 	"github.com/spf13/cobra"
-	log "github.com/sirupsen/logrus"
 )
 
 var depManager string
@@ -49,11 +50,6 @@ func printDepsFunc(cmd *cobra.Command, args []string) error {
 	}
 	projutil.MustInProjectRoot()
 
-	// Allow the cases of some sub-commands might not require check the deps files.
-	if projutil.GetOperatorType() == projutil.OperatorTypeUnknown {
-		log.Fatal(fmt.Errorf("unknown project type, we were unable to print the deps"))
-	}
-
 	if err := printDeps(depManager); err != nil {
 		return fmt.Errorf("print deps failed: %v", err)
 	}
@@ -61,7 +57,6 @@ func printDepsFunc(cmd *cobra.Command, args []string) error {
 }
 
 func printDeps(depManager string) (err error) {
-
 	// Use depManager if set. Fall back to the project's current dep manager
 	// type if unset.
 	mt := projutil.DepManagerType(depManager)

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -35,13 +35,13 @@ const (
 	GoModEnv   = "GO111MODULE"
 	SrcDir     = "src"
 
-	fsep          = string(filepath.Separator)
-	buildDir      = "build" + fsep
-	rolesDir      = "roles"
-	pkgApiDir      = "pkg" + fsep + "apis" + fsep
-	helmChartsDir = "helm-charts"
-	goModFile     = "go.mod"
-	gopkgTOMLFile = "Gopkg.toml"
+	fsep            = string(filepath.Separator)
+	mainFile        = "cmd" + fsep + "manager" + fsep + "main.go"
+	buildDockerfile = "build" + fsep + "Dockerfile"
+	rolesDir        = "roles"
+	helmChartsDir   = "helm-charts"
+	goModFile       = "go.mod"
+	gopkgTOMLFile   = "Gopkg.toml"
 )
 
 // OperatorType - the type of operator
@@ -114,11 +114,11 @@ func MustInProjectRoot() {
 // CheckProjectRoot checks if the current dir is the project root, and returns
 // an error if not.
 func CheckProjectRoot() error {
-	// If the current directory has a "build/", then it is safe to say
+	// If the current directory has a "build/Dockerfile", then it is safe to say
 	// we are at the project root.
-	if _, err := os.Stat(buildDir); err != nil {
+	if _, err := os.Stat(buildDockerfile); err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("must run command in project root dir: project structure requires %s", buildDir)
+			return fmt.Errorf("must run command in project root dir: project structure requires %s", buildDockerfile)
 		}
 		return errors.Wrap(err, "error while checking if current directory is the project root")
 	}
@@ -129,7 +129,7 @@ func CheckGoProjectCmd(cmd *cobra.Command) error {
 	if IsOperatorGo() {
 		return nil
 	}
-	return fmt.Errorf("'%s' can only be run for Go operators; %s, %s or %s does not exist", cmd.CommandPath(), goModFile, gopkgTOMLFile, pkgApiDir)
+	return fmt.Errorf("'%s' can only be run for Go operators; %s does not exist", cmd.CommandPath(), mainFile)
 }
 
 func MustGetwd() string {
@@ -215,12 +215,8 @@ func GetOperatorType() OperatorType {
 }
 
 func IsOperatorGo() bool {
-	_, errGoMod := os.Stat(goModFile)
-	_, errGopkgTOMLFile := os.Stat(gopkgTOMLFile)
-	_, errPkgApiDir := os.Stat(pkgApiDir)
-
-	// check if has go modules or dep files or pkg/api
-	return errGoMod == nil || errGopkgTOMLFile == nil || errPkgApiDir == nil
+	_, err := os.Stat(mainFile)
+	return err == nil
 }
 
 func IsOperatorAnsible() bool {


### PR DESCRIPTION
…files. (#1966)"

**Description of the change:**
This reverts #1966 (commit a3458abbd42712c1b1bd0d8a8520450f4df3d565).

**Motivation for the change:**
We need to improve the CHANGELOG wording, error messages, and make sure there are no unintended side effects of these changes before including them in a release.