### PR TITLE
doc/ansible/project_layout.md: fix Ansible Galaxy link

### DIFF
--- a/doc/ansible/project_layout.md
+++ b/doc/ansible/project_layout.md
@@ -7,6 +7,6 @@ After creating a new operator project using
 | File/Folders   | Purpose                           |
 | :---           | :--- |
 | deploy/ | Contains a generic set of Kubernetes manifests for deploying this operator on a Kubernetes cluster. |
-| roles/\<kind> | Contains an Ansible Role initialized using [Ansible Galaxy](https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html) |
+| roles/\<kind> | Contains an Ansible Role initialized using [Ansible Galaxy](https://docs.ansible.com/ansible/latest/galaxy/user_guide.html) |
 | build/ | Contains scripts that the `operator-sdk` uses for build and initialization. |
 | watches.yaml | Contains Group, Version, Kind, and the Ansible invocation method. |


### PR DESCRIPTION
**Description of the change:** fix Ansible Galaxy reference link


**Motivation for the change:** page seems to have been moved to https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html