### PR TITLE
Link directly to Helm CLI examples from helm user guide

### DIFF
--- a/doc/helm/user-guide.md
+++ b/doc/helm/user-guide.md
@@ -403,4 +403,4 @@ Events:
 [helm-charts]:https://helm.sh/docs/topics/charts/
 [helm-values]:https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing
 [quay-link]:https://quay.io
-[helm-reference-cli-doc]:./../sdk-cli-reference.md
+[helm-reference-cli-doc]:./../sdk-cli-reference.md#helm-project


### PR DESCRIPTION
**Description of the change:**
Following up from #2404, this PR adds an anchor to the link so that users are directed to the section of the SDK CLI reference guide that contains the examples for creating a helm operator. 

**Motivation for the change:**
Improve UX
