### PR TITLE
controller: make operator sdk support to create multiple controllers for a resource with multiple version

### DIFF
--- a/internal/scaffold/add_controller.go
+++ b/internal/scaffold/add_controller.go
@@ -30,8 +30,9 @@ type AddController struct {
 
 func (s *AddController) GetInput() (input.Input, error) {
 	if s.Path == "" {
-		fileName := "add_" + s.Resource.LowerKind + ".go"
+		fileName := "add_" + s.Resource.Version + "_" + s.Resource.LowerKind + ".go"
 		s.Path = filepath.Join(ControllerDir, fileName)
+
 	}
 	s.TemplateBody = addControllerTemplate
 	return s.Input, nil
@@ -40,11 +41,11 @@ func (s *AddController) GetInput() (input.Input, error) {
 const addControllerTemplate = `package controller
 
 import (
-	"{{ .Repo }}/pkg/controller/{{ .Resource.LowerKind }}"
+	"{{ .Repo }}/pkg/controller/{{ .Resource.LowerKind }}/{{ .Resource.Version }}"
 )
 
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, {{ .Resource.LowerKind }}.Add)
+    AddToManagerFuncs = append(AddToManagerFuncs, {{ .Resource.Version }}.Add)
 }
 `

--- a/internal/scaffold/add_controller_test.go
+++ b/internal/scaffold/add_controller_test.go
@@ -40,11 +40,11 @@ func TestAddController(t *testing.T) {
 const addControllerExp = `package controller
 
 import (
-	"github.com/example-inc/app-operator/pkg/controller/appservice"
+	"github.com/example-inc/app-operator/pkg/controller/appservice/v1alpha1"
 )
 
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, appservice.Add)
+	AddToManagerFuncs = append(AddToManagerFuncs, v1alpha1.Add)
 }
 `

--- a/internal/scaffold/controller_kind.go
+++ b/internal/scaffold/controller_kind.go
@@ -47,7 +47,7 @@ type ControllerKind struct {
 func (s *ControllerKind) GetInput() (input.Input, error) {
 	if s.Path == "" {
 		fileName := s.Resource.LowerKind + "_controller.go"
-		s.Path = filepath.Join(ControllerDir, s.Resource.LowerKind, fileName)
+		s.Path = filepath.Join(ControllerDir, s.Resource.LowerKind, s.Resource.Version, fileName)
 	}
 	// Error if this file exists.
 	s.IfExistsAction = input.Error
@@ -137,7 +137,7 @@ var controllerKindImports = map[string]string{
 	"sigs.k8s.io/controller-runtime/pkg/source":                    "",
 }
 
-const controllerKindTemplate = `package {{ .Resource.LowerKind }}
+const controllerKindTemplate = `package {{ .Resource.Version }}
 
 import (
 	"context"
@@ -147,7 +147,7 @@ import (
 	{{end}}
 )
 
-var log = logf.Log.WithName("controller_{{ .Resource.LowerKind }}")
+var log = logf.Log.WithName("controller_{{ .Resource.LowerKind }}_{{ .Resource.Version }}")
 
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
@@ -168,7 +168,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("{{ .Resource.LowerKind }}-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("{{ .Resource.LowerKind }}-{{ .Resource.Version }}-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
 		return err
 	}

--- a/internal/scaffold/controller_kind_test.go
+++ b/internal/scaffold/controller_kind_test.go
@@ -37,7 +37,7 @@ func TestControllerKind(t *testing.T) {
 	}
 }
 
-const controllerKindExp = `package appservice
+const controllerKindExp = `package v1alpha1
 
 import (
 	"context"
@@ -58,7 +58,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var log = logf.Log.WithName("controller_appservice")
+var log = logf.Log.WithName("controller_appservice_v1alpha1")
 
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
@@ -79,7 +79,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("appservice-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("appservice-v1alpha1-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
* `operator-sdk add controller` will generate `add_<version>_<kind>.go`, instead of previous `add_<kind>.go`

* `operator-sdk add controller` will generate controller folder hierarchy as  `controller/<kind>/<version>`, instead of previous `controller/<kind>`.

**Motivation for the change:**
Current operator sdk only supports to create a single controller for each resource, in fact, there could have some scenarios where need to create multiple controllers for a resource with multiple version, e.g. Openstack's loadbalancer `pool` resource has v1 and v2. Therefore, this requires to make operator sdk support to create multiple controllers for a resource with multiple version.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
