### PR TITLE
Allow up local detection by operator

### DIFF
--- a/cmd/operator-sdk/up/local.go
+++ b/cmd/operator-sdk/up/local.go
@@ -80,6 +80,9 @@ var (
 func upLocalFunc(cmd *cobra.Command, args []string) error {
 	log.Info("Running the operator locally.")
 
+	// set env variable for operator to assess up-local
+	os.Setenv("OPERATOR_UP_LOCAL", "true")
+
 	// get default namespace to watch if unset
 	if !cmd.Flags().Changed("namespace") {
 		_, defaultNamespace, err := k8sInternal.GetKubeconfigAndNamespace(kubeConfig)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
When `operator-sdk up local` is called. Set OPERATOR_UP_LOCAL=true

**Motivation for the change:**
When developing locally, it would be convenient to detect this in
the actual operator code so things like metrics can be bypassed.

With the OPERATOR_UP_LOCAL=true, operators can skip certain
bootstrapping tasks like attempting to register with a metrics service
while still maintaining logic for registering failures in production.

An example can be seen below:

```
	// detect if operator-sdk up local is run
	detectLocal := os.Getenv("OPERATOR_UP_LOCAL")

	// Configure metrics. If it errors, log the error and exit
	if detectLocal != "true" {
		if err := metrics.ConfigureMetrics(context.TODO(), *metricsServer); err != nil {
			log.Error(err, "Failed to configure Metrics")
			os.Exit(1)
		}
	}
```

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
