### PR TITLE
pkg/helm: add overrideValues to watches.yaml (with env expansion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added new `bundle validation` test to the `operator-sdk scorecard` OLM tests. ([#1916](https://github.com/operator-framework/operator-sdk/pull/1916)
 - Added scorecard test short names to each scorecard test to allow users to run a specific scorecard test using the selector flag. ([#1916](https://github.com/operator-framework/operator-sdk/pull/1916)
 - Improve Ansible logs in the Operator container for Ansible-based Operators. ([#2321](https://github.com/operator-framework/operator-sdk/pull/2321))
+- Added support for override values with environment variable expansion in the `watches.yaml` file for Helm-based operators. ([#2325](https://github.com/operator-framework/operator-sdk/pull/2325))
 
 ### Changed
 

--- a/pkg/helm/run.go
+++ b/pkg/helm/run.go
@@ -114,6 +114,7 @@ func Run(flags *hoflags.HelmOperatorFlags) error {
 			ManagerFactory:          release.NewManagerFactory(mgr, w.ChartDir),
 			ReconcilePeriod:         flags.ReconcilePeriod,
 			WatchDependentResources: w.WatchDependentResources,
+			OverrideValues:          w.OverrideValues,
 		})
 		if err != nil {
 			log.Error(err, "Failed to add manager factory to controller.")

--- a/pkg/helm/watches/watches.go
+++ b/pkg/helm/watches/watches.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	yaml "gopkg.in/yaml.v2"
 	"helm.sh/helm/v3/pkg/chartutil"
@@ -30,14 +31,16 @@ type Watch struct {
 	GroupVersionKind        schema.GroupVersionKind
 	ChartDir                string
 	WatchDependentResources bool
+	OverrideValues          map[string]string
 }
 
 type yamlWatch struct {
-	Group                   string `yaml:"group"`
-	Version                 string `yaml:"version"`
-	Kind                    string `yaml:"kind"`
-	Chart                   string `yaml:"chart"`
-	WatchDependentResources bool   `yaml:"watchDependentResources"`
+	Group                   string            `yaml:"group"`
+	Version                 string            `yaml:"version"`
+	Kind                    string            `yaml:"kind"`
+	Chart                   string            `yaml:"chart"`
+	WatchDependentResources bool              `yaml:"watchDependentResources"`
+	OverrideValues          map[string]string `yaml:"overrideValues"`
 }
 
 func (w *yamlWatch) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -87,15 +90,25 @@ func Load(path string) ([]Watch, error) {
 		if _, ok := watchesMap[gvk]; ok {
 			return nil, fmt.Errorf("duplicate GVK: %s", gvk)
 		}
+
 		watch := Watch{
 			GroupVersionKind:        gvk,
 			ChartDir:                w.Chart,
 			WatchDependentResources: w.WatchDependentResources,
+			OverrideValues:          expandOverrideEnvs(w.OverrideValues),
 		}
 		watchesMap[gvk] = watch
 		watches = append(watches, watch)
 	}
 	return watches, nil
+}
+
+func expandOverrideEnvs(in map[string]string) map[string]string {
+	out := make(map[string]string)
+	for k, v := range in {
+		out[k] = os.ExpandEnv(v)
+	}
+	return out
 }
 
 func verifyGVK(gvk schema.GroupVersionKind) error {


### PR DESCRIPTION
**Description of the change:**
Adds `overrideValues` field to Helm operator's watches.yaml file, which allows an operator author to specify a values map that is merged with (and overrides) CR `spec` values.

The values defined in `overrideValues` can use environment variable expansion (e.g. `$MY_VAR` or `${MY_VAR}`) to use values from the environment.

**Motivation for the change:**
In order to support disconnected scenarios and automated operand image rebuilds (e.g. to fix a CVE) it is necessary 

**To Do**
- [x] Update CHANGELOG
- [x] Update documentation to include information about `overrideValues`
- [x] Document that if environment variables are used in `overrideValues`, the container image should be built such that each environment variable is set to the chart's default value for that field.
- [x] Log a warning, add condition to CR status, and/or use a Kubernetes event to notify when CR values are overridden

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
