### PR TITLE
internal/scaffold/helm: added role rule for creating events

### DIFF
--- a/internal/scaffold/helm/role.go
+++ b/internal/scaffold/helm/role.go
@@ -57,6 +57,13 @@ var DefaultRoleScaffold = scaffold.Role{
 			Resources: []string{"configmaps", "secrets"},
 			Verbs:     []string{rbacv1.VerbAll},
 		},
+
+		// We need this rule for creating Kubernetes events
+		{
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+			Verbs:     []string{"create"},
+		},
 	},
 }
 

--- a/internal/scaffold/helm/role_test.go
+++ b/internal/scaffold/helm/role_test.go
@@ -41,28 +41,28 @@ func TestGenerateRoleScaffold(t *testing.T) {
 			chart:                  failChart(),
 			expectSkipDefaultRules: false,
 			expectIsClusterScoped:  false,
-			expectLenCustomRules:   2,
+			expectLenCustomRules:   3,
 		},
 		{
 			name:                   "skip rule for unknown API",
 			chart:                  unknownAPIChart(),
 			expectSkipDefaultRules: true,
 			expectIsClusterScoped:  false,
-			expectLenCustomRules:   3,
+			expectLenCustomRules:   4,
 		},
 		{
 			name:                   "namespaced manifest",
 			chart:                  namespacedChart(),
 			expectSkipDefaultRules: true,
 			expectIsClusterScoped:  false,
-			expectLenCustomRules:   3,
+			expectLenCustomRules:   4,
 		},
 		{
 			name:                   "cluster scoped manifest",
 			chart:                  clusterScopedChart(),
 			expectSkipDefaultRules: true,
 			expectIsClusterScoped:  true,
-			expectLenCustomRules:   4,
+			expectLenCustomRules:   5,
 		},
 	}
 
@@ -77,7 +77,7 @@ func TestGenerateRoleScaffold(t *testing.T) {
 		t.Run(fmt.Sprintf("%s with broken discovery client", tc.name), func(t *testing.T) {
 			roleScaffold := helm.GenerateRoleScaffold(brokenDiscoveryClient, tc.chart)
 			assert.Equal(t, false, roleScaffold.SkipDefaultRules)
-			assert.Equal(t, 2, len(roleScaffold.CustomRules))
+			assert.Equal(t, 3, len(roleScaffold.CustomRules))
 			assert.Equal(t, false, roleScaffold.IsClusterScoped)
 		})
 	}


### PR DESCRIPTION
**Description of the change:**
This PR adds a new role rule during project scaffolding that allows the operator to create events.

**Motivation for the change:**
This is a follow-up fix for #2325, which is required for the operator to be able to create events on CRs when override values are in use.

