### PR TITLE
internal/generate/olm-catalog/package_manifest_test.go: fix sanity test

### DIFF
--- a/internal/generate/olm-catalog/package_manifest_test.go
+++ b/internal/generate/olm-catalog/package_manifest_test.go
@@ -161,7 +161,8 @@ func TestNewPackageManifest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := newPackageManifest(tt.args.operatorName, tt.args.channelName, tt.args.version); !reflect.DeepEqual(got, tt.want) {
+			got := newPackageManifest(tt.args.operatorName, tt.args.channelName, tt.args.version)
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewPackageManifest() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
**Description of the change:**
Shorten line so that golangci-lint lll test passes

**Motivation for the change:**
Fix CI
