### PR TITLE
Enable s390x builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,7 +154,17 @@ jobs:
     # Build and deploy ppc64le helm-operator docker image
     - <<: *deploy
       name: Docker image for helm-operator (ppc64le)
-      os: linux-ppc64le
+      os: linux
+      arch: ppc64le
+      script:
+        - make image-build-helm
+        - make image-push-helm
+
+    # Build and deploy s390x helm-operator docker image
+    - <<: *deploy
+      name: Docker image for helm-operator (s390x)
+      os: linux
+      arch: s390x
       script:
         - make image-build-helm
         - make image-push-helm

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ANSIBLE_IMAGE ?= $(ANSIBLE_BASE_IMAGE)
 HELM_IMAGE ?= $(HELM_BASE_IMAGE)
 SCORECARD_PROXY_IMAGE ?= $(SCORECARD_PROXY_BASE_IMAGE)
 
-HELM_ARCHES:="amd64" "ppc64le"
+HELM_ARCHES:="amd64" "ppc64le" "s390x"
 
 export CGO_ENABLED:=0
 .DEFAULT_GOAL:=help
@@ -99,13 +99,15 @@ generate: gen-cli-doc gen-test-framework  ## Run all generate targets
 release_builds := \
 	build/operator-sdk-$(VERSION)-x86_64-linux-gnu \
 	build/operator-sdk-$(VERSION)-x86_64-apple-darwin \
-	build/operator-sdk-$(VERSION)-ppc64le-linux-gnu
+	build/operator-sdk-$(VERSION)-ppc64le-linux-gnu \
+	build/operator-sdk-$(VERSION)-s390x-linux-gnu
 
 release: clean $(release_builds) $(release_builds:=.asc) ## Release the Operator SDK
 
 build/operator-sdk-%-x86_64-linux-gnu: GOARGS = GOOS=linux GOARCH=amd64
 build/operator-sdk-%-x86_64-apple-darwin: GOARGS = GOOS=darwin GOARCH=amd64
 build/operator-sdk-%-ppc64le-linux-gnu: GOARGS = GOOS=linux GOARCH=ppc64le
+build/operator-sdk-%-s390x-linux-gnu: GOARGS = GOOS=linux GOARCH=s390x
 build/operator-sdk-%-linux-gnu: GOARGS = GOOS=linux
 
 build/%: $(SOURCES)

--- a/doc/dev/release.md
+++ b/doc/dev/release.md
@@ -22,9 +22,9 @@ As the Operator SDK interacts directly with the Kubernetes API, certain API feat
 
 ### Operating systems and architectures
 
-Release binaries will be built for the `x86_64` architecture for both GNU Linux and MacOS Darwin platforms and for the `ppc64le` architecture for GNU Linux.
+Release binaries will be built for the `x86_64` architecture for both GNU Linux and MacOS Darwin platforms and for the `ppc64le` and `s390x` architectures for GNU Linux.
 
-Base images for ansible-operator, helm-operator, and scorecard-proxy will be built for the `x86_64` architecture for GNU Linux. Base images for the `ppc64le` architecture for GNU Linux are a work-in-progress.
+Base images for ansible-operator, helm-operator, and scorecard-proxy will be built for the `x86_64` architecture for GNU Linux. Base images for the `ppc64le` and `s390x` architectures for GNU Linux are a work-in-progress.
 
 Support for the Windows platform is not on the roadmap at this time.
 


### PR DESCRIPTION
OpenShift is now available on IBM Z (s390x) systems, and therefore it would be beneficial for developers to have this available thereon as well.  TravisCI has support for Z now, so hardware availability shouldn't be an issue.