### PR TITLE
internal/scaffold/olm-catalog/csv*.go: set install strategy if empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Bug Fixes
 - Fix issue faced in the Ansible based operators when `jmespath` queries are used because it was not installed. ([#2252](https://github.com/operator-framework/operator-sdk/pull/2252))
 - Fix scorecard behavior such that a CSV file is read correctly when `olm-deployed` is set to `true`. ([#2274](https://github.com/operator-framework/operator-sdk/pull/2274))
+- Populates a CSV's `spec.install` strategy if either name or strategy body are missing with a deployment-type strategy. ([#2298](https://github.com/operator-framework/operator-sdk/pull/2298))
 
 ## v0.12.0
 


### PR DESCRIPTION
**Description of the change:** set install strategy if empty in CSV updaters.

**Motivation for the change:** if a CSV does not have an install strategy when being updated, a CSV updater will error when it should instead set the strategy to `StrategyDetailsDeployment` (the only strategy available).