### PR TITLE
Documents Unsupported ansible modules Q/A

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -48,7 +48,7 @@ USER 1001
 ```
 
 If you aren't sure what dependencies are required, start up a container using the image in the `FROM` line as root. That's probably look something like this.
-`docker run -u 0 -it --rm --entrypoint /bin/bash quay.io/operator-framework/ansible-operator:v0.11.0`
+`docker run -u 0 -it --rm --entrypoint /bin/bash quay.io/operator-framework/ansible-operator:<sdk-tag-version>`
 
 [kube-apiserver_options]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/#options
 [controller-runtime_faq]: https://github.com/kubernetes-sigs/controller-runtime/blob/master/FAQ.md#q-how-do-i-have-different-logic-in-my-reconciler-for-different-types-of-events-eg-create-update-delete

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -47,7 +47,7 @@ RUN pip3 install my-python-dependency
 USER 1001
 ```
 
-If you aren't sure what dependencies are required, start up a container using the image in the `FROM` line as root. That's probably look something like this.
+If you aren't sure what dependencies are required, start up a container using the image in the `FROM` line as root. That will look something like this.
 `docker run -u 0 -it --rm --entrypoint /bin/bash quay.io/operator-framework/ansible-operator:<sdk-tag-version>`
 
 [kube-apiserver_options]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/#options

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -36,6 +36,19 @@ Add the following to your `deploy/role.yaml` file to grant the operator permissi
   - deployments/finalizers
 ```
 
+## My Ansible module is missing a dependency. How do I add it to the image? 
+
+Unfortunately, adding the entire dependency tree for all Ansible modules would be excessive. Fortunately, you can add it easily. Simply edit your build/Dockerfile. You'll want to change to root for the install command, just be sure to swap back using a series of commands like the following right after the `FROM` line.
+
+```
+USER 0
+RUN yum -y install my-dependency
+RUN pip3 install my-python-dependency
+USER 1001
+```
+
+If you aren't sure what dependencies are required, start up a container using the image in the `FROM` line as root. That's probably look something like this.
+`docker run -u 0 -it --rm --entrypoint /bin/bash quay.io/operator-framework/ansible-operator:v0.11.0`
 
 [kube-apiserver_options]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/#options
 [controller-runtime_faq]: https://github.com/kubernetes-sigs/controller-runtime/blob/master/FAQ.md#q-how-do-i-have-different-logic-in-my-reconciler-for-different-types-of-events-eg-create-update-delete


### PR DESCRIPTION
Adds a question and the answer to the documentation for dealing with dependencies for ansible modules that aren't included in the ansible-operator image.

**Description of the change:**
Adds a question and the answer to the documentation for dealing with dependencies for ansible modules that aren't included in the ansible-operator image.

**Motivation for the change:**
I had to piece this together myself and thought it would be good to document for others (and when I forget).