### PR TITLE
Add back TypeMeta which is mandatory for scorecard object because it is used to distinguish the versions (v1alpha1 and v1alpha2)

### DIFF
--- a/internal/scorecard/helpers/helpers.go
+++ b/internal/scorecard/helpers/helpers.go
@@ -88,9 +88,9 @@ func CalculateResult(tests []scapiv1alpha1.ScorecardTestResult) scapiv1alpha1.Sc
 // TestSuitesToScorecardOutput takes an array of test suites and generates a v1alpha1 ScorecardOutput object with the
 // provided suites and log
 func TestSuitesToScorecardOutput(suites []TestSuite, log string) scapiv1alpha1.ScorecardOutput {
-	test := scapiv1alpha1.ScorecardOutput{
-		Log: log,
-	}
+	test := scapiv1alpha1.NewScorecardOutput()
+	test.Log = log
+
 	scorecardSuiteResults := []scapiv1alpha1.ScorecardSuiteResult{}
 	for _, suite := range suites {
 		results := []scapiv1alpha1.ScorecardTestResult{}
@@ -105,7 +105,7 @@ func TestSuitesToScorecardOutput(suites []TestSuite, log string) scapiv1alpha1.S
 		scorecardSuiteResults = append(scorecardSuiteResults, scorecardSuiteResult)
 	}
 	test.Results = scorecardSuiteResults
-	return test
+	return *test
 }
 
 // TestResultToScorecardTestResult is a helper function for converting from the TestResult type to the ScorecardTestResult type

--- a/pkg/apis/scorecard/v1alpha1/types.go
+++ b/pkg/apis/scorecard/v1alpha1/types.go
@@ -105,6 +105,16 @@ type ScorecardOutputList struct {
 	Items           []ScorecardOutput `json:"items"`
 }
 
+func NewScorecardOutput() *ScorecardOutput {
+	return &ScorecardOutput{
+		// The TypeMeta is mandatory because it is used to distinguish the versions (v1alpha1 and v1alpha2)
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ScorecardOutput",
+			APIVersion: "osdk.openshift.io/v1alpha1",
+		},
+	}
+}
+
 func init() {
 	SchemeBuilder.Register(&ScorecardOutput{}, &ScorecardOutputList{})
 }

--- a/pkg/apis/scorecard/v1alpha2/types.go
+++ b/pkg/apis/scorecard/v1alpha2/types.go
@@ -64,6 +64,16 @@ type ScorecardOutput struct {
 	Results []ScorecardTestResult `json:"results"`
 }
 
+func NewScorecardOutput() *ScorecardOutput {
+	return &ScorecardOutput{
+		// The TypeMeta is mandatory because it is used to distinguish the versions (v1alpha1 and v1alpha2)
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ScorecardOutput",
+			APIVersion: "osdk.openshift.io/v1alpha2",
+		},
+	}
+}
+
 func init() {
 	SchemeBuilder.Register(&ScorecardOutput{})
 }

--- a/pkg/apis/scorecard/v1v2conversions.go
+++ b/pkg/apis/scorecard/v1v2conversions.go
@@ -21,7 +21,7 @@ import (
 
 func ConvertScorecardOutputV1ToV2(v1ScorecardOutput scapiv1alpha1.ScorecardOutput) scapiv1alpha2.ScorecardOutput {
 
-	output := scapiv1alpha2.ScorecardOutput{}
+	output := scapiv1alpha2.NewScorecardOutput()
 
 	// convert v1 suite into v2 test results
 	output.Results = make([]scapiv1alpha2.ScorecardTestResult, 0)
@@ -31,7 +31,7 @@ func ConvertScorecardOutputV1ToV2(v1ScorecardOutput scapiv1alpha1.ScorecardOutpu
 	}
 	output.Log = v1ScorecardOutput.Log
 
-	return output
+	return *output
 }
 
 func ConvertSuiteResultV1ToV2TestResults(v1SuiteResult scapiv1alpha1.ScorecardSuiteResult) []scapiv1alpha2.ScorecardTestResult {


### PR DESCRIPTION
**Description of the change:**
Add back TypeMeta which is mandatory for scorecard object because it is used to distinguish the versions (v1alpha1 and v1alpha2)

**Motivation for the change:**
https://github.com/operator-framework/operator-sdk/pull/2153#discussion_r342882783