### PR TITLE
Update uclient.go

### DIFF
--- a/pkg/kube-metrics/uclient.go
+++ b/pkg/kube-metrics/uclient.go
@@ -97,6 +97,6 @@ func setConfigDefaults(groupVersion string, config *rest.Config) error {
 	if config.GroupVersion.Group == "" && config.GroupVersion.Version == "v1" {
 		config.APIPath = "/api"
 	}
-	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	config.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs}
 	return nil
 }


### PR DESCRIPTION
DirectCodecFactory was renamed to WithoutConversionCodecFactory

**Description of the change:**
DirectCodecFactory was renamed to WithoutConversionCodecFactory in 1.15 and was removed in 1.16

**Motivation for the change:**