### PR TITLE
gen-csv: non-Go operators are not yet supported

### DIFF
--- a/doc/user/olm-catalog/csv-annotations.md
+++ b/doc/user/olm-catalog/csv-annotations.md
@@ -4,6 +4,8 @@
 
 This document describes the semantics of Cluster Service Version (CSV) [code annotations][code-annotations-design] and lists all possible annotations.
 
+**Note:** CSV annotations can only be used in Go Operator projects. Annotations for Ansible and Helm Operator projects will be added in the future.
+
 ## Usage
 
 All annotations have a `+operator-sdk:gen-csv` prefix, denoting that they're parsed while executing [`operator-sdk olm-catalog gen-csv`][sdk-cli-ref].

--- a/doc/user/olm-catalog/generating-a-csv.md
+++ b/doc/user/olm-catalog/generating-a-csv.md
@@ -6,6 +6,8 @@ This document describes how to manage the following lifecycle for your Operator 
 - **Upgrade your Operator** - Carry over any customizations you have made and ensure a rolling update to the next version of your Operator.
 - **Refresh your CRDs** - If a new version has updated CRDs, refresh those definitions within the CSV automatically.
 
+**Note:** `operator-sdk olm-catalog gen-csv` only officially supports Go Operators. Ansible and Helm Operators will be fully supported in the future. However, `gen-csv` _may_ work with Ansible and Helm Operators if their project structure aligns with that described below.
+
 ## Configuration
 
 Operator SDK projects have an expected [project layout][doc-project-layout]. In particular, a few manifests are expected to be present in the `deploy` directory:

--- a/internal/scaffold/olm-catalog/csv.go
+++ b/internal/scaffold/olm-catalog/csv.go
@@ -27,6 +27,7 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/scaffold"
 	"github.com/operator-framework/operator-sdk/internal/scaffold/input"
 	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
+	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 	"github.com/operator-framework/operator-sdk/internal/util/yamlutil"
 
 	"github.com/blang/semver"
@@ -392,7 +393,11 @@ func (s *CSV) updateCSVFromManifests(cfg *CSVConfig, csv *olmapiv1alpha1.Cluster
 		case "Deployment":
 			err = deployments(manifests).apply(csv)
 		case "CustomResourceDefinition":
-			err = crds(manifests).apply(csv)
+			// TODO(estroz): customresourcedefinition should not be updated for
+			// Ansible and Helm CSV's until annotated updates are implemented.
+			if projutil.IsOperatorGo() {
+				err = crds(manifests).apply(csv)
+			}
 		default:
 			if _, ok := crGVKSet[gvk]; ok {
 				crUpdaters = append(crUpdaters, manifests...)


### PR DESCRIPTION
**Description of the change:**
* doc/user/olm-catalog: document that gen-csv and code annotations are only officially supported for Go Operators for now

* internal/scaffold/olm-catalog/csv.go: do not overwrite a CSV's `spec.customresourcedefinitions` for non-Go Operators

**Motivation for the change:** although `gen-csv` _may_ work with non-Go operators, it does not officially support them (for now). This constraint needs to be documented. Since it may work for Helm and Ansible operator projects as of now, this constraint should not be enforced and prior behavior reinstated.
