### PR TITLE
Adding context timeout for Ansible proxy

### DIFF
--- a/changelog/fragments/fix-issue-bug-1701041.yaml
+++ b/changelog/fragments/fix-issue-bug-1701041.yaml
@@ -2,9 +2,9 @@
 # release notes and/or the migration guide
 entries:
   - description: >
-      Fix issue by adding proxy timeout for the Ansible based-operators to add error conditional status properly when the operator has not the required permissions (RBAC) to perform the operations.
+      Added timeout to child resource watches for Ansible based-operators. This is necessary to avoid appears that reconciler is blocked when the operator does not have the required RBAC permissions to List and Watch the child resource and update the CR with the error in the `status.conditions` field.
 
-    # kind is one of:
+    # kind iss one of:
     # - addition
     # - change
     # - deprecation

--- a/changelog/fragments/fix-issue-bug-1701041.yaml
+++ b/changelog/fragments/fix-issue-bug-1701041.yaml
@@ -1,0 +1,13 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Fix issue by adding proxy timeout for the Ansible based-operators to add error conditional status properly when the operator has not the required permissions (RBAC) to perform the operations.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"

--- a/changelog/fragments/fix-issue-bug-1701041.yaml
+++ b/changelog/fragments/fix-issue-bug-1701041.yaml
@@ -2,7 +2,7 @@
 # release notes and/or the migration guide
 entries:
   - description: >
-      Added timeout to child resource watches for Ansible based-operators. This is necessary to avoid appears that reconciler is blocked when the operator does not have the required RBAC permissions to List and Watch the child resource and update the CR with the error in the `status.conditions` field.
+      Added timeout to the Ansible based-operator proxy, which enables error reporting for requests that fail due to RBAC permissions issues to List and Watch the resources. 
 
     # kind iss one of:
     # - addition

--- a/pkg/ansible/proxy/cache_response.go
+++ b/pkg/ansible/proxy/cache_response.go
@@ -19,14 +19,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
 	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/ansible/proxy/controllermap"
 	"github.com/operator-framework/operator-sdk/pkg/ansible/proxy/requestfactory"
 	k8sRequest "github.com/operator-framework/operator-sdk/pkg/ansible/proxy/requestfactory"
 	osdkHandler "github.com/operator-framework/operator-sdk/pkg/handler"
-	"net/http"
-	"regexp"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalscheme "k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme"
@@ -271,7 +272,6 @@ func (c *cacheResponseHandler) getListFromCache(r *requestfactory.RequestInfo, r
 	k.Kind = k.Kind + "List"
 	un := unstructured.UnstructuredList{}
 	un.SetGroupVersionKind(k)
-
 	ctx, cancel := context.WithTimeout(context.Background(), cacheEscacheEstablishmentTimeout)
 	defer cancel()
 	err := c.informerCache.List(ctx, &un, clientListOpts...)

--- a/pkg/ansible/proxy/cache_response.go
+++ b/pkg/ansible/proxy/cache_response.go
@@ -287,7 +287,7 @@ func (c *cacheResponseHandler) getListFromCache(r *requestfactory.RequestInfo, r
 			log.Info(fmt.Sprintf("cache miss: %v err-%v", k, watchErr))
 			return nil, watchErr
 		}
-	case <-time.After(3 * time.Second):
+	case <-time.After(cacheEscacheEstablishmentTimeout):
 		return nil, fmt.Errorf("timeout establishing watch, commonly permissions of the controller are not sufficent")
 	}
 	return &un, nil
@@ -312,7 +312,7 @@ func (c *cacheResponseHandler) getObjectFromCache(r *requestfactory.RequestInfo,
 			log.Info(fmt.Sprintf("cache miss: %v err-%v", k, watchErr))
 			return nil, watchErr
 		}
-	case <-time.After(3 * time.Second):
+	case <-time.After(cacheEstacacheEstablishmentTimeout):
 		return nil, fmt.Errorf("timeout establishing watch, commonly permissions of the controller are not sufficent")
 	}
 

--- a/pkg/ansible/proxy/cache_response.go
+++ b/pkg/ansible/proxy/cache_response.go
@@ -272,7 +272,7 @@ func (c *cacheResponseHandler) getListFromCache(r *requestfactory.RequestInfo, r
 	k.Kind = k.Kind + "List"
 	un := unstructured.UnstructuredList{}
 	un.SetGroupVersionKind(k)
-	ctx, cancel := context.WithTimeout(context.Background(), cacheEscacheEstablishmentTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), cacheEstablishmentTimeout)
 	defer cancel()
 	err := c.informerCache.List(ctx, &un, clientListOpts...)
 	if err != nil {
@@ -289,7 +289,7 @@ func (c *cacheResponseHandler) getObjectFromCache(r *requestfactory.RequestInfo,
 	un := &unstructured.Unstructured{}
 	un.SetGroupVersionKind(k)
 	obj := client.ObjectKey{Namespace: r.Namespace, Name: r.Name}
-	ctx, cancel := context.WithTimeout(context.Background(), cacheEscacheEstablishmentTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), cacheEstablishmentTimeout)
 	defer cancel()
 	err := c.informerCache.Get(ctx, obj, un)
 	if err != nil {

--- a/pkg/ansible/proxy/cache_response.go
+++ b/pkg/ansible/proxy/cache_response.go
@@ -19,14 +19,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/ansible/proxy/controllermap"
 	"github.com/operator-framework/operator-sdk/pkg/ansible/proxy/requestfactory"
 	k8sRequest "github.com/operator-framework/operator-sdk/pkg/ansible/proxy/requestfactory"
 	osdkHandler "github.com/operator-framework/operator-sdk/pkg/handler"
-	"net/http"
-	"regexp"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalscheme "k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme"
@@ -271,15 +273,22 @@ func (c *cacheResponseHandler) getListFromCache(r *requestfactory.RequestInfo, r
 	k.Kind = k.Kind + "List"
 	un := unstructured.UnstructuredList{}
 	un.SetGroupVersionKind(k)
+	errChan := make(chan error, 1)
+	go func() {
+		err := c.informerCache.List(context.Background(), &un, clientListOpts...)
+		errChan <- err
+	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), cacheEscacheEstablishmentTimeout)
-	defer cancel()
-	err := c.informerCache.List(ctx, &un, clientListOpts...)
-	if err != nil {
-		// break here in case resource doesn't exist in cache but exists on APIserver
-		// This is very unlikely but provides user with expected 404
-		log.Info(fmt.Sprintf("cache miss: %v err-%v", k, err))
-		return nil, err
+	select {
+	case watchErr := <-errChan:
+		if watchErr != nil {
+			// break here in case resource doesn't exist in cache but exists on APIserver
+			// This is very unlikely but provides user with expected 404
+			log.Info(fmt.Sprintf("cache miss: %v err-%v", k, watchErr))
+			return nil, watchErr
+		}
+	case <-time.After(cacheEscacheEstablishmentTimeout):
+		return nil, fmt.Errorf("timeout establishing watch, commonly permissions of the controller are not sufficent")
 	}
 	return &un, nil
 }
@@ -289,15 +298,24 @@ func (c *cacheResponseHandler) getObjectFromCache(r *requestfactory.RequestInfo,
 	un := &unstructured.Unstructured{}
 	un.SetGroupVersionKind(k)
 	obj := client.ObjectKey{Namespace: r.Namespace, Name: r.Name}
-	ctx, cancel := context.WithTimeout(context.Background(), cacheEscacheEstablishmentTimeout)
-	defer cancel()
-	err := c.informerCache.Get(ctx, obj, un)
-	if err != nil {
-		// break here in case resource doesn't exist in cache but exists on APIserver
-		// This is very unlikely but provides user with expected 404
-		log.Info(fmt.Sprintf("Cache miss: %v, %v", k, obj))
-		return nil, err
+	errChan := make(chan error, 1)
+	go func() {
+		err := c.informerCache.Get(context.Background(), obj, un)
+		errChan <- err
+	}()
+
+	select {
+	case watchErr := <-errChan:
+		if watchErr != nil {
+			// break here in case resource doesn't exist in cache but exists on APIserver
+			// This is very unlikely but provides user with expected 404
+			log.Info(fmt.Sprintf("cache miss: %v err-%v", k, watchErr))
+			return nil, watchErr
+		}
+	case <-time.After(cacheEscacheEstablishmentTimeout):
+		return nil, fmt.Errorf("timeout establishing watch, commonly permissions of the controller are not sufficent")
 	}
+
 	// Once we get the resource, we are going to attempt to recover the dependent watches here,
 	// This will happen in the background, and log errors.
 	if c.injectOwnerRef {

--- a/pkg/ansible/proxy/cache_response.go
+++ b/pkg/ansible/proxy/cache_response.go
@@ -19,16 +19,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"regexp"
-	"strings"
-	"time"
-
 	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/ansible/proxy/controllermap"
 	"github.com/operator-framework/operator-sdk/pkg/ansible/proxy/requestfactory"
 	k8sRequest "github.com/operator-framework/operator-sdk/pkg/ansible/proxy/requestfactory"
 	osdkHandler "github.com/operator-framework/operator-sdk/pkg/handler"
+	"net/http"
+	"regexp"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalscheme "k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme"
@@ -273,22 +271,15 @@ func (c *cacheResponseHandler) getListFromCache(r *requestfactory.RequestInfo, r
 	k.Kind = k.Kind + "List"
 	un := unstructured.UnstructuredList{}
 	un.SetGroupVersionKind(k)
-	errChan := make(chan error, 1)
-	go func() {
-		err := c.informerCache.List(context.Background(), &un, clientListOpts...)
-		errChan <- err
-	}()
 
-	select {
-	case watchErr := <-errChan:
-		if watchErr != nil {
-			// break here in case resource doesn't exist in cache but exists on APIserver
-			// This is very unlikely but provides user with expected 404
-			log.Info(fmt.Sprintf("cache miss: %v err-%v", k, watchErr))
-			return nil, watchErr
-		}
-	case <-time.After(cacheEscacheEstablishmentTimeout):
-		return nil, fmt.Errorf("timeout establishing watch, commonly permissions of the controller are not sufficent")
+	ctx, cancel := context.WithTimeout(context.Background(), cacheEscacheEstablishmentTimeout)
+	defer cancel()
+	err := c.informerCache.List(ctx, &un, clientListOpts...)
+	if err != nil {
+		// break here in case resource doesn't exist in cache but exists on APIserver
+		// This is very unlikely but provides user with expected 404
+		log.Info(fmt.Sprintf("cache miss: %v err-%v", k, err))
+		return nil, err
 	}
 	return &un, nil
 }
@@ -298,24 +289,15 @@ func (c *cacheResponseHandler) getObjectFromCache(r *requestfactory.RequestInfo,
 	un := &unstructured.Unstructured{}
 	un.SetGroupVersionKind(k)
 	obj := client.ObjectKey{Namespace: r.Namespace, Name: r.Name}
-	errChan := make(chan error, 1)
-	go func() {
-		err := c.informerCache.Get(context.Background(), obj, un)
-		errChan <- err
-	}()
-
-	select {
-	case watchErr := <-errChan:
-		if watchErr != nil {
-			// break here in case resource doesn't exist in cache but exists on APIserver
-			// This is very unlikely but provides user with expected 404
-			log.Info(fmt.Sprintf("cache miss: %v err-%v", k, watchErr))
-			return nil, watchErr
-		}
-	case <-time.After(cacheEscacheEstablishmentTimeout):
-		return nil, fmt.Errorf("timeout establishing watch, commonly permissions of the controller are not sufficent")
+	ctx, cancel := context.WithTimeout(context.Background(), cacheEscacheEstablishmentTimeout)
+	defer cancel()
+	err := c.informerCache.Get(ctx, obj, un)
+	if err != nil {
+		// break here in case resource doesn't exist in cache but exists on APIserver
+		// This is very unlikely but provides user with expected 404
+		log.Info(fmt.Sprintf("Cache miss: %v, %v", k, obj))
+		return nil, err
 	}
-
 	// Once we get the resource, we are going to attempt to recover the dependent watches here,
 	// This will happen in the background, and log errors.
 	if c.injectOwnerRef {

--- a/pkg/ansible/proxy/cache_response.go
+++ b/pkg/ansible/proxy/cache_response.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/ansible/proxy/controllermap"
@@ -272,12 +273,22 @@ func (c *cacheResponseHandler) getListFromCache(r *requestfactory.RequestInfo, r
 	k.Kind = k.Kind + "List"
 	un := unstructured.UnstructuredList{}
 	un.SetGroupVersionKind(k)
-	err := c.informerCache.List(context.Background(), &un, clientListOpts...)
-	if err != nil {
-		// break here in case resource doesn't exist in cache but exists on APIserver
-		// This is very unlikely but provides user with expected 404
-		log.Info(fmt.Sprintf("cache miss: %v err-%v", k, err))
-		return nil, err
+	errChan := make(chan error, 1)
+	go func() {
+		err := c.informerCache.List(context.Background(), &un, clientListOpts...)
+		errChan <- err
+	}()
+
+	select {
+	case watchErr := <-errChan:
+		if watchErr != nil {
+			// break here in case resource doesn't exist in cache but exists on APIserver
+			// This is very unlikely but provides user with expected 404
+			log.Info(fmt.Sprintf("cache miss: %v err-%v", k, watchErr))
+			return nil, watchErr
+		}
+	case <-time.After(3 * time.Second):
+		return nil, fmt.Errorf("timeout establishing watch, commonly permissions of the controller are not sufficent")
 	}
 	return &un, nil
 }
@@ -287,13 +298,24 @@ func (c *cacheResponseHandler) getObjectFromCache(r *requestfactory.RequestInfo,
 	un := &unstructured.Unstructured{}
 	un.SetGroupVersionKind(k)
 	obj := client.ObjectKey{Namespace: r.Namespace, Name: r.Name}
-	err := c.informerCache.Get(context.Background(), obj, un)
-	if err != nil {
-		// break here in case resource doesn't exist in cache but exists on APIserver
-		// This is very unlikely but provides user with expected 404
-		log.Info(fmt.Sprintf("Cache miss: %v, %v", k, obj))
-		return nil, err
+	errChan := make(chan error, 1)
+	go func() {
+		err := c.informerCache.Get(context.Background(), obj, un)
+		errChan <- err
+	}()
+
+	select {
+	case watchErr := <-errChan:
+		if watchErr != nil {
+			// break here in case resource doesn't exist in cache but exists on APIserver
+			// This is very unlikely but provides user with expected 404
+			log.Info(fmt.Sprintf("cache miss: %v err-%v", k, watchErr))
+			return nil, watchErr
+		}
+	case <-time.After(3 * time.Second):
+		return nil, fmt.Errorf("timeout establishing watch, commonly permissions of the controller are not sufficent")
 	}
+
 	// Once we get the resource, we are going to attempt to recover the dependent watches here,
 	// This will happen in the background, and log errors.
 	if c.injectOwnerRef {

--- a/pkg/ansible/proxy/proxy.go
+++ b/pkg/ansible/proxy/proxy.go
@@ -47,7 +47,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+<<<<<<< HEAD
 const AutoSkipCacheREList = "^/api/.*/pods/.*/exec,^/api/.*/pods/.*/attach"
+=======
+// This is the default timeout to wait for the cache to respond
+// TODO: Eventually this should be configurable
+const cacheEstablishmentTimeout = 6 * time.Second
+>>>>>>> adding constant and todo for cache timeout
 
 // RequestLogHandler - log the requests that come through the proxy.
 func RequestLogHandler(h http.Handler) http.Handler {
@@ -279,7 +285,7 @@ func addWatch(c controller.Controller, s source.Source, eh handler.EventHandler,
 	select {
 	case watchErr := <-errChan:
 		return watchErr
-	case <-time.After(3 * time.Second):
+	case <-time.After(cacheEstablishmentTimeout):
 		return fmt.Errorf("timeout establishing watch, commonly permissions of the controller are not sufficent")
 	}
 }

--- a/pkg/ansible/proxy/proxy.go
+++ b/pkg/ansible/proxy/proxy.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/operator-framework/operator-sdk/pkg/ansible/proxy/controllermap"
 	"github.com/operator-framework/operator-sdk/pkg/ansible/proxy/kubeconfig"
@@ -40,7 +41,9 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -238,12 +241,11 @@ func addWatchToController(owner kubeconfig.NamespacedOwnerReference, cMap *contr
 			}
 
 			owMap.Store(resource.GroupVersionKind())
-			log.Info("Watching child resource", "kind", resource.GroupVersionKind(),
-				"enqueue_kind", u.GroupVersionKind())
-			err := contents.Controller.Watch(&source.Kind{Type: resource},
-				&handler.EnqueueRequestForOwner{OwnerType: u}, dependentPredicate)
+			log.Info("Watching child resource", "kind", resource.GroupVersionKind(), "enqueue_kind", u.GroupVersionKind())
 			// Store watch in map
+			err := addWatch(contents.Controller, &source.Kind{Type: resource}, &handler.EnqueueRequestForOwner{OwnerType: u}, dependentPredicate))
 			if err != nil {
+				log.Error(err, "gvk", resource.GroupVersionKind())
 				return err
 			}
 		case (!useOwnerRef && dataNamespaceScoped) || contents.WatchClusterScopedResources:
@@ -254,11 +256,10 @@ func addWatchToController(owner kubeconfig.NamespacedOwnerReference, cMap *contr
 			}
 			awMap.Store(resource.GroupVersionKind())
 			typeString := fmt.Sprintf("%v.%v", owner.Kind, ownerGV.Group)
-			log.Info("Watching child resource", "kind", resource.GroupVersionKind(),
-				"enqueue_annotation_type", typeString)
-			err = contents.Controller.Watch(&source.Kind{Type: resource},
-				&osdkHandler.EnqueueRequestForAnnotation{Type: typeString}, dependentPredicate)
+			log.Info("Watching child resource", "kind", resource.GroupVersionKind(), "enqueue_annotation_type", typeString)
+			err = addWatch(contents.Controller, &source.Kind{Type: resource}, &osdkHandler.EnqueueRequestForAnnotation{Type: typeString}, dependentPredicate)
 			if err != nil {
+				log.Error(err, "gvk", resource.GroupVersionKind())
 				return err
 			}
 		}
@@ -266,6 +267,21 @@ func addWatchToController(owner kubeconfig.NamespacedOwnerReference, cMap *contr
 		log.Info("Resource will not be watched/cached.", "GVK", resource.GroupVersionKind())
 	}
 	return nil
+}
+
+func addWatch(c controller.Controller, s source.Source, eh handler.EventHandler, predicates ...predicate.Predicate) error {
+	errChan := make(chan error, 1)
+	go func() {
+		err := c.Watch(s, eh, predicates...)
+		errChan <- err
+	}()
+
+	select {
+	case watchErr := <-errChan:
+		return watchErr
+	case <-time.After(3 * time.Second):
+		return fmt.Errorf("timeout establishing watch, commonly permissions of the controller are not sufficent")
+	}
 }
 
 func removeAuthorizationHeader(h http.Handler) http.Handler {

--- a/pkg/ansible/proxy/proxy.go
+++ b/pkg/ansible/proxy/proxy.go
@@ -47,7 +47,7 @@ import (
 
 // This is the default timeout to wait for the cache to respond
 // todo(shawn-hurley): Eventually this should be configurable
-const cacheEscacheEstablishmentTimeout = 6 * time.Second
+const cacheEstablishmentTimeout = 6 * time.Second
 const AutoSkipCacheREList = "^/api/.*/pods/.*/exec,^/api/.*/pods/.*/attach"
 
 // RequestLogHandler - log the requests that come through the proxy.
@@ -248,7 +248,8 @@ func addWatchToController(owner kubeconfig.NamespacedOwnerReference, cMap *contr
 				&handler.EnqueueRequestForOwner{OwnerType: u}, dependentPredicate)
 			// Store watch in map
 			if err != nil {
-				log.Error(err, "GVK", resource.GroupVersionKind())
+				log.Error(err, "Failed to watch child resource",
+					"kind", resource.GroupVersionKind(), "enqueue_kind", u.GroupVersionKind())
 				return err
 			}
 		case (!useOwnerRef && dataNamespaceScoped) || contents.WatchClusterScopedResources:
@@ -264,7 +265,8 @@ func addWatchToController(owner kubeconfig.NamespacedOwnerReference, cMap *contr
 			err = contents.Controller.Watch(&source.Kind{Type: resource},
 				&osdkHandler.EnqueueRequestForAnnotation{Type: typeString}, dependentPredicate)
 			if err != nil {
-				log.Error(err, "GVK", resource.GroupVersionKind())
+				log.Error(err, "Failed to watch child resource",
+					"kind", resource.GroupVersionKind(), "enqueue_kind", u.GroupVersionKind())
 				return err
 			}
 		}

--- a/pkg/ansible/proxy/proxy.go
+++ b/pkg/ansible/proxy/proxy.go
@@ -246,6 +246,7 @@ func addWatchToController(owner kubeconfig.NamespacedOwnerReference, cMap *contr
 				"enqueue_kind", u.GroupVersionKind())
 			err := contents.Controller.Watch(&source.Kind{Type: resource},
 				&handler.EnqueueRequestForOwner{OwnerType: u}, dependentPredicate)
+			
 			// Store watch in map
 			if err != nil {
 				log.Error(err, "GVK", resource.GroupVersionKind())

--- a/pkg/ansible/proxy/proxy.go
+++ b/pkg/ansible/proxy/proxy.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"strings"
 	"sync"
 	"time"
@@ -244,10 +246,8 @@ func addWatchToController(owner kubeconfig.NamespacedOwnerReference, cMap *contr
 			owMap.Store(resource.GroupVersionKind())
 			log.Info("Watching child resource", "kind", resource.GroupVersionKind(),
 				"enqueue_kind", u.GroupVersionKind())
-			err := contents.Controller.Watch(&source.Kind{Type: resource},
-				&handler.EnqueueRequestForOwner{OwnerType: u}, dependentPredicate)
-			
 			// Store watch in map
+			err := addWatch(contents.Controller, &source.Kind{Type: resource}, &handler.EnqueueRequestForOwner{OwnerType: u}, dependentPredicate)
 			if err != nil {
 				log.Error(err, "GVK", resource.GroupVersionKind())
 				return err
@@ -262,8 +262,7 @@ func addWatchToController(owner kubeconfig.NamespacedOwnerReference, cMap *contr
 			typeString := fmt.Sprintf("%v.%v", owner.Kind, ownerGV.Group)
 			log.Info("Watching child resource", "kind", resource.GroupVersionKind(),
 				"enqueue_annotation_type", typeString)
-			err = contents.Controller.Watch(&source.Kind{Type: resource},
-				&osdkHandler.EnqueueRequestForAnnotation{Type: typeString}, dependentPredicate)
+			err = addWatch(contents.Controller, &source.Kind{Type: resource}, &osdkHandler.EnqueueRequestForAnnotation{Type: typeString})
 			if err != nil {
 				log.Error(err, "GVK", resource.GroupVersionKind())
 				return err
@@ -385,4 +384,19 @@ func (a *apiResources) IsVirtualResource(gvk schema.GroupVersionKind) (bool, err
 	}
 
 	return false, nil
+}
+
+func addWatch(c controller.Controller, s source.Source, eh handler.EventHandler, predicates ...predicate.Predicate) error {
+	errChan := make(chan error, 1)
+	go func() {
+		err := c.Watch(s, eh, predicates...)
+		errChan <- err
+	}()
+
+	select {
+	case watchErr := <-errChan:
+		return watchErr
+	case <-time.After(cacheEscacheEstablishmentTimeout):
+		return fmt.Errorf("timeout establishing watch, commonly permissions of the controller are not sufficent")
+	}
 }

--- a/pkg/ansible/proxy/proxy.go
+++ b/pkg/ansible/proxy/proxy.go
@@ -245,7 +245,7 @@ func addWatchToController(owner kubeconfig.NamespacedOwnerReference, cMap *contr
 			// Store watch in map
 			err := addWatch(contents.Controller, &source.Kind{Type: resource}, &handler.EnqueueRequestForOwner{OwnerType: u}, dependentPredicate))
 			if err != nil {
-				log.Error(err, "gvk", resource.GroupVersionKind())
+				log.Error(err, "GVK", resource.GroupVersionKind())
 				return err
 			}
 		case (!useOwnerRef && dataNamespaceScoped) || contents.WatchClusterScopedResources:
@@ -259,7 +259,7 @@ func addWatchToController(owner kubeconfig.NamespacedOwnerReference, cMap *contr
 			log.Info("Watching child resource", "kind", resource.GroupVersionKind(), "enqueue_annotation_type", typeString)
 			err = addWatch(contents.Controller, &source.Kind{Type: resource}, &osdkHandler.EnqueueRequestForAnnotation{Type: typeString}, dependentPredicate)
 			if err != nil {
-				log.Error(err, "gvk", resource.GroupVersionKind())
+				log.Error(err, "GVK", resource.GroupVersionKind())
 				return err
 			}
 		}


### PR DESCRIPTION
**Description of the change:**
Add timeout in the watch feature for Ansible based-operators proxy to avoid appears that the reconcile is stuck and hang when the operator has not the correct permissions to List and Watch the resources. 

**Motivation for the change:**

- https://github.com/operator-framework/operator-sdk/pull/1638
- https://bugzilla.redhat.com/show_bug.cgi?id=1701041

**Note**
Also, solved by https://github.com/kubernetes-sigs/controller-runtime/pull/663. 

**Steps to test it locally**

- Build an ansible image with this PR
- Use the image in an ansible POC ( can be the Memchaced sample )
- Remove the required permission to perform some operations defined in the playbook/roles. E.g to create a resource. 
- After installing the CR which will call the playbook/role check in the logs the permissions issues and then verify that the CR will be updated properly with the error faced.  
PS.: The tests made to verify this fix was by removing the deployment permission. 

<img width="1452" alt="Screenshot 2020-04-21 at 12 21 45" src="https://user-images.githubusercontent.com/7708031/79861474-5cb2a500-83cc-11ea-9ded-1856f916e888.png">


