### PR TITLE
*: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v0.11.0
 
 ### Added
 

--- a/doc/user/install-operator-sdk.md
+++ b/doc/user/install-operator-sdk.md
@@ -18,7 +18,7 @@ $ brew install operator-sdk
 
 ```sh
 # Set the release version variable
-$ RELEASE_VERSION=v0.10.0
+$ RELEASE_VERSION=v0.11.0
 # Linux
 $ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
 # macOS

--- a/internal/pkg/scaffold/ansible/go_mod.go
+++ b/internal/pkg/scaffold/ansible/go_mod.go
@@ -66,6 +66,8 @@ replace (
 	// resolve it correctly.
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus d20e84d0fb64aff2f62a977adc8cfb656da4e286
 )
+
+replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.11.0
 `
 
 func PrintGoMod() error {

--- a/internal/pkg/scaffold/ansible/gopkgtoml.go
+++ b/internal/pkg/scaffold/ansible/gopkgtoml.go
@@ -37,8 +37,8 @@ func (s *GopkgToml) GetInput() (input.Input, error) {
 const gopkgTomlTmpl = `[[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  branch = "master" #osdk_branch_annotation
-  # version = "=v0.10.0" #osdk_version_annotation
+  # branch = "master" #osdk_branch_annotation
+  version = "=v0.11.0" #osdk_version_annotation
 
 [[override]]
   name = "k8s.io/api"

--- a/internal/pkg/scaffold/go_mod.go
+++ b/internal/pkg/scaffold/go_mod.go
@@ -65,6 +65,8 @@ replace (
 	// resolve it correctly.
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus d20e84d0fb64aff2f62a977adc8cfb656da4e286
 )
+
+replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.11.0
 `
 
 func PrintGoMod() error {

--- a/internal/pkg/scaffold/gopkgtoml.go
+++ b/internal/pkg/scaffold/gopkgtoml.go
@@ -74,8 +74,8 @@ const gopkgTomlTmpl = `[[override]]
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  branch = "master" #osdk_branch_annotation
-  # version = "=v0.10.0" #osdk_version_annotation
+  # branch = "master" #osdk_branch_annotation
+  version = "=v0.11.0" #osdk_version_annotation
 
 [prune]
   go-tests = true

--- a/internal/pkg/scaffold/helm/go_mod.go
+++ b/internal/pkg/scaffold/helm/go_mod.go
@@ -87,6 +87,8 @@ replace (
 	// resolve it correctly.
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus d20e84d0fb64aff2f62a977adc8cfb656da4e286
 )
+
+replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.11.0
 `
 
 func PrintGoMod() error {

--- a/internal/pkg/scaffold/helm/gopkgtoml.go
+++ b/internal/pkg/scaffold/helm/gopkgtoml.go
@@ -37,8 +37,8 @@ func (s *GopkgToml) GetInput() (input.Input, error) {
 const gopkgTomlTmpl = `[[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  branch = "master" #osdk_branch_annotation
-  # version = "=v0.10.0" #osdk_version_annotation
+  # branch = "master" #osdk_branch_annotation
+  version = "=v0.11.0" #osdk_version_annotation
 
 [[override]]
   name = "k8s.io/api"

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	Version    = "v0.10.0+git"
+	Version    = "v0.11.0"
 	GitVersion = "unknown"
 	GitCommit  = "unknown"
 	GoVersion  = fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)


### PR DESCRIPTION
**Description of the change:**
Update release and dependency versions to `v0.11.0`

**Motivation for the change:**
Retrying the release after #2043 