### PR TITLE
doc: improve README to try operator-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,18 @@ $ operator-sdk add api --api-version=app.example.com/v1alpha1 --kind=AppService
 $ operator-sdk add controller --api-version=app.example.com/v1alpha1 --kind=AppService
 
 # Build and push the app-operator image to a public registry such as quay.io
-$ operator-sdk build quay.io/example/app-operator
-$ docker push quay.io/example/app-operator
+$ operator-sdk build quay.io/<username>/app-operator
+
+# Login to public registry such as quay.io
+$ docker login quay.io
+
+# Push image
+$ docker push quay.io/<username>/app-operator
 
 # Update the operator manifest to use the built image name (if you are performing these steps on OSX, see note below)
-$ sed -i 's|REPLACE_IMAGE|quay.io/example/app-operator|g' deploy/operator.yaml
+$ sed -i 's|REPLACE_IMAGE|quay.io/<username>/app-operator|g' deploy/operator.yaml
 # On OSX use:
-$ sed -i "" 's|REPLACE_IMAGE|quay.io/example/app-operator|g' deploy/operator.yaml
+$ sed -i "" 's|REPLACE_IMAGE|quay.io/<username>/app-operator|g' deploy/operator.yaml
 
 # Setup Service Account
 $ kubectl create -f deploy/service_account.yaml


### PR DESCRIPTION
**Description of the change:**
To [avoid confusion for new user](https://github.com/operator-framework/operator-sdk/issues/1337) trying `operator-sdk`, Improve README and replace `example` with `<username>`. 

Also add step to login to public registry like quay.io. If user is not logged in through CLI, He will face following error

`quay unauthorized: access to the requested resource is not authorized`

After login push work seamlessly.

**Motivation for the change:**
This will improve user experience for trying `operator-sdk` for the first time.
