### PR TITLE
Only add explicit -mod=vendor if needed

### DIFF
--- a/internal/util/projutil/exec.go
+++ b/internal/util/projutil/exec.go
@@ -124,7 +124,7 @@ func (opts GoCmdOptions) getGeneralArgsWithCmd(cmd string) ([]string, error) {
 		}
 		// Does the first "go" subcommand accept -mod=vendor?
 		_, ok := validVendorCmds[bargs[0]]
-		if err == nil && info.IsDir() && ok {
+		if err == nil && info.IsDir() && ok && needsModVendor() {
 			bargs = append(bargs, "-mod=vendor")
 		}
 	}
@@ -133,6 +133,10 @@ func (opts GoCmdOptions) getGeneralArgsWithCmd(cmd string) ([]string, error) {
 		bargs = append(bargs, opts.PackagePath)
 	}
 	return bargs, nil
+}
+
+func needsModVendor() bool {
+	return !strings.Contains(os.Getenv("GOFLAGS"), "-mod=vendor")
 }
 
 func (opts GoCmdOptions) setCmdFields(c *exec.Cmd) {

--- a/internal/util/projutil/exec.go
+++ b/internal/util/projutil/exec.go
@@ -124,6 +124,8 @@ func (opts GoCmdOptions) getGeneralArgsWithCmd(cmd string) ([]string, error) {
 		}
 		// Does the first "go" subcommand accept -mod=vendor?
 		_, ok := validVendorCmds[bargs[0]]
+		// TODO: remove needsModVendor when
+		// https://github.com/golang/go/issues/32471 is resolved.
 		if err == nil && info.IsDir() && ok && needsModVendor() {
 			bargs = append(bargs, "-mod=vendor")
 		}
@@ -135,6 +137,10 @@ func (opts GoCmdOptions) getGeneralArgsWithCmd(cmd string) ([]string, error) {
 	return bargs, nil
 }
 
+// needsModVendor resolves https://github.com/golang/go/issues/32471,
+// where any flags in GOFLAGS that are also set in the CLI are
+// duplicated, causing 'go' invocation errors.
+// TODO: remove once the issue is resolved.
 func needsModVendor() bool {
 	return !strings.Contains(os.Getenv("GOFLAGS"), "-mod=vendor")
 }


### PR DESCRIPTION
**Description of the change:**
-mod=vendor is not needed if it's already set in GOFLAGS. So let's not
set it unless it's needed.

This is an issue for commands such as `go test` and `go vet` (
see https://github.com/golang/go/issues/32471 ). This avoids such an
issue.


**Motivation for the change:**
With the enforcement of `GOFLAGS=-mod=vendor` in openshift, some projects got broken given that environment variable being set by default and operator-sdk setting that explicitly if the vendor directory exists..