### PR TITLE
pkg/test/client: retry cleanup function if cluster is temporarily unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Changed error wrapping according to Go version 1.13+ [error handling](https://blog.golang.org/go1.13-errors). ([#2355](https://github.com/operator-framework/operator-sdk/pull/2355))
+- Added retry logic to the cleanup function from the e2e test framework in order to allow it to be achieved in the scenarios where temporary network issues are faced. ([#2277](https://github.com/operator-framework/operator-sdk/pull/2277))
 
 ### Deprecated
 

--- a/pkg/test/client.go
+++ b/pkg/test/client.go
@@ -21,6 +21,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,6 +37,10 @@ type FrameworkClient interface {
 	Create(gCtx goctx.Context, obj runtime.Object, cleanupOptions *CleanupOptions) error
 	Delete(gCtx goctx.Context, obj runtime.Object, opts ...dynclient.DeleteOption) error
 	Update(gCtx goctx.Context, obj runtime.Object) error
+}
+
+func retryOnAnyError(err error) bool {
+	return !apierrors.IsNotFound(err)
 }
 
 // Create uses the dynamic client to create an object and then adds a
@@ -57,7 +62,9 @@ func (f *frameworkClient) Create(gCtx goctx.Context, obj runtime.Object, cleanup
 		cleanupOptions.TestContext.t.Logf("resource type %+v with namespace/name (%+v) created\n", objCopy.GetObjectKind().GroupVersionKind().Kind, key)
 	}
 	cleanupOptions.TestContext.AddCleanupFn(func() error {
-		err = f.Client.Delete(gCtx, objCopy)
+		err = retry.OnError(retry.DefaultRetry, retryOnAnyError, func() error {
+			return f.Client.Delete(gCtx, objCopy)
+		})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}


### PR DESCRIPTION
### Description
There are instances where the cluster could be temporarily unavailable.
e.g. when etcd is doing leader re-election.

https://search.svc.ci.openshift.org/?search=etcdserver%3A+leader+changed&maxAge=336h&context=2&type=all

While this is not a very normal scenario, it would be good to be lenient
on the cleanup side of things and retry if such a case happens.

This will be reflected as Timeout or Unavailable errors coming from etcd.

### Motivation

When using the e2e test framework to test an operator, if there are network issues, the cleanup functions might fail. This would present itself with the following logs:

```
client.go:75: resource type Deployment with namespace/name (openshift-compliance/compliance-operator) successfully deleted
client.go:75: resource type ClusterRoleBinding with namespace/name (openshift-compliance/compliance-operator) successfully deleted
context.go:76: A cleanup function failed with error: (rpc error: code = Unavailable desc = etcdserver: leader changed)
client.go:75: resource type RoleBinding with namespace/name (openshift-compliance/compliance-operator) successfully deleted
client.go:75: resource type ClusterRole with namespace/name (openshift-compliance/compliance-operator) successfully deleted
```
Not that this would be a fairly random and transcient error. This is why I chose to add it to the Cleanup functions, since there are several of them (one per object tracked by the framework) and there is a higher probability of hitting this.

### Solution

This patch proposes to retry with backoff if an error happens. After a set number of retries, it'll return the appropriate error. This wouldn't retry forever, only until the timeout hits.