### PR TITLE
Add the ability to add the -race flag to the local operator builder

### DIFF
--- a/cmd/operator-sdk/up/local.go
+++ b/cmd/operator-sdk/up/local.go
@@ -57,7 +57,7 @@ kubernetes cluster using a kubeconfig file.
 	upLocalCmd.Flags().StringVar(&operatorFlags, "operator-flags", "", "The flags that the operator needs. Example: \"--flag1 value1 --flag2=value2\"")
 	upLocalCmd.Flags().StringVar(&namespace, "namespace", "", "The namespace where the operator watches for changes.")
 	upLocalCmd.Flags().StringVar(&ldFlags, "go-ldflags", "", "Set Go linker options")
-	upLocalCmd.Flags().BoolVar(&enableRaceDetector, "enable-race-detector", false, "Enables the go runtime's race detector when compiling the operator")
+	upLocalCmd.Flags().BoolVar(&enableRaceDetector, "race", false, "Enables the go runtime's race detector when compiling the operator")
 	upLocalCmd.Flags().BoolVar(&enableDelve, "enable-delve", false, "Start the operator using the delve debugger")
 	switch projutil.GetOperatorType() {
 	case projutil.OperatorTypeAnsible:

--- a/cmd/operator-sdk/up/local.go
+++ b/cmd/operator-sdk/up/local.go
@@ -57,6 +57,7 @@ kubernetes cluster using a kubeconfig file.
 	upLocalCmd.Flags().StringVar(&operatorFlags, "operator-flags", "", "The flags that the operator needs. Example: \"--flag1 value1 --flag2=value2\"")
 	upLocalCmd.Flags().StringVar(&namespace, "namespace", "", "The namespace where the operator watches for changes.")
 	upLocalCmd.Flags().StringVar(&ldFlags, "go-ldflags", "", "Set Go linker options")
+	upLocalCmd.Flags().BoolVar(&enableRaceDetector, "enable-race-detector", false, "Enables the go runtime's race detector when compiling the operator")
 	upLocalCmd.Flags().BoolVar(&enableDelve, "enable-delve", false, "Start the operator using the delve debugger")
 	switch projutil.GetOperatorType() {
 	case projutil.OperatorTypeAnsible:
@@ -72,6 +73,7 @@ var (
 	operatorFlags        string
 	namespace            string
 	ldFlags              string
+	enableRaceDetector   bool
 	enableDelve          bool
 	ansibleOperatorFlags *aoflags.AnsibleOperatorFlags
 	helmOperatorFlags    *hoflags.HelmOperatorFlags

--- a/doc/cli/operator-sdk_up_local.md
+++ b/doc/cli/operator-sdk_up_local.md
@@ -22,6 +22,7 @@ operator-sdk up local [flags]
       --kubeconfig string       The file path to kubernetes configuration file; defaults to location specified by $KUBECONFIG with a fallback to $HOME/.kube/config if not set
       --namespace string        The namespace where the operator watches for changes.
       --operator-flags string   The flags that the operator needs. Example: "--flag1 value1 --flag2=value2"
+      --race                    Enables the go runtime's race detector when compiling the operator
 ```
 
 ### SEE ALSO

--- a/internal/util/projutil/exec.go
+++ b/internal/util/projutil/exec.go
@@ -49,6 +49,8 @@ type GoCmdOptions struct {
 	Env []string
 	// Dir is the dir to run "go {cmd}" in; exec.Command.Dir is set to this value.
 	Dir string
+	// Race is to add the -race flag when compiling the operator
+	Race bool
 }
 
 // GoTestOptions is the set of options for "go test".
@@ -127,6 +129,10 @@ func (opts GoCmdOptions) getGeneralArgsWithCmd(cmd string) ([]string, error) {
 		if err == nil && info.IsDir() && ok {
 			bargs = append(bargs, "-mod=vendor")
 		}
+	}
+
+	if opts.Race {
+		bargs = append(bargs, "-race")
 	}
 
 	if opts.PackagePath != "" {


### PR DESCRIPTION
**Description of the change:**
Add a command line option to enable building the local version of the operator with the `-race`flag.


**Motivation for the change:**
When running the operator locally, I wanted to compile it with the `-race` flag to enable the runtime race detection. 
