### PR TITLE
Add labels to scorecard tests

### DIFF
--- a/internal/pkg/scorecard/helpers/helpers.go
+++ b/internal/pkg/scorecard/helpers/helpers.go
@@ -131,6 +131,7 @@ func TestResultToScorecardTestResult(tr TestResult) scapiv1alpha1.ScorecardTestR
 		stringErrors = append(stringErrors, err.Error())
 	}
 	sctr.Errors = stringErrors
+	sctr.Labels = tr.Test.GetLabels()
 	return sctr
 }
 

--- a/internal/pkg/scorecard/helpers/test_definitions.go
+++ b/internal/pkg/scorecard/helpers/test_definitions.go
@@ -28,6 +28,7 @@ import (
 type Test interface {
 	GetName() string
 	GetDescription() string
+	GetLabels() map[string]string
 	IsCumulative() bool
 	Run(context.Context) *TestResult
 }
@@ -49,6 +50,7 @@ type TestInfo struct {
 	// If a test is set to cumulative, the scores of multiple runs of the same test on separate CRs are added together for the total score.
 	// If cumulative is false, if any test failed, the total score is 0/1. Otherwise 1/1.
 	Cumulative bool
+	Labels     map[string]string
 }
 
 // GetName return the test name
@@ -56,6 +58,9 @@ func (i TestInfo) GetName() string { return i.Name }
 
 // GetDescription returns the test description
 func (i TestInfo) GetDescription() string { return i.Description }
+
+// GetLabels returns the labels for this test
+func (i TestInfo) GetLabels() map[string]string { return i.Labels }
 
 // IsCumulative returns true if the test's scores are intended to be cumulative
 func (i TestInfo) IsCumulative() bool { return i.Cumulative }

--- a/internal/pkg/scorecard/plugins/basic_tests.go
+++ b/internal/pkg/scorecard/plugins/basic_tests.go
@@ -51,6 +51,7 @@ func NewCheckSpecTest(conf BasicTestConfig) *CheckSpecTest {
 			Name:        "Spec Block Exists",
 			Description: "Custom Resource has a Spec Block",
 			Cumulative:  false,
+			Labels:      map[string]string{"required": "true", "suite": "basic"},
 		},
 	}
 }
@@ -69,6 +70,7 @@ func NewCheckStatusTest(conf BasicTestConfig) *CheckStatusTest {
 			Name:        "Status Block Exists",
 			Description: "Custom Resource has a Status Block",
 			Cumulative:  false,
+			Labels:      map[string]string{"required": "true", "suite": "basic"},
 		},
 	}
 }
@@ -87,6 +89,7 @@ func NewWritingIntoCRsHasEffectTest(conf BasicTestConfig) *WritingIntoCRsHasEffe
 			Name:        "Writing into CRs has an effect",
 			Description: "A CR sends PUT/POST requests to the API server to modify resources in response to spec block changes",
 			Cumulative:  false,
+			Labels:      map[string]string{"required": "true", "suite": "basic"},
 		},
 	}
 }

--- a/internal/pkg/scorecard/plugins/basic_tests.go
+++ b/internal/pkg/scorecard/plugins/basic_tests.go
@@ -51,7 +51,7 @@ func NewCheckSpecTest(conf BasicTestConfig) *CheckSpecTest {
 			Name:        "Spec Block Exists",
 			Description: "Custom Resource has a Spec Block",
 			Cumulative:  false,
-			Labels:      map[string]string{"required": "true", "suite": "basic"},
+			Labels:      map[string]string{necessityKey: requiredNecessity, suiteKey: basicSuiteName},
 		},
 	}
 }
@@ -70,7 +70,7 @@ func NewCheckStatusTest(conf BasicTestConfig) *CheckStatusTest {
 			Name:        "Status Block Exists",
 			Description: "Custom Resource has a Status Block",
 			Cumulative:  false,
-			Labels:      map[string]string{"required": "true", "suite": "basic"},
+			Labels:      map[string]string{necessityKey: requiredNecessity, suiteKey: basicSuiteName},
 		},
 	}
 }
@@ -89,7 +89,7 @@ func NewWritingIntoCRsHasEffectTest(conf BasicTestConfig) *WritingIntoCRsHasEffe
 			Name:        "Writing into CRs has an effect",
 			Description: "A CR sends PUT/POST requests to the API server to modify resources in response to spec block changes",
 			Cumulative:  false,
-			Labels:      map[string]string{"required": "true", "suite": "basic"},
+			Labels:      map[string]string{necessityKey: requiredNecessity, suiteKey: basicSuiteName},
 		},
 	}
 }

--- a/internal/pkg/scorecard/plugins/labels.go
+++ b/internal/pkg/scorecard/plugins/labels.go
@@ -1,0 +1,25 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scplugins
+
+const (
+	necessityKey      = "necessity"
+	requiredNecessity = "required"
+	optionalNecessity = "optional"
+
+	suiteKey       = "suite"
+	basicSuiteName = "basic"
+	olmSuiteName   = "olm"
+)

--- a/internal/pkg/scorecard/plugins/olm_tests.go
+++ b/internal/pkg/scorecard/plugins/olm_tests.go
@@ -58,7 +58,7 @@ func NewCRDsHaveValidationTest(conf OLMTestConfig) *CRDsHaveValidationTest {
 			Name:        "Provided APIs have validation",
 			Description: "All CRDs have an OpenAPI validation subsection",
 			Cumulative:  true,
-			Labels:      map[string]string{"required": "true", "suite": "olm"},
+			Labels:      map[string]string{necessityKey: requiredNecessity, suiteKey: olmSuiteName},
 		},
 	}
 }
@@ -77,7 +77,7 @@ func NewCRDsHaveResourcesTest(conf OLMTestConfig) *CRDsHaveResourcesTest {
 			Name:        "Owned CRDs have resources listed",
 			Description: "All Owned CRDs contain a resources subsection",
 			Cumulative:  true,
-			Labels:      map[string]string{"required": "true", "suite": "olm"},
+			Labels:      map[string]string{necessityKey: requiredNecessity, suiteKey: olmSuiteName},
 		},
 	}
 }
@@ -96,7 +96,7 @@ func NewAnnotationsContainExamplesTest(conf OLMTestConfig) *AnnotationsContainEx
 			Name:        "CRs have at least 1 example",
 			Description: "The CSV's metadata contains an alm-examples section",
 			Cumulative:  true,
-			Labels:      map[string]string{"required": "true", "suite": "olm"},
+			Labels:      map[string]string{necessityKey: requiredNecessity, suiteKey: olmSuiteName},
 		},
 	}
 }
@@ -115,7 +115,7 @@ func NewSpecDescriptorsTest(conf OLMTestConfig) *SpecDescriptorsTest {
 			Name:        "Spec fields with descriptors",
 			Description: "All spec fields have matching descriptors in the CSV",
 			Cumulative:  true,
-			Labels:      map[string]string{"required": "true", "suite": "olm"},
+			Labels:      map[string]string{necessityKey: requiredNecessity, suiteKey: olmSuiteName},
 		},
 	}
 }
@@ -134,7 +134,7 @@ func NewStatusDescriptorsTest(conf OLMTestConfig) *StatusDescriptorsTest {
 			Name:        "Status fields with descriptors",
 			Description: "All status fields have matching descriptors in the CSV",
 			Cumulative:  true,
-			Labels:      map[string]string{"required": "true", "suite": "olm"},
+			Labels:      map[string]string{necessityKey: requiredNecessity, suiteKey: olmSuiteName},
 		},
 	}
 }

--- a/internal/pkg/scorecard/plugins/olm_tests.go
+++ b/internal/pkg/scorecard/plugins/olm_tests.go
@@ -58,6 +58,7 @@ func NewCRDsHaveValidationTest(conf OLMTestConfig) *CRDsHaveValidationTest {
 			Name:        "Provided APIs have validation",
 			Description: "All CRDs have an OpenAPI validation subsection",
 			Cumulative:  true,
+			Labels:      map[string]string{"required": "true", "suite": "olm"},
 		},
 	}
 }
@@ -76,6 +77,7 @@ func NewCRDsHaveResourcesTest(conf OLMTestConfig) *CRDsHaveResourcesTest {
 			Name:        "Owned CRDs have resources listed",
 			Description: "All Owned CRDs contain a resources subsection",
 			Cumulative:  true,
+			Labels:      map[string]string{"required": "true", "suite": "olm"},
 		},
 	}
 }
@@ -94,6 +96,7 @@ func NewAnnotationsContainExamplesTest(conf OLMTestConfig) *AnnotationsContainEx
 			Name:        "CRs have at least 1 example",
 			Description: "The CSV's metadata contains an alm-examples section",
 			Cumulative:  true,
+			Labels:      map[string]string{"required": "true", "suite": "olm"},
 		},
 	}
 }
@@ -112,6 +115,7 @@ func NewSpecDescriptorsTest(conf OLMTestConfig) *SpecDescriptorsTest {
 			Name:        "Spec fields with descriptors",
 			Description: "All spec fields have matching descriptors in the CSV",
 			Cumulative:  true,
+			Labels:      map[string]string{"required": "true", "suite": "olm"},
 		},
 	}
 }
@@ -130,6 +134,7 @@ func NewStatusDescriptorsTest(conf OLMTestConfig) *StatusDescriptorsTest {
 			Name:        "Status fields with descriptors",
 			Description: "All status fields have matching descriptors in the CSV",
 			Cumulative:  true,
+			Labels:      map[string]string{"required": "true", "suite": "olm"},
 		},
 	}
 }

--- a/pkg/apis/scorecard/v1alpha1/types.go
+++ b/pkg/apis/scorecard/v1alpha1/types.go
@@ -77,6 +77,8 @@ type ScorecardTestResult struct {
 	Suggestions []string `json:"suggestions"`
 	// Errors is a list of the errors that occured during the test (this can include both fatal and non-fatal errors)
 	Errors []string `json:"errors"`
+	// Labels used for v1alpha2, not included in v1alpha1 JSON output
+	Labels map[string]string `json:"-"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/scorecard/v1v2conversions.go
+++ b/pkg/apis/scorecard/v1v2conversions.go
@@ -67,8 +67,7 @@ func ConvertTestResultV1ToV2(v1SuiteName string, v1TestResult scapiv1alpha1.Scor
 	output.Errors = make([]string, len(v1TestResult.Errors))
 	copy(output.Errors, v1TestResult.Errors)
 
-	output.Labels = make(map[string]string)
-	output.Labels["suite"] = v1SuiteName
+	output.Labels = v1TestResult.Labels
 
 	return output
 }


### PR DESCRIPTION


**Description of the change:**

part of the v1alpha2 implementation of the scorecard, this PR only adds the pre-defined labels to the basic and olm test definitions and adds the labels into the test results for displaying in JSON format (v1alpha2 only).

**Motivation for the change:**

this PR sets up future work where label selectors will be added and used to determine
what tests get executed.
