### PR TITLE
hack/tests/sanity-check.sh: ignore go.mod changes caused by go vet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,6 @@ go:
 # so we can use it to create a bunch of common build step
 # YAML anchors which we use in our build jobs.
 x_base_steps:
-  # before_install for jobs that require dep
-  - &dep_before_install
-    before_install:
-      - travis_retry make tidy
-
   # before_install for jobs that require go builds and do not run for doc-only changes
   - &go_before_install
     before_install:
@@ -151,7 +146,6 @@ jobs:
       name: Unit, Sanity, and Markdown Tests
       # Currently, prow/api-ci tests all PRs that target master; use travis for post merge testing and non-master PRs
       if: type != pull_request OR branch != master
-      <<: *dep_before_install
       script: make test/sanity test/unit test/markdown
       after_success: echo 'Tests Passed'
       after_failure: echo 'Failure in unit, sanity, or markdown test'

--- a/hack/tests/sanity-check.sh
+++ b/hack/tests/sanity-check.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 set -ex
 
+# Make sure repo is in clean state before running go vet
+git diff --exit-code
+
 go vet ./...
 go fmt ./...
+
+# Ignore changes to go.mod caused by running go vet
+git checkout go.mod
+
 ./hack/check_license.sh
 ./hack/check_error_log_msg_format.sh
 
-# Make sure repo is in clean state
+# Make sure repo is still in a clean state.
 git diff --exit-code

--- a/hack/tests/sanity-check.sh
+++ b/hack/tests/sanity-check.sh
@@ -4,6 +4,7 @@ set -ex
 # Make sure repo is in clean state before running go vet
 git diff --exit-code
 
+go mod tidy
 go vet ./...
 go fmt ./...
 


### PR DESCRIPTION
**Description of the change:**
This PR updates the sanity check script to ignore changes to go.mod caused by `go vet` (and other go commands).

**Motivation for the change:**
Many `go` commands change the `go.mod` file if it does not match what the go tooling expects. `go.mod` files managed by go1.12 are changed when running go commands with go1.13. This causes problems with the sanity check script when trying to migrate from go1.12 to go1.13.

During the transition, we can ignore `go.mod` file changes that occur when `go vet` runs earlier in the sanity check script. After the transition, we will revert this PR so that future `go.mod` files are checked for adherance to the go tooling expectations.

**Order of operations to complete go1.13 migration**
- [ ] 1. Merge #2073 (this PR)
- [ ] 2. Merge openshift/release#5443 (assuming #2073 fixes sanity test failures)
- [ ] 3. Merge #2040 (or #1949)
- [ ] 4. Revert #2073 (this PR) 