### PR TITLE
hack/tests/e2e-ansible*: fix travis ansible e2e tests

### DIFF
--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -19,10 +19,10 @@ deploy_prereqs() {
 }
 
 remove_prereqs() {
-    kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/service_account.yaml"
-    kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/role.yaml"
-    kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/role_binding.yaml"
-    kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/crds/ansible.example.com_memcacheds_crd.yaml"
+    kubectl delete --wait=true --ignore-not-found=true --timeout=60s -f "$OPERATORDIR/deploy/crds/ansible.example.com_memcacheds_crd.yaml"
+    kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/service_account.yaml"
+    kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/role.yaml"
+    kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/role_binding.yaml"
 }
 
 pushd "$TMPDIR"

--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -23,12 +23,12 @@ deploy_operator() {
 }
 
 remove_operator() {
-    kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/service_account.yaml"
-    kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/role.yaml"
-    kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/role_binding.yaml"
-    kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/crds/ansible.example.com_memcacheds_crd.yaml"
-    kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/crds/ansible.example.com_foos_crd.yaml"
-    kubectl delete --ignore-not-found=true -f "$OPERATORDIR/deploy/operator.yaml"
+    kubectl delete --wait=true --ignore-not-found=true --timeout=60s -f "$OPERATORDIR/deploy/crds/ansible.example.com_memcacheds_crd.yaml"
+    kubectl delete --wait=true --ignore-not-found=true --timeout=60s -f "$OPERATORDIR/deploy/crds/ansible.example.com_foos_crd.yaml"
+    kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/operator.yaml"
+    kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/service_account.yaml"
+    kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/role.yaml"
+    kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/role_binding.yaml"
 }
 
 operator_logs() {


### PR DESCRIPTION
**Description of the change:**
Updates the Travis Ansible e2e tests to match the OpenShift Ansible e2e tests.

**Motivation for the change:**
Deleting the service account before deleting the CRD causes the e2e tests to fail because the operator no longer has the necessary permissions to complete the test.
