### PR TITLE
Makefile,.travis.yml: simplify unit test and code coverage make target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ jobs:
         - go get github.com/mattn/goveralls
       script:
         - make test-sanity test-unit test-markdown test-linter
-        - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=coverage-all.out -repotoken=$COVERALLS_TOKEN
+        - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=coverage.out -repotoken=$COVERALLS_TOKEN
       after_success: echo 'Tests Passed'
       after_failure: echo 'Failure in unit, sanity, markdown, coverage or linter test'
 

--- a/Makefile
+++ b/Makefile
@@ -183,12 +183,9 @@ test-markdown test/markdown:
 test-sanity test/sanity: tidy build/operator-sdk
 	./hack/tests/sanity-check.sh
 
+TEST_PKGS:=$(shell go list ./... | grep -v -P 'github.com/operator-framework/operator-sdk/(hack|test/e2e)')
 test-unit test/unit: ## Run the unit tests
-	- rm -f coverage-all.out
-	- echo 'mode: count' > coverage-all.out
-	$(Q)go test -coverprofile=coverage.out -covermode=count -count=1 -short ./cmd/... && tail -n +2 coverage.out >> coverage-all.out;
-	$(Q)go test -coverprofile=coverage.out -covermode=count -count=1 -short ./pkg/... && tail -n +2 coverage.out >> coverage-all.out;
-	$(Q)go test -coverprofile=coverage.out -covermode=count -count=1 -short ./internal/... && tail -n +2 coverage.out >> coverage-all.out;
+	$(Q)go test -coverprofile=coverage.out -covermode=count -count=1 -short ${TEST_PKGS}
 
 # CI tests.
 .PHONY: test-ci


### PR DESCRIPTION
**Description of the change:**
* Change unit test packages from whitelist to blacklist, so new root-level packages are automatically included in unit testing.
* Run `go test` in one run instead of three to simplify collection of code coverage stats.

**Motivation for the change:**
Improve package selection for unit tests, simplify Makefile
