### PR TITLE
test(ansible): Refactor ansible's functional tests

### DIFF
--- a/ci/tests/e2e-ansible.sh
+++ b/ci/tests/e2e-ansible.sh
@@ -49,6 +49,13 @@ remove_operator() {
     kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/operator.yaml"
 }
 
+operator_logs() {
+    kubectl describe pods
+    kubectl logs deployment/memcached-operator -c operator
+    kubectl logs deployment/memcached-operator -c ansible
+}
+
+
 test_operator() {
     local metrics_test_image="registry.access.redhat.com/ubi8/ubi-minimal:latest"
 
@@ -56,9 +63,7 @@ test_operator() {
     if ! timeout 1m kubectl rollout status deployment/memcached-operator;
     then
         echo FAIL: operator failed to run
-        kubectl describe pods
-        kubectl logs deployment/memcached-operator -c operator
-        kubectl logs deployment/memcached-operator -c ansible
+        operator_logs
         exit 1
     fi
 
@@ -66,9 +71,7 @@ test_operator() {
     if ! timeout 20s bash -c -- "until kubectl get service/memcached-operator-metrics > /dev/null 2>&1; do sleep 1; done";
     then
         echo "Failed to get metrics service"
-        kubectl describe pods
-        kubectl logs deployment/memcached-operator -c operator
-        kubectl logs deployment/memcached-operator -c ansible
+        operator_logs
         exit 1
     fi
 
@@ -76,9 +79,7 @@ test_operator() {
     if ! timeout 1m bash -c -- "until kubectl run --attach --rm --restart=Never test-metrics --image=$metrics_test_image -- curl -sfo /dev/null http://memcached-operator-metrics:8383/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
-        kubectl describe pods
-        kubectl logs deployment/memcached-operator -c operator
-        kubectl logs deployment/memcached-operator -c ansible
+        operator_logs
         exit 1
     fi
 
@@ -86,9 +87,7 @@ test_operator() {
     if ! timeout 1m bash -c -- "until kubectl run --attach --rm --restart=Never test-metrics --image=$metrics_test_image -- curl -sfo /dev/null http://memcached-operator-metrics:8686/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
-        kubectl describe pods
-        kubectl logs deployment/memcached-operator -c operator
-        kubectl logs deployment/memcached-operator -c ansible
+        operator_logs
         exit 1
     fi
 
@@ -97,19 +96,15 @@ test_operator() {
     if ! timeout 20s bash -c -- 'until kubectl get deployment -l app=memcached | grep memcached; do sleep 1; done';
     then
         echo FAIL: operator failed to create memcached Deployment
-        kubectl describe pods
-        kubectl logs deployment/memcached-operator -c operator
-        kubectl logs deployment/memcached-operator -c ansible
+        operator_logs
         exit 1
     fi
 
     # verify that metrics reflect cr creation
-    if ! bash -c -- "kubectl run --attach --rm --restart=Never test-metrics --image=$metrics_test_image -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached";
+    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=$metrics_test_image -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached; do sleep 1; done";
     then
         echo "Failed to verify custom resource metrics"
-        kubectl describe pods
-        kubectl logs deployment/memcached-operator -c operator
-        kubectl logs deployment/memcached-operator -c ansible
+        operator_logs
         exit 1
     fi
 
@@ -117,7 +112,7 @@ test_operator() {
     if ! timeout 1m kubectl rollout status deployment/${memcached_deployment};
     then
         echo FAIL: memcached Deployment failed rollout
-        kubectl describe pods
+        operator_logs
         kubectl logs deployment/${memcached_deployment}
         exit 1
     fi
@@ -132,9 +127,7 @@ test_operator() {
     if kubectl get configmap deleteme 2> /dev/null;
     then
         echo FAIL: the finalizer did not delete the configmap
-        kubectl describe pods
-        kubectl logs deployment/memcached-operator -c operator
-        kubectl logs deployment/memcached-operator -c ansible
+        operator_logs
         exit 1
     fi
 
@@ -142,9 +135,7 @@ test_operator() {
     if ! timeout 20s bash -c -- "while kubectl get deployment ${memcached_deployment} 2> /dev/null; do sleep 1; done";
     then
         echo FAIL: memcached Deployment did not get garbage collected
-        kubectl describe pods
-        kubectl logs deployment/memcached-operator -c operator
-        kubectl logs deployment/memcached-operator -c ansible
+        operator_logs
         exit 1
     fi
 
@@ -152,9 +143,7 @@ test_operator() {
     if kubectl logs deployment/memcached-operator -c operator | grep -i error;
     then
         echo FAIL: the operator log includes errors
-        kubectl describe pods
-        kubectl logs deployment/memcached-operator -c operator
-        kubectl logs deployment/memcached-operator -c ansible
+        operator_logs
         exit 1
     fi
 }
@@ -184,9 +173,7 @@ remove_operator
 if ! timeout 60s bash -c -- "until kubectl get pods -l name=memcached-operator |& grep \"No resources found\"; do sleep 2; done";
 then
     echo FAIL: memcached-operator Deployment did not get garbage collected
-    kubectl describe pods
-    kubectl logs deployment/memcached-operator -c operator
-    kubectl logs deployment/memcached-operator -c ansible
+    operator_logs
     exit 1
 fi
 

--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -31,6 +31,12 @@ remove_operator() {
     kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/operator.yaml"
 }
 
+operator_logs() {
+    kubectl describe pods
+    kubectl logs deployment/memcached-operator -c operator
+    kubectl logs deployment/memcached-operator -c ansible
+}
+
 test_operator() {
     # kind has an issue with certain image registries (ex. redhat's), so use a
     # different test pod image.
@@ -40,8 +46,7 @@ test_operator() {
     if ! timeout 1m kubectl rollout status deployment/memcached-operator;
     then
         echo FAIL: operator failed to run
-        kubectl logs deployment/memcached-operator -c operator
-        kubectl logs deployment/memcached-operator -c ansible
+        operator_logs
         exit 1
     fi
 
@@ -57,7 +62,7 @@ test_operator() {
     if ! timeout 1m bash -c -- "until kubectl run --attach --rm --restart=Never test-metrics --image=$metrics_test_image -- curl -sfo /dev/null http://memcached-operator-metrics:8383/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
-        kubectl logs deployment/memcached-operator
+        operator_logs
         exit 1
     fi
 
@@ -65,7 +70,7 @@ test_operator() {
     if ! timeout 1m bash -c -- "until kubectl run --attach --rm --restart=Never test-metrics --image=$metrics_test_image -- curl -sfo /dev/null http://memcached-operator-metrics:8686/metrics; do sleep 1; done";
     then
         echo "Failed to verify that metrics endpoint exists"
-        kubectl logs deployment/memcached-operator
+        operator_logs
         exit 1
     fi
 
@@ -74,16 +79,15 @@ test_operator() {
     if ! timeout 20s bash -c -- 'until kubectl get deployment -l app=memcached | grep memcached; do sleep 1; done';
     then
         echo FAIL: operator failed to create memcached Deployment
-        kubectl logs deployment/memcached-operator -c operator
-        kubectl logs deployment/memcached-operator -c ansible
+        operator_logs
         exit 1
     fi
 
     # verify that metrics reflect cr creation
-    if ! bash -c -- "kubectl run --attach --rm --restart=Never test-metrics --image=$metrics_test_image -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached";
+    if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=$metrics_test_image -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached; do sleep 1; done";
     then
         echo "Failed to verify custom resource metrics"
-        kubectl logs deployment/memcached-operator
+        operator_logs
         exit 1
     fi
     memcached_deployment=$(kubectl get deployment -l app=memcached -o jsonpath="{..metadata.name}")
@@ -104,8 +108,7 @@ test_operator() {
     if kubectl get configmap deleteme 2> /dev/null;
     then
         echo FAIL: the finalizer did not delete the configmap
-        kubectl logs deployment/memcached-operator -c operator
-        kubectl logs deployment/memcached-operator -c ansible
+        operator_logs
         exit 1
     fi
 
@@ -113,8 +116,7 @@ test_operator() {
     if ! timeout 20s bash -c -- "while kubectl get deployment ${memcached_deployment} 2> /dev/null; do sleep 1; done";
     then
         echo FAIL: memcached Deployment did not get garbage collected
-        kubectl logs deployment/memcached-operator -c operator
-        kubectl logs deployment/memcached-operator -c ansible
+        operator_logs
         exit 1
     fi
 
@@ -122,8 +124,7 @@ test_operator() {
     if kubectl logs deployment/memcached-operator -c operator | grep -i error;
     then
         echo FAIL: the operator log includes errors
-        kubectl logs deployment/memcached-operator -c operator
-        kubectl logs deployment/memcached-operator -c ansible
+        operator_logs
         exit 1
     fi
 }


### PR DESCRIPTION
**Description of the change:**

- Puts the common debugging logic in a `operator_logs()` function
- Call `operator_logs()` in failure scenarios
- Gives the operator a minute to reconcile the test CR

**Motivation for the change:**

Make it easier to do the right thing to add useful information to the logs when tests fail.
