### PR TITLE
doc: ansible.operator-sdk/verbosity become string.

### DIFF
--- a/doc/ansible/dev/advanced_options.md
+++ b/doc/ansible/dev/advanced_options.md
@@ -170,6 +170,6 @@ kind: "PostgreSQL"
 metadata:
   name: "example-db"
   annotations:
-    "ansible.operator-sdk/verbosity": 5
+    "ansible.operator-sdk/verbosity": "5"
 spec: {}
 ```

--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -379,7 +379,7 @@ kind: "Memcached"
 metadata:
   name: "example-memcached"
   annotations:
-    "ansible.operator-sdk/verbosity": 4
+    "ansible.operator-sdk/verbosity": "4"
 spec:
   size: 4
 ```

--- a/test/ansible/deploy/crds/test.example.com_v1alpha1_inventory_cr.yaml
+++ b/test/ansible/deploy/crds/test.example.com_v1alpha1_inventory_cr.yaml
@@ -2,6 +2,8 @@ apiVersion: test.example.com/v1alpha1
 kind: Inventory
 metadata:
   name: example-inventory
+  annotations:
+    "ansible.operator-sdk/verbosity": "3"
 spec:
   # Add fields here
   size: 3


### PR DESCRIPTION
Metadata annotations must be string.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Value of `ansible.operator-sdk/verbosity` become string.

**Motivation for the change:**

If you use numeric value on `ansible.operator-sdk/verbosity` on CR, you face following error.

```
resource.metadataOnlyObject.ObjectMeta: v1.ObjectMeta.Name: Annotations: ReadString: expects " or n, but found 3,
```

I've tried string value on `ansible.operator-sdk/verbosity`, it works.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
