### PR TITLE
pkg/test/e2eutil: wait for a deployment to have >= n replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Upgrade Kubernetes version from `kubernetes-1.15.4` to `kubernetes-1.16.2`. ([#2145](https://github.com/operator-framework/operator-sdk/pull/2145))
 - Upgrade Helm version from `v2.15.0` to `v2.16.1`. ([#2145](https://github.com/operator-framework/operator-sdk/pull/2145))
 - Upgrade [`controller-runtime`](https://github.com/kubernetes-sigs/controller-runtime) version from `v0.3.0` to [`v0.4.0`](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.4.0). ([#2145](https://github.com/operator-framework/operator-sdk/pull/2145))
+- Updated `pkg/test/e2eutil.WaitForDeployment()` and `pkg/test/e2eutil.WaitForOperatorDeployment()` to successfully complete waiting when the available replica count is _at least_ (rather than exactly) the minimum replica count required. ([#2248](https://github.com/operator-framework/operator-sdk/pull/2248))
 
 ### Deprecated
 

--- a/pkg/test/e2eutil/wait_util.go
+++ b/pkg/test/e2eutil/wait_util.go
@@ -58,7 +58,7 @@ func waitForDeployment(t *testing.T, kubeclient kubernetes.Interface, namespace,
 			return false, err
 		}
 
-		if int(deployment.Status.AvailableReplicas) == replicas {
+		if int(deployment.Status.AvailableReplicas) >= replicas {
 			return true, nil
 		}
 		t.Logf("Waiting for full availability of %s deployment (%d/%d)\n", name, deployment.Status.AvailableReplicas, replicas)


### PR DESCRIPTION
Before waitForDeployment was waiting until the exact number of replicas
were available. Now, wait for at least that number of replicas to be
available.

scenario:
I'm using an operator with 3 replicas, but only 1 is needed for tests to
work. If all 3 replicas were available before waitForDeployment started
then it would wait until it timed out because 3 does not equal 1. Now,
since 3 replicas is greater than the 1 needed for tests waitForDeployment
successfully waits.
