### PR TITLE
.travis.yml: goveralls download should not affect SDK go.mod contents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,7 @@ jobs:
     - stage: test
       name: Unit, Sanity, and Markdown Tests
       before_install:
-        - go get github.com/mattn/goveralls
+        - (cd / && go get github.com/mattn/goveralls)
       script:
         - make test-sanity test-unit test-markdown
         - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=coverage.out -repotoken=$COVERALLS_TOKEN


### PR DESCRIPTION
**Description of the change:**
Download goveralls outside of project directory.

**Motivation for the change:**
Make sure downloading CI dependencies doesn't affect SDK go.mod contents.
