### PR TITLE
doc/proposals: update OLM integration proposal with OperatorGroup logic

### DIFF
--- a/doc/proposals/sdk-integration-with-olm.md
+++ b/doc/proposals/sdk-integration-with-olm.md
@@ -70,7 +70,7 @@ I should be able to uninstall a specific version of OLM from a cluster
 
 #### Story 3
 
-I should be able to deploy a specific version of an Operator using OLM and a bundle director.
+I should be able to deploy a specific version of an Operator using OLM and a bundle directory.
 
 #### Story 4
 
@@ -115,9 +115,25 @@ writing an `OperatorGroup` for their Operator initially. To assist them,
 supplied.
 
 To perform compilation, the user can optionally supply the desired install
-mode type by which the CSV is installed, and the set of namespaces (may be all
-namespaces, `""`) in which the CSV will be installed. The compilation
-algorithm is as follows:
+mode type by which the CSV is installed through an `--install-mode` flag, and
+the set of namespaces (may be all namespaces, `""`) in which the CSV will be
+installed. For example, `--install-mode=MultiNamespace=[ns1,ns2]` will create
+this `OperatorGroup`:
+```yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: my-group
+  namespace: my-namespace
+  labels:
+    operator-sdk: true
+spec:
+  targetNamespaces:
+  - ns1
+  - ns2
+```
+
+The compilation algorithm is as follows:
 
 ```
 1. If an OperatorGroup manifest is supplied:
@@ -135,7 +151,7 @@ is attempted is a more complex problem, but prevents annoying-to-debug
 deployment issues that will occur in the following scenarios:
 
 - A user wants to deploy two or more Operators with CSV install modes
-incompatible for one `OperatorGroup` to handle in the name namespace.
+incompatible for one `OperatorGroup` to handle in the same namespace.
 - A user wants to create an `OperatorGroup` in a namespace that already has
 an `OperatorGroup`.
     - The new and existing `OperatorGroup` namespace intersection is:
@@ -151,9 +167,9 @@ Algorithm for creating an `OperatorGroup`:
 1. Follow the compilation algorithm above to create an OperatorGroup g.
 2. Determine whether an OperatorGroup exists in a given namespace n.
 3. If no OperatorGroup exists in n:
-    1. If h was not compiled by operator-sdk:
+    1. If g was not compiled by operator-sdk:
         1. Label g with a static label to signify g was not created by operator-sdk.
-    2. Else if h was created by operator-sdk:
+    2. Else if g was created by operator-sdk:
         1. Label g with a static label to signify g was created by operator-sdk.
     3. Create g in n and return.
 4. Else if an OperatorGroup h exists in n:

--- a/doc/proposals/sdk-integration-with-olm.md
+++ b/doc/proposals/sdk-integration-with-olm.md
@@ -157,7 +157,7 @@ Algorithm for creating an `OperatorGroup`:
         1. Label g with a static label to signify g was created by operator-sdk.
     3. Create g in n and return.
 4. Else if an OperatorGroup h exists in n:
-    1. If h was not compiled by operator-sdk, return
+    1. If h was not compiled by operator-sdk, return an error.
     2. Else if h was compiled by operator-sdk:
         1. Determine which CSV's are members of h, h's targetNamespaces hn, and g's targetNamespaces gn.
         2. If gn is equivalent to hn, return.
@@ -186,6 +186,8 @@ deleted in any case.
 - An `OperatorGroup` not compiled by `operator-sdk` is considered a user-
 managed resource. All conflicts must be resolved by the user, so an error
 is returned if a non-compiled `OperatorGroup` is already present in a namespace.
+- Deleting an `OperatorGroup` associated with 1..N CSVs will cause those CSVs
+to transition to a failure state, so we should not delete if this is the case.
 
 [olm-operatorgroup-membership]: https://github.com/operator-framework/operator-lifecycle-manager/blob/1cb0681/doc/design/operatorgroups.md
 [olm-operatorgroup-installmodes]: https://github.com/operator-framework/operator-lifecycle-manager/blob/1cb0681/doc/design/operatorgroups.md

--- a/doc/proposals/sdk-integration-with-olm.md
+++ b/doc/proposals/sdk-integration-with-olm.md
@@ -98,13 +98,26 @@ These resources can be created from bundle data with minimal user input. They ca
 
 #### OperatorGroups and tenancy requirements
 
-[`OperatorGroup`][olm-operatorgroup]'s configure CSV tenancy in multiple namespaces in a cluster. Each Operator must be a [member][olm-operatorgroup-membership] with one `OperatorGroup` resource in the cluster, which defines a set of namespaces the CSV can exist in. A CSV's `installModes` determine what [type of `OperatorGroup`][olm-operatorgroup-installmodes] it is permitted to be a member of.
+[`OperatorGroup`][olm-operatorgroup]'s configure CSV tenancy in multiple
+namespaces in a cluster. Each Operator must be a
+[member][olm-operatorgroup-membership] with one `OperatorGroup` resource in
+the cluster, which defines a set of namespaces the CSV can exist in. A CSV's
+`installModes` determine what [type][olm-operatorgroup-installmodes] of
+`OperatorGroup` it can be a member of.
 
-No two `OperatorGroup`'s can exist in the same namespace, and a CSV with membership in an `OperatorGroup` of a type it does not support (determined by `installModes`) will transition to a failure state.
+No two `OperatorGroup`'s can exist in the same namespace, and a CSV with
+membership in an `OperatorGroup` of a type it does not support (determined
+by `installModes`) will transition to a failure state.
 
-Given these rules and constraints, Operator developers may have a tough time writing an `OperatorGroup` for their Operator initially. To assist them, `operator-sdk` should automate `OperatorGroup` "compilation" if one is not supplied.
+Given these rules and constraints, Operator developers may have a tough time
+writing an `OperatorGroup` for their Operator initially. To assist them,
+`operator-sdk` should automate `OperatorGroup` "compilation" if one is not
+supplied.
 
-To perform compilation, the user can optionally supply the desired install mode type by which to install the CSV, and the set of namespaces (may be all namespaces, `""`) in which the CSV will be installed. The compilation algorithm is as follows:
+To perform compilation, the user can optionally supply the desired install
+mode type by which the CSV is installed, and the set of namespaces (may be all
+namespaces, `""`) in which the CSV will be installed. The compilation
+algorithm is as follows:
 
 ```
 1. If an OperatorGroup manifest is supplied:
@@ -126,7 +139,8 @@ incompatible for one `OperatorGroup` to handle in the name namespace.
 - A user wants to create an `OperatorGroup` in a namespace that already has
 an `OperatorGroup`.
     - The new and existing `OperatorGroup` namespace intersection is:
-        - Equivalent to the set of new and existing namespaces (they have the same set).
+        - Equivalent to the set of new and existing namespaces (they have the
+          same set).
         - The empty set (not intersecting).
         - A strict subset of either namespace set.
 
@@ -166,8 +180,12 @@ Algorithm for deleting an `OperatorGroup`:
 ```
 
 Notes on these algorithms:
-- Labeling allows `operator-sdk` to determine whether an `OperatorGroup` can be deleted; `OperatorGroup`'s not compiled by `operator-sdk` should not be deleted in any case.
-- An `OperatorGroup` not compiled by `operator-sdk` is considered a user-managed resource. All conflicts must be resolved by the user, so an error is returned if a non-compiled `OperatorGroup` is already present in a namespace.
+- Labeling allows `operator-sdk` to determine whether an `OperatorGroup` can
+be deleted; `OperatorGroup`'s not compiled by `operator-sdk` should not be
+deleted in any case.
+- An `OperatorGroup` not compiled by `operator-sdk` is considered a user-
+managed resource. All conflicts must be resolved by the user, so an error
+is returned if a non-compiled `OperatorGroup` is already present in a namespace.
 
 [olm-operatorgroup-membership]: https://github.com/operator-framework/operator-lifecycle-manager/blob/1cb0681/doc/design/operatorgroups.md
 [olm-operatorgroup-installmodes]: https://github.com/operator-framework/operator-lifecycle-manager/blob/1cb0681/doc/design/operatorgroups.md

--- a/doc/proposals/sdk-integration-with-olm.md
+++ b/doc/proposals/sdk-integration-with-olm.md
@@ -106,19 +106,25 @@ Given these rules and constraints, Operator developers may have a tough time wri
 
 To perform compilation, the user can optionally supply the desired install mode type by which to install the CSV, and the set of namespaces (may be all namespaces, `""`) in which the CSV will be installed. The compilation algorithm is as follows:
 
-1. If an `OperatorGroup` manifest is supplied:
+```
+1. If an OperatorGroup manifest is supplied:
     1. Use the one supplied and return.
-1. If an `OperatorGroup` manifest is not supplied, compile an `OperatorGroup` `g`:
-    1. If no `installMode` and set of namespaces is supplied:
-        1. Default to `OwnNamespace` by setting `g`'s `targetNamespaces` to the Operator's namespace, and return.
-    1. If an `installMode` and set of namespaces is supplied:
+2. Else if an OperatorGroup manifest is not supplied, compile an OperatorGroup g:
+    1. If no installMode and set of namespaces is supplied:
+        1. Initialize g as type OwnNamespace by setting g's targetNamespaces to the Operator's namespace, and return.
+    2. Else if an installMode and set of namespaces is supplied:
         1. Validate the set of namespaces against the install mode's constraints and the Operator's namespace.
-        1. Initialize `g` as the desired type with the set of namespaces and return.
+        2. Initialize g as the desired type with the set of namespaces and return.
+```
 
-Managing `OperatorGroup` resources for multiple Operators _before_ deployment is attempted is a more complex problem, but prevents annoying-to-debug deployment issues that will occur in the following scenarios:
+Managing `OperatorGroup` resources for multiple Operators _before_ deployment
+is attempted is a more complex problem, but prevents annoying-to-debug
+deployment issues that will occur in the following scenarios:
 
-- A user wants to deploy two or more Operators with CSV install modes incompatible for one `OperatorGroup` to handle in the name namespace.
-- A user wants to create an `OperatorGroup` in a namespace that already has an `OperatorGroup`.
+- A user wants to deploy two or more Operators with CSV install modes
+incompatible for one `OperatorGroup` to handle in the name namespace.
+- A user wants to create an `OperatorGroup` in a namespace that already has
+an `OperatorGroup`.
     - The new and existing `OperatorGroup` namespace intersection is:
         - Equivalent to the set of new and existing namespaces (they have the same set).
         - The empty set (not intersecting).
@@ -127,33 +133,37 @@ Managing `OperatorGroup` resources for multiple Operators _before_ deployment is
 A solution to these types of conflicts is the following two algorithms:
 
 Algorithm for creating an `OperatorGroup`:
-1. Follow the compilation algorithm above to create an `OperatorGroup` `g`.
-1. Determine whether an `OperatorGroup` exists in a given namespace `n`.
-1. If one does not exist in `n`.
-    1. If `h` was not compiled by `operator-sdk`:
-        1. Label `g` with a static label to signify `g` was not created by `operator-sdk`.
-    1. If `h` was created by `operator-sdk`:
-        1. Label `g` with a static label to signify `g` was created by `operator-sdk`.
-    1. Create `g` in `n` and return.
-1. If an `OperatorGroup` `h` exists in `n`:
-    1. If `h` was not compiled by `operator-sdk`, return
-    1. If `h` was compiled by `operator-sdk`:
-        1. Determine which CSV's are members of `h`, `h`'s `targetNamespaces` `hn`, and `g`'s `targetNamespaces` `gn`.
-        1. If `gn` is equivalent to `hn`, return.
-        1. If the intersection of `gn` and `hn` is the empty set or a subset of either:
-            1. Label `g` with a static label to signify `g` was created by `operator-sdk`.
-            1. Create `g` in another namespace `m` and return.
+```
+1. Follow the compilation algorithm above to create an OperatorGroup g.
+2. Determine whether an OperatorGroup exists in a given namespace n.
+3. If no OperatorGroup exists in n:
+    1. If h was not compiled by operator-sdk:
+        1. Label g with a static label to signify g was not created by operator-sdk.
+    2. Else if h was created by operator-sdk:
+        1. Label g with a static label to signify g was created by operator-sdk.
+    3. Create g in n and return.
+4. Else if an OperatorGroup h exists in n:
+    1. If h was not compiled by operator-sdk, return
+    2. Else if h was compiled by operator-sdk:
+        1. Determine which CSV's are members of h, h's targetNamespaces hn, and g's targetNamespaces gn.
+        2. If gn is equivalent to hn, return.
+        3. Else if the intersection of gn and hn is the empty set or a subset of either:
+            1. Label g with a static label to signify g was created by operator-sdk.
+            2. Create g in another namespace m and return.
+```
 
 Algorithm for deleting an `OperatorGroup`:
-1. Determine whether an `OperatorGroup` exists in a given namespace `n`.
-1. If one does not exist in `n`, return.
-1. If an `OperatorGroup` `g` exists in `n`:
-    1. If `g` is not labeled with an `operator-sdk` static label, return.
-    1. If `g` is labeled with an `operator-sdk` static label:
-        1. Determine the set of CSV's `cs` that are members of `g`.
-        1. If `cs` is the empty set:
-            1. Delete `g` and return.
-        1. If `cs` is not the empty set, return.
+```
+1. Determine whether an OperatorGroup exists in a given namespace n.
+2. If no OperatorGroup exists in n, return.
+3. Else if an OperatorGroup g exists in n:
+    1. If g is not labeled with an operator-sdk static label, return.
+    2. Else if g is labeled with an operator-sdk static label:
+        1. Determine the set of CSV's cs that are members of g.
+        2. If cs is the empty set:
+            1. Delete g and return.
+        3. Else if cs is not the empty set, return.
+```
 
 Notes on these algorithms:
 - Labeling allows `operator-sdk` to determine whether an `OperatorGroup` can be deleted; `OperatorGroup`'s not compiled by `operator-sdk` should not be deleted in any case.


### PR DESCRIPTION
**Description of the change:** 
* doc/proposals/sdk-integration-with-olm.md: document OperatorGroup handling logic

**Motivation for the change:** #1912 implements some of this logic, but a few corner cases need to be discussed. The algorithms added here should cover these corner cases.

/ping @ecordell @njhale @kevinrizza 