### PR TITLE
internal/scaffold: don't change /etc/passwd perms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     - There is no longer any Ansible templating done in the `deploy/` directory, any templates used for testing will be located in `molecule/templates/` instead.
     - The scaffolded molecule.yml files now use the Ansible verifier. All asserts.yml files were renamed to verify.yml to reflect this.
     - The prepare/converge/verify tasks now make use of the new `k8s` `wait` option to simplify the deployment logic.
+- Operator user setup and entrypoint scripts no longer insert dynamic runtime user entries into `/etc/passwd`. To use dynamic runtime users, use a container runtime that supports it (e.g. CRI-O). ([#2469](https://github.com/operator-framework/operator-sdk/pull/2469))
 
 ### Deprecated
 

--- a/internal/scaffold/ansible/entrypoint.go
+++ b/internal/scaffold/ansible/entrypoint.go
@@ -36,15 +36,6 @@ func (e *Entrypoint) GetInput() (input.Input, error) {
 
 const entrypointTmpl = `#!/bin/bash -e
 
-# This is documented here:
-# https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
-
-if ! whoami &>/dev/null; then
-  if [ -w /etc/passwd ]; then
-    echo "${USER_NAME:-runner}:x:$(id -u):$(id -g):${USER_NAME:-runner} user:${HOME}:/sbin/nologin" >> /etc/passwd
-  fi
-fi
-
 cd $HOME
 exec ${OPERATOR} exec-entrypoint ansible --watches-file=$HOME/watches.yaml $@
 `

--- a/internal/scaffold/ansible/usersetup.go
+++ b/internal/scaffold/ansible/usersetup.go
@@ -38,12 +38,10 @@ const userSetupTmpl = `#!/bin/sh
 set -x
 
 # ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
 mkdir -p ${HOME}/.ansible/tmp
 chown -R ${USER_UID}:0 ${HOME}
 chmod -R ug+rwx ${HOME}
-
-# runtime user will need to be able to self-insert in /etc/passwd
-chmod g+rw /etc/passwd
 
 # no need for this script to remain in the image after running
 rm $0

--- a/internal/scaffold/entrypoint.go
+++ b/internal/scaffold/entrypoint.go
@@ -39,14 +39,5 @@ func (e *Entrypoint) GetInput() (input.Input, error) {
 //nolint:lll //affects the template fi the line is trimmed
 const entrypointTmpl = `#!/bin/sh -e
 
-# This is documented here:
-# https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
-
-if ! whoami &>/dev/null; then
-  if [ -w /etc/passwd ]; then
-    echo "${USER_NAME:-{{.ProjectName}}}:x:$(id -u):$(id -g):${USER_NAME:-{{.ProjectName}}} user:${HOME}:/sbin/nologin" >> /etc/passwd
-  fi
-fi
-
 exec ${OPERATOR} $@
 `

--- a/internal/scaffold/entrypoint_test.go
+++ b/internal/scaffold/entrypoint_test.go
@@ -36,14 +36,5 @@ func TestEntrypointTest(t *testing.T) {
 //nolint:lll
 const entrypointExp = `#!/bin/sh -e
 
-# This is documented here:
-# https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
-
-if ! whoami &>/dev/null; then
-  if [ -w /etc/passwd ]; then
-    echo "${USER_NAME:-app-operator}:x:$(id -u):$(id -g):${USER_NAME:-app-operator} user:${HOME}:/sbin/nologin" >> /etc/passwd
-  fi
-fi
-
 exec ${OPERATOR} $@
 `

--- a/internal/scaffold/helm/entrypoint.go
+++ b/internal/scaffold/helm/entrypoint.go
@@ -36,15 +36,6 @@ func (e *Entrypoint) GetInput() (input.Input, error) {
 
 const entrypointTmpl = `#!/bin/sh -e
 
-# This is documented here:
-# https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
-
-if ! whoami &>/dev/null; then
-  if [ -w /etc/passwd ]; then
-    echo "${USER_NAME:-helm}:x:$(id -u):$(id -g):${USER_NAME:-helm} user:${HOME}:/sbin/nologin" >> /etc/passwd
-  fi
-fi
-
 cd $HOME
 exec ${OPERATOR} exec-entrypoint helm --watches-file=$HOME/watches.yaml $@
 `

--- a/internal/scaffold/helm/usersetup.go
+++ b/internal/scaffold/helm/usersetup.go
@@ -38,12 +38,10 @@ const userSetupTmpl = `#!/bin/sh
 set -x
 
 # ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
 mkdir -p ${HOME}
 chown ${USER_UID}:0 ${HOME}
 chmod ug+rwx ${HOME}
-
-# runtime user will need to be able to self-insert in /etc/passwd
-chmod g+rw /etc/passwd
 
 # no need for this script to remain in the image after running
 rm $0

--- a/internal/scaffold/usersetup.go
+++ b/internal/scaffold/usersetup.go
@@ -40,12 +40,10 @@ const userSetupTmpl = `#!/bin/sh
 set -x
 
 # ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
 mkdir -p ${HOME}
 chown ${USER_UID}:0 ${HOME}
 chmod ug+rwx ${HOME}
-
-# runtime user will need to be able to self-insert in /etc/passwd
-chmod g+rw /etc/passwd
 
 # no need for this script to remain in the image after running
 rm $0

--- a/internal/scaffold/usersetup_test.go
+++ b/internal/scaffold/usersetup_test.go
@@ -37,12 +37,10 @@ const userSetupExp = `#!/bin/sh
 set -x
 
 # ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
 mkdir -p ${HOME}
 chown ${USER_UID}:0 ${HOME}
 chmod ug+rwx ${HOME}
-
-# runtime user will need to be able to self-insert in /etc/passwd
-chmod g+rw /etc/passwd
 
 # no need for this script to remain in the image after running
 rm $0


### PR DESCRIPTION
**Description of the change:**
This PR updates entrypoint and user_setup scaffolds to remove the steps that add the runtime user to `/etc/passwd` _at runtime_.

**Motivation for the change:**
These steps are not actually required to support containers running with dynamic UIDs.

Instead, we statically add the user to the image _at build time_ and ensure its files are read/writeable by the gid=0. The container runtime can set the GID of the runtime user to 0 when the container is started.
