### PR TITLE
log: add option to deactivate zap stack trace generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- Add a new option to set the minimum log level that triggers stack trace generation in logs (`--zap-stacktrace-level`) ([#2319](https://github.com/operator-framework/operator-sdk/pull/2319))
+
 ### Changed
 
 ### Deprecated

--- a/doc/user/logging.md
+++ b/doc/user/logging.md
@@ -14,6 +14,7 @@ By default, `zap.Logger()` will return a logger that is ready for production use
 * `--zap-encoder` string - Sets the zap log encoding (`json` or `console`)
 * `--zap-level` string or integer - Sets the zap log level (`debug`, `info`, `error`, or an integer value greater than 0). If 4 or greater the verbosity of client-go will be set to this level.
 * `--zap-sample` - Enables zap's sampling mode. Sampling will be disabled for integer log levels greater than 1.
+* `--zap-stacktrace-level` - Set the minimum log level that triggers stacktrace generation (default: `error`)
 * `--zap-time-encoding` string - Sets the zap time format (`epoch`, `millis`, `nano`, or `iso8601`)
 
 ### A simple example

--- a/pkg/log/zap/flags.go
+++ b/pkg/log/zap/flags.go
@@ -34,15 +34,17 @@ var (
 	levelVal        levelValue
 	sampleVal       sampleValue
 	timeEncodingVal timeEncodingValue
+	stacktraceLevel stackLevelValue
 )
 
 func init() {
 	zapFlagSet = pflag.NewFlagSet("zap", pflag.ExitOnError)
-	zapFlagSet.BoolVar(&development, "zap-devel", false, "Enable zap development mode (changes defaults to console encoder, debug log level, and disables sampling)")
+	zapFlagSet.BoolVar(&development, "zap-devel", false, "Enable zap development mode (changes defaults to console encoder, debug log level, disables sampling and stacktrace from 'warning' level)")
 	zapFlagSet.Var(&encoderVal, "zap-encoder", "Zap log encoding ('json' or 'console')")
 	zapFlagSet.Var(&levelVal, "zap-level", "Zap log level (one of 'debug', 'info', 'error' or any integer value > 0)")
 	zapFlagSet.Var(&sampleVal, "zap-sample", "Enable zap log sampling. Sampling will be disabled for integer log levels > 1")
 	zapFlagSet.Var(&timeEncodingVal, "zap-time-encoding", "Sets the zap time format ('epoch', 'millis', 'nano', or 'iso8601')")
+	zapFlagSet.Var(&stacktraceLevel, "zap-stacktrace-level", "Set the minimum log level that triggers stacktrace generation")
 }
 
 // FlagSet - The zap logging flagset.
@@ -103,27 +105,11 @@ type levelValue struct {
 
 func (v *levelValue) Set(l string) error {
 	v.set = true
-	lower := strings.ToLower(l)
-	var lvl int
-	switch lower {
-	case "debug":
-		lvl = -1
-	case "info":
-		lvl = 0
-	case "error":
-		lvl = 2
-	default:
-		i, err := strconv.Atoi(lower)
-		if err != nil {
-			return fmt.Errorf("invalid log level \"%s\"", l)
-		}
-
-		if i > 0 {
-			lvl = -1 * i
-		} else {
-			return fmt.Errorf("invalid log level \"%s\"", l)
-		}
+	lvl, err := intLogLevel(l)
+	if err != nil {
+		return err
 	}
+
 	v.level = zapcore.Level(int8(lvl))
 	// If log level is greater than debug, set glog/klog level to that level.
 	if lvl < -3 {
@@ -143,6 +129,59 @@ func (v levelValue) String() string {
 
 func (v levelValue) Type() string {
 	return "level"
+}
+
+type stackLevelValue struct {
+	set   bool
+	level zapcore.Level
+}
+
+func (v *stackLevelValue) Set(l string) error {
+	v.set = true
+	lvl, err := intLogLevel(l)
+	if err != nil {
+		return err
+	}
+
+	v.level = zapcore.Level(int8(lvl))
+	return nil
+}
+
+func (v stackLevelValue) String() string {
+	if v.set {
+		return v.level.String()
+	}
+
+	return "error"
+}
+
+func (v stackLevelValue) Type() string {
+	return "level"
+}
+
+func intLogLevel(l string) (int, error) {
+	lower := strings.ToLower(l)
+	var lvl int
+	switch lower {
+	case "debug":
+		lvl = -1
+	case "info":
+		lvl = 0
+	case "error":
+		lvl = 2
+	default:
+		i, err := strconv.Atoi(lower)
+		if err != nil {
+			return lvl, fmt.Errorf("invalid log level \"%s\"", l)
+		}
+
+		if i > 0 {
+			lvl = -1 * i
+		} else {
+			return lvl, fmt.Errorf("invalid log level \"%s\"", l)
+		}
+	}
+	return lvl, nil
 }
 
 type sampleValue struct {

--- a/pkg/log/zap/logger_test.go
+++ b/pkg/log/zap/logger_test.go
@@ -28,13 +28,14 @@ import (
 func TestGetConfig(t *testing.T) {
 	var opts []zap.Option
 	type fields struct {
-		name           string
-		inEncoder      *encoderValue
-		inLevel        *levelValue
-		inSample       *sampleValue
-		inTimeEncoding *timeEncodingValue
-		expected       *config
-		inDevel        bool
+		name              string
+		inEncoder         *encoderValue
+		inLevel           *levelValue
+		inSample          *sampleValue
+		inTimeEncoding    *timeEncodingValue
+		expected          *config
+		inDevel           bool
+		inStackTraceLevel *stackLevelValue
 	}
 	tests := []struct {
 		name    string
@@ -54,6 +55,9 @@ func TestGetConfig(t *testing.T) {
 					set: false,
 				},
 				inTimeEncoding: &timeEncodingValue{
+					set: false,
+				},
+				inStackTraceLevel: &stackLevelValue{
 					set: false,
 				},
 				expected: &config{
@@ -76,6 +80,9 @@ func TestGetConfig(t *testing.T) {
 					set: false,
 				},
 				inTimeEncoding: &timeEncodingValue{
+					set: false,
+				},
+				inStackTraceLevel: &stackLevelValue{
 					set: false,
 				},
 				expected: &config{
@@ -101,6 +108,9 @@ func TestGetConfig(t *testing.T) {
 				inTimeEncoding: &timeEncodingValue{
 					set: false,
 				},
+				inStackTraceLevel: &stackLevelValue{
+					set: false,
+				},
 				expected: &config{
 					encoder: newConsoleEncoder(),
 					level:   zap.NewAtomicLevelAt(zap.InfoLevel),
@@ -122,6 +132,9 @@ func TestGetConfig(t *testing.T) {
 					set: false,
 				},
 				inTimeEncoding: &timeEncodingValue{
+					set: false,
+				},
+				inStackTraceLevel: &stackLevelValue{
 					set: false,
 				},
 				expected: &config{
@@ -147,6 +160,9 @@ func TestGetConfig(t *testing.T) {
 				inTimeEncoding: &timeEncodingValue{
 					set: false,
 				},
+				inStackTraceLevel: &stackLevelValue{
+					set: false,
+				},
 				expected: &config{
 					encoder: newJSONEncoder(),
 					level:   zap.NewAtomicLevelAt(zapcore.Level(-10)),
@@ -168,6 +184,9 @@ func TestGetConfig(t *testing.T) {
 					sample: false,
 				},
 				inTimeEncoding: &timeEncodingValue{
+					set: false,
+				},
+				inStackTraceLevel: &stackLevelValue{
 					set: false,
 				},
 				expected: &config{
@@ -194,6 +213,9 @@ func TestGetConfig(t *testing.T) {
 				inTimeEncoding: &timeEncodingValue{
 					set: false,
 				},
+				inStackTraceLevel: &stackLevelValue{
+					set: false,
+				},
 				expected: &config{
 					encoder: newJSONEncoder(),
 					level:   zap.NewAtomicLevelAt(zapcore.Level(-10)),
@@ -217,11 +239,43 @@ func TestGetConfig(t *testing.T) {
 					set:         true,
 					timeEncoder: zapcore.EpochMillisTimeEncoder,
 				},
+				inStackTraceLevel: &stackLevelValue{
+					set: false,
+				},
 				expected: &config{
 					encoder: newJSONEncoder(withTimeEncoding(zapcore.EpochMillisTimeEncoder)),
 					level:   zap.NewAtomicLevelAt(zap.InfoLevel),
 					opts:    append(opts, zap.AddStacktrace(zap.WarnLevel)),
 					sample:  true,
+				}},
+		},
+		{
+			name: "set stacktrace generation on 'panic' level only",
+			fields: fields{
+				inDevel: false,
+				inEncoder: &encoderValue{
+					set: false,
+				},
+				inLevel: &levelValue{
+					set:   true,
+					level: zapcore.Level(-10),
+				},
+				inSample: &sampleValue{
+					set:    true,
+					sample: true,
+				},
+				inTimeEncoding: &timeEncodingValue{
+					set: false,
+				},
+				inStackTraceLevel: &stackLevelValue{
+					set:   true,
+					level: zapcore.Level(zapcore.PanicLevel),
+				},
+				expected: &config{
+					encoder: newJSONEncoder(),
+					level:   zap.NewAtomicLevelAt(zapcore.Level(-10)),
+					opts:    append(opts, zap.AddStacktrace(zap.PanicLevel)),
+					sample:  false,
 				}},
 		},
 	}
@@ -246,6 +300,7 @@ func TestGetConfig(t *testing.T) {
 			levelVal = *tc.fields.inLevel
 			sampleVal = *tc.fields.inSample
 			timeEncodingVal = *tc.fields.inTimeEncoding
+			stacktraceLevel = *tc.fields.inStackTraceLevel
 
 			cfg := getConfig()
 			assert.Equal(t, tc.fields.expected.level, cfg.level)


### PR DESCRIPTION
Add an option to deactivate stack trace generation, similar to an existing option in Zap itself.
https://github.com/uber-go/zap/blob/v1.10.0/config.go#L202

For some of our public operators, we would like to keep logs clean and tidy to improve readability/investigations for our customers