### PR TITLE
Remove TypeMeta initializations

### DIFF
--- a/internal/scorecard/helpers/helpers.go
+++ b/internal/scorecard/helpers/helpers.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 
 	scapiv1alpha1 "github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha1"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // These functions should be in the public test definitions file, but they are not complete/stable,
@@ -91,10 +89,6 @@ func CalculateResult(tests []scapiv1alpha1.ScorecardTestResult) scapiv1alpha1.Sc
 // provided suites and log
 func TestSuitesToScorecardOutput(suites []TestSuite, log string) scapiv1alpha1.ScorecardOutput {
 	test := scapiv1alpha1.ScorecardOutput{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ScorecardOutput",
-			APIVersion: "osdk.openshift.io/v1alpha1",
-		},
 		Log: log,
 	}
 	scorecardSuiteResults := []scapiv1alpha1.ScorecardSuiteResult{}

--- a/pkg/apis/scorecard/v1v2conversions.go
+++ b/pkg/apis/scorecard/v1v2conversions.go
@@ -17,17 +17,11 @@ package scorecard
 import (
 	scapiv1alpha1 "github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha1"
 	scapiv1alpha2 "github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func ConvertScorecardOutputV1ToV2(v1ScorecardOutput scapiv1alpha1.ScorecardOutput) scapiv1alpha2.ScorecardOutput {
 
-	output := scapiv1alpha2.ScorecardOutput{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ScorecardOutput",
-			APIVersion: "osdk.openshift.io/v1alpha2",
-		},
-	}
+	output := scapiv1alpha2.ScorecardOutput{}
 
 	// convert v1 suite into v2 test results
 	output.Results = make([]scapiv1alpha2.ScorecardTestResult, 0)

--- a/test/test-framework/pkg/controller/memcached/memcached_controller.go
+++ b/test/test-framework/pkg/controller/memcached/memcached_controller.go
@@ -180,10 +180,6 @@ func (r *ReconcileMemcached) deploymentForMemcached(m *cachev1alpha1.Memcached) 
 	replicas := m.Spec.Size
 
 	dep := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name,
 			Namespace: m.Namespace,


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Remove TypeMeta.

**Motivation for the change:**

When we do a new object{} the TypeMeta will be added into the initialization.  Then, is not a good practice to add it manually. 

PS: It was removed from other places in the past (operator-framework/operator-sdk-samples#64, #1462 ). 