### PR TITLE
*: allow add crd to run for ansible/helm projects outside $GOPATH

### DIFF
--- a/ci/tests/e2e-ansible.sh
+++ b/ci/tests/e2e-ansible.sh
@@ -9,7 +9,7 @@ eval IMAGE=$IMAGE_FORMAT
 component="osdk-ansible-e2e-hybrid"
 eval IMAGE2=$IMAGE_FORMAT
 ROOTDIR="$(pwd)"
-GOTMP="$(mktemp -d -p $GOPATH/src)"
+GOTMP="$(mktemp -d)"
 trap_add 'rm -rf $GOTMP' EXIT
 
 mkdir -p $ROOTDIR/bin

--- a/ci/tests/e2e-ansible.sh
+++ b/ci/tests/e2e-ansible.sh
@@ -9,8 +9,8 @@ eval IMAGE=$IMAGE_FORMAT
 component="osdk-ansible-e2e-hybrid"
 eval IMAGE2=$IMAGE_FORMAT
 ROOTDIR="$(pwd)"
-GOTMP="$(mktemp -d)"
-trap_add 'rm -rf $GOTMP' EXIT
+TMPDIR="$(mktemp -d)"
+trap_add 'rm -rf $TMPDIR' EXIT
 
 mkdir -p $ROOTDIR/bin
 export PATH=$ROOTDIR/bin:$PATH
@@ -163,7 +163,7 @@ test_operator() {
 oc project default
 
 # create and build the operator
-pushd "$GOTMP"
+pushd "$TMPDIR"
 operator-sdk new memcached-operator --api-version=ansible.example.com/v1alpha1 --kind=Memcached --type=ansible
 
 pushd memcached-operator

--- a/ci/tests/e2e-helm.sh
+++ b/ci/tests/e2e-helm.sh
@@ -9,8 +9,8 @@ eval IMAGE=$IMAGE_FORMAT
 component="osdk-helm-e2e-hybrid"
 eval IMAGE2=$IMAGE_FORMAT
 ROOTDIR="$(pwd)"
-GOTMP="$(mktemp -d)"
-trap_add 'rm -rf $GOTMP' EXIT
+TMPDIR="$(mktemp -d)"
+trap_add 'rm -rf $TMPDIR' EXIT
 
 mkdir -p $ROOTDIR/bin
 export PATH=$ROOTDIR/bin:$PATH
@@ -136,7 +136,7 @@ if oc api-versions | grep openshift; then
 fi
 
 # create and build the operator
-pushd "$GOTMP"
+pushd "$TMPDIR"
 operator-sdk new nginx-operator --api-version=helm.example.com/v1alpha1 --kind=Nginx --type=helm
 
 pushd nginx-operator

--- a/ci/tests/e2e-helm.sh
+++ b/ci/tests/e2e-helm.sh
@@ -9,7 +9,7 @@ eval IMAGE=$IMAGE_FORMAT
 component="osdk-helm-e2e-hybrid"
 eval IMAGE2=$IMAGE_FORMAT
 ROOTDIR="$(pwd)"
-GOTMP="$(mktemp -d -p $GOPATH/src)"
+GOTMP="$(mktemp -d)"
 trap_add 'rm -rf $GOTMP' EXIT
 
 mkdir -p $ROOTDIR/bin

--- a/cmd/operator-sdk/add/crd.go
+++ b/cmd/operator-sdk/add/crd.go
@@ -59,8 +59,11 @@ func crdFunc(cmd *cobra.Command, args []string) error {
 
 	cfg := &input.Config{
 		AbsProjectPath: projutil.MustGetwd(),
-		Repo:           projutil.GetGoPkg(),
 	}
+	if projutil.IsOperatorGo() {
+		cfg.Repo = projutil.GetGoPkg()
+	}
+
 	if len(args) != 0 {
 		return fmt.Errorf("command %s doesn't accept any arguments", cmd.CommandPath())
 	}

--- a/hack/image/build-ansible-image.sh
+++ b/hack/image/build-ansible-image.sh
@@ -6,9 +6,9 @@ source hack/lib/test_lib.sh
 source hack/lib/image_lib.sh
 
 ROOTDIR="$(pwd)"
-GOTMP="$(mktemp -d)"
-trap_add 'rm -rf $GOTMP' EXIT
-BASEIMAGEDIR="$GOTMP/ansible-operator"
+TMPDIR="$(mktemp -d)"
+trap_add 'rm -rf $TMPDIR' EXIT
+BASEIMAGEDIR="$TMPDIR/ansible-operator"
 mkdir -p "$BASEIMAGEDIR"
 go build -o $BASEIMAGEDIR/scaffold-ansible-image ./hack/image/ansible/scaffold-ansible-image.go
 

--- a/hack/image/build-helm-image.sh
+++ b/hack/image/build-helm-image.sh
@@ -6,9 +6,9 @@ source hack/lib/test_lib.sh
 source hack/lib/image_lib.sh
 
 ROOTDIR="$(pwd)"
-GOTMP="$(mktemp -d)"
-trap_add 'rm -rf $GOTMP' EXIT
-BASEIMAGEDIR="$GOTMP/helm-operator"
+TMPDIR="$(mktemp -d)"
+trap_add 'rm -rf $TMPDIR' EXIT
+BASEIMAGEDIR="$TMPDIR/helm-operator"
 mkdir -p "$BASEIMAGEDIR"
 go build -o $BASEIMAGEDIR/scaffold-helm-image ./hack/image/helm/scaffold-helm-image.go
 

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -5,8 +5,8 @@ source hack/lib/test_lib.sh
 set -eux
 
 ROOTDIR="$(pwd)"
-GOTMP="$(mktemp -d)"
-trap_add 'rm -rf $GOTMP' EXIT
+TMPDIR="$(mktemp -d)"
+trap_add 'rm -rf $TMPDIR' EXIT
 pip3 install --user pyasn1==0.4.7 pyasn1-modules==0.2.6 idna==2.8 ipaddress==1.0.22
 pip3 install --user molecule==2.22
 pip3 install --user docker openshift jmespath
@@ -25,7 +25,7 @@ remove_prereqs() {
     kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/crds/ansible.example.com_memcacheds_crd.yaml"
 }
 
-pushd "$GOTMP"
+pushd "$TMPDIR"
 operator-sdk new memcached-operator \
   --api-version=ansible.example.com/v1alpha1 \
   --kind=Memcached \

--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -10,8 +10,8 @@ go test -count=1 ./pkg/ansible/proxy/...
 
 DEST_IMAGE="quay.io/example/memcached-operator:v0.0.2"
 ROOTDIR="$(pwd)"
-GOTMP="$(mktemp -d)"
-trap_add 'rm -rf $GOTMP' EXIT
+TMPDIR="$(mktemp -d)"
+trap_add 'rm -rf $TMPDIR' EXIT
 
 deploy_operator() {
     kubectl create -f "$OPERATORDIR/deploy/service_account.yaml"
@@ -129,7 +129,7 @@ test_operator() {
 }
 
 # create and build the operator
-pushd "$GOTMP"
+pushd "$TMPDIR"
 operator-sdk new memcached-operator \
   --api-version=ansible.example.com/v1alpha1 \
   --kind=Memcached \

--- a/hack/tests/e2e-helm.sh
+++ b/hack/tests/e2e-helm.sh
@@ -7,8 +7,8 @@ source hack/lib/image_lib.sh
 
 DEST_IMAGE="quay.io/example/nginx-operator:v0.0.2"
 ROOTDIR="$(pwd)"
-GOTMP="$(mktemp -d)"
-trap_add 'rm -rf $GOTMP' EXIT
+TMPDIR="$(mktemp -d)"
+trap_add 'rm -rf $TMPDIR' EXIT
 
 deploy_operator() {
     kubectl create -f "$OPERATORDIR/deploy/service_account.yaml"
@@ -112,7 +112,7 @@ test_operator() {
 }
 
 # create and build the operator
-pushd "$GOTMP"
+pushd "$TMPDIR"
 log=$(operator-sdk new nginx-operator \
   --api-version=helm.example.com/v1alpha1 \
   --kind=Nginx \


### PR DESCRIPTION
**Description of the change:**
- Allow `add crd` command to run outside `$GOPATH/src` for Helm/Ansible projects.
- Change `GOTMP="$(mktemp -d -p $GOPATH/src)"` ==> `GOTMP="$(mktemp -d)"` 
- Change the var name `GOTMP` to `TMPDIR` in the ansible/helm CI scripts

**Motivation for the change:**
Fix the bug introduced to `add crd` in #1660 
The CI script var `GOTMP` name change is to avoid setting it as`GOTMP="$(mktemp -d -p $GOPATH/src)"` since those tests shouldn't need any Go related envs/paths. This is what caused the break in `add crd` to not be detected by the prow CI scripts in #1660 