### PR TITLE
scorecard: Fix basic tests run when 'olm-deployed: true'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Bug Fixes
 - Fix issue faced in the Ansible based operators when `jmespath` queries are used because it was not installed. ([#2252](https://github.com/operator-framework/operator-sdk/pull/2252))
+- Fix scorecard behavior such that a CSV file is read correctly when `olm-deployed` is set to `true`. ([#2274](https://github.com/operator-framework/operator-sdk/pull/2274))
 
 ## v0.12.0
 

--- a/internal/scorecard/plugins/plugin_runner.go
+++ b/internal/scorecard/plugins/plugin_runner.go
@@ -126,7 +126,7 @@ func RunInternalPlugin(pluginType PluginType, config BasicAndOLMPluginConfig, lo
 	runtimeClient, _ = client.New(kubeconfig, client.Options{Scheme: scheme, Mapper: restMapper})
 
 	csv := &olmapiv1alpha1.ClusterServiceVersion{}
-	if pluginType == OLMIntegration {
+	if pluginType == OLMIntegration || config.OLMDeployed {
 		yamlSpec, err := ioutil.ReadFile(config.CSVManifest)
 		if err != nil {
 			return scapiv1alpha1.ScorecardOutput{}, fmt.Errorf("failed to read csv: %v", err)

--- a/internal/scorecard/plugins/resource_handler.go
+++ b/internal/scorecard/plugins/resource_handler.go
@@ -174,7 +174,7 @@ func getPodFromDeployment(depName, namespace string) (pod *v1.Pod, err error) {
 	// instead of the new one.
 	err = wait.PollImmediate(time.Second*1, time.Second*60, func() (bool, error) {
 		pods := &v1.PodList{}
-		err = runtimeClient.List(context.TODO(), pods, client.MatchingLabels(dep.Spec.Selector.MatchLabels))
+		err = runtimeClient.List(context.TODO(), pods, client.InNamespace(namespace), client.MatchingLabels(dep.Spec.Selector.MatchLabels))
 		if err != nil {
 			return false, fmt.Errorf("failed to get list of pods in deployment: %v", err)
 		}


### PR DESCRIPTION
**Description of the change:**
* read CSV when config.OLMDeployed is enabled
* filter listing pods based on deployment's namespace

**Motivation for the change:**

Closes #2271
