### PR TITLE
add checking GOROOT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ $ cd $HOME/projects/example-inc/
 $ operator-sdk new app-operator --repo github.com/example-inc/app-operator
 $ cd app-operator
 
+# Check GOROOT environment variable
+$ env | grep GOROOT
+GOROOT=<your goroot path>
+
 # Add a new API for the custom resource AppService
 $ operator-sdk add api --api-version=app.example.com/v1alpha1 --kind=AppService
 


### PR DESCRIPTION
If there is no GOROOT environment variable, 'operator-sdk add api'
fails.
see https://github.com/operator-framework/operator-sdk/issues/1854#issuecomment-525132306

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
