### PR TITLE
Helm: always use GOOS=linux for operator base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ release: clean $(release_builds) $(release_builds:=.asc) ## Release the Operator
 build/operator-sdk-%-x86_64-linux-gnu: GOARGS = GOOS=linux GOARCH=amd64
 build/operator-sdk-%-x86_64-apple-darwin: GOARGS = GOOS=darwin GOARCH=amd64
 build/operator-sdk-%-ppc64le-linux-gnu: GOARGS = GOOS=linux GOARCH=ppc64le
+build/operator-sdk-%-linux-gnu: GOARGS = GOOS=linux
 
 build/%: $(SOURCES)
 	$(Q)$(GOARGS) go build \
@@ -143,7 +144,7 @@ image-build: image-build-ansible image-build-helm image-build-scorecard-proxy ##
 image-build-ansible: build/operator-sdk-dev-x86_64-linux-gnu
 	./hack/image/build-ansible-image.sh $(ANSIBLE_BASE_IMAGE):dev
 
-image-build-helm: build/operator-sdk-dev
+image-build-helm: build/operator-sdk-dev-linux-gnu
 	./hack/image/build-helm-image.sh $(HELM_BASE_IMAGE):dev
 
 image-build-scorecard-proxy:

--- a/hack/image/build-helm-image.sh
+++ b/hack/image/build-helm-image.sh
@@ -17,7 +17,7 @@ pushd "$BASEIMAGEDIR"
 ./scaffold-helm-image
 
 mkdir -p build/_output/bin/
-cp $ROOTDIR/build/operator-sdk-dev build/_output/bin/helm-operator
+cp $ROOTDIR/build/operator-sdk-dev-linux-gnu build/_output/bin/helm-operator
 operator-sdk build $1
 # If using a kind cluster, load the image into all nodes.
 load_image_if_kind "$1"


### PR DESCRIPTION
**Description of the change:**
Adds Makefile configuration and updates helm-operator's base image build script to always use GOOS=linux

**Motivation for the change:**
Running the build script on non-linux hosts currently results in a helm operator base image that contains a binary with GOOS matching the non-linux host OS, which fails to run in Linux-based Kubernetes clusters.

The UBI base image used by the helm operator is based on Linux, so there should not be an OS compatibility problem with this change.


Closes: #2289