### PR TITLE
Add check for API rule validation and fix type for Memcached test data

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -91,7 +91,7 @@ type MemcachedStatus struct {
 }
 ```
 
-**NOTE** To know more about `+listType=set` see : https://godoc.org/k8s.io/kube-openapi/pkg/idl 
+**NOTE:** Comment directives, such as +listType=set, are necessary for certain situations to avoid API rule violations when generating OpenAPI files. See https://godoc.org/k8s.io/kube-openapi/pkg/idl learn more.
 
 After modifying the `*_types.go` file always run the following command to update the generated code for that resource type:
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -85,10 +85,13 @@ type MemcachedSpec struct {
 	Size int32 `json:"size"`
 }
 type MemcachedStatus struct {
-	// Nodes are the names of the memcached pods
+	// Nodes are the names of the memcached pods 
+	// +listType=set  
 	Nodes []string `json:"nodes"`
 }
 ```
+
+**NOTE** To know more about `+listType=set` see : https://godoc.org/k8s.io/kube-openapi/pkg/idl 
 
 After modifying the `*_types.go` file always run the following command to update the generated code for that resource type:
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -91,7 +91,7 @@ type MemcachedStatus struct {
 }
 ```
 
-**NOTE:** Comment directives, such as +listType=set, are necessary for certain situations to avoid API rule violations when generating OpenAPI files. See https://godoc.org/k8s.io/kube-openapi/pkg/idl learn more.
+**NOTE:** Comment directives, such as +listType=set, are necessary in certain situations to avoid API rule violations when generating OpenAPI files. See https://godoc.org/k8s.io/kube-openapi/pkg/idl to learn more.
 
 After modifying the `*_types.go` file always run the following command to update the generated code for that resource type:
 

--- a/hack/tests/scaffolding/scaffold-memcached.go
+++ b/hack/tests/scaffolding/scaffold-memcached.go
@@ -179,6 +179,10 @@ func main() {
 		log.Fatalf("Error: %v\nCommand Output: %s\n", err, string(cmdOut))
 	}
 
+	// TODO(camilamacedo86) Move this test to a unit test in
+	// `cmd/operator-sdk/internal/genutil/`. Unit tests are
+	// faster and are run more often during development, so it
+	// would be an improvement to implement this test there.
 	log.Print("Checking API rule violations")
 	if strings.Contains(string(cmdOut), "API rule violation") {
 		log.Fatalf("Error: %v\nCommand Output: %s\n", "API rule violations :", string(cmdOut))

--- a/hack/tests/scaffolding/scaffold-memcached.go
+++ b/hack/tests/scaffolding/scaffold-memcached.go
@@ -125,6 +125,7 @@ func main() {
 		filepath.Join(localSDKPath, "test/e2e/_incluster-test-code/main_test.go"):              "test/e2e/main_test.go",
 		filepath.Join(localSDKPath, "test/e2e/_incluster-test-code/memcached_test.go"):         "test/e2e/memcached_test.go",
 	}
+
 	for src, dst := range tmplFiles {
 		if err := os.MkdirAll(filepath.Dir(dst), fileutil.DefaultDirFileMode); err != nil {
 			log.Fatalf("Could not create template destination directory: %s", err)
@@ -139,6 +140,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Could not read pkg/apis/cache/v1alpha1/memcached_types.go: %v", err)
 	}
+
 	memcachedTypesFileLines := bytes.Split(memcachedTypesFile, []byte("\n"))
 	for lineNum, line := range memcachedTypesFileLines {
 		if strings.Contains(string(line), "type MemcachedSpec struct {") {
@@ -147,13 +149,16 @@ func main() {
 			break
 		}
 	}
+
 	for lineNum, line := range memcachedTypesFileLines {
 		if strings.Contains(string(line), "type MemcachedStatus struct {") {
-			memcachedTypesFileLinesIntermediate := append(memcachedTypesFileLines[:lineNum+1], []byte("\tNodes []string `json:\"nodes\"`"))
+			memcachedTypesFileLinesIntermediate := append(memcachedTypesFileLines[:lineNum+1], []byte("\t// +listType=set"))
+			memcachedTypesFileLinesIntermediate = append(memcachedTypesFileLinesIntermediate, []byte("\tNodes []string `json:\"nodes\"`"))
 			memcachedTypesFileLines = append(memcachedTypesFileLinesIntermediate, memcachedTypesFileLines[lineNum+3:]...)
 			break
 		}
 	}
+
 	if err := os.Remove("pkg/apis/cache/v1alpha1/memcached_types.go"); err != nil {
 		log.Fatalf("Failed to remove old memcached_type.go file: (%v)", err)
 	}
@@ -172,6 +177,11 @@ func main() {
 	cmdOut, err = exec.Command("operator-sdk", "generate", "openapi").CombinedOutput()
 	if err != nil {
 		log.Fatalf("Error: %v\nCommand Output: %s\n", err, string(cmdOut))
+	}
+
+	log.Print("Checking API rule violations")
+	if strings.Contains(string(cmdOut), "API rule violation") {
+		log.Fatalf("Error: %v\nCommand Output: %s\n", "API rule violations :", string(cmdOut))
 	}
 
 	log.Print("Pulling new dependencies with go mod")


### PR DESCRIPTION
**Description of the change:**
- Add check in the tests to ensure that no issues related the API rule validations should be faced. 
- Fix type of spec for Memcached test data implementation. 

**Motivation for the change:**

Closes #2114 
Related to: https://github.com/operator-framework/operator-sdk/issues/2042