### PR TITLE
cmd/operator-sdk/run: use Windows binary suffix with '--local'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed issue with Go dependencies caused by removed tag in `openshift/api` repository ([#2466](https://github.com/operator-framework/operator-sdk/issues/2466))
 - Fixed a regression in the `operator-sdk run` command that caused `--local` flags to be ignored ([#2478](https://github.com/operator-framework/operator-sdk/issues/2478))
+- Fix command `operator-sdk run --local` which was not working on Windows. #2481
 
 ## v0.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Fixed issue with Go dependencies caused by removed tag in `openshift/api` repository ([#2466](https://github.com/operator-framework/operator-sdk/issues/2466))
 - Fixed a regression in the `operator-sdk run` command that caused `--local` flags to be ignored ([#2478](https://github.com/operator-framework/operator-sdk/issues/2478))
-- Fix command `operator-sdk run --local` which was not working on Windows. #2481
+- Fix command `operator-sdk run --local` which was not working on Windows. ([#2481](https://github.com/operator-framework/operator-sdk/pull/2481))
 
 ## v0.15.1
 

--- a/cmd/operator-sdk/run/local.go
+++ b/cmd/operator-sdk/run/local.go
@@ -21,6 +21,7 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -75,7 +76,11 @@ func (c runLocalArgs) runGo() error {
 	projutil.MustInProjectRoot()
 	absProjectPath := projutil.MustGetwd()
 	projectName := filepath.Base(absProjectPath)
-	outputBinName := filepath.Join(scaffold.BuildBinDir, projectName+"-local")
+	var exeSuffix string
+	if runtime.GOOS == "windows" {
+		exeSuffix = ".exe"
+	}
+	outputBinName := filepath.Join(scaffold.BuildBinDir, projectName+"-local"+exeSuffix)
 	if err := c.buildLocal(outputBinName); err != nil {
 		return fmt.Errorf("failed to build operator to run locally: %v", err)
 	}

--- a/cmd/operator-sdk/run/local.go
+++ b/cmd/operator-sdk/run/local.go
@@ -76,11 +76,10 @@ func (c runLocalArgs) runGo() error {
 	projutil.MustInProjectRoot()
 	absProjectPath := projutil.MustGetwd()
 	projectName := filepath.Base(absProjectPath)
-	var exeSuffix string
+	outputBinName := filepath.Join(scaffold.BuildBinDir, projectName+"-local")
 	if runtime.GOOS == "windows" {
-		exeSuffix = ".exe"
+		outputBinName += ".exe"
 	}
-	outputBinName := filepath.Join(scaffold.BuildBinDir, projectName+"-local"+exeSuffix)
 	if err := c.buildLocal(outputBinName); err != nil {
 		return fmt.Errorf("failed to build operator to run locally: %v", err)
 	}


### PR DESCRIPTION
On Windows, we need to add the .exe suffix to the executable that is
generated by the operator-sdk run --local command, otherwise it will
fail because the file doesn't have an executable extension.

Closes #2480