### PR TITLE
*: remove broken and unnecessary Go env for v0.12.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ SCORECARD_PROXY_IMAGE ?= $(SCORECARD_PROXY_BASE_IMAGE)
 HELM_ARCHES:="amd64" "ppc64le"
 
 export CGO_ENABLED:=0
-export GO111MODULE:=on
-export GOPROXY?=https://proxy.golang.org/
 .DEFAULT_GOAL:=help
 
 .PHONY: help

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Follow the steps in the [installation guide][install_guide] to learn how to inst
 $ mkdir -p $HOME/projects/example-inc/
 # Create a new app-operator project
 $ cd $HOME/projects/example-inc/
-$ export GO111MODULE=on
 $ operator-sdk new app-operator --repo github.com/example-inc/app-operator
 $ cd app-operator
 

--- a/ci/dockerfiles/builder.Dockerfile
+++ b/ci/dockerfiles/builder.Dockerfile
@@ -1,7 +1,7 @@
 FROM openshift/origin-release:golang-1.13
 
 WORKDIR /go/src/github.com/operator-framework/operator-sdk
-ENV GOPATH=/go PATH=/go/src/github.com/operator-framework/operator-sdk/build:$PATH GOPROXY=https://proxy.golang.org/ GO111MODULE=on
+ENV GOPATH=/go PATH=/go/src/github.com/operator-framework/operator-sdk/build:$PATH
 
 COPY . .
 

--- a/ci/prow.Makefile
+++ b/ci/prow.Makefile
@@ -1,8 +1,6 @@
 # Makefile specifically intended for use in prow/api-ci only.
 
 export CGO_ENABLED := 0
-export GO111MODULE := on
-export GOPROXY ?= https://proxy.golang.org/
 
 build:
 	$(MAKE) -f Makefile build/operator-sdk

--- a/ci/tests/scaffolding/e2e-ansible-scaffold-hybrid.sh
+++ b/ci/tests/scaffolding/e2e-ansible-scaffold-hybrid.sh
@@ -23,8 +23,6 @@ pushd memcached-operator
 # Add a second Kind to test watching multiple GVKs
 operator-sdk add crd --kind=Foo --api-version=ansible.example.com/v1alpha1
 
-export GO111MODULE=on
-export GOPROXY=https://proxy.golang.org
 operator-sdk migrate
 
 if [[ ! -e build/Dockerfile.sdkold ]];

--- a/ci/tests/scaffolding/e2e-helm-scaffold-hybrid.sh
+++ b/ci/tests/scaffolding/e2e-helm-scaffold-hybrid.sh
@@ -13,7 +13,6 @@ pushd "$HELMDIR"
 operator-sdk new nginx-operator --api-version=helm.example.com/v1alpha1 --kind=Nginx --type=helm
 
 pushd nginx-operator
-export GO111MODULE=on
 operator-sdk migrate
 
 if [[ ! -e build/Dockerfile.sdkold ]];

--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -170,7 +170,6 @@ echo "### Base image testing passed"
 echo "### Now testing migrate to hybrid operator"
 echo "###"
 
-export GO111MODULE=on
 operator-sdk migrate --repo=github.com/example-inc/memcached-operator
 
 if [[ ! -e build/Dockerfile.sdkold ]];

--- a/hack/tests/e2e-helm.sh
+++ b/hack/tests/e2e-helm.sh
@@ -150,7 +150,6 @@ echo "### Base image testing passed"
 echo "### Now testing migrate to hybrid operator"
 echo "###"
 
-export GO111MODULE=on
 operator-sdk migrate --repo=github.com/example-inc/nginx-operator
 
 if [[ ! -e build/Dockerfile.sdkold ]];

--- a/hack/tests/scaffolding/scaffold-memcached.go
+++ b/hack/tests/scaffolding/scaffold-memcached.go
@@ -58,10 +58,6 @@ func main() {
 	if localSDKPath == "" {
 		localSDKPath = sdkTestE2EDir
 	}
-	// For go commands in operator projects.
-	if err = os.Setenv("GO111MODULE", "on"); err != nil {
-		log.Fatal(err)
-	}
 
 	log.Print("Creating new operator project")
 	cmdOut, err := exec.Command("operator-sdk",


### PR DESCRIPTION
**Description of the change:**
Removes use of GO111MODULE and GOPROXY environment variables in build and test scripts.

**Motivation for the change:**
Now that we have updated SDK to support Go 1.13, these environment variables are no longer necessary.
- GO111MODULE semantics have changed, such that any project with a `go.mod` file is considered a go module unless GO111MODULE is explicitly set to `off`
- GOPROXY now defaults to `https://proxy.golang.org,direct`. Adding `direct` as an alternative also incidentally solves a problem with resolving branch names (e.g. `v0.12.x`) when used in `require` blocks.