### PR TITLE
Improve flag names and behavior in up local and test sub-commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,16 @@
 ### Added
 - Support for vars in top level ansible watches. ([#2147](https://github.com/operator-framework/operator-sdk/pull/2147))
 
+- Added `--watch-namespace` flag to `operator-sdk test local <test-dir> --up-local` command. ([#2149](https://github.com/operator-framework/operator-sdk/pull/2149))
+
 ### Changed
+
 - Upgrade minimal Ansible version in the init projects from `2.4` to `2.6`. ([#2107](https://github.com/operator-framework/operator-sdk/pull/2107))
 - Upgrade Kubernetes version from `kubernetes-1.15.4` to `kubernetes-1.16.2`. ([#2145](https://github.com/operator-framework/operator-sdk/pull/2145))
 - Upgrade Helm version from `v2.15.0` to `v2.16.1`. ([#2145](https://github.com/operator-framework/operator-sdk/pull/2145))
 - Upgrade [`controller-runtime`](https://github.com/kubernetes-sigs/controller-runtime) version from `v0.3.0` to [`v0.4.0`](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.4.0). ([#2145](https://github.com/operator-framework/operator-sdk/pull/2145))
+- **Breaking Change:** Renamed `--namespace` flag as `--watch-namespace` in `operator-sdk up local` command. ([#2149](https://github.com/operator-framework/operator-sdk/pull/2149))
+- **Breaking Change:** Renamed `--namespace` flag as `--deploy-namespace` in `operator-sdk test local <test-dir> --up-local` command. ([#2149](https://github.com/operator-framework/operator-sdk/pull/2149))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### Added
 - Support for vars in top level ansible watches. ([#2147](https://github.com/operator-framework/operator-sdk/pull/2147))
-
 - Added `--watch-namespace` flag to `operator-sdk test local <test-dir> --up-local` command. ([#2149](https://github.com/operator-framework/operator-sdk/pull/2149))
 
 ### Changed

--- a/doc/cli/operator-sdk_test_local.md
+++ b/doc/cli/operator-sdk_test_local.md
@@ -25,7 +25,7 @@ operator-sdk test local <path to tests directory> [flags]
       --namespaced-manifest string    Path to manifest for per-test, namespaced resources (e.g. RBAC and Operator manifest)
       --no-setup                      Disable test resource creation
       --up-local                      Enable running operator locally with go run instead of as an image in the cluster
-      --watch-namespace string        The namespace where the operator watches for changes (with --up-local, if not set, watches deployNamespace
+      --watch-namespace string        The namespace where the operator watches for changes (only valid with --up-local). Explicitly set to empty string to watch all namespaces (defaults to the deploy namespace).
 ```
 
 ### SEE ALSO

--- a/doc/cli/operator-sdk_test_local.md
+++ b/doc/cli/operator-sdk_test_local.md
@@ -14,6 +14,7 @@ operator-sdk test local <path to tests directory> [flags]
 
 ```
       --debug                         Enable debug-level logging
+      --deploy-namespace string       If non-empty, single namespace to run tests in (deploys namespaced resources here); default: "" which resolves to namespace from kubeconfig
       --global-manifest string        Path to manifest for Global resources (e.g. CRD manifests)
       --go-test-flags string          Additional flags to pass to go test
   -h, --help                          help for local
@@ -21,10 +22,10 @@ operator-sdk test local <path to tests directory> [flags]
       --kubeconfig string             Kubeconfig path
       --local-operator-flags string   The flags that the operator needs (while using --up-local). Example: "--flag1 value1 --flag2=value2"
       --molecule-test-flags string    Additional flags to pass to molecule test
-      --namespace string              If non-empty, single namespace to run tests in
       --namespaced-manifest string    Path to manifest for per-test, namespaced resources (e.g. RBAC and Operator manifest)
       --no-setup                      Disable test resource creation
       --up-local                      Enable running operator locally with go run instead of as an image in the cluster
+      --watch-namespace string        The namespace where the operator watches for changes (with --up-local, if not set, watches deployNamespace
 ```
 
 ### SEE ALSO

--- a/doc/cli/operator-sdk_up_local.md
+++ b/doc/cli/operator-sdk_up_local.md
@@ -16,12 +16,12 @@ operator-sdk up local [flags]
 ### Options
 
 ```
-      --enable-delve            Start the operator using the delve debugger
-      --go-ldflags string       Set Go linker options
-  -h, --help                    help for local
-      --kubeconfig string       The file path to kubernetes configuration file; defaults to location specified by $KUBECONFIG with a fallback to $HOME/.kube/config if not set
-      --namespace string        The namespace where the operator watches for changes.
-      --operator-flags string   The flags that the operator needs. Example: "--flag1 value1 --flag2=value2"
+      --enable-delve             Start the operator using the delve debugger
+      --go-ldflags string        Set Go linker options
+  -h, --help                     help for local
+      --kubeconfig string        The file path to kubernetes configuration file; defaults to location specified by $KUBECONFIG with a fallback to $HOME/.kube/config if not set
+      --operator-flags string    The flags that the operator needs. Example: "--flag1 value1 --flag2=value2"
+      --watch-namespace string   The namespace where the operator watches for changes.
 ```
 
 ### SEE ALSO

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -460,7 +460,8 @@ Runs the tests locally
 * `--kubeconfig` string - location of kubeconfig for Kubernetes cluster (default "~/.kube/config")
 * `--global-manifest` string - path to manifest for global resources (default "deploy/crd.yaml)
 * `--namespaced-manifest` string - path to manifest for per-test, namespaced resources (default: combines deploy/service_account.yaml, deploy/rbac.yaml, and deploy/operator.yaml)
-* `--namespace` string - if non-empty, single namespace to run tests in (e.g. "operator-test") (default: "")
+* `--deploy-namespace` string - if non-empty, single namespace to run tests in (e.g. "operator-test") (default: "")
+* `--watch-namespace` string - if set, namespace which operator watches while testing with `--up-local`.  if set to "", operator watches AllNamespaces. if not set while testing with `--up-local` operator watches deploy-namespace
 * `--go-test-flags` string - Additional flags to pass to go test
 * `--molecule-test-flags` string - Additional flags to pass to molecule test
 * `--up-local` - enable running operator locally with go run instead of as an image in the cluster
@@ -500,7 +501,7 @@ the operator-sdk binary itself as the operator.
 * `--enable-delve` bool - starts the operator locally and enables the delve debugger listening on port 2345
 * `--go-ldflags` string - Set Go linker options
 * `--kubeconfig` string - The file path to Kubernetes configuration file; defaults to $HOME/.kube/config
-* `--namespace` string - The namespace where the operator watches for changes. (default "default")
+* `--watch-namespace` string - The namespace where the operator watches for changes. (default "default"). set to `""` to watch All-Namepsaces
 * `--operator-flags` string - Flags that the local operator may need.
 * `-h, --help` - help for local
 

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -239,11 +239,11 @@ $ operator-sdk test local ./test/e2e --image quay.io/example/my-operator:v0.0.2
 
 ### Namespace Flag
 
-If you wish to run all the tests in 1 namespace (which also forces `-parallel=1`), you can use the `--namespace` flag:
+If you wish to run all the tests in 1 namespace (which also forces `-parallel=1`), you can use the `--deploy-namespace` flag:
 
 ```shell
 $ kubectl create namespace operator-test
-$ operator-sdk test local ./test/e2e --namespace operator-test
+$ operator-sdk test local ./test/e2e --deploy-namespace operator-test
 ```
 
 ### Up-Local Flag
@@ -252,11 +252,11 @@ To run the operator itself locally during the tests instead of starting a deploy
 `--up-local` flag. This mode will still create global resources, but by default will not create any in-cluster namespaced
 resources unless the user specifies one through the `--namespaced-manifest` flag.
 
-**NOTE**: The `--up-local` flag requires the `--namespace` flag and the command will NOT create the namespace. Then, be sure that you are specifying a valid namespace.
+**NOTE**: The `--up-local` flag requires the `--deploy-namespace` flag and the command will NOT create the namespace. Then, be sure that you are specifying a valid namespace.
 
 ```shell
 $ kubectl create namespace operator-test
-$ operator-sdk test local ./test/e2e --namespace operator-test --up-local
+$ operator-sdk test local ./test/e2e --deploy-namespace operator-test --up-local
 ```
 
 ### No-Setup Flag
@@ -269,7 +269,7 @@ $ kubectl create -f deploy/service_account.yaml --namespace operator-test
 $ kubectl create -f deploy/role.yaml --namespace operator-test
 $ kubectl create -f deploy/role_binding.yaml --namespace operator-test
 $ kubectl create -f deploy/operator.yaml --namespace operator-test
-$ operator-sdk test local ./test/e2e --namespace operator-test --no-setup
+$ operator-sdk test local ./test/e2e --deploy-namespace operator-test --no-setup
 ```
 
 For more documentation on the `operator-sdk test local` command, see the [SDK CLI Reference][sdk-cli-ref] doc.

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -303,7 +303,7 @@ export OPERATOR_NAME=memcached-operator
 Run the operator locally with the default Kubernetes config file present at `$HOME/.kube/config`:
 
 ```sh
-$ operator-sdk up local --namespace=default
+$ operator-sdk up local --watch-namespace=default
 2018/09/30 23:10:11 Go Version: go1.10.2
 2018/09/30 23:10:11 Go OS/Arch: darwin/amd64
 2018/09/30 23:10:11 operator-sdk Version: 0.0.6+git

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -52,7 +52,7 @@ pushd memcached-operator
 # The following code is the default used (Not valid for MacOSX)
 sed -i 's|\(FROM quay.io/operator-framework/ansible-operator\)\(:.*\)\?|\1:dev|g' build/Dockerfile
 OPERATORDIR="$(pwd)"
-TEST_CLUSTER_PORT=24443 operator-sdk test local --namespace default
+TEST_CLUSTER_PORT=24443 operator-sdk test local --deploy-namespace default
 
 remove_prereqs
 
@@ -65,6 +65,6 @@ pushd "${ROOTDIR}/test/ansible-inventory"
 # sed -i "" 's|\(FROM quay.io/operator-framework/ansible-operator\)\(:.*\)\?|\1:dev|g' build/Dockerfile
 # The following code is the default used (Not valid for MacOSX)
 sed -i 's|\(FROM quay.io/operator-framework/ansible-operator\)\(:.*\)\?|\1:dev|g' build/Dockerfile
-TEST_CLUSTER_PORT=24443 operator-sdk test local --namespace default
+TEST_CLUSTER_PORT=24443 operator-sdk test local --deploy-namespace default
 
 popd

--- a/hack/tests/subcommand.sh
+++ b/hack/tests/subcommand.sh
@@ -16,32 +16,37 @@ operator-sdk test local ./test/e2e --global-manifest deploy/crds/cache.example.c
 
 # we use the test-memcached namespace for all future tests, so we only need to set this trap once
 kubectl create namespace test-memcached
-trap_add 'kubectl delete namespace test-memcached || true' EXIT
-operator-sdk test local ./test/e2e --namespace=test-memcached
+trap_add 'kubectl delete --ignore-not-found namespace test-memcached' EXIT
+operator-sdk test local ./test/e2e --deploy-namespace=test-memcached
 kubectl delete namespace test-memcached
 
 # test operator in up local mode
 kubectl create namespace test-memcached
-operator-sdk test local ./test/e2e --up-local --namespace=test-memcached
+operator-sdk test local ./test/e2e --up-local --deploy-namespace=test-memcached
+kubectl delete namespace test-memcached
+
+# test operator in up local mode with --watch-namespace flag
+kubectl create namespace test-memcached
+operator-sdk test local ./test/e2e --up-local --deploy-namespace=test-memcached --watch-namespace=""
 kubectl delete namespace test-memcached
 
 # test operator in up local mode with kubeconfig
 kubectl create namespace test-memcached
-operator-sdk test local ./test/e2e --up-local --namespace=test-memcached --kubeconfig $KUBECONFIG
+operator-sdk test local ./test/e2e --up-local --deploy-namespace=test-memcached --kubeconfig $KUBECONFIG
 kubectl delete namespace test-memcached
 
 # test operator in no-setup mode
 kubectl create namespace test-memcached
 kubectl create -f deploy/crds/cache.example.com_memcacheds_crd.yaml
 # this runs after the popd at the end, so it needs the path from the project root
-trap_add 'kubectl delete -f test/test-framework/deploy/crds/cache.example.com_memcacheds_crd.yaml' EXIT
+trap_add 'kubectl delete --ignore-not-found -f test/test-framework/deploy/crds/cache.example.com_memcacheds_crd.yaml' EXIT
 kubectl create -f deploy/crds/cache.example.com_memcachedrs_crd.yaml
 # this runs after the popd at the end, so it needs the path from the project root
-trap_add 'kubectl delete -f test/test-framework/deploy/crds/cache.example.com_memcachedrs_crd.yaml' EXIT
+trap_add 'kubectl delete --ignore-not-found -f test/test-framework/deploy/crds/cache.example.com_memcachedrs_crd.yaml' EXIT
 kubectl create -f deploy/service_account.yaml --namespace test-memcached
 kubectl create -f deploy/role.yaml --namespace test-memcached
 kubectl create -f deploy/role_binding.yaml --namespace test-memcached
 kubectl create -f deploy/operator.yaml --namespace test-memcached
-operator-sdk test local ./test/e2e --namespace=test-memcached --no-setup
+operator-sdk test local ./test/e2e --deploy-namespace=test-memcached --no-setup
 kubectl delete namespace test-memcached
 popd

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -66,7 +66,7 @@ func (f *Framework) newTestCtx(t *testing.T) *TestCtx {
 
 	var namespace string
 	if f.singleNamespaceMode {
-		namespace = f.Namespace
+		namespace = f.DeployNamespace
 	}
 	return &TestCtx{
 		id:                id,

--- a/pkg/test/e2eutil/wait_util.go
+++ b/pkg/test/e2eutil/wait_util.go
@@ -52,7 +52,7 @@ func waitForDeployment(t *testing.T, kubeclient kubernetes.Interface, namespace,
 		deployment, err := kubeclient.AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				t.Logf("Waiting for availability of %s deployment\n", name)
+				t.Logf("Waiting for availability of %s/%s deployment\n", namespace, name)
 				return false, nil
 			}
 			return false, err

--- a/pkg/test/framework.go
+++ b/pkg/test/framework.go
@@ -75,26 +75,24 @@ type Framework struct {
 }
 
 type frameworkOpts struct {
-	projectRoot          string
-	kubeconfigPath       string
-	globalManPath        string
-	namespacedManPath    string
-	localOperator        bool
-	singleNamespaceMode  bool
-	watchDeployNamespace bool
-	isLocalOperator      bool
-	localOperatorArgs    string
+	projectRoot         string
+	kubeconfigPath      string
+	globalManPath       string
+	namespacedManPath   string
+	localOperator       bool
+	singleNamespaceMode bool
+	isLocalOperator     bool
+	localOperatorArgs   string
 }
 
 const (
-	ProjRootFlag             = "root"
-	KubeConfigFlag           = "kubeconfig"
-	NamespacedManPathFlag    = "namespacedMan"
-	GlobalManPathFlag        = "globalMan"
-	SingleNamespaceFlag      = "singleNamespace"
-	WatchDeployNamespaceFlag = "watchDeployNamespace"
-	LocalOperatorFlag        = "localOperator"
-	LocalOperatorArgs        = "localOperatorArgs"
+	ProjRootFlag          = "root"
+	KubeConfigFlag        = "kubeconfig"
+	NamespacedManPathFlag = "namespacedMan"
+	GlobalManPathFlag     = "globalMan"
+	SingleNamespaceFlag   = "singleNamespace"
+	LocalOperatorFlag     = "localOperator"
+	LocalOperatorArgs     = "localOperatorArgs"
 
 	TestDeployNamespaceEnv = "TEST_DEPLOY_NAMESPACE"
 	TestWatchNamespaceEnv  = "TEST_WATCH_NAMESPACE"
@@ -107,7 +105,6 @@ func (opts *frameworkOpts) addToFlagSet(flagset *flag.FlagSet) {
 	flagset.StringVar(&opts.kubeconfigPath, KubeConfigFlag, "", "path to kubeconfig")
 	flagset.StringVar(&opts.globalManPath, GlobalManPathFlag, "", "path to operator manifest")
 	flagset.BoolVar(&opts.singleNamespaceMode, SingleNamespaceFlag, false, "enable single namespace mode")
-	flagset.BoolVar(&opts.watchDeployNamespace, WatchDeployNamespaceFlag, false, "set watch namespace to deploy namespace")
 	flagset.StringVar(&opts.localOperatorArgs, LocalOperatorArgs, "", "flags that the operator needs (while using --up-local). example: \"--flag1 value1 --flag2=value2\"")
 }
 
@@ -126,9 +123,6 @@ func newFramework(opts *frameworkOpts) (*Framework, error) {
 	}
 
 	watchNamespace := os.Getenv(TestWatchNamespaceEnv)
-	if watchNamespace == "" && opts.watchDeployNamespace {
-		watchNamespace = deployNamespace
-	}
 
 	kubeclient, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {

--- a/test/ansible-memcached/molecule.yml
+++ b/test/ansible-memcached/molecule.yml
@@ -29,7 +29,7 @@ provisioner:
   inventory:
     group_vars:
       all:
-        namespace: ${TEST_NAMESPACE:-osdk-test}
+        namespace: ${TEST_DEPLOY_NAMESPACE:-osdk-test}
   env:
     K8S_AUTH_KUBECONFIG: /tmp/molecule/kind-test-local/kubeconfig
     KUBECONFIG: /tmp/molecule/kind-test-local/kubeconfig

--- a/test/e2e/_incluster-test-code/memcached_test.go
+++ b/test/e2e/_incluster-test-code/memcached_test.go
@@ -217,7 +217,7 @@ func MemcachedLocal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command("operator-sdk", "up", "local", "--namespace="+namespace)
+	cmd := exec.Command("operator-sdk", "up", "local", "--watch-namespace="+namespace)
 	stderr, err := os.Create("stderr.txt")
 	if err != nil {
 		t.Fatalf("Failed to create stderr.txt: %v", err)


### PR DESCRIPTION
This patch enables an operator to be tested locally with explicitly setting
`WATCH_NAMESPACE=""`

This PR implements the behavior discussed and decided in the pr,
[2100 Allow WATCH_NAMESPACE="" in operator-sdk test with --up-local flag
](https://github.com/operator-framework/operator-sdk/pull/2100)

Hence, the operator under test (localRunMode) can watch primary/secondary resource events from any namespace.

**Description of the change:**

1. Change `--namespace` to  `--watch-namespace` in `operator-sdk up local`
1. Change `--namespace` to `--deploy-namespace` in `operator-sdk test local`
1. Add `--watch-namespace` to `operator-sdk test local`

**`--deploy-namespace` vs `--watch-namespace`**

- `--deploy-namespace` flag specifies namespace where namespaced resources are deployed for testing

- `--watch-namespace` flag specifies the namespace which operator watches. That is the value of `WATCH_NAMESPACE` envvar

**Behavior of `--deploy-namespace` flag in operator-sdk test local**

`--deploy-namespace` flag preserves the behavior of old `--namespace` flag in operator-sdk test local`

**Behavior of `--watch-namespace` flag in operator-sdk test local**

- `--watch-namespace=foo` 
    `WATCH_NAMESPACES=foo` operator watches namespace `foo` during testing

- `--watch-namespace=""` 
    `WATCH_NAMESPACES=""` operator watches all namespaces during testing

- when not set 
    `WATCH_NAMESPACE` is set to deploy-namespace. 
    which means when `--watch-namespace` is not set, watch-namespace == deploy-namespace
    operator watches deploy-namespace during testing


**Behavior of `--watch-namespace` flag in operator-sdk up local**

already existing behavior of old `--namespace` flag is preserved in `--watch-namespace` flag

- `--watch-namespace=foo` 
    `WATCH_NAMESPACES=foo` operator watches namespace `foo`

- `--watch-namespace=""` 
    `WATCH_NAMESPACES=""` operator watches all namespaces

- when not set 
    `WATCH_NAMESPACE` is set to default namespace from kubecontext 

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Motivation for the change:**

We couldn't receive events on secondary resources when they created in a namespace other than the namespace specified by `--namespace` flag, when testing with `--up-local` flag

This is not a problem while deploying the operator or testing without `--up-local` flag as the `WATCH_NAMESPACE=""` set in operator.yaml deployment manifest

The pain that motivated me for this patch is https://github.com/tektoncd/operator/issues/34.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>