### PR TITLE
doc: add better info and example over --custom-api-import flag

### DIFF
--- a/cmd/operator-sdk/add/controller.go
+++ b/cmd/operator-sdk/add/controller.go
@@ -32,11 +32,17 @@ func newAddControllerCmd() *cobra.Command {
 		Use:   "controller",
 		Short: "Adds a new controller pkg",
 		Long: `operator-sdk add controller --kind=<kind> --api-version=<group/version> creates a new
-controller pkg under pkg/controller/<kind> that, by default, reconciles on a custom resource for the specified apiversion and kind.
-The controller will expect to use the custom resource type that should already be defined under pkg/apis/<group>/<version>
-via the "operator-sdk add api --kind=<kind> --api-version=<group/version>" command.
-This command must be run from the project root directory.
-If the controller pkg for that Kind already exists at pkg/controller/<kind> then the command will not overwrite and return an error.
+controller pkg under pkg/controller/<kind> that, by default, reconciles on a custom resource for the specified
+apiversion and kind. The controller will expect to use the custom resource type that should already be defined 
+under pkg/apis/<group>/<version> via the operator-sdk add api --kind=<kind> --api-version=<group/version> command. 
+
+**IMPORTANT:** This command must be run from the project root directory.
+		
+**NOTE:** If the controller pkg for that Kind already exists at pkg/controller/<kind> then the command will not 
+overwrite and return an error.
+		
+The following example will create a controller to manage, watch and reconcile as primary resource the 
+<v1alpha1.AppService> from the domain <app.example.com>.    
 
 Example:
 
@@ -48,19 +54,36 @@ Example:
 	│   └── appservice_controller.go
 	└── controller.go
 
+The following example will create a controller to manage, watch and reconcile as a primary resource a resource which is 
+not defined in the project (external). Note that, it can be used to create controllers for any External API. In this 
+case, it will be done for the resource "v1.Deployments" from the Kubernetes API. 	
+
+Example:
+
+	$ operator-sdk add controller  --api-version=k8s.io.api/v1 --kind=Deployment  --custom-api-import=k8s.io/api/apps
+	$ tree pkg/controller
+	pkg/controller/
+	├── add_deployment.go
+	├── deployment
+	│   └── deployment_controller.go 
+	└── controller.go
 `,
 		RunE: controllerRun,
 	}
 
-	controllerCmd.Flags().StringVar(&apiVersion, "api-version", "", "Kubernetes APIVersion that has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)")
+	controllerCmd.Flags().StringVar(&apiVersion, "api-version", "",
+		"Kubernetes APIVersion that has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)")
 	if err := controllerCmd.MarkFlagRequired("api-version"); err != nil {
 		log.Fatalf("Failed to mark `api-version` flag for `add controller` subcommand as required")
 	}
-	controllerCmd.Flags().StringVar(&kind, "kind", "", "Kubernetes resource Kind name. (e.g AppService)")
+	controllerCmd.Flags().StringVar(&kind, "kind", "",
+		"Kubernetes resource Kind name. (e.g AppService)")
 	if err := controllerCmd.MarkFlagRequired("kind"); err != nil {
 		log.Fatalf("Failed to mark `kind` flag for `add controller` subcommand as required")
 	}
-	controllerCmd.Flags().StringVar(&customAPIImport, "custom-api-import", "", `External Kubernetes resource import path of the form "host.com/repo/path[=import_identifier]". import_identifier is optional`)
+	controllerCmd.Flags().StringVar(&customAPIImport, "custom-api-import", "",
+		`The External API import path of the form "host.com/repo/path[=import_identifier]" which will be managed 
+	by the controller. Note that import_identifier is optional. ( E.g. --custom-api-import=k8s.io/api/apps )`)
 
 	return controllerCmd
 }

--- a/cmd/operator-sdk/add/controller.go
+++ b/cmd/operator-sdk/add/controller.go
@@ -27,26 +27,26 @@ import (
 
 var customAPIImport string
 
+//nolint:lll
 func newAddControllerCmd() *cobra.Command {
 	controllerCmd := &cobra.Command{
 		Use:   "controller",
 		Short: "Adds a new controller pkg",
-		Long: `operator-sdk add controller --kind=<kind> --api-version=<group/version> creates a new
-controller pkg under pkg/controller/<kind> that, by default, reconciles on a custom resource for the specified
-apiversion and kind. The controller will expect to use the custom resource type that should already be defined 
-under pkg/apis/<group>/<version> via the operator-sdk add api --kind=<kind> --api-version=<group/version> command. 
+		Long: `
+Add a new controller package to your operator project.
 
-**IMPORTANT:** This command must be run from the project root directory.
-		
-**NOTE:** If the controller pkg for that Kind already exists at pkg/controller/<kind> then the command will not 
-overwrite and return an error.
-		
-The following example will create a controller to manage, watch and reconcile as primary resource the 
-<v1alpha1.AppService> from the domain <app.example.com>.    
+This command creates a new controller package under pkg/controller/<kind> that, by default, reconciles on a custom resource for the specified apiversion and kind. The controller will expect to use the custom resource type that should already be defined under pkg/apis/<group>/<version> via the "operator-sdk add api" command. 
+
+Note that, if the controller pkg for that Kind already exists at pkg/controller/<kind> then the command will not overwrite and return an error.
+
+This command MUST be run from the project root directory.`,
+
+		Example: `
+The following example will create a controller to manage, watch and reconcile as primary resource the <v1.AppService> from the domain <app.example.com>.    
 
 Example:
 
-	$ operator-sdk add controller --api-version=app.example.com/v1alpha1 --kind=AppService
+	$ operator-sdk add controller --api-version=app.example.com/v1 --kind=AppService
 	$ tree pkg/controller
 	pkg/controller/
 	├── add_appservice.go
@@ -54,9 +54,7 @@ Example:
 	│   └── appservice_controller.go
 	└── controller.go
 
-The following example will create a controller to manage, watch and reconcile as a primary resource a resource which is 
-not defined in the project (external). Note that, it can be used to create controllers for any External API. In this 
-case, it will be done for the resource "v1.Deployments" from the Kubernetes API. 	
+The following example will create a controller to manage, watch and reconcile as a primary resource the <v1.Deployment> from the domain <k8s.io.api>, which is not defined in the project (external). Note that, it can be used to create controllers for any External API. 	
 
 Example:
 
@@ -67,7 +65,7 @@ Example:
 	├── deployment
 	│   └── deployment_controller.go 
 	└── controller.go
-`,
+		`,
 		RunE: controllerRun,
 	}
 
@@ -82,8 +80,7 @@ Example:
 		log.Fatalf("Failed to mark `kind` flag for `add controller` subcommand as required")
 	}
 	controllerCmd.Flags().StringVar(&customAPIImport, "custom-api-import", "",
-		`The External API import path of the form "host.com/repo/path[=import_identifier]" which will be managed 
-	by the controller. Note that import_identifier is optional. ( E.g. --custom-api-import=k8s.io/api/apps )`)
+		`The External API import path of the form "host.com/repo/path[=import_identifier]" Note that import_identifier is optional. ( E.g. --custom-api-import=k8s.io/api/apps )`)
 
 	return controllerCmd
 }

--- a/doc/cli/operator-sdk_add_controller.md
+++ b/doc/cli/operator-sdk_add_controller.md
@@ -4,22 +4,28 @@ Adds a new controller pkg
 
 ### Synopsis
 
-operator-sdk add controller --kind=<kind> --api-version=<group/version> creates a new
-controller pkg under pkg/controller/<kind> that, by default, reconciles on a custom resource for the specified
-apiversion and kind. The controller will expect to use the custom resource type that should already be defined 
-under pkg/apis/<group>/<version> via the operator-sdk add api --kind=<kind> --api-version=<group/version> command. 
 
-**IMPORTANT:** This command must be run from the project root directory.
-		
-**NOTE:** If the controller pkg for that Kind already exists at pkg/controller/<kind> then the command will not 
-overwrite and return an error.
-		
-The following example will create a controller to manage, watch and reconcile as primary resource the 
-<v1alpha1.AppService> from the domain <app.example.com>.    
+Add a new controller package to your operator project.
+
+This command creates a new controller package under pkg/controller/<kind> that, by default, reconciles on a custom resource for the specified apiversion and kind. The controller will expect to use the custom resource type that should already be defined under pkg/apis/<group>/<version> via the "operator-sdk add api" command. 
+
+Note that, if the controller pkg for that Kind already exists at pkg/controller/<kind> then the command will not overwrite and return an error.
+
+This command MUST be run from the project root directory.
+
+```
+operator-sdk add controller [flags]
+```
+
+### Examples
+
+```
+
+The following example will create a controller to manage, watch and reconcile as primary resource the <v1.AppService> from the domain <app.example.com>.    
 
 Example:
 
-	$ operator-sdk add controller --api-version=app.example.com/v1alpha1 --kind=AppService
+	$ operator-sdk add controller --api-version=app.example.com/v1 --kind=AppService
 	$ tree pkg/controller
 	pkg/controller/
 	├── add_appservice.go
@@ -27,9 +33,7 @@ Example:
 	│   └── appservice_controller.go
 	└── controller.go
 
-The following example will create a controller to manage, watch and reconcile as a primary resource a resource which is 
-not defined in the project (external). Note that, it can be used to create controllers for any External API. In this 
-case, it will be done for the resource "v1.Deployments" from the Kubernetes API. 	
+The following example will create a controller to manage, watch and reconcile as a primary resource the <v1.Deployment> from the domain <k8s.io.api>, which is not defined in the project (external). Note that, it can be used to create controllers for any External API. 	
 
 Example:
 
@@ -40,18 +44,14 @@ Example:
 	├── deployment
 	│   └── deployment_controller.go 
 	└── controller.go
-
-
-```
-operator-sdk add controller [flags]
+		
 ```
 
 ### Options
 
 ```
       --api-version string         Kubernetes APIVersion that has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)
-      --custom-api-import string   The External API import path of the form "host.com/repo/path[=import_identifier]" which will be managed 
-                                   	by the controller. Note that import_identifier is optional. ( E.g. --custom-api-import=k8s.io/api/apps )
+      --custom-api-import string   The External API import path of the form "host.com/repo/path[=import_identifier]" Note that import_identifier is optional. ( E.g. --custom-api-import=k8s.io/api/apps )
   -h, --help                       help for controller
       --kind string                Kubernetes resource Kind name. (e.g AppService)
 ```

--- a/doc/cli/operator-sdk_add_controller.md
+++ b/doc/cli/operator-sdk_add_controller.md
@@ -5,11 +5,17 @@ Adds a new controller pkg
 ### Synopsis
 
 operator-sdk add controller --kind=<kind> --api-version=<group/version> creates a new
-controller pkg under pkg/controller/<kind> that, by default, reconciles on a custom resource for the specified apiversion and kind.
-The controller will expect to use the custom resource type that should already be defined under pkg/apis/<group>/<version>
-via the "operator-sdk add api --kind=<kind> --api-version=<group/version>" command.
-This command must be run from the project root directory.
-If the controller pkg for that Kind already exists at pkg/controller/<kind> then the command will not overwrite and return an error.
+controller pkg under pkg/controller/<kind> that, by default, reconciles on a custom resource for the specified
+apiversion and kind. The controller will expect to use the custom resource type that should already be defined 
+under pkg/apis/<group>/<version> via the operator-sdk add api --kind=<kind> --api-version=<group/version> command. 
+
+**IMPORTANT:** This command must be run from the project root directory.
+		
+**NOTE:** If the controller pkg for that Kind already exists at pkg/controller/<kind> then the command will not 
+overwrite and return an error.
+		
+The following example will create a controller to manage, watch and reconcile as primary resource the 
+<v1alpha1.AppService> from the domain <app.example.com>.    
 
 Example:
 
@@ -21,6 +27,19 @@ Example:
 	│   └── appservice_controller.go
 	└── controller.go
 
+The following example will create a controller to manage, watch and reconcile as a primary resource a resource which is 
+not defined in the project (external). Note that, it can be used to create controllers for any External API. In this 
+case, it will be done for the resource "v1.Deployments" from the Kubernetes API. 	
+
+Example:
+
+	$ operator-sdk add controller  --api-version=k8s.io.api/v1 --kind=Deployment  --custom-api-import=k8s.io/api/apps
+	$ tree pkg/controller
+	pkg/controller/
+	├── add_deployment.go
+	├── deployment
+	│   └── deployment_controller.go 
+	└── controller.go
 
 
 ```
@@ -31,7 +50,8 @@ operator-sdk add controller [flags]
 
 ```
       --api-version string         Kubernetes APIVersion that has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)
-      --custom-api-import string   External Kubernetes resource import path of the form "host.com/repo/path[=import_identifier]". import_identifier is optional
+      --custom-api-import string   The External API import path of the form "host.com/repo/path[=import_identifier]" which will be managed 
+                                   	by the controller. Note that import_identifier is optional. ( E.g. --custom-api-import=k8s.io/api/apps )
   -h, --help                       help for controller
       --kind string                Kubernetes resource Kind name. (e.g AppService)
 ```


### PR DESCRIPTION
**Description of the change:**
- Improve the command controller help 
- Make clear how to use and what is the purpose of the flag `--custom-api-import flag`

**Motivation for the change:**

Closes #2415

