### PR TITLE
scorecard - add return code logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Added new `--version` flag to the `operator-sdk scorecard` command to support a new output format for the scorecard. ([#1916](https://github.com/operator-framework/operator-sdk/pull/1916)
 - Added new `--selector` flag to the `operator-sdk scorecard` command to support filtering scorecard tests based on labels added to each test. ([#1916](https://github.com/operator-framework/operator-sdk/pull/1916)
 - Added new `--list` flag to the `operator-sdk scorecard` command to support listing scorecard tests that would be executed based on selector filters. ([#1916](https://github.com/operator-framework/operator-sdk/pull/1916)
+- For scorecard version v1alpha2 only, return code logic was added to return 1 if any of the selected scorecard tests fail.  A return code of 0 is returned if all selected tests pass. ([#1916](https://github.com/operator-framework/operator-sdk/pull/1916)
 
 ### Changed
 

--- a/doc/test-framework/scorecard.md
+++ b/doc/test-framework/scorecard.md
@@ -49,6 +49,7 @@ Following are some requirements for the operator project which would be  checked
 1. Setup the `.osdk-scorecard.yaml` configuration file in your project.. See [Config file](#config-file)
 2. Create the namespace defined in the RBAC files(`role_bindinding`)
 3. Then, run the scorecard, for example `$ operator-sdk scorecard`. See the [Command args](#command-args) to check its options.
+4. Note, starting with version v1alpha2, the scorecard return code is 1 if any of the tests executed did not pass and 0 if all selected tests pass.
 
 **NOTE:** If your operator is non-SDK then some steps will be required in order to meet its requirements.
 

--- a/doc/test-framework/scorecard.md
+++ b/doc/test-framework/scorecard.md
@@ -49,9 +49,12 @@ Following are some requirements for the operator project which would be  checked
 1. Setup the `.osdk-scorecard.yaml` configuration file in your project.. See [Config file](#config-file)
 2. Create the namespace defined in the RBAC files(`role_bindinding`)
 3. Then, run the scorecard, for example `$ operator-sdk scorecard`. See the [Command args](#command-args) to check its options.
-4. Note, starting with version v1alpha2, the scorecard return code is 1 if any of the tests executed did not pass and 0 if all selected tests pass.
 
 **NOTE:** If your operator is non-SDK then some steps will be required in order to meet its requirements.
+
+## Exit Status
+
+Starting with version v1alpha2, the scorecard return code is 1 if any of the tests executed did not pass and 0 if all selected tests pass.
 
 ## Configuration
 

--- a/doc/test-framework/scorecard.md
+++ b/doc/test-framework/scorecard.md
@@ -176,7 +176,7 @@ Following the description of each internal [Plugin](#plugins). Note that are 8 i
 
 ## Exit Status
 
-In version v1alpha2, the scorecard return code is 1 if any of the tests executed did not pass and 0 if all selected tests pass.
+In version v1alpha2, the scorecard return code is 1 if any of the tests executed did not pass and 0 if all selected tests pass.  Version v1alpha1 returns exit code of 0 regardless if tests fail.
 
 ## Extending the Scorecard with Plugins
 

--- a/doc/test-framework/scorecard.md
+++ b/doc/test-framework/scorecard.md
@@ -17,6 +17,7 @@
 - [Tests Performed](#tests-performed)
   - [Basic Operator](#basic-operator)
   - [OLM Integration](#olm-integration)
+- [Exit Status](#exit-status)
 - [Extending the Scorecard with Plugins](#extending-the-scorecard-with-plugins)
   - [JSON format](#json-format)
 - [Running the scorecard with an OLM-managed operator](#running-the-scorecard-with-an-olm-managed-operator)
@@ -51,10 +52,6 @@ Following are some requirements for the operator project which would be  checked
 3. Then, run the scorecard, for example `$ operator-sdk scorecard`. See the [Command args](#command-args) to check its options.
 
 **NOTE:** If your operator is non-SDK then some steps will be required in order to meet its requirements.
-
-## Exit Status
-
-Starting with version v1alpha2, the scorecard return code is 1 if any of the tests executed did not pass and 0 if all selected tests pass.
 
 ## Configuration
 
@@ -176,6 +173,10 @@ Following the description of each internal [Plugin](#plugins). Note that are 8 i
 | CRs Have At Least 1 Example | This test checks that the CSV has an [`alm-examples` annotation][alm-examples] for each CR passed to the `cr-manifest` option in its metadata. This test has a maximum score equal to the number of CRs provided via the `cr-manifest` option. |
 | Spec Fields With Descriptors | This test verifies that every field in the Custom Resources' spec sections have a corresponding descriptor listed in the CSV. This test has a maximum score equal to the total number of fields in the spec sections of each custom resource passed in via the `cr-manifest` option. |
 | Status Fields With Descriptors | This test verifies that every field in the Custom Resources' status sections have a corresponding descriptor listed in the CSV. This test has a maximum score equal to the total number of fields in the status sections of each custom resource passed in via the `cr-manifest` option. |
+
+## Exit Status
+
+In version v1alpha2, the scorecard return code is 1 if any of the tests executed did not pass and 0 if all selected tests pass.
 
 ## Extending the Scorecard with Plugins
 

--- a/hack/tests/subcommand-scorecard.sh
+++ b/hack/tests/subcommand-scorecard.sh
@@ -16,42 +16,44 @@ set -ex
 pushd test/test-framework
 
 # test to see if scorecard fails when version is v1alpha2 and when external plugins are configured
-!(operator-sdk scorecard --version v1alpha2 --config "$CONFIG_PATH" |& grep '^.*error validating plugin config.*$')
-
-set +ex
+if ! $(operator-sdk scorecard --version v1alpha2 --config "$CONFIG_PATH" |& grep -q '^.*error validating plugin config.*$'); then
+	echo "expected scorecard to fail when version is v1alpha2 and when external plugins are configured"
+	exit 1
+fi
 
 # test to see if v1alpha2 is used from the command line
-commandoutput="$(operator-sdk scorecard --version v1alpha2 --config "$CONFIG_PATH_V1ALPHA2" 2>&1)"
-echo $commandoutput
-failCount=`echo $commandoutput | grep -o "fail" | wc -l`
-expectedFailCount=3
-if [ $failCount -ne $expectedFailCount ]
-then
-	echo "expected fail count $expectedFailCount, got $failCount"
-	exit 1
+if ! commandoutput="$(operator-sdk scorecard --version v1alpha2 --config "$CONFIG_PATH_V1ALPHA2" 2>&1)"; then 
+	echo $commandoutput
+	failCount=`echo $commandoutput | grep -o "fail" | wc -l`
+	expectedFailCount=3
+	if [ $failCount -ne $expectedFailCount ]
+	then
+		echo "expected fail count $expectedFailCount, got $failCount"
+		exit 1
+	fi
 fi
 
 # test to see if list flag work
-commandoutput="$(operator-sdk scorecard --version v1alpha2 --list --selector=suite=basic --config "$CONFIG_PATH_V1ALPHA2" 2>&1)"
-labelCount=`echo $commandoutput | grep -o "Label" | wc -l`
-expectedLabelCount=3
-if [ $labelCount -ne $expectedLabelCount ]
-then
-	echo "expected label count $expectedLabelCount, got $labelCount"
-	exit 1
+if ! commandoutput="$(operator-sdk scorecard --version v1alpha2 --list --selector=suite=basic --config "$CONFIG_PATH_V1ALPHA2" 2>&1)"; then
+	labelCount=`echo $commandoutput | grep -o "Label" | wc -l`
+	expectedLabelCount=3
+	if [ $labelCount -ne $expectedLabelCount ]
+	then
+		echo "expected label count $expectedLabelCount, got $labelCount"
+		exit 1
+	fi
 fi
 
 # test to see if selector flags work
-commandoutput="$(operator-sdk scorecard --version v1alpha2 --selector=suite=basic --config "$CONFIG_PATH_V1ALPHA2" 2>&1)"
-labelCount=`echo $commandoutput | grep -o "Label" | wc -l`
-expectedLabelCount=3
-if [ $labelCount -ne $expectedLabelCount ]
-then
-	echo "expected label count $expectedLabelCount, got $labelCount"
-	exit 1
+if ! commandoutput="$(operator-sdk scorecard --version v1alpha2 --selector=suite=basic --config "$CONFIG_PATH_V1ALPHA2" 2>&1)"; then
+	labelCount=`echo $commandoutput | grep -o "Label" | wc -l`
+	expectedLabelCount=3
+	if [ $labelCount -ne $expectedLabelCount ]
+	then
+		echo "expected label count $expectedLabelCount, got $labelCount"
+		exit 1
+	fi
 fi
-
-set -xe 
 
 # test to see if version in config file allows v1alpha1 to be specified
 commandoutput="$(operator-sdk scorecard --config "$CONFIG_PATH_V1ALPHA1" 2>&1)"

--- a/hack/tests/subcommand-scorecard.sh
+++ b/hack/tests/subcommand-scorecard.sh
@@ -15,13 +15,21 @@ set -ex
 # the test framework directory has all the manifests needed to run the cluster
 pushd test/test-framework
 
-# test to see if scorecard fails when version is v1alpha2 and when external plugins are configured
-if ! $(operator-sdk scorecard --version v1alpha2 --config "$CONFIG_PATH" |& grep -q '^.*error validating plugin config.*$'); then
-	echo "expected scorecard to fail when version is v1alpha2 and when external plugins are configured"
+# test to see if scorecard fails when version is v1alpha2 
+# when external plugins are configured which should cause return code 1 
+# to be returned
+if ! commandoutput="$(operator-sdk scorecard --version v1alpha2 --config "$CONFIG_PATH" 2>&1)"; then
+       	if ! (echo $commandoutput | grep -q '^.*error validating plugin config.*$'); then
+		echo "expected scorecard to fail when version is v1alpha2 and when external plugins are configured"
+		exit 1
+	fi
+else
+	echo "test failed: expected return code 1"
 	exit 1
 fi
 
-# test to see if v1alpha2 is used from the command line
+# test to see if v1alpha2 is used from the command line, this test should have
+# failures which cause return code 1 to be returned
 if ! commandoutput="$(operator-sdk scorecard --version v1alpha2 --config "$CONFIG_PATH_V1ALPHA2" 2>&1)"; then 
 	echo $commandoutput
 	failCount=`echo $commandoutput | grep -o "fail" | wc -l`
@@ -31,28 +39,30 @@ if ! commandoutput="$(operator-sdk scorecard --version v1alpha2 --config "$CONFI
 		echo "expected fail count $expectedFailCount, got $failCount"
 		exit 1
 	fi
+else
+	echo "test failed: expected return code 1"
+	exit 1
 fi
 
-# test to see if list flag work
-if ! commandoutput="$(operator-sdk scorecard --version v1alpha2 --list --selector=suite=basic --config "$CONFIG_PATH_V1ALPHA2" 2>&1)"; then
-	labelCount=`echo $commandoutput | grep -o "Label" | wc -l`
-	expectedLabelCount=3
-	if [ $labelCount -ne $expectedLabelCount ]
-	then
-		echo "expected label count $expectedLabelCount, got $labelCount"
-		exit 1
-	fi
+# test to see if list flag work which should cause return code 0 to be returned
+commandoutput="$(operator-sdk scorecard --version v1alpha2 --list --selector=suite=basic --config "$CONFIG_PATH_V1ALPHA2" 2>&1)"
+labelCount=`echo $commandoutput | grep -o "Label" | wc -l`
+expectedLabelCount=3
+if [ $labelCount -ne $expectedLabelCount ]
+then
+	echo "expected label count $expectedLabelCount, got $labelCount"
+	exit 1
 fi
 
-# test to see if selector flags work
-if ! commandoutput="$(operator-sdk scorecard --version v1alpha2 --selector=suite=basic --config "$CONFIG_PATH_V1ALPHA2" 2>&1)"; then
-	labelCount=`echo $commandoutput | grep -o "Label" | wc -l`
-	expectedLabelCount=3
-	if [ $labelCount -ne $expectedLabelCount ]
-	then
-		echo "expected label count $expectedLabelCount, got $labelCount"
-		exit 1
-	fi
+# test to see if selector flags work, this test should have no failures which
+# should cause return code 0 to be returned
+commandoutput="$(operator-sdk scorecard --version v1alpha2 --selector=suite=basic --config "$CONFIG_PATH_V1ALPHA2" 2>&1)"
+labelCount=`echo $commandoutput | grep -o "Label" | wc -l`
+expectedLabelCount=3
+if [ $labelCount -ne $expectedLabelCount ]
+then
+	echo "expected label count $expectedLabelCount, got $labelCount"
+	exit 1
 fi
 
 # test to see if version in config file allows v1alpha1 to be specified

--- a/hack/tests/subcommand-scorecard.sh
+++ b/hack/tests/subcommand-scorecard.sh
@@ -16,10 +16,13 @@ set -ex
 pushd test/test-framework
 
 # test to see if scorecard fails when version is v1alpha2 and when external plugins are configured
-operator-sdk scorecard --version v1alpha2 --config "$CONFIG_PATH" |& grep '^.*error validating plugin config.*$'
+!(operator-sdk scorecard --version v1alpha2 --config "$CONFIG_PATH" |& grep '^.*error validating plugin config.*$')
+
+set +ex
 
 # test to see if v1alpha2 is used from the command line
 commandoutput="$(operator-sdk scorecard --version v1alpha2 --config "$CONFIG_PATH_V1ALPHA2" 2>&1)"
+echo $commandoutput
 failCount=`echo $commandoutput | grep -o "fail" | wc -l`
 expectedFailCount=3
 if [ $failCount -ne $expectedFailCount ]
@@ -47,6 +50,8 @@ then
 	echo "expected label count $expectedLabelCount, got $labelCount"
 	exit 1
 fi
+
+set -xe 
 
 # test to see if version in config file allows v1alpha1 to be specified
 commandoutput="$(operator-sdk scorecard --config "$CONFIG_PATH_V1ALPHA1" 2>&1)"

--- a/internal/scorecard/scorecard.go
+++ b/internal/scorecard/scorecard.go
@@ -148,7 +148,7 @@ func ScorecardTests(cmd *cobra.Command, args []string) error {
 	if schelpers.IsV1alpha2(apiVersion) {
 		for _, scorecardOutput := range pluginOutputs {
 			for _, result := range scorecardOutput.Results {
-				if result.Fail > 0 {
+				if result.Fail > 0 || result.PartialPass > 0 {
 					os.Exit(1)
 				}
 			}

--- a/internal/scorecard/scorecard.go
+++ b/internal/scorecard/scorecard.go
@@ -25,6 +25,7 @@ import (
 	scplugins "github.com/operator-framework/operator-sdk/internal/scorecard/plugins"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 	scapiv1alpha1 "github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha1"
+	scapiv1alpha2 "github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
 	"github.com/operator-framework/operator-sdk/version"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -140,8 +141,19 @@ func ScorecardTests(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if err := printPluginOutputs(scViper.GetString(schelpers.VersionOpt), pluginOutputs); err != nil {
+	output, err := printPluginOutputs(scViper.GetString(schelpers.VersionOpt), pluginOutputs)
+	if err != nil {
 		return err
+	}
+
+	apiVersion := scViper.GetString(schelpers.VersionOpt)
+	if schelpers.IsV1alpha2(apiVersion) {
+		testOutput := output.(scapiv1alpha2.ScorecardOutput)
+		for _, result := range testOutput.Results {
+			if result.State == scapiv1alpha2.FailState {
+				os.Exit(1)
+			}
+		}
 	}
 
 	return nil

--- a/internal/scorecard/scorecard.go
+++ b/internal/scorecard/scorecard.go
@@ -25,7 +25,6 @@ import (
 	scplugins "github.com/operator-framework/operator-sdk/internal/scorecard/plugins"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 	scapiv1alpha1 "github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha1"
-	scapiv1alpha2 "github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
 	"github.com/operator-framework/operator-sdk/version"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -141,17 +140,17 @@ func ScorecardTests(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	output, err := printPluginOutputs(scViper.GetString(schelpers.VersionOpt), pluginOutputs)
-	if err != nil {
+	if err := printPluginOutputs(scViper.GetString(schelpers.VersionOpt), pluginOutputs); err != nil {
 		return err
 	}
 
 	apiVersion := scViper.GetString(schelpers.VersionOpt)
 	if schelpers.IsV1alpha2(apiVersion) {
-		testOutput := output.(scapiv1alpha2.ScorecardOutput)
-		for _, result := range testOutput.Results {
-			if result.State == scapiv1alpha2.FailState {
-				os.Exit(1)
+		for _, scorecardOutput := range pluginOutputs {
+			for _, result := range scorecardOutput.Results {
+				if result.Fail > 0 {
+					os.Exit(1)
+				}
 			}
 		}
 	}

--- a/internal/scorecard/scorecard_output.go
+++ b/internal/scorecard/scorecard_output.go
@@ -24,13 +24,13 @@ import (
 	"io/ioutil"
 )
 
-func printPluginOutputs(version string, pluginOutputs []scapiv1alpha1.ScorecardOutput) (scapi.ScorecardFormatter, error) {
+func printPluginOutputs(version string, pluginOutputs []scapiv1alpha1.ScorecardOutput) error {
 
 	var list scapi.ScorecardFormatter
 	var err error
 	list, err = combinePluginOutput(pluginOutputs)
 	if err != nil {
-		return list, err
+		return err
 	}
 
 	if schelpers.IsV1alpha2(version) {
@@ -47,18 +47,18 @@ func printPluginOutputs(version string, pluginOutputs []scapiv1alpha1.ScorecardO
 	case TextOutputFormat:
 		output, err := list.MarshalText()
 		if err != nil {
-			return list, err
+			return err
 		}
 		fmt.Printf("%s\n", output)
 	case JSONOutputFormat:
 		bytes, err := json.MarshalIndent(list, "", "  ")
 		if err != nil {
-			return list, err
+			return err
 		}
 		fmt.Printf("%s\n", string(bytes))
 	}
 
-	return list, nil
+	return nil
 }
 
 func combinePluginOutput(pluginOutputs []scapiv1alpha1.ScorecardOutput) (scapiv1alpha1.ScorecardOutput, error) {

--- a/internal/scorecard/scorecard_output.go
+++ b/internal/scorecard/scorecard_output.go
@@ -43,26 +43,28 @@ func printPluginOutputs(version string, pluginOutputs []scapiv1alpha1.ScorecardO
 		}
 	}
 
-	// produce text output
-	if scViper.GetString(OutputFormatOpt) == TextOutputFormat {
+	switch format := scViper.GetString(OutputFormatOpt); format {
+	case TextOutputFormat:
 		output, err := list.MarshalText()
 		if err != nil {
 			return err
 		}
 		fmt.Printf("%s\n", output)
-
-		return nil
-	}
-
-	// produce json output
-	if scViper.GetString(OutputFormatOpt) == JSONOutputFormat {
+	case JSONOutputFormat:
 		bytes, err := json.MarshalIndent(list, "", "  ")
 		if err != nil {
 			return err
 		}
 		fmt.Printf("%s\n", string(bytes))
-		return nil
+	}
 
+	if schelpers.IsV1alpha2(version) {
+		testOutput := list.(scapiv1alpha2.ScorecardOutput)
+		for _, result := range testOutput.Results {
+			if result.State == scapiv1alpha2.FailState {
+				return fmt.Errorf("test %s, did not pass", result.Name)
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
this PR adds return code logic into the scorecard subcommand, so that if any selected
test fails, a return code of 1 is produced.  If no tests fail, then the normal return code of 0 is produced.


**Description of the change:**
adds return code logic, updates the scorecard docs to mention the new logic, and also adjusts the scorecard tests to allow for non-zero return codes.

**Motivation for the change:**

this change is part of the scorecard v1alpha2 implementation and supports pipelines that run the scorecard in particular so that they can look for non-zero return codes instead of having to parse the scorecard output.
