### PR TITLE
install  golangci-lint via curl as recommended by its docs

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -20,7 +20,7 @@ function fetch_go_linter {
   header_text "Checking if golangci-lint is installed"
   if ! is_installed golangci-lint; then
     header_text "Installing golangci-lint"
-    go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.21.0
+    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.21.0
   fi
 }
 


### PR DESCRIPTION
**Description of the change:**
install golangci-lint via curl as recommended by its docs

**Motivation for the change:**

@asmacdo find out that besides controller-runtime been installing it via go get as we are dong here it is not recommended. See: https://github.com/golangci/golangci-lint#go-get
