### PR TITLE
fix role for the metric services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Bug Fixes
 
 - OLM internal manager is not returning errors in the initialization. ([#1976](https://github.com/operator-framework/operator-sdk/pull/1976))
-- Fixed missing default role "deployments" which is required to create the metrics Service for the operator project. ([#1976](https://github.com/operator-framework/operator-sdk/pull/2090)) 
+- Added missing default role permission for `deployments`, which is required to create the metrics service for the operator. ([#2090](https://github.com/operator-framework/operator-sdk/pull/2090)) 
 
 ## v0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bug Fixes
 
 - OLM internal manager is not returning errors in the initialization. ([#1976](https://github.com/operator-framework/operator-sdk/pull/1976))
+- Fixed missing default role "deployments" which is required to create the metrics Service for the operator project. ([#1976](https://github.com/operator-framework/operator-sdk/pull/2090)) 
 
 ## v0.11.0
 

--- a/internal/scaffold/role.go
+++ b/internal/scaffold/role.go
@@ -238,6 +238,7 @@ rules:
   - apps
   resources:
   - replicasets
+  - deployments
   verbs:
   - get
 `

--- a/internal/scaffold/role_test.go
+++ b/internal/scaffold/role_test.go
@@ -126,6 +126,7 @@ rules:
   - apps
   resources:
   - replicasets
+  - deployments
   verbs:
   - get
 `
@@ -182,6 +183,7 @@ rules:
   - apps
   resources:
   - replicasets
+  - deployments
   verbs:
   - get
 `
@@ -231,6 +233,7 @@ rules:
   - apps
   resources:
   - replicasets
+  - deployments
   verbs:
   - get
 `


### PR DESCRIPTION
**Description of the change:**
Add default role required for the services.

```
- apiGroups:
  - apps
  resources:
  - deployments
  verbs:
  - '*'
```

**Motivation for the change:**
https://github.com/operator-framework/operator-sdk/issues/2088

**Steps to verify it**

Following the steps to make the review easier to be done. 

- Run `operator-sdk new memcached-operator --api-version=cache.test.com/v1alpha1 --kind=Memcached --type=helm --helm-chart=stable/memcached`
- Replace the `  AntiAffinity: "hard"` for ` AntiAffinity: "soft"` in the values and CR
- Rename the CRD for `cache.test.com_v1alpha1_memcached_crd.yaml`
- Use the following makefile to make its easier 
```
.DEFAULT_GOAL:=help
SHELL:=/bin/bash
NAMESPACE=fix

##@ Application

install: ## Install all resources (CR/CRD's, RBCA and Operator)
	@echo ....... Creating namespace ....... 
	- kubectl create namespace ${NAMESPACE}
	@echo ....... Applying CRDS and Operator .......
	- kubectl apply -f deploy/crds/cache.test.com_v1alpha1_memcached_crd.yaml -n ${NAMESPACE}
	@echo ....... Applying Rules and Service Account .......
	- kubectl apply -f deploy/role.yaml -n ${NAMESPACE}
	- kubectl apply -f deploy/role_binding.yaml  -n ${NAMESPACE}
	- kubectl apply -f deploy/service_account.yaml  -n ${NAMESPACE}
	@echo ....... Applying Operator .......
	- kubectl apply -f deploy/operator.yaml -n ${NAMESPACE}
	@echo ....... Creating the Memcached Instance .......
	- kubectl apply -f deploy/crds/cache.test.com_v1alpha1_memcached_cr.yaml -n ${NAMESPACE}

uninstall: ## Uninstall all that all performed in the $ make install
	@echo ....... Uninstalling .......
	@echo ....... Deleting CR and CRD.......
	- kubectl apply -f deploy/crds/cache.test.com_v1alpha1_memcached_cr.yaml -n ${NAMESPACE}
	- kubectl delete -f deploy/crds/cache.test.com_v1alpha1_memcached_crd.yaml -n ${NAMESPACE}
	@echo ....... Deleting Rules and Service Account .......
	- kubectl delete -f deploy/role.yaml -n ${NAMESPACE}
	- kubectl delete -f deploy/role_binding.yaml -n ${NAMESPACE}
	- kubectl delete -f deploy/service_account.yaml -n ${NAMESPACE}
	@echo ....... Deleting Operator .......
	- kubectl delete -f deploy/operator.yaml -n ${NAMESPACE}
	@echo ....... Deleting namespace ${NAMESPACE}.......
	- kubectl delete namespace ${NAMESPACE}

.PHONY: help
help:  ## Display this help
	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
```
- Update the IMAGE in the operator.yaml file `cmacedo/memcached-operator-fix`
- Run `make install`
- Now, check if the `cmacedo/memcached-operator-fix` was created as follows. 

```
$ kubectl get all -n fix
NAME                                      READY   STATUS    RESTARTS   AGE
pod/example-memcached-0                   1/1     Running   0          7m11s
pod/example-memcached-1                   1/1     Running   0          7m5s
pod/example-memcached-2                   1/1     Running   0          6m50s
pod/memcached-operator-79bd87dfbb-m7vc9   1/1     Running   0          7m15s

NAME                                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
service/example-memcached            ClusterIP   None            <none>        11211/TCP           7m11s
service/memcached-operator-metrics   ClusterIP   10.109.225.44   <none>        8686/TCP,8383/TCP   7m11s

NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/memcached-operator   1/1     1            1           7m15s

NAME                                            DESIRED   CURRENT   READY   AGE
replicaset.apps/memcached-operator-79bd87dfbb   1         1         1       7m15s

NAME                                 READY   AGE
statefulset.apps/example-memcached   3/3     7m11s
```
