### PR TITLE
fix: copy Umask function and remove private package k8s.io/kubernetes/pkg/kubectl/util

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/technosophos/moniker v0.0.0-20180509230615-a5dbd03a2245 // indirect
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	go.uber.org/zap v1.10.0
+	golang.org/x/sys v0.0.0-20190515120540-06a5c4944438
 	golang.org/x/tools v0.0.0-20191018212557-ed542cd5b28a
 	gopkg.in/gorp.v1 v1.7.2 // indirect
 	gopkg.in/yaml.v2 v2.2.2


### PR DESCRIPTION

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
- Copy `Umask` function from https://github.com/kubernetes/kubernetes/blob/v1.15.4/pkg/kubectl/util/umask.go
- Remove imported package "k8s.io/kubernetes/pkg/kubectl/util"

**Motivation for the change:**

"k8s.io/kubernetes/pkg/kubectl/util" has been imported from `pkg/ansible/proxy/kubectl.go`. However, due to https://github.com/kubernetes/kubernetes/blob/v1.15.4/pkg/kubectl/util/BUILD, this go_library has been declared as a private package only visible inner kubernetes. So if we use bazel in operator-sdk by ourself, this will lead to an error
```
in go_library rule @com_github_operator_framework_operator_sdk//pkg/ansible/proxy:go_default_library: target '@io_k8s_kubernetes//pkg/kubectl/util:go_default_library' is not visible from target '@com_github_operator_framework_operator_sdk//pkg/ansible/proxy:go_default_library'. Check the visibility declaration of the former target if you think the dependency is legitimate
```
So we should copy this simple function into out `kubectl.go` file to avoid this private import

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
