### PR TITLE
hack/generate/gen-test-framework.sh: fix for release branches

### DIFF
--- a/hack/generate/gen-test-framework.sh
+++ b/hack/generate/gen-test-framework.sh
@@ -13,7 +13,7 @@ cd test/test-framework
 
 # Ensure test-framework is up-to-date with current Go project dependencies.
 echo "$(../../build/operator-sdk print-deps)" > go.mod
-sed -i".bak" -E -e "s|github.com/operator-framework/operator-sdk[[:blank:]]+master||g" go.mod; rm -f go.mod.bak
+sed -i".bak" -E -e "/github.com\/operator-framework\/operator-sdk .+/d" go.mod; rm -f go.mod.bak
 echo -e "\nreplace github.com/operator-framework/operator-sdk => ../../" >> go.mod
 go mod edit -require "github.com/operator-framework/operator-sdk@v0.0.0"
 go build ./...


### PR DESCRIPTION
**Description of the change:**
Update the test framework generator script to handle any branch name produced by `print-deps`

**Motivation for the change:**
To ensure the sanity test passes on all branches.

This fix is already included in the `v0.13.x` post release PR (#2315) 
