### PR TITLE
Allow WATCH_NAMESPACE="" in operator-sdk test with --up-local flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- Add support to test locally cluster-scoped operators by running the command operator-sdk test local --up-local with the flag --namespace="". ([#2100](https://github.com/operator-framework/operator-sdk/pull/2100))
+
 ### Changed
 - Upgrade minimal Ansible version in the init projects from `2.4` to `2.6`. ([#2107](https://github.com/operator-framework/operator-sdk/pull/2107))
 

--- a/hack/tests/subcommand.sh
+++ b/hack/tests/subcommand.sh
@@ -30,14 +30,28 @@ kubectl create namespace test-memcached
 operator-sdk test local ./test/e2e --up-local --namespace=test-memcached --kubeconfig $KUBECONFIG
 kubectl delete namespace test-memcached
 
+# test operator in up local mode with namespace set to ""
+# --namespace="" is allowed in local mode only when --no-setup is set
+kubectl create namespace test-memcached
+kubectl create -f deploy/crds/cache.example.com_memcacheds_crd.yaml
+# this runs after the popd at the end (trap_add popd), so it needs the path from the project root
+trap_add 'kubectl delete --ignore-not-found test/test-framework/deploy/crds/cache.example.com_memcacheds_crd.yaml' EXIT
+kubectl create -f deploy/crds/cache.example.com_memcachedrs_crd.yaml
+# this runs after the popd at the end (trap_add popd), so it needs the path from the project root
+trap_add 'kubectl delete --ignore-not-found test/test-framework/deploy/crds/cache.example.com_memcachedrs_crd.yaml' EXIT
+operator-sdk test local ./test/e2e --up-local --namespace="" --no-setup --debug
+kubectl delete -f deploy/crds/cache.example.com_memcacheds_crd.yaml
+kubectl delete -f deploy/crds/cache.example.com_memcachedrs_crd.yaml
+kubectl delete namespace test-memcached
+
 # test operator in no-setup mode
 kubectl create namespace test-memcached
 kubectl create -f deploy/crds/cache.example.com_memcacheds_crd.yaml
 # this runs after the popd at the end, so it needs the path from the project root
-trap_add 'kubectl delete -f test/test-framework/deploy/crds/cache.example.com_memcacheds_crd.yaml' EXIT
+trap_add 'kubectl delete --ignore-not-found -f test/test-framework/deploy/crds/cache.example.com_memcacheds_crd.yaml' EXIT
 kubectl create -f deploy/crds/cache.example.com_memcachedrs_crd.yaml
 # this runs after the popd at the end, so it needs the path from the project root
-trap_add 'kubectl delete -f test/test-framework/deploy/crds/cache.example.com_memcachedrs_crd.yaml' EXIT
+trap_add 'kubectl delete --ignore-not-found -f test/test-framework/deploy/crds/cache.example.com_memcachedrs_crd.yaml' EXIT
 kubectl create -f deploy/service_account.yaml --namespace test-memcached
 kubectl create -f deploy/role.yaml --namespace test-memcached
 kubectl create -f deploy/role_binding.yaml --namespace test-memcached


### PR DESCRIPTION
**Description of the change:**

This patch enables an operaor to be tested locally with explicitly setting
`WATCH_NAMESPACE=""`

This patch makes the already existing behavior (check for explicit `namespace=""`)
in `operator-sdk up local --namespace ""` [ref](https://github.com/operator-framework/operator-sdk/blob/c7f429f05808406068b1a67f49b0de9e6481f545/cmd/operator-sdk/up/local.go#L84)
into local testing.
which means, this patch makes
`operator-sdk test local ./test/e2e --uplocal --namespace "" --no-setup` possible

Hence, the operator under test (localRunMode) can watch primary/secondary resource events from any namespace.

**Motivation for the change:**

We couldn't receive events on secondary resources when they created in a namespace other than the namespace specified by `--namespace` flag, when testing with `--up-local` flag

This is not a problem while deploying the operator or testing without `--up-local` flag as the `WATCH_NAMESPACE=""` set in operator.yaml deployment manifest

The pain that motivated me for this patch is https://github.com/tektoncd/operator/issues/34.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>


Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD






<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
