### PR TITLE
scorecard - refactor - remove merging of results, add CR name to output

### DIFF
--- a/hack/tests/subcommand-scorecard.sh
+++ b/hack/tests/subcommand-scorecard.sh
@@ -29,7 +29,7 @@ header_text 'scorecard test to see if total score matches expected value'
 if ! commandoutput="$(operator-sdk scorecard --config "$CONFIG_PATH" 2>&1)"; then
 	echo $commandoutput
 	passCount=`echo $commandoutput | grep -o "pass" | wc -l`
-	expectedPassCount=4
+	expectedPassCount=10
 	if [ $passCount -ne $expectedPassCount ]
 	then
 		echo "expected label count $expectedLabelCount, got $labelCount"
@@ -83,7 +83,7 @@ fi
 header_text 'scorecard test to see if --selector flag works'
 commandoutput="$(operator-sdk scorecard --selector=suite=basic --config "$CONFIG_PATH_V1ALPHA2" 2>&1)"
 labelCount=`echo $commandoutput | grep -o "Label" | wc -l`
-expectedLabelCount=3
+expectedLabelCount=6
 if [ $labelCount -ne $expectedLabelCount ]
 then
 	echo "expected label count $expectedLabelCount, got $labelCount"

--- a/internal/scorecard/plugins/basic_tests.go
+++ b/internal/scorecard/plugins/basic_tests.go
@@ -91,7 +91,6 @@ func NewWritingIntoCRsHasEffectTest(conf BasicTestConfig) *WritingIntoCRsHasEffe
 			Name: "Writing into CRs has an effect",
 			Description: "A CR sends PUT/POST requests to the API server to modify resources in" +
 				" response to spec block changes",
-			Cumulative: false,
 			Labels: map[string]string{necessityKey: requiredNecessity, suiteKey: basicSuiteName,
 				testKey: getStructShortName(WritingIntoCRsHasEffectTest{})},
 		},
@@ -116,7 +115,7 @@ func NewBasicTestSuite(conf BasicTestConfig) *schelpers.TestSuite {
 
 // Run - implements Test interface
 func (t *CheckSpecTest) Run(ctx context.Context) *schelpers.TestResult {
-	res := &schelpers.TestResult{Test: t, State: scapiv1alpha2.PassState}
+	res := &schelpers.TestResult{Test: t, CRName: t.CR.GetName(), State: scapiv1alpha2.PassState}
 
 	err := t.Client.Get(ctx, types.NamespacedName{Namespace: t.CR.GetNamespace(), Name: t.CR.GetName()}, t.CR)
 	if err != nil {
@@ -135,7 +134,7 @@ func (t *CheckSpecTest) Run(ctx context.Context) *schelpers.TestResult {
 
 // Run - implements Test interface
 func (t *CheckStatusTest) Run(ctx context.Context) *schelpers.TestResult {
-	res := &schelpers.TestResult{Test: t, State: scapiv1alpha2.PassState}
+	res := &schelpers.TestResult{Test: t, CRName: t.CR.GetName(), State: scapiv1alpha2.PassState}
 
 	err := t.Client.Get(ctx, types.NamespacedName{Namespace: t.CR.GetNamespace(), Name: t.CR.GetName()}, t.CR)
 	if err != nil {
@@ -152,7 +151,7 @@ func (t *CheckStatusTest) Run(ctx context.Context) *schelpers.TestResult {
 
 // Run - implements Test interface
 func (t *WritingIntoCRsHasEffectTest) Run(ctx context.Context) *schelpers.TestResult {
-	res := &schelpers.TestResult{Test: t, State: scapiv1alpha2.PassState}
+	res := &schelpers.TestResult{Test: t, CRName: t.CR.GetName(), State: scapiv1alpha2.PassState}
 
 	logs, err := getProxyLogs(t.ProxyPod)
 	if err != nil {

--- a/internal/scorecard/plugins/olm_tests.go
+++ b/internal/scorecard/plugins/olm_tests.go
@@ -67,7 +67,6 @@ func NewBundleValidationTest(conf OLMTestConfig) *BundleValidationTest {
 		TestInfo: schelpers.TestInfo{
 			Name:        "Bundle Validation Test",
 			Description: "Validates bundle contents",
-			Cumulative:  true,
 			Labels: map[string]string{necessityKey: requiredNecessity, suiteKey: olmSuiteName,
 				testKey: getStructShortName(BundleValidationTest{})},
 		},
@@ -87,7 +86,6 @@ func NewCRDsHaveValidationTest(conf OLMTestConfig) *CRDsHaveValidationTest {
 		TestInfo: schelpers.TestInfo{
 			Name:        "Provided APIs have validation",
 			Description: "All CRDs have an OpenAPI validation subsection",
-			Cumulative:  true,
 			Labels: map[string]string{necessityKey: requiredNecessity, suiteKey: olmSuiteName,
 				testKey: getStructShortName(CRDsHaveValidationTest{})},
 		},
@@ -107,7 +105,6 @@ func NewCRDsHaveResourcesTest(conf OLMTestConfig) *CRDsHaveResourcesTest {
 		TestInfo: schelpers.TestInfo{
 			Name:        "Owned CRDs have resources listed",
 			Description: "All Owned CRDs contain a resources subsection",
-			Cumulative:  true,
 			Labels: map[string]string{necessityKey: requiredNecessity, suiteKey: olmSuiteName,
 				testKey: getStructShortName(CRDsHaveResourcesTest{})},
 		},
@@ -127,7 +124,6 @@ func NewSpecDescriptorsTest(conf OLMTestConfig) *SpecDescriptorsTest {
 		TestInfo: schelpers.TestInfo{
 			Name:        "Spec fields with descriptors",
 			Description: "All spec fields have matching descriptors in the CSV",
-			Cumulative:  true,
 			Labels: map[string]string{necessityKey: requiredNecessity, suiteKey: olmSuiteName,
 				testKey: getStructShortName(SpecDescriptorsTest{})},
 		},
@@ -147,7 +143,6 @@ func NewStatusDescriptorsTest(conf OLMTestConfig) *StatusDescriptorsTest {
 		TestInfo: schelpers.TestInfo{
 			Name:        "Status fields with descriptors",
 			Description: "All status fields have matching descriptors in the CSV",
-			Cumulative:  true,
 			Labels: map[string]string{necessityKey: requiredNecessity, suiteKey: olmSuiteName,
 				testKey: getStructShortName(StatusDescriptorsTest{})},
 		},
@@ -188,7 +183,7 @@ func NewOLMTestSuite(conf OLMTestConfig) *schelpers.TestSuite {
 
 // Run - implements Test interface
 func (t *BundleValidationTest) Run(ctx context.Context) *schelpers.TestResult {
-	res := &schelpers.TestResult{Test: t, State: scapiv1alpha2.PassState}
+	res := &schelpers.TestResult{Test: t, CRName: t.CR.GetName(), State: scapiv1alpha2.PassState}
 
 	if t.OLMTestConfig.Bundle == "" {
 		res.Errors = append(res.Errors,
@@ -237,7 +232,7 @@ func matchVersion(version string, crd *apiextv1beta1.CustomResourceDefinition) b
 
 // Run - implements Test interface
 func (t *CRDsHaveValidationTest) Run(ctx context.Context) *schelpers.TestResult {
-	res := &schelpers.TestResult{Test: t, State: scapiv1alpha2.PassState}
+	res := &schelpers.TestResult{Test: t, CRName: t.CR.GetName(), State: scapiv1alpha2.PassState}
 	crds, err := k8sutil.GetCRDs(t.CRDsDir)
 	if err != nil {
 		res.Errors = append(res.Errors, fmt.Errorf("failed to get CRDs in %s directory: %v", t.CRDsDir, err))
@@ -294,7 +289,7 @@ func (t *CRDsHaveValidationTest) Run(ctx context.Context) *schelpers.TestResult 
 
 // Run - implements Test interface
 func (t *CRDsHaveResourcesTest) Run(ctx context.Context) *schelpers.TestResult {
-	res := &schelpers.TestResult{Test: t, State: scapiv1alpha2.PassState}
+	res := &schelpers.TestResult{Test: t, CRName: t.CR.GetName(), State: scapiv1alpha2.PassState}
 
 	var missingResources []string
 	for _, crd := range t.CSV.Spec.CustomResourceDefinitions.Owned {
@@ -432,7 +427,7 @@ func getUsedResources(proxyPod *v1.Pod) ([]schema.GroupVersionKind, error) {
 
 // Run - implements Test interface
 func (t *StatusDescriptorsTest) Run(ctx context.Context) *schelpers.TestResult {
-	res := &schelpers.TestResult{Test: t, State: scapiv1alpha2.PassState}
+	res := &schelpers.TestResult{Test: t, CRName: t.CR.GetName(), State: scapiv1alpha2.PassState}
 
 	err := t.Client.Get(ctx, types.NamespacedName{Namespace: t.CR.GetNamespace(), Name: t.CR.GetName()}, t.CR)
 	if err != nil {
@@ -446,7 +441,7 @@ func (t *StatusDescriptorsTest) Run(ctx context.Context) *schelpers.TestResult {
 
 // Run - implements Test interface
 func (t *SpecDescriptorsTest) Run(ctx context.Context) *schelpers.TestResult {
-	res := &schelpers.TestResult{Test: t, State: scapiv1alpha2.PassState}
+	res := &schelpers.TestResult{Test: t, CRName: t.CR.GetName(), State: scapiv1alpha2.PassState}
 	err := t.Client.Get(ctx, types.NamespacedName{Namespace: t.CR.GetNamespace(), Name: t.CR.GetName()}, t.CR)
 	if err != nil {
 		res.Errors = append(res.Errors, err)

--- a/internal/scorecard/plugins/plugin_runner.go
+++ b/internal/scorecard/plugins/plugin_runner.go
@@ -187,11 +187,6 @@ func RunInternalPlugin(pluginType PluginType, config BasicAndOLMPluginConfig,
 		suites = append(suites, crSuites...)
 	}
 
-	suites, err = schelpers.MergeSuites(suites)
-	if err != nil {
-		return scapiv1alpha2.ScorecardOutput{}, fmt.Errorf("failed to merge test suite results: %v", err)
-	}
-
 	output := schelpers.TestSuitesToScorecardOutput(suites, "")
 	return output, nil
 }
@@ -232,10 +227,6 @@ func ListInternalPlugin(pluginType PluginType, config BasicAndOLMPluginConfig) (
 			olmTests.TestResults = append(olmTests.TestResults, result)
 		}
 		suites = append(suites, *olmTests)
-	}
-	suites, err := schelpers.MergeSuites(suites)
-	if err != nil {
-		return scapiv1alpha2.ScorecardOutput{}, fmt.Errorf("failed to merge test suite results: %v", err)
 	}
 
 	output := schelpers.TestSuitesToScorecardOutput(suites, "")

--- a/pkg/apis/scorecard/v1alpha2/formatter.go
+++ b/pkg/apis/scorecard/v1alpha2/formatter.go
@@ -57,6 +57,8 @@ func (s ScorecardOutput) MarshalText() (string, error) {
 			sb.WriteString(fmt.Sprintf("\n"))
 		}
 
+		sb.WriteString(fmt.Sprintf("\tCR: %s\n", result.CRName))
+
 		sb.WriteString("\tLabels: \n")
 		for labelKey, labelValue := range result.Labels {
 			sb.WriteString(fmt.Sprintf("\t\t%q:%q\n", labelKey, labelValue))

--- a/pkg/apis/scorecard/v1alpha2/types.go
+++ b/pkg/apis/scorecard/v1alpha2/types.go
@@ -48,6 +48,8 @@ type ScorecardTestResult struct {
 	Suggestions []string `json:"suggestions,omitempty"`
 	// Log holds a log produced from the test (if applicable)
 	Log string `json:"log,omitempty"`
+	// CRName holds the CR name this test was run with (if applicable)
+	CRName string `json:"crname,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION


**Description of the change:**
this PR removes the merge/cumulative concept in scorecard, instead it inserts the CR name into the test result (and scorecard output) to distiguish test results between multiple CRs if specified by the scorecard end user.

merge/cumulative code was removed as part of this change.

With this change, you end up with more test output than before, with each CR producing test results (per CR).

**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
