### PR TITLE
 improve the ansible tests and its logs

### DIFF
--- a/ci/tests/e2e-ansible.sh
+++ b/ci/tests/e2e-ansible.sh
@@ -68,7 +68,7 @@ test_operator() {
     fi
 
     # verify that metrics service was created
-    if ! timeout 20s bash -c -- "until kubectl get service/memcached-operator-metrics > /dev/null 2>&1; do sleep 1; done";
+    if ! timeout 60s bash -c -- "until kubectl get service/memcached-operator-metrics > /dev/null 2>&1; do sleep 1; done";
     then
         echo "Failed to get metrics service"
         operator_logs
@@ -93,7 +93,7 @@ test_operator() {
 
     # create CR
     kubectl create -f deploy/crds/ansible.example.com_v1alpha1_memcached_cr.yaml
-    if ! timeout 20s bash -c -- 'until kubectl get deployment -l app=memcached | grep memcached; do sleep 1; done';
+    if ! timeout 60s bash -c -- 'until kubectl get deployment -l app=memcached | grep memcached; do sleep 1; done';
     then
         echo FAIL: operator failed to create memcached Deployment
         operator_logs
@@ -132,7 +132,7 @@ test_operator() {
     fi
 
     # The deployment should get garbage collected, so we expect to fail getting the deployment.
-    if ! timeout 20s bash -c -- "while kubectl get deployment ${memcached_deployment} 2> /dev/null; do sleep 1; done";
+    if ! timeout 60s bash -c -- "while kubectl get deployment ${memcached_deployment} 2> /dev/null; do sleep 1; done";
     then
         echo FAIL: memcached Deployment did not get garbage collected
         operator_logs

--- a/ci/tests/e2e-helm.sh
+++ b/ci/tests/e2e-helm.sh
@@ -55,7 +55,7 @@ test_operator() {
     fi
 
     # verify that metrics service was created
-    if ! timeout 20s bash -c -- "until kubectl get service/nginx-operator-metrics > /dev/null 2>&1; do sleep 1; done";
+    if ! timeout 60s bash -c -- "until kubectl get service/nginx-operator-metrics > /dev/null 2>&1; do sleep 1; done";
     then
         echo "Failed to get metrics service"
         kubectl logs deployment/nginx-operator

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -6,14 +6,20 @@ set -e
 NO_COLOR=${NO_COLOR:-""}
 if [ -z "$NO_COLOR" ]; then
   header=$'\e[1;33m'
+  error=$'\e[0;31m'
   reset=$'\e[0m'
 else
   header=''
+  error=''
   reset=''
 fi
 
 function header_text {
   echo "$header$*$reset"
+}
+
+function error_text {
+  echo "$error$*$reset"
 }
 
 function fetch_go_linter {

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
 source hack/lib/test_lib.sh
+source ./hack/common.sh
 
-set -eux
+set -eu
+
+header_text "Running tests to check ansible molecule"
 
 ROOTDIR="$(pwd)"
 TMPDIR="$(mktemp -d)"
@@ -12,6 +15,7 @@ pip3 install --user molecule==2.22
 pip3 install --user docker openshift jmespath
 
 deploy_prereqs() {
+    header_text "Deploying resources"
     kubectl create -f "$OPERATORDIR/deploy/service_account.yaml"
     kubectl create -f "$OPERATORDIR/deploy/role.yaml"
     kubectl create -f "$OPERATORDIR/deploy/role_binding.yaml"
@@ -19,6 +23,7 @@ deploy_prereqs() {
 }
 
 remove_prereqs() {
+    header_text "Deleting resources"
     kubectl delete --wait=true --ignore-not-found=true --timeout=60s -f "$OPERATORDIR/deploy/crds/ansible.example.com_memcacheds_crd.yaml"
     kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/service_account.yaml"
     kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/role.yaml"
@@ -26,11 +31,14 @@ remove_prereqs() {
 }
 
 pushd "$TMPDIR"
+
+header_text "Creating memcached-operator"
 operator-sdk new memcached-operator \
   --api-version=ansible.example.com/v1alpha1 \
   --kind=Memcached \
   --type=ansible \
   --generate-playbook
+header_text "Replacing operator contents"
 cp "$ROOTDIR/test/ansible-memcached/tasks.yml" memcached-operator/roles/memcached/tasks/main.yml
 cp "$ROOTDIR/test/ansible-memcached/defaults.yml" memcached-operator/roles/memcached/defaults/main.yml
 cp "$ROOTDIR/test/ansible-memcached/asserts.yml"  memcached-operator/molecule/default/asserts.yml
@@ -39,12 +47,10 @@ cp -a "$ROOTDIR/test/ansible-memcached/memfin" memcached-operator/roles/
 cp -a "$ROOTDIR/test/ansible-memcached/secret" memcached-operator/roles/
 cat "$ROOTDIR/test/ansible-memcached/watches-finalizer.yaml" >> memcached-operator/watches.yaml
 cat "$ROOTDIR/test/ansible-memcached/prepare-test-image.yml" >> memcached-operator/molecule/test-local/prepare.yml
-# Append v1 kind to watches to test watching already registered GVK
+header_text "Append v1 kind to watches to test watching already registered GVK"
 cat "$ROOTDIR/test/ansible-memcached/watches-v1-kind.yaml" >> memcached-operator/watches.yaml
 
-
-
-# Test local
+header_text "Test local"
 pushd memcached-operator
 # Use the following sed command to check it on macOsX.
 # More info: https://www.mkyong.com/mac/sed-command-hits-undefined-label-error-on-mac-os-x/
@@ -59,6 +65,7 @@ remove_prereqs
 popd
 popd
 
+header_text "Test Ansible Inventory"
 pushd "${ROOTDIR}/test/ansible-inventory"
 # Use the following sed command to check it on macOsX.
 # More info: https://www.mkyong.com/mac/sed-command-hits-undefined-label-error-on-mac-os-x/

--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-set -eux
+set -eu
 
 source hack/lib/test_lib.sh
 source hack/lib/image_lib.sh
+source ./hack/common.sh
 
 # ansible proxy test require a running cluster; run during e2e instead
 go test -count=1 ./pkg/ansible/proxy/...
@@ -14,6 +15,7 @@ TMPDIR="$(mktemp -d)"
 trap_add 'rm -rf $TMPDIR' EXIT
 
 deploy_operator() {
+    header_text "Running deploy operator"
     kubectl create -f "$OPERATORDIR/deploy/service_account.yaml"
     kubectl create -f "$OPERATORDIR/deploy/role.yaml"
     kubectl create -f "$OPERATORDIR/deploy/role_binding.yaml"
@@ -23,8 +25,9 @@ deploy_operator() {
 }
 
 remove_operator() {
-    kubectl delete --wait=true --ignore-not-found=true --timeout=60s -f "$OPERATORDIR/deploy/crds/ansible.example.com_memcacheds_crd.yaml"
-    kubectl delete --wait=true --ignore-not-found=true --timeout=60s -f "$OPERATORDIR/deploy/crds/ansible.example.com_foos_crd.yaml"
+    header_text "Running remove operator"
+    kubectl delete --wait=true --ignore-not-found=true --timeout=2m -f "$OPERATORDIR/deploy/crds/ansible.example.com_memcacheds_crd.yaml"
+    kubectl delete --wait=true --ignore-not-found=true --timeout=2m -f "$OPERATORDIR/deploy/crds/ansible.example.com_foos_crd.yaml"
     kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/operator.yaml"
     kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/service_account.yaml"
     kubectl delete --wait=true --ignore-not-found=true -f "$OPERATORDIR/deploy/role.yaml"
@@ -32,104 +35,112 @@ remove_operator() {
 }
 
 operator_logs() {
+    header_text "Getting Pod logs"
     kubectl describe pods
+    header_text "Getting events"
+    kubectl get events
+    header_text "Getting operator logs"
     kubectl logs deployment/memcached-operator -c operator
+    header_text "Getting Ansible logs"
     kubectl logs deployment/memcached-operator -c ansible
 }
 
 test_operator() {
+    header_text "Testing operator metrics"
     # kind has an issue with certain image registries (ex. redhat's), so use a
     # different test pod image.
     local metrics_test_image="fedora:latest"
 
-    # wait for operator pod to run
+    header_text "wait for operator pod to run"
     if ! timeout 1m kubectl rollout status deployment/memcached-operator;
     then
-        echo FAIL: operator failed to run
+        error_text "FAIL: Failed to run"
         operator_logs
         exit 1
     fi
 
-    # verify that metrics service was created
-    if ! timeout 20s bash -c -- "until kubectl get service/memcached-operator-metrics > /dev/null 2>&1; do sleep 1; done";
+    header_text "verify that metrics service was created"
+    if ! timeout 60s bash -c -- "until kubectl get service/memcached-operator-metrics > /dev/null 2>&1; do sleep 1; done";
     then
-        echo "Failed to get metrics service"
-        kubectl logs deployment/memcached-operator
+        error_text "FAIL: Failed to get metrics service"
+        operator_logs
         exit 1
     fi
 
-    # verify that the metrics endpoint exists
+    header_text "verify that the metrics endpoint exists (Port 8383)"
     if ! timeout 1m bash -c -- "until kubectl run --attach --rm --restart=Never test-metrics --image=$metrics_test_image -- curl -sfo /dev/null http://memcached-operator-metrics:8383/metrics; do sleep 1; done";
     then
-        echo "Failed to verify that metrics endpoint exists"
+        error_text "FAIL: Failed to verify that metrics endpoint exists"
         operator_logs
         exit 1
     fi
 
-    # verify that the operator metrics endpoint exists
+    header_text "verify that the metrics endpoint exists (Port 8686)"
     if ! timeout 1m bash -c -- "until kubectl run --attach --rm --restart=Never test-metrics --image=$metrics_test_image -- curl -sfo /dev/null http://memcached-operator-metrics:8686/metrics; do sleep 1; done";
     then
-        echo "Failed to verify that metrics endpoint exists"
+        error_text "FAIL: Failed to verify that metrics endpoint exists"
         operator_logs
         exit 1
     fi
 
-    # create CR
+    header_text "create custom resource (Memcached CR)"
     kubectl create -f deploy/crds/ansible.example.com_v1alpha1_memcached_cr.yaml
-    if ! timeout 20s bash -c -- 'until kubectl get deployment -l app=memcached | grep memcached; do sleep 1; done';
+    if ! timeout 60s bash -c -- 'until kubectl get deployment -l app=memcached | grep memcached; do sleep 1; done';
     then
-        echo FAIL: operator failed to create memcached Deployment
+        error_text "FAIL: Failed to verify to create memcached Deployment"
         operator_logs
         exit 1
     fi
 
-    # verify that metrics reflect cr creation
+    header_text "verify that metrics reflect cr creation"
     if ! timeout 1m bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=$metrics_test_image -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached; do sleep 1; done";
     then
-        echo "Failed to verify custom resource metrics"
+        error_text "FAIL: Failed to verify custom resource metrics"
         operator_logs
         exit 1
     fi
+
+    header_text "get memcached deploy by labels"
     memcached_deployment=$(kubectl get deployment -l app=memcached -o jsonpath="{..metadata.name}")
     if ! timeout 1m kubectl rollout status deployment/${memcached_deployment};
     then
-        echo FAIL: memcached Deployment failed rollout
+        error_text "FAIL: Failed memcached Deployment failed rollout"
         kubectl logs deployment/${memcached_deployment}
         exit 1
     fi
 
-
-    # make a configmap that the finalizer should remove
+    header_text "create a configmap that the finalizer should remove"
     kubectl create configmap deleteme
     trap_add 'kubectl delete --ignore-not-found configmap deleteme' EXIT
 
+    header_text "delete custom resource (Memcached CR)"
     kubectl delete -f ${OPERATORDIR}/deploy/crds/ansible.example.com_v1alpha1_memcached_cr.yaml --wait=true
-    # if the finalizer did not delete the configmap...
+    header_text "if the finalizer did not delete the configmap..."
     if kubectl get configmap deleteme 2> /dev/null;
     then
-        echo FAIL: the finalizer did not delete the configmap
+        error_text "FAIL: the finalizer did not delete the configmap"
         operator_logs
         exit 1
     fi
 
-    # The deployment should get garbage collected, so we expect to fail getting the deployment.
-    if ! timeout 20s bash -c -- "while kubectl get deployment ${memcached_deployment} 2> /dev/null; do sleep 1; done";
+    header_text "The deployment should get garbage collected, so we expect to fail getting the deployment."
+    if ! timeout 60s bash -c -- "while kubectl get deployment ${memcached_deployment} 2> /dev/null; do sleep 1; done";
     then
-        echo FAIL: memcached Deployment did not get garbage collected
+        error_text "FAIL: memcached Deployment did not get garbage collected"
         operator_logs
         exit 1
     fi
 
-    # Ensure that no errors appear in the log
+    header_text "Ensure that no errors appear in the log"
     if kubectl logs deployment/memcached-operator -c operator | grep -i error;
     then
-        echo FAIL: the operator log includes errors
+        error_text "FAIL: the operator log includes errors"
         operator_logs
         exit 1
     fi
 }
 
-# create and build the operator
+header_text "Creating and building the operator"
 pushd "$TMPDIR"
 operator-sdk new memcached-operator \
   --api-version=ansible.example.com/v1alpha1 \
@@ -143,7 +154,8 @@ cat "$ROOTDIR/test/ansible-memcached/watches-finalizer.yaml" >> memcached-operat
 cat "$ROOTDIR/test/ansible-memcached/watches-foo-kind.yaml" >> memcached-operator/watches.yaml
 
 pushd memcached-operator
-# Add a second Kind to test watching multiple GVKs
+
+header_text "Adding a second Kind to test watching multiple GVKs"
 operator-sdk add crd --kind=Foo --api-version=ansible.example.com/v1alpha1
 sed -i 's|\(FROM quay.io/operator-framework/ansible-operator\)\(:.*\)\?|\1:dev|g' build/Dockerfile
 operator-sdk build "$DEST_IMAGE"
@@ -165,25 +177,26 @@ trap_add 'remove_operator' EXIT
 test_operator
 remove_operator
 
-echo "###"
-echo "### Base image testing passed"
-echo "### Now testing migrate to hybrid operator"
-echo "###"
+header_text "###"
+header_text "### Base image testing passed"
+header_text "### Now testing migrate to hybrid operator"
+header_text "###"
 
 operator-sdk migrate --repo=github.com/example-inc/memcached-operator
 
 if [[ ! -e build/Dockerfile.sdkold ]];
 then
-    echo FAIL the old Dockerfile should have been renamed to Dockerfile.sdkold
+    error_text "FAIL the old Dockerfile should have been renamed to Dockerfile.sdkold"
     exit 1
 fi
 
 add_go_mod_replace "github.com/operator-framework/operator-sdk" "$ROOTDIR"
-# Build the project to resolve dependency versions in the modfile.
+header_text "Build the project to resolve dependency versions in the modfile."
 go build ./...
 
 operator-sdk build "$DEST_IMAGE"
-# If using a kind cluster, load the image into all nodes.
+
+header_text "If using a kind cluster, load the image into all nodes."
 load_image_if_kind "$DEST_IMAGE"
 
 deploy_operator

--- a/hack/tests/e2e-helm.sh
+++ b/hack/tests/e2e-helm.sh
@@ -39,7 +39,7 @@ test_operator() {
     fi
 
     # verify that metrics service was created
-    if ! timeout 20s bash -c -- "until kubectl get service/nginx-operator-metrics > /dev/null 2>&1; do sleep 1; done";
+    if ! timeout 60s bash -c -- "until kubectl get service/nginx-operator-metrics > /dev/null 2>&1; do sleep 1; done";
     then
         echo "Failed to get metrics service"
         kubectl logs deployment/nginx-operator


### PR DESCRIPTION
**Description of the change:**

- Replace comments for highlighted texts in the logs to be easier troubleshooting
- Make errors be outputted in red 
- Increase timeouts from 20s to 60s in order to avoid the errors faced in the CI because of it.

**Motivation for the change:**

- Issues in CI that are solved be re-triggered it
- Be easier to check its issues faced with the changes


**NOTES:**
- See that it passed directly at the first without the need to re-triggered it. 
- See that now is easier to identify what step it is, errors and etc.  

<img width="1225" alt="Screenshot 2019-11-29 at 19 35 27" src="https://user-images.githubusercontent.com/7708031/69887561-74837280-12df-11ea-958a-27682b515a96.png">
