### PR TITLE
Helm: fix misleading "release not found" errors during CR deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@
 
 
 ### Bug Fixes
+
 - Fix `operator-sdk build`'s `--image-build-args` to support spaces within quotes like `--label some.name="First Last"`. ([#2312](https://github.com/operator-framework/operator-sdk/pull/2312))
+- Fix misleading Helm operator "release not found" errors during CR deletion. ([#2359](https://github.com/operator-framework/operator-sdk/pull/2359))
 
 
 ## v0.13.0

--- a/pkg/helm/release/manager.go
+++ b/pkg/helm/release/manager.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"strings"
 
+	"helm.sh/helm/v3/pkg/storage/driver"
+
 	"helm.sh/helm/v3/pkg/action"
 	cpb "helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/kube"
@@ -299,13 +301,13 @@ func (m manager) UninstallRelease(ctx context.Context) (*rpb.Release, error) {
 	// Get history of this release
 	h, err := m.storageBackend.History(m.releaseName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get release history: %s", err)
+		return nil, fmt.Errorf("failed to get release history: %w", err)
 	}
 
 	// If there is no history, the release has already been uninstalled,
-	// so return ErrNotFound.
+	// so return ErrReleaseNotFound.
 	if len(h) == 0 {
-		return nil, ErrNotFound
+		return nil, driver.ErrReleaseNotFound
 	}
 
 	uninstall := action.NewUninstall(m.actionConfig)


### PR DESCRIPTION
**Description of the change:**
When reconciling deleted Helm operator CRs, wait for the CR to be deleted from the cache before returning. Also improve the error handling to take advantage of Helm v3's new `ErrReleaseNotFound`

**Motivation for the change:**
Closes #2342

