### PR TITLE
Helm: allow relative paths for helm charts in watches.yaml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 - Support for vars in top level ansible watches. ([#2147](https://github.com/operator-framework/operator-sdk/pull/2147))
 - Support for `"ansible.operator-sdk/verbosity"` annotation on Custom Resources watched by Ansible based operators to override verbosity on an individual resource. ([#2102](https://github.com/operator-framework/operator-sdk/pull/2102))
+- Support for relative helm chart paths in the Helm operator's watches.yaml file. ([#2287](https://github.com/operator-framework/operator-sdk/pull/2287))
 
 ### Changed
 - Upgrade minimal Ansible version in the init projects from `2.4` to `2.6`. ([#2107](https://github.com/operator-framework/operator-sdk/pull/2107))

--- a/doc/helm/dev/developer_guide.md
+++ b/doc/helm/dev/developer_guide.md
@@ -228,7 +228,8 @@ mandatory fields:
 **chart**:  This is the path to the Helm chart that you have added to the
 container. For example, if your Helm charts directory is at
 `/opt/helm/helm-charts/` and your Helm chart is named `busybox`, this value
-will be `/opt/helm/helm-charts/busybox`.
+will be `/opt/helm/helm-charts/busybox`. If the path is relative, it is
+relative to the current working directory.
 
 Example specifying a Helm chart watch:
 
@@ -266,18 +267,6 @@ communicate with a Kubernetes cluster just as the `kubectl apply` commands did
 when we were testing our Helm chart locally. This section assumes the developer
 has read the [Helm Operator user guide][helm_operator_user_guide] and has the
 proper dependencies installed.
-
-Since `up local` reads from `./watches.yaml`, there are a couple options
-available to the developer. If `chart` is left alone (by default
-`/opt/helm/helm-charts/<name>`) the Helm chart must exist at that location in
-the filesystem. It is recommended that the developer create a symlink at this
-location, pointed to the Helm chart in the project directory, so that changes
-to the Helm chart are reflected where necessary.
-
-```sh
-sudo mkdir -p /opt/helm/helm-charts
-sudo ln -s $PWD/helm-charts/<name> /opt/helm/helm-charts/<name>
-```
 
 Create a Custom Resource Definition (CRD) for resource Foo. `operator-sdk` autogenerates this file
 inside of the `deploy` folder:

--- a/doc/helm/user-guide.md
+++ b/doc/helm/user-guide.md
@@ -88,7 +88,7 @@ in `watches.yaml` and executes Helm releases using the specified chart:
 - version: v1alpha1
   group: example.com
   kind: Nginx
-  chart: /opt/helm/helm-charts/nginx
+  chart: helm-charts/nginx
 ```
 
 ### Reviewing the Nginx Helm Chart
@@ -209,18 +209,6 @@ nginx-operator       1         1         1            1           1m
 ### 2. Run outside the cluster
 
 This method is preferred during the development cycle to speed up deployment and testing.
-
-It is important that the `chart` path referenced in `watches.yaml` exists
-on your machine. By default, the `watches.yaml` file is scaffolded to work with
-an operator image built with `operator-sdk build`. When developing and
-testing your operator with `operator-sdk up local`, the SDK will look in your
-local filesystem for this path. The SDK team recommends creating a symlink at
-this location to point to your helm chart's path:
-
-```sh
-sudo mkdir -p /opt/helm/helm-charts
-sudo ln -s $PWD/helm-charts/nginx /opt/helm/helm-charts/nginx
-```
 
 Run the operator locally with the default Kubernetes config file present at
 `$HOME/.kube/config`:

--- a/internal/scaffold/helm/entrypoint.go
+++ b/internal/scaffold/helm/entrypoint.go
@@ -45,5 +45,6 @@ if ! whoami &>/dev/null; then
   fi
 fi
 
-exec ${OPERATOR} run helm --watches-file=/opt/helm/watches.yaml $@
+cd $HOME
+exec ${OPERATOR} run helm --watches-file=$HOME/watches.yaml $@
 `

--- a/internal/scaffold/helm/watches.go
+++ b/internal/scaffold/helm/watches.go
@@ -47,5 +47,5 @@ const watchesYAMLTmpl = `---
 - version: {{.Resource.Version}}
   group: {{.Resource.FullGroup}}
   kind: {{.Resource.Kind}}
-  chart: /opt/helm/{{.HelmChartsDir}}/{{.ChartName}}
+  chart: {{.HelmChartsDir}}/{{.ChartName}}
 `


### PR DESCRIPTION
**Description of the change:**
* Changes the Helm operator to support relative paths to chart directories in the watches.yaml file. If a relative paths is found, a base path will be prepended. The prefered base path comes from the HELM_CHARTS_PATH environment variable. If that is empty or not set, the operator falls back to the HOME directory, which maintains backward compatibility with existing projects.
* Updates the Helm operator project's watches.yaml scaffold to use a relative path instead of an absolute path.

**Motivation for the change:**
Allowing relative paths simplifies the experience of switching between `operator-sdk up local` and running in-cluster.

Now local filesystem changes do not have to be made for `up local` to work. Previously, developers had to copy their chart to `/opt/helm/helm-charts/<chart-name>`, create a symlink, or change their watches.yaml temporarily to point to the absolute path of their local project (and then be forced to change it back before running `operator-sdk build`)

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
