### PR TITLE
Run all tests of the project and counting then with coveralls 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,9 +190,14 @@ test-markdown test/markdown:
 test-sanity test/sanity: tidy build/operator-sdk lint
 	./hack/tests/sanity-check.sh
 
-TEST_PKGS:=$(shell go list ./... | grep -v -E 'github.com/operator-framework/operator-sdk/(hack/|test/)')
+# NOTE: It is required to ignore the : pkg/ansible/proxy/proxy_test.go which requires network permissions
+TEST_PKGS:=$(shell go list ./... | grep -v -E 'github.com/operator-framework/operator-sdk/(hack/|test/|pkg/ansible/proxy/proxy_test.go)')
 test-unit test/unit: ## Run the unit tests
-	$(Q)go test -coverprofile=coverage.out -covermode=count -count=1 -short ${TEST_PKGS}
+	# -failfast: disables running additional tests after any test fails
+	# -tags=integration: run tests tagged as integration
+	# -coverprofile: define the name of the file with the coverage
+	# -covermode: will count the % of coverage
+	$(Q)go test -failfast -tags=integration -coverprofile=coverage.out -covermode=count ${TEST_PKGS}
 
 # CI tests.
 .PHONY: test-ci

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,8 @@ test-sanity test/sanity: tidy build/operator-sdk lint
 	./hack/tests/sanity-check.sh
 
 # NOTE: It is required to ignore the : pkg/ansible/proxy/proxy_test.go which requires network permissions
-TEST_PKGS:=$(shell go list ./... | grep -v -E 'github.com/operator-framework/operator-sdk/(hack/|test/|pkg/ansible/proxy/proxy_test.go)')
+TEST_PKGS:=$(shell go list ./... | grep -v -E 'github.com/operator-framework/operator-sdk/(hack/|test/|pkg/ansible/proxy/)')
+
 test-unit test/unit: ## Run the unit tests
 	# -failfast: disables running additional tests after any test fails
 	# -tags=integration: run tests tagged as integration

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ test-sanity test/sanity: tidy build/operator-sdk lint
 	./hack/tests/sanity-check.sh
 
 # NOTE: It is required to ignore the : pkg/ansible/proxy/proxy_test.go which requires network permissions
-TEST_PKGS:=$(shell go list ./... | grep -v -E 'github.com/operator-framework/operator-sdk/(hack/|test/|pkg/ansible/proxy/)')
+TEST_PKGS:=$(shell go list ./... | grep -v -E 'github.com/operator-framework/operator-sdk/(hack/|test/|pkg/ansible/proxy/proxy_test.go)')
 
 test-unit test/unit: ## Run the unit tests
 	# -failfast: disables running additional tests after any test fails


### PR DESCRIPTION
**Description of the change:**
- The tests were been executed with the `--sort` which as not running all scenarios
- The only test that will not work in the CI is the ansible/proxy_test.go so it has been ignored 

**Motivation for the change:**
- Have a more accurate %
- Ensure that all tests which can be executed will use in the CI as well. 

