### PR TITLE
auto-detect build runtime arch

### DIFF
--- a/cmd/operator-sdk/build/cmd.go
+++ b/cmd/operator-sdk/build/cmd.go
@@ -20,6 +20,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/operator-framework/operator-sdk/internal/scaffold"
@@ -94,7 +95,7 @@ func buildFunc(cmd *cobra.Command, args []string) error {
 	if value, ok := os.LookupEnv("GOARCH"); ok {
 		goBuildEnv = append(goBuildEnv, "GOARCH="+value)
 	} else {
-		goBuildEnv = append(goBuildEnv, "GOARCH=amd64")
+		goBuildEnv = append(goBuildEnv, "GOARCH="+runtime.GOARCH)
 	}
 
 	// If CGO_ENABLED is not set, set it to '0'.


### PR DESCRIPTION
If the user hasn't explictyly set GOARCH, don't default to amd64. This
way, a user has to expliciltly cross-compile, instead of needing to know
to set GOARCH on build for a native arch that isn't amd64 (the current behaviour).

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
use the go runtime's goarch instead of a potentially (probably) un-set local environment variable

**Motivation for the change:**
an internal build team was getting a ppc64le docker image with an x86 binary inside and was super confused :D 

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
