### PR TITLE
Fix cr/crds file names 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Removed
 
 ### Bug Fixes
+- Do no replace  hyphens `-` into the group names to generated CR/CRD file names. ([#2163](https://github.com/operator-framework/operator-sdk/pull/2163))
 
 ## v0.12.0
 

--- a/internal/scaffold/cr.go
+++ b/internal/scaffold/cr.go
@@ -23,7 +23,7 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/scaffold/input"
 )
 
-// CR is the input needed to generate a deploy/crds/<full group>_<version>_<kind>_cr.yaml file
+// CR is the input needed to generate a deploy/crds/<group>_<version>_<kind>_cr.yaml file
 type CR struct {
 	input.Input
 
@@ -48,7 +48,7 @@ func (s *CR) GetInput() (input.Input, error) {
 }
 
 func crPathForResource(dir string, r *Resource) string {
-	file := fmt.Sprintf("%s_%s_%s_cr.yaml", r.FullGroup, r.Version, r.LowerKind)
+	file := fmt.Sprintf("%s_%s_%s_cr.yaml", r.Group, r.Version, r.LowerKind)
 	return filepath.Join(dir, file)
 }
 

--- a/internal/scaffold/crd.go
+++ b/internal/scaffold/crd.go
@@ -69,7 +69,7 @@ func (s *CRD) GetInput() (input.Input, error) {
 }
 
 func crdPathForResource(dir string, r *Resource) string {
-	file := fmt.Sprintf("%s_%s_crd.yaml", r.FullGroup, r.Resource)
+	file := fmt.Sprintf("%s_%s_crd.yaml", r.Group, r.Resource)
 	return filepath.Join(dir, file)
 }
 

--- a/internal/scaffold/resource.go
+++ b/internal/scaffold/resource.go
@@ -128,9 +128,9 @@ func (r *Resource) checkAndSetGroups() error {
 	}
 	r.FullGroup = fg[0]
 	r.Group = g[0]
+	r.Group = strings.ToLower(r.Group)
 
-	s := strings.ToLower(r.Group)
-	r.GoImportGroup = strings.Replace(s, "-", "", -1)
+	r.GoImportGroup = strings.Replace(r.Group, "-", "", -1)
 
 	if err := validation.IsDNS1123Subdomain(r.Group); err != nil {
 		return fmt.Errorf("group name is invalid: %v", err)
@@ -143,7 +143,7 @@ func (r *Resource) checkAndSetVersion() error {
 	if len(api) < 2 || len(api[1]) == 0 {
 		return errors.New("version cannot be empty")
 	}
-	r.Version = api[1]
+	r.Version = strings.ToLower(api[1])
 
 	if !ResourceVersionRegexp.MatchString(r.Version) {
 		return errors.New("version is not in the correct Kubernetes version format, ex. v1alpha1")


### PR DESCRIPTION
**Description of the change:**

- Keep the original group value to create the file name. 
 
**Motivation for the change:**

Closes #2162 and #2058 

**Test performed locally**
```
$ operator-sdk add api --api-version=my-cool-thing.grdryn.me/v1alpha1 --kind Test
INFO[0000] Generating api version my-cool-thing.grdryn.me/v1alpha1 for kind Test. 
...
INFO[0000] Created deploy/crds/my-cool-thing_v1alpha1_test_cr.yaml 
INFO[0001] Created deploy/crds/my-cool-thing_v1alpha1_test_crd.yaml 
...       
```  