### PR TITLE
pkg/helm: install resources in same namespace as CR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- Added [`run`](./doc/cli/operator-sdk_alpha_run.md) and [`cleanup`](./doc/cli/operator-sdk_alpha_cleanup.md) subcommands (under the `alpha` subcommand) to manage deployment/deletion of operators. These commands currently interact with OLM via an in-cluster registry-server created using an operator's on-disk manifests and managed by `operator-sdk`. ([#2402](ttps://github.com/operator-framework/operator-sdk/pull/2402))
+- Added [`run`](./doc/cli/operator-sdk_alpha_run.md) and [`cleanup`](./doc/cli/operator-sdk_alpha_cleanup.md) subcommands (under the `alpha` subcommand) to manage deployment/deletion of operators. These commands currently interact with OLM via an in-cluster registry-server created using an operator's on-disk manifests and managed by `operator-sdk`. ([#2402](https://github.com/operator-framework/operator-sdk/pull/2402))
 
 ### Changed
 - Changed error wrapping according to Go version 1.13+ [error handling](https://blog.golang.org/go1.13-errors). ([#2355](https://github.com/operator-framework/operator-sdk/pull/2355))
@@ -13,6 +13,7 @@
 
 ### Bug Fixes
 
+- Fixed a regression in the helm-operator that caused all releases to be deployed in the same namespace that the operator was deployed in, regardless of which namespace the CR was created in. Now release resources are created in the same namespace as the CR. ([#2414](https://github.com/operator-framework/operator-sdk/pull/2414))
 - Fix issue when the test-framework would attempt to create a namespace exceeding 63 characters. `pkg/test/NewCtx()` now creates a unique id instead of using the test name. `TestCtx.GetNamespace()` uses this unique id to create a namespace that avoids this scenario. ([#2335](https://github.com/operator-framework/operator-sdk/pull/2335))
 
 ## v0.14.0

--- a/pkg/helm/release/manager_factory.go
+++ b/pkg/helm/release/manager_factory.go
@@ -77,11 +77,11 @@ func (f managerFactory) NewManager(cr *unstructured.Unstructured, overrideValues
 
 	// Get the necessary clients and client getters. Use a client that injects the CR
 	// as an owner reference into all resources templated by the chart.
-	rcg, err := client.NewRESTClientGetter(f.mgr)
+	rcg, err := client.NewRESTClientGetter(f.mgr, cr.GetNamespace())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get REST client getter from manager: %w", err)
 	}
-	kubeClient := kube.New(nil)
+	kubeClient := kube.New(rcg)
 	ownerRef := metav1.NewControllerRef(cr, cr.GroupVersionKind())
 	ownerRefClient := client.NewOwnerRefInjectingClient(*kubeClient, *ownerRef)
 


### PR DESCRIPTION
**Description of the change:**
This PR fixes a bug that causes all release resources
to be created in the namespace that the helm-operator is deployed
in, not the namespace that the CR is deployed in.

**Motivation for the change:**
Closes #2416 