### PR TITLE
Mock kubebuilder integration with 'operator-sdk alpha kubebuilder' cmd

### DIFF
--- a/cmd/operator-sdk/alpha/kubebuilder/cmd.go
+++ b/cmd/operator-sdk/alpha/kubebuilder/cmd.go
@@ -1,0 +1,71 @@
+// Copyright 2019 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubebuilder
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/alpha/kubebuilder/olmcatalog"
+	"github.com/operator-framework/operator-sdk/internal/util/projutil"
+
+	"github.com/google/shlex"
+	"github.com/spf13/cobra"
+)
+
+var kbFlags string
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "kubebuilder [init/create cmds]",
+		Short: "Kubebuilder aligned subcommands",
+		Long: `
+This subcommand is a placeholder to test the integration of Kubebuilder and Operator SDK 
+subcommands until a plugin system is available to integrate the Kubebuilder CLI.
+See: https://github.com/kubernetes-sigs/kubebuilder/pull/1250
+and https://github.com/operator-framework/operator-sdk/blob/master/doc/proposals/openshift-4.4/kubebuilder-integration.md
+`,
+		RunE:   runKubebuilder,
+		Hidden: true,
+
+		Example: `
+	# Initialize your project
+	operator-sdk alpha kubebuilder init --kb-flags="--domain example.com --license apache2 --owner \"The Kubernetes authors\""
+
+	# Create a frigates API with Group: ship, Version: v1beta1 and Kind: Frigate
+	operator-sdk alpha kubebuilder create api --kb-flags="--group ship --version v1beta1 --kind Frigate"
+`,
+	}
+
+	cmd.Flags().StringVar(&kbFlags, "kb-flags", "", "Extra kubebuilder flags passed to init/create commands \"--group cache --version=v1alpha1\"")
+
+	cmd.AddCommand(
+		olmcatalog.NewCmd(),
+		// newScorecardCmd(),
+		// newTestFrameworkCmd(),
+	)
+	return cmd
+}
+
+func runKubebuilder(cmd *cobra.Command, args []string) error {
+	splitArgs, err := shlex.Split(kbFlags)
+	if err != nil {
+		return fmt.Errorf("kb-flags is not parseable: %v", err)
+	}
+	args = append(args, splitArgs...)
+
+	kbCmd := exec.Command("kubebuilder", args...)
+	return projutil.ExecCmd(kbCmd)
+}

--- a/cmd/operator-sdk/alpha/kubebuilder/olmcatalog/cmd.go
+++ b/cmd/operator-sdk/alpha/kubebuilder/olmcatalog/cmd.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Operator-SDK Authors
+// Copyright 2018 The Operator-SDK Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package alpha
+package olmcatalog
 
 import (
-	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/alpha/kubebuilder"
-	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/alpha/olm"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "alpha",
-		Short: "Run an alpha subcommand",
+		Use:   "olm-catalog <olm-catalog-command>",
+		Short: "Invokes a olm-catalog command",
+		Long: `The operator-sdk olm-catalog command invokes a command to perform
+Catalog related actions.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			log.Info("TODO")
+		},
 	}
-
-	cmd.AddCommand(olm.NewCmd())
-	cmd.AddCommand(kubebuilder.NewCmd())
+	// cmd.AddCommand(newGenCSVCmd())
 	return cmd
 }

--- a/internal/util/projutil/exec.go
+++ b/internal/util/projutil/exec.go
@@ -27,6 +27,7 @@ import (
 func ExecCmd(cmd *exec.Cmd) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
 	log.Debugf("Running %#v", cmd.Args)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to exec %#v: %w", cmd.Args, err)


### PR DESCRIPTION
**Description of the change:**

- Added a hidden subcommand `operator-sdk alpha kubebuilder ...` that calls out to the kubebuilder binary for Kubebuilder cmds, e.g:
  - `operator-sdk alpha kubebuilder init` ==> `kubebuilder init`.
- SDK specific subcommands are not shimmed out to the kubebuilder binary and will be handled separately, e.g:
  - `operator-sdk alpha kubebuilder olm-catalog gen-csv ...`
- Flags for Kubebuilder specific subcommands are passed in via the flag `--kb-flags`, e.g:
  - `operator-sdk alpha kubebuilder create api --kb-flags="--group cache --version v1 --kind Memcached"`
- Updated `ExecCmd()` util to read from stdin for kubebuilder command prompts.

**Motivation for the change:**
While the upstream [proposal for Kubebuilder CLI extensibility](https://github.com/kubernetes-sigs/kubebuilder/pull/1250) is under consideration this mock integration provides a starting point to work on aligning the SDK specific commands like `olm-catalog gen-csv`, `scorecard` and `test`.
This will be replaced by whatever the final plugin interface ends up being.

See [kubebuilder-integration proposal](https://github.com/operator-framework/operator-sdk/blob/master/doc/proposals/openshift-4.4/kubebuilder-integration.md#implementation-detailsnotesconstraints).