### PR TITLE
hack/tests/sanity-check.sh: fail on changed go.mod and go.sum

### DIFF
--- a/hack/tests/sanity-check.sh
+++ b/hack/tests/sanity-check.sh
@@ -1,18 +1,12 @@
 #!/usr/bin/env bash
 set -ex
 
-# Make sure repo is in clean state before running go tools
-git diff --exit-code
-
 go mod tidy
 go vet ./...
 go fmt ./...
 
 ./hack/check_license.sh
 ./hack/check_error_log_msg_format.sh
-
-# Ignore changes to go.mod and go.sum
-git checkout go.mod go.sum
 
 # Make sure repo is still in a clean state.
 git diff --exit-code


### PR DESCRIPTION
**Description of the change:**
Revert sanity test changes from #1949 

**Motivation for the change:**
In order to migrate to Go 1.13, we needed to temporarily ignore `go.mod` and `go.sum` changes that were caused by Go tooling during the sanity tests. Now that openshift/releases#5443 is merged, we can revert that temporary change so that we require that PRs correctly update `go.mod` and `go.sum`.
