### PR TITLE
cmd/.../gen-csv.go: set operatorName from config after CLI if empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Bug Fixes
 - Fix issue faced in the Ansible based operators when `jmespath` queries are used because it was not installed. ([#2252](https://github.com/operator-framework/operator-sdk/pull/2252))
 - Fix scorecard behavior such that a CSV file is read correctly when `olm-deployed` is set to `true`. ([#2274](https://github.com/operator-framework/operator-sdk/pull/2274))
+- A CSV config's `operator-name` field will be used if `--operator-name` is not set. ([#2297](https://github.com/operator-framework/operator-sdk/pull/2297))
 
 ## v0.12.0
 

--- a/cmd/operator-sdk/olmcatalog/gen-csv.go
+++ b/cmd/operator-sdk/olmcatalog/gen-csv.go
@@ -90,8 +90,17 @@ func genCSVFunc(cmd *cobra.Command, args []string) error {
 
 	log.Infof("Generating CSV manifest version %s", csvVersion)
 
+	csvCfg, err := catalog.GetCSVConfig(csvConfigPath)
+	if err != nil {
+		return err
+	}
 	if operatorName == "" {
-		operatorName = filepath.Base(absProjectPath)
+		// Use config operator name if not set by CLI, i.e. prefer CLI value over
+		// config value.
+		if operatorName = csvCfg.OperatorName; operatorName == "" {
+			// Default to using project name if both are empty.
+			operatorName = filepath.Base(absProjectPath)
+		}
 	}
 
 	s := &scaffold.Scaffold{}
@@ -101,7 +110,7 @@ func genCSVFunc(cmd *cobra.Command, args []string) error {
 		ConfigFilePath: csvConfigPath,
 		OperatorName:   operatorName,
 	}
-	err := s.Execute(cfg,
+	err = s.Execute(cfg,
 		csv,
 		&catalog.PackageManifest{
 			CSVVersion:       csvVersion,
@@ -120,11 +129,7 @@ func genCSVFunc(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		cfg, err := catalog.GetCSVConfig(csvConfigPath)
-		if err != nil {
-			return err
-		}
-		err = writeCRDsToDir(cfg.CRDCRPaths, filepath.Dir(input.Path))
+		err = writeCRDsToDir(csvCfg.CRDCRPaths, filepath.Dir(input.Path))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**Description of the change:** set `operatorName` from config after checking if set via CLI.

**Motivation for the change:** fixes #2266.

Closes #2266 
