### PR TITLE
Set namespsace for metrics to WATCH_NAMESPACE

### DIFF
--- a/internal/pkg/scaffold/cmd.go
+++ b/internal/pkg/scaffold/cmd.go
@@ -198,7 +198,7 @@ func serveCRMetrics(cfg *rest.Config) error {
 	    return err
 	}
 	// Get the namespace the operator is currently deployed in.
-	operatorNs, err := k8sutil.GetOperatorNamespace()
+	operatorNs, err := k8sutil.GetWatchNamespace()
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/scaffold/cmd_test.go
+++ b/internal/pkg/scaffold/cmd_test.go
@@ -197,7 +197,7 @@ func serveCRMetrics(cfg *rest.Config) error {
 		return err
 	}
 	// Get the namespace the operator is currently deployed in.
-	operatorNs, err := k8sutil.GetOperatorNamespace()
+	operatorNs, err := k8sutil.GetWatchNamespace()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Often the operator is in the same namespace as the things it's watching
and this works okay. We deploy the operator to a different namespace.
Anyway, I think this should be the watch namespace since that's where
we're expecting the CRDs to be.