### PR TITLE
Use k8s_info module instead of deprecated k8s_facts in molecule scaffold (#2168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Upgrade Helm version from `v2.15.0` to `v2.16.1`. ([#2145](https://github.com/operator-framework/operator-sdk/pull/2145))
 - Upgrade [`controller-runtime`](https://github.com/kubernetes-sigs/controller-runtime) version from `v0.3.0` to [`v0.4.0`](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.4.0). ([#2145](https://github.com/operator-framework/operator-sdk/pull/2145))
 - Updated `pkg/test/e2eutil.WaitForDeployment()` and `pkg/test/e2eutil.WaitForOperatorDeployment()` to successfully complete waiting when the available replica count is _at least_ (rather than exactly) the minimum replica count required. ([#2248](https://github.com/operator-framework/operator-sdk/pull/2248))
+- Use `k8s_info` module instead of deprecated `k8s_facts` module in molecule test scaffold. ([#2168](https://github.com/operator-framework/operator-sdk/issues/2168))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 - Upgrade Helm version from `v2.15.0` to `v2.16.1`. ([#2145](https://github.com/operator-framework/operator-sdk/pull/2145))
 - Upgrade [`controller-runtime`](https://github.com/kubernetes-sigs/controller-runtime) version from `v0.3.0` to [`v0.4.0`](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.4.0). ([#2145](https://github.com/operator-framework/operator-sdk/pull/2145))
 - Updated `pkg/test/e2eutil.WaitForDeployment()` and `pkg/test/e2eutil.WaitForOperatorDeployment()` to successfully complete waiting when the available replica count is _at least_ (rather than exactly) the minimum replica count required. ([#2248](https://github.com/operator-framework/operator-sdk/pull/2248))
-- Use `k8s_info` module instead of deprecated `k8s_facts` module in molecule test scaffold. ([#2168](https://github.com/operator-framework/operator-sdk/issues/2168))
+- Replace in the Ansible based operators module tests `k8s_info` for `k8s_facts` which is deprecated. ([#2168](https://github.com/operator-framework/operator-sdk/issues/2168))
+- Upgrade the Ansible version from `2.8` to `2.9` on the Ansible based operators image. ([#2168](https://github.com/operator-framework/operator-sdk/issues/2168))
 
 ### Deprecated
 

--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -31,7 +31,7 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
       ansible-runner==1.3.4 \
       ansible-runner-http==1.0.0 \
       openshift==0.8.9 \
-      ansible~=2.8 \
+      ansible~=2.9 \
       jmespath \
  && yum remove -y gcc python36-devel \
  && yum clean all \

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -30,7 +30,7 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
       ansible-runner==1.3.4 \
       ansible-runner-http==1.0.0 \
       openshift==0.8.9 \
-      ansible~=2.8 \
+      ansible~=2.9 \
       jmespath \
  && yum remove -y gcc python36-devel \
  && yum clean all \

--- a/doc/ansible/dev/retroactively-owned-resources.md
+++ b/doc/ansible/dev/retroactively-owned-resources.md
@@ -133,7 +133,7 @@ This file can be used as-is without user adjustments.
     - name: Import user variables
       include_vars: vars.yml
     - name: Retrieve owning resource
-      k8s_facts:
+      k8s_info:
         api_version: "{{ owning_resource.apiVersion }}"
         kind: "{{ owning_resource.kind }}"
         name: "{{ owning_resource.name }}"

--- a/internal/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/scaffold/ansible/dockerfilehybrid.go
@@ -72,7 +72,6 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
       openshift==0.8.9 \
       ansible~=2.9 \
       jmespath \
->>>>>>> Update Ansible minimum version to 2.9 in various Dockerfiles (#2203)
  && yum remove -y gcc python36-devel \
  && yum clean all \
  && rm -rf /var/cache/yum

--- a/internal/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/scaffold/ansible/dockerfilehybrid.go
@@ -70,8 +70,9 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
       ansible-runner==1.3.4 \
       ansible-runner-http==1.0.0 \
       openshift==0.8.9 \
-      ansible~=2.8 \
+      ansible~=2.9 \
       jmespath \
+>>>>>>> Update Ansible minimum version to 2.9 in various Dockerfiles (#2203)
  && yum remove -y gcc python36-devel \
  && yum clean all \
  && rm -rf /var/cache/yum

--- a/internal/scaffold/ansible/molecule_default_asserts.go
+++ b/internal/scaffold/ansible/molecule_default_asserts.go
@@ -46,7 +46,7 @@ const moleculeDefaultAssertsAnsibleTmpl = `---
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
   tasks:
     - name: Get all pods in {{ namespace }}
-      k8s_facts:
+      k8s_info:
         api_version: v1
         kind: Pod
         namespace: '{{ namespace }}'

--- a/internal/scaffold/ansible/molecule_test_cluster_playbook.go
+++ b/internal/scaffold/ansible/molecule_test_cluster_playbook.go
@@ -60,7 +60,7 @@ const moleculeTestClusterPlaybookAnsibleTmpl = `---
       msg: "{{ lookup('k8s', group='[[.Resource.FullGroup]]', api_version='[[.Resource.Version]]', kind='[[.Resource.Kind]]', namespace=namespace, resource_name=custom_resource.metadata.name) }}"
 
   - name: Wait 2m for reconciliation to run
-    k8s_facts:
+    k8s_info:
       api_version: '[[.Resource.Version]]'
       kind: '[[.Resource.Kind]]'
       namespace: '{{ namespace }}'

--- a/internal/scaffold/ansible/molecule_test_local_playbook.go
+++ b/internal/scaffold/ansible/molecule_test_local_playbook.go
@@ -77,7 +77,7 @@ const moleculeTestLocalPlaybookAnsibleTmpl = `---
       when: hostvars[groups.k8s.0].build_cmd.changed
 
     - name: Wait 30s for Operator Deployment to terminate
-      k8s_facts:
+      k8s_info:
         api_version: '{{ definition.apiVersion }}'
         kind: '{{ definition.kind }}'
         namespace: '{{ namespace }}'
@@ -102,7 +102,7 @@ const moleculeTestLocalPlaybookAnsibleTmpl = `---
         definition: '{{ custom_resource }}'
 
     - name: Wait 2m for reconciliation to run
-      k8s_facts:
+      k8s_info:
         api_version: '{{ custom_resource.apiVersion }}'
         kind: '{{ custom_resource.kind }}'
         namespace: '{{ namespace }}'

--- a/test/ansible-inventory/molecule/test-local/playbook.yml
+++ b/test/ansible-inventory/molecule/test-local/playbook.yml
@@ -35,7 +35,7 @@
     when: hostvars[groups.k8s.0].build_cmd.changed
 
   - name: Wait 30s for Operator Deployment to terminate
-    k8s_facts:
+    k8s_info:
       api_version: '{{ definition.apiVersion }}'
       kind: '{{ definition.kind }}'
       namespace: '{{ namespace }}'
@@ -60,7 +60,7 @@
       definition: "{{ custom_resource }}"
 
   - name: Wait 2m for reconciliation to run
-    k8s_facts:
+    k8s_info:
       api_version: '{{ custom_resource.apiVersion }}'
       kind: '{{ custom_resource.kind }}'
       namespace: '{{ namespace }}'

--- a/test/ansible-memcached/asserts.yml
+++ b/test/ansible-memcached/asserts.yml
@@ -135,7 +135,7 @@
           definition: '{{ custom_resource }}'
 
       - name: Wait for the custom resource to be deleted
-        k8s_facts:
+        k8s_info:
           api_version: '{{ custom_resource.apiVersion }}'
           kind: '{{ custom_resource.kind }}'
           namespace: '{{ namespace }}'


### PR DESCRIPTION
**Description of the change:**
Replaces uses of the deprecated `k8s_facts` module with `k8s_info`, which is the standard module for k8s information lookups in Ansible 2.9+.

**Motivation for the change:**

Closes #2168