### PR TITLE
Be able to execute the commands operator-sdk generate k8s and openapi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Change sub-commands for no longer relay in the `Dockerfile` and `main.go` files. ([#2054](https://github.com/operator-framework/operator-sdk/pull/2054)) 
+
 ### Deprecated
 
 ### Removed

--- a/cmd/operator-sdk/main.go
+++ b/cmd/operator-sdk/main.go
@@ -57,7 +57,8 @@ func main() {
 				log.Debug("Debug logging is set")
 			}
 			if err := checkDepManagerForCmd(cmd); err != nil {
-				log.Fatal(err)
+				// Allow cases where subcommands do not require deps files
+				log.Warnf("Operator type %s and the %s. Please, review the structure of your project.", projutil.GetOperatorType(), err)
 			}
 		},
 	}

--- a/cmd/operator-sdk/printdeps/cmd.go
+++ b/cmd/operator-sdk/printdeps/cmd.go
@@ -16,13 +16,12 @@ package printdeps
 
 import (
 	"fmt"
-
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold"
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/ansible"
 	"github.com/operator-framework/operator-sdk/internal/pkg/scaffold/helm"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
-
 	"github.com/spf13/cobra"
+	log "github.com/sirupsen/logrus"
 )
 
 var depManager string
@@ -50,6 +49,11 @@ func printDepsFunc(cmd *cobra.Command, args []string) error {
 	}
 	projutil.MustInProjectRoot()
 
+	// Allow the cases of some sub-commands might not require check the deps files.
+	if projutil.GetOperatorType() == projutil.OperatorTypeUnknown {
+		log.Fatal(fmt.Errorf("unknown project type, we were unable to print the deps"))
+	}
+
 	if err := printDeps(depManager); err != nil {
 		return fmt.Errorf("print deps failed: %v", err)
 	}
@@ -57,6 +61,7 @@ func printDepsFunc(cmd *cobra.Command, args []string) error {
 }
 
 func printDeps(depManager string) (err error) {
+
 	// Use depManager if set. Fall back to the project's current dep manager
 	// type if unset.
 	mt := projutil.DepManagerType(depManager)


### PR DESCRIPTION
**Description of the change:**
- Change sub-commands for no longer relay in the `Dockerfile` and `main.go` files.

PS.: It was tested/review already for 2 teammates but we revert this one in order to not risk the release. Also, the Changelog was improved as suggested by @joelanford.  
- See the original PR: https://github.com/operator-framework/operator-sdk/pull/1966/
- See the revert one: https://github.com/operator-framework/operator-sdk/pull/2039 

**Motivation for the change:**
Closes: #1804 and #1686
PS.: Helpful for #1964

 