### PR TITLE
Go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ cache:
     - $HOME/.cache/go-build
 
 go:
-- 1.12.x
+- 1.13.x
 
 # The `x_base_steps` top-level key is unknown to travis,
 # so we can use it to create a bunch of common build step

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ SCORECARD_PROXY_IMAGE ?= $(SCORECARD_PROXY_BASE_IMAGE)
 HELM_ARCHES:="amd64" "ppc64le"
 
 export CGO_ENABLED:=0
-export GO111MODULE:=on
 export GOPROXY?=https://proxy.golang.org/
 .DEFAULT_GOAL:=help
 

--- a/ci/dockerfiles/builder.Dockerfile
+++ b/ci/dockerfiles/builder.Dockerfile
@@ -1,7 +1,7 @@
 FROM openshift/origin-release:golang-1.13
 
 WORKDIR /go/src/github.com/operator-framework/operator-sdk
-ENV GOPATH=/go PATH=/go/src/github.com/operator-framework/operator-sdk/build:$PATH GOPROXY=https://proxy.golang.org/ GO111MODULE=on
+ENV GOPATH=/go PATH=/go/src/github.com/operator-framework/operator-sdk/build:$PATH GOPROXY=https://proxy.golang.org/
 
 COPY . .
 

--- a/ci/dockerfiles/builder.Dockerfile
+++ b/ci/dockerfiles/builder.Dockerfile
@@ -1,7 +1,7 @@
 FROM openshift/origin-release:golang-1.13
 
 WORKDIR /go/src/github.com/operator-framework/operator-sdk
-ENV GOPATH=/go PATH=/go/src/github.com/operator-framework/operator-sdk/build:$PATH GOPROXY=https://proxy.golang.org/
+ENV GOPROXY=https://proxy.golang.org/
 
 COPY . .
 

--- a/ci/dockerfiles/builder.Dockerfile
+++ b/ci/dockerfiles/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.12
+FROM openshift/origin-release:golang-1.13
 
 WORKDIR /go/src/github.com/operator-framework/operator-sdk
 ENV GOPATH=/go PATH=/go/src/github.com/operator-framework/operator-sdk/build:$PATH GOPROXY=https://proxy.golang.org/ GO111MODULE=on

--- a/ci/prow.Makefile
+++ b/ci/prow.Makefile
@@ -1,7 +1,6 @@
 # Makefile specifically intended for use in prow/api-ci only.
 
 export CGO_ENABLED := 0
-export GO111MODULE := on
 export GOPROXY ?= https://proxy.golang.org/
 
 build:

--- a/ci/prow.Makefile
+++ b/ci/prow.Makefile
@@ -4,6 +4,7 @@ export CGO_ENABLED := 0
 export GOPROXY ?= https://proxy.golang.org/
 
 build:
+	go get ./...
 	$(MAKE) -f Makefile build/operator-sdk
 
 test/e2e/go:

--- a/ci/tests/scaffolding/e2e-ansible-scaffold-hybrid.sh
+++ b/ci/tests/scaffolding/e2e-ansible-scaffold-hybrid.sh
@@ -23,7 +23,6 @@ pushd memcached-operator
 # Add a second Kind to test watching multiple GVKs
 operator-sdk add crd --kind=Foo --api-version=ansible.example.com/v1alpha1
 
-export GO111MODULE=on
 export GOPROXY=https://proxy.golang.org
 operator-sdk migrate
 

--- a/ci/tests/scaffolding/e2e-helm-scaffold-hybrid.sh
+++ b/ci/tests/scaffolding/e2e-helm-scaffold-hybrid.sh
@@ -13,7 +13,7 @@ pushd "$HELMDIR"
 operator-sdk new nginx-operator --api-version=helm.example.com/v1alpha1 --kind=Nginx --type=helm
 
 pushd nginx-operator
-export GO111MODULE=on
+export GOPROXY=https://proxy.golang.org
 operator-sdk migrate
 
 if [[ ! -e build/Dockerfile.sdkold ]];

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/operator-framework/operator-sdk
 
-go 1.12
+go 1.13
 
 require (
 	cloud.google.com/go v0.37.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -116,8 +116,11 @@ replace (
 	// Locking to a specific version (from 'go mod graph'):
 	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 	github.com/operator-framework/operator-lifecycle-manager => github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190605231540-b8a4faf68e36
-)
 
-// Remove when controller-tools v0.2.2 is released
-// Required for the bugfix https://github.com/kubernetes-sigs/controller-tools/pull/322
-replace sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.2.2-0.20190919011008-6ed4ff330711
+	// github.com/ugorji/go/codec: ambiguous import: found github.com/ugorji/go/codec in multiple modules
+	github.com/ugorji/go v1.1.1 => github.com/ugorji/go v0.0.0-20181204163529-d75b2dcb6bc8
+
+	// Remove when controller-tools v0.2.2 is released
+	// Required for the bugfix https://github.com/kubernetes-sigs/controller-tools/pull/322
+	sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.2.2-0.20190919011008-6ed4ff330711
+)

--- a/go.mod
+++ b/go.mod
@@ -117,8 +117,17 @@ replace (
 	git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 	github.com/operator-framework/operator-lifecycle-manager => github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190605231540-b8a4faf68e36
 
-	// github.com/ugorji/go/codec: ambiguous import: found github.com/ugorji/go/codec in multiple modules
-	github.com/ugorji/go v1.1.1 => github.com/ugorji/go v0.0.0-20181204163529-d75b2dcb6bc8
+	// These replacements are required because various SDK dependencies
+	// depend on different versions of github.com/ugorji/go and
+	// github.com/ugorji/go/codec that conflict and break Go tooling due to the
+	// go.mod changes that have occurred recently in github.com/ugorji/go
+	// and github.com/ugorji/go/codec.
+	// See: https://github.com/ugorji/go/issues/299
+	//
+	// TODO: these replacements can be removed once the SDK
+	// dependencies have been updated to require at least v1.1.7
+	github.com/ugorji/go => github.com/ugorji/go v1.1.7
+	github.com/ugorji/go/codec => github.com/ugorji/go/codec v1.1.7
 
 	// Remove when controller-tools v0.2.2 is released
 	// Required for the bugfix https://github.com/kubernetes-sigs/controller-tools/pull/322

--- a/go.sum
+++ b/go.sum
@@ -424,10 +424,10 @@ github.com/technosophos/moniker v0.0.0-20180509230615-a5dbd03a2245 h1:DNVk+NIkGS
 github.com/technosophos/moniker v0.0.0-20180509230615-a5dbd03a2245/go.mod h1:O1c8HleITsZqzNZDjSNzirUGsMT0oGu9LhHKoJrqO+A=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/ugorji/go v0.0.0-20181204163529-d75b2dcb6bc8 h1:Kcv6ck5PWsaDifMwDDgexKfbmP1k63r3tcVppPa+FyM=
-github.com/ugorji/go v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
-github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8 h1:3SVOIvH7Ae1KRYyQWRjXWJEA9sS/c/pjvH++55Gr648=
-github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
+github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
+github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
+github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 h1:j2hhcujLRHAg872RWAV5yaUrEjHEObwDv3aImCaNLek=

--- a/go.sum
+++ b/go.sum
@@ -424,8 +424,8 @@ github.com/technosophos/moniker v0.0.0-20180509230615-a5dbd03a2245 h1:DNVk+NIkGS
 github.com/technosophos/moniker v0.0.0-20180509230615-a5dbd03a2245/go.mod h1:O1c8HleITsZqzNZDjSNzirUGsMT0oGu9LhHKoJrqO+A=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/ugorji/go v1.1.1 h1:gmervu+jDMvXTbcHQ0pd2wee85nEoE0BsVyEuzkfK8w=
-github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
+github.com/ugorji/go v0.0.0-20181204163529-d75b2dcb6bc8 h1:Kcv6ck5PWsaDifMwDDgexKfbmP1k63r3tcVppPa+FyM=
+github.com/ugorji/go v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8 h1:3SVOIvH7Ae1KRYyQWRjXWJEA9sS/c/pjvH++55Gr648=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=

--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -169,7 +169,7 @@ echo "### Base image testing passed"
 echo "### Now testing migrate to hybrid operator"
 echo "###"
 
-export GO111MODULE=on
+export GOPROXY=https://proxy.golang.org
 operator-sdk migrate --repo=github.com/example-inc/memcached-operator
 
 if [[ ! -e build/Dockerfile.sdkold ]];

--- a/hack/tests/e2e-helm.sh
+++ b/hack/tests/e2e-helm.sh
@@ -150,7 +150,7 @@ echo "### Base image testing passed"
 echo "### Now testing migrate to hybrid operator"
 echo "###"
 
-export GO111MODULE=on
+export GOPROXY=https://proxy.golang.org
 operator-sdk migrate --repo=github.com/example-inc/nginx-operator
 
 if [[ ! -e build/Dockerfile.sdkold ]];

--- a/hack/tests/scaffolding/scaffold-memcached.go
+++ b/hack/tests/scaffolding/scaffold-memcached.go
@@ -58,10 +58,6 @@ func main() {
 	if localSDKPath == "" {
 		localSDKPath = sdkTestE2EDir
 	}
-	// For go commands in operator projects.
-	if err = os.Setenv("GO111MODULE", "on"); err != nil {
-		log.Fatal(err)
-	}
 
 	log.Print("Creating new operator project")
 	cmdOut, err := exec.Command("operator-sdk",

--- a/release.sh
+++ b/release.sh
@@ -23,7 +23,7 @@ if ! $(git diff-index --quiet HEAD --); then
 	exit 1
 fi
 
-GO_VER="1.12"
+GO_VER="1.13"
 if ! go version | cut -d" " -f3 | grep -q "$GO_VER"; then
 	echo "must compile binaries with Go compiler version v${GO_VER}"
 	exit 1


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Upgrade the repo to use go v1.13.

Previous efforts in here, https://github.com/operator-framework/operator-sdk/pull/1949

**Motivation for the change:**

Homebrew build is using go v1.13, https://github.com/Homebrew/homebrew-core/pull/45185

Also personal interest to bump the repo to use the latest golang offering.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
