### PR TITLE
images: install Python kubernetes-validate in Ansible images

### DIFF
--- a/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
+++ b/ci/dockerfiles/ansible-e2e-hybrid.Dockerfile
@@ -31,6 +31,7 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
       ansible-runner==1.3.4 \
       ansible-runner-http==1.0.0 \
       openshift==0.8.9 \
+      kubernetes-validate \
       ansible~=2.9 \
       jmespath \
  && yum remove -y gcc python36-devel \

--- a/ci/dockerfiles/ansible.Dockerfile
+++ b/ci/dockerfiles/ansible.Dockerfile
@@ -30,6 +30,7 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
       ansible-runner==1.3.4 \
       ansible-runner-http==1.0.0 \
       openshift==0.8.9 \
+      kubernetes-validate \
       ansible~=2.9 \
       jmespath \
  && yum remove -y gcc python36-devel \


### PR DESCRIPTION
this allows usage of the validation feature in Ansible k8s module

Fixes #2433

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
