### PR TITLE
Revert "*: release v0.11.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.11.0
+## Unreleased
 
 ### Added
 
@@ -52,6 +52,8 @@
 - CRD file names were previously of the form `<group>_<version>_<kind>_crd.yaml`. Now that CRD manifest `spec.version` is deprecated in favor of `spec.versions`, i.e. multiple versions can be specified in one CRD, CRD file names have the form `<full group>_<resource>_crd.yaml`. `<full group>` is the full group name of your CRD while `<group>` is the last subdomain of `<full group>`, ex. `foo.bar.com` vs `foo`. `<resource>` is the plural lower-case CRD Kind found at `spec.names.plural`. ([#1876](https://github.com/operator-framework/operator-sdk/pull/1876))
 - Upgrade Python version from `2.7` to `3.6`, Ansible version from `2.8.0` to `~=2.8` and ansible-runner from `1.2` to `1.3.4` in the Ansible based images. ([#1947](https://github.com/operator-framework/operator-sdk/pull/1947)) 
 - Replaced `pkg/kube-metrics.NewCollectors()` with `pkg/kube-metrics.NewMetricsStores()` and changed exported function signature for `pkg/kube-metrics.ServeMetrics()` due to a [breaking change in kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/pull/786). ([#1943](https://github.com/operator-framework/operator-sdk/pull/1943))
+
+### Deprecated
 
 ### Removed
 

--- a/doc/user/install-operator-sdk.md
+++ b/doc/user/install-operator-sdk.md
@@ -18,7 +18,7 @@ $ brew install operator-sdk
 
 ```sh
 # Set the release version variable
-$ RELEASE_VERSION=v0.11.0
+$ RELEASE_VERSION=v0.10.0
 # Linux
 $ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
 # macOS

--- a/internal/pkg/scaffold/ansible/go_mod.go
+++ b/internal/pkg/scaffold/ansible/go_mod.go
@@ -66,8 +66,6 @@ replace (
 	// resolve it correctly.
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus d20e84d0fb64aff2f62a977adc8cfb656da4e286
 )
-
-replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.11.0
 `
 
 func PrintGoMod() error {

--- a/internal/pkg/scaffold/ansible/gopkgtoml.go
+++ b/internal/pkg/scaffold/ansible/gopkgtoml.go
@@ -37,8 +37,8 @@ func (s *GopkgToml) GetInput() (input.Input, error) {
 const gopkgTomlTmpl = `[[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
-  version = "=v0.11.0" #osdk_version_annotation
+  branch = "master" #osdk_branch_annotation
+  # version = "=v0.10.0" #osdk_version_annotation
 
 [[override]]
   name = "k8s.io/api"

--- a/internal/pkg/scaffold/go_mod.go
+++ b/internal/pkg/scaffold/go_mod.go
@@ -65,8 +65,6 @@ replace (
 	// resolve it correctly.
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus d20e84d0fb64aff2f62a977adc8cfb656da4e286
 )
-
-replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.11.0
 `
 
 func PrintGoMod() error {

--- a/internal/pkg/scaffold/gopkgtoml.go
+++ b/internal/pkg/scaffold/gopkgtoml.go
@@ -74,8 +74,8 @@ const gopkgTomlTmpl = `[[override]]
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
-  version = "=v0.11.0" #osdk_version_annotation
+  branch = "master" #osdk_branch_annotation
+  # version = "=v0.10.0" #osdk_version_annotation
 
 [prune]
   go-tests = true

--- a/internal/pkg/scaffold/helm/go_mod.go
+++ b/internal/pkg/scaffold/helm/go_mod.go
@@ -87,8 +87,6 @@ replace (
 	// resolve it correctly.
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus d20e84d0fb64aff2f62a977adc8cfb656da4e286
 )
-
-replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.11.0
 `
 
 func PrintGoMod() error {

--- a/internal/pkg/scaffold/helm/gopkgtoml.go
+++ b/internal/pkg/scaffold/helm/gopkgtoml.go
@@ -37,8 +37,8 @@ func (s *GopkgToml) GetInput() (input.Input, error) {
 const gopkgTomlTmpl = `[[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  # branch = "master" #osdk_branch_annotation
-  version = "=v0.11.0" #osdk_version_annotation
+  branch = "master" #osdk_branch_annotation
+  # version = "=v0.10.0" #osdk_version_annotation
 
 [[override]]
   name = "k8s.io/api"

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	Version    = "v0.11.0"
+	Version    = "v0.10.0+git"
 	GitVersion = "unknown"
 	GitCommit  = "unknown"
 	GoVersion  = fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)


### PR DESCRIPTION
Reverts operator-framework/operator-sdk#2034

There is a bug in `add crd` #1660  which causes it to fail outside `$GOPATH/src` for ansible projects:
```
$ operator-sdk add crd --kind=Foo --api-version=ansible.example.com/v1alpha1
FATA[0000] Project not in $GOPATH
```

This will currently cause the release tag to fail CI.
https://travis-ci.org/operator-framework/operator-sdk/jobs/596366754#L3017-L3020