### PR TITLE
hack/ci/setup-k8s.sh: update kindest/node to v1.6.3, kind to latest

### DIFF
--- a/hack/ci/setup-k8s.sh
+++ b/hack/ci/setup-k8s.sh
@@ -5,18 +5,12 @@ set -eux
 # This image tag corresponds to a Kubernetes version that kind installs using
 # images at:
 # https://hub.docker.com/r/kindest/node/tags
-K8S_VERSION="v1.15.4"
-KIND_IMAGE="quay.io/estroz/node:${K8S_VERSION}"
-# TODO: use the below image once it is rebuilt with the following base image:
-# kindest/base:v20190926-e6b6f7f0@sha256:1ec92b2910f2bfb8a4814cc90e15974a499f0c93d203b879277fa4bdb3762ce2
-# KIND_IMAGE="docker.io/kindest/node:${K8S_VERSION}"
+K8S_VERSION="v1.16.3"
+KIND_IMAGE="docker.io/kindest/node:${K8S_VERSION}"
 
 # Download the latest version of kind, which supports all versions of
 # Kubernetes v1.11+.
-# TODO: use "latest" release URL once full releases are being made.
-# Currently at pre-release.
-KIND_VERSION="v0.5.1"
-curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/latest/download/kind-$(uname)-amd64
 chmod +x kind
 sudo mv kind /usr/local/bin/
 

--- a/hack/ci/setup-k8s.sh
+++ b/hack/ci/setup-k8s.sh
@@ -18,7 +18,7 @@ sudo mv kind /usr/local/bin/
 kind create cluster --image="$KIND_IMAGE"
 
 # Run this command externally after installation:
-export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+kind export kubeconfig
 
 # kubectl is needed for the single namespace local test and the ansible tests.
 curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl

--- a/hack/lib/image_lib.sh
+++ b/hack/lib/image_lib.sh
@@ -119,7 +119,7 @@ function is_latest_tag() {
 # load_image_if_kind loads an image into all nodes in a kind cluster.
 #
 function load_image_if_kind() {
-  if [[ "$(kubectl config current-context)" == "kubernetes-admin@kind" ]]; then
+  if [[ "$(kubectl config current-context)" == "kind-kind" ]]; then
     if which kind 2>/dev/null; then
       kind load docker-image "$1"
     fi


### PR DESCRIPTION
**Description of the change:**
* hack/ci/setup-k8s.sh: update kindest/node to v1.6.3, kind to latest

**Motivation for the change:** `kind` has released a stable version `v0.6.0`, and has pushed a `v1.16.3` image built with this stable version. We can use this k8s version now that deps have been [bumped](#2145) to `kubernetes-1.16`.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
