### PR TITLE
fix(ansible): invalid maxArtifacts annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - OLM internal manager is not returning errors in the initialization. ([#1976](https://github.com/operator-framework/operator-sdk/pull/1976))
 - Added missing default role permission for `deployments`, which is required to create the metrics service for the operator. ([#2090](https://github.com/operator-framework/operator-sdk/pull/2090)) 
+- Handle invalid maxArtifacts annotation on CRs for Ansible based operators. ([2093](https://github.com/operator-framework/operator-sdk/pull/2093))
 
 ## v0.11.0
 

--- a/pkg/ansible/runner/runner.go
+++ b/pkg/ansible/runner/runner.go
@@ -177,8 +177,9 @@ func (r *runner) Run(ident string, u *unstructured.Unstructured, kubeconfig stri
 		i, err := strconv.Atoi(ma)
 		if err != nil {
 			log.Info("Invalid max runner artifact annotation", "err", err, "value", ma)
+		} else {
+			maxArtifacts = i
 		}
-		maxArtifacts = i
 	}
 
 	go func() {


### PR DESCRIPTION
When the maxArtifacts annotation can not be converted to an integer, do
not use it.
