### PR TITLE
cmd/operator-sdk/olmcatalog: gen-csv must run in project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Replace usage of `github.com/operator-framework/operator-sdk/pkg/restmapper.DynamicRESTMapper` with `sigs.k8s.io/controller-runtime/pkg/client/apiutil.DynamicRESTMapper`. ([#2309](https://github.com/operator-framework/operator-sdk/pull/2309))
 - Upgraded Helm operator packages and base image from Helm v2 to Helm v3. Cluster state for pre-existing CRs using Helm v2-based operators will be automatically migrated to Helm v3's new release storage format, and existing releases may be upgraded due to changes in Helm v3's label injection. ([#2080](https://github.com/operator-framework/operator-sdk/pull/2080))
+- Fail `operator-sdk olm-catalog gen-csv` if it is not run from a project's root, which the command already assumes is the case. ([#2322](https://github.com/operator-framework/operator-sdk/pull/2322))
 
 ### Deprecated
 

--- a/cmd/operator-sdk/olmcatalog/gen-csv.go
+++ b/cmd/operator-sdk/olmcatalog/gen-csv.go
@@ -71,6 +71,10 @@ Configure CSV generation by writing a config file 'deploy/olm-catalog/csv-config
 }
 
 func genCSVFunc(cmd *cobra.Command, args []string) error {
+	// The CSV generator assumes that the deploy and pkg directories are present
+	// at runtime, so this command must be run in a project's root.
+	projutil.MustInProjectRoot()
+
 	if len(args) != 0 {
 		return fmt.Errorf("command %s doesn't accept any arguments", cmd.CommandPath())
 	}


### PR DESCRIPTION
**Description of the change:** ensure gen-csv is run in the project root.

**Motivation for the change:** see #2081 

Closes #2081 

