### PR TITLE
Use the namespace the operator is running from when creating servicem…

### DIFF
--- a/internal/scaffold/cmd.go
+++ b/internal/scaffold/cmd.go
@@ -112,6 +112,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Retrieve the namespace the operator is running in
+	operatorNs, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		log.Error(err, "Failed to get operator namespace")
+	}
+
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -152,7 +158,7 @@ func main() {
 	}
 
 	// Add the Metrics Service
-	addMetrics(ctx, cfg, namespace)
+	addMetrics(ctx, cfg, operatorNs)
 
 	log.Info("Starting the Cmd.")
 


### PR DESCRIPTION
…onitors for metrics

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
The namespace which is passed to the addMetrics function will now use the namespace which the operator is running inside rather than the one it is watching.


**Motivation for the change:**
I noticed this issue when running an operator created using version `v0.12.0` of the Operator SDK, when running the operator in one namespace, and having it watch another namespace. It appears to still affect the codebase on `master`, hence the PR.

Errors would appear on startup when creating the service monitor:

```
{"level":"info","ts":1580740974.4433243,"logger":"cmd","msg":"Could not create ServiceMonitor object","error":"the namespace of the provided object does not match the namespace sent on the request"}
```