### PR TITLE
scorecard - add PATCH to list of methods in scorecard CR update test

### DIFF
--- a/internal/scorecard/plugins/basic_tests.go
+++ b/internal/scorecard/plugins/basic_tests.go
@@ -170,7 +170,8 @@ func (t *WritingIntoCRsHasEffectTest) Run(ctx context.Context) *schelpers.TestRe
 		if !ok {
 			continue
 		}
-		if method == "PUT" || method == "POST" {
+
+		if method == "PUT" || method == "POST" || method == "PATCH" {
 			writes = true
 			break
 		}
@@ -178,7 +179,7 @@ func (t *WritingIntoCRsHasEffectTest) Run(ctx context.Context) *schelpers.TestRe
 
 	if !writes {
 		res.Suggestions = append(res.Suggestions, "The operator should write into objects to update state."+
-			"No PUT or POST requests from the operator were recorded by the scorecard.")
+			"No PUT, PATCH, or POST requests from the operator were recorded by the scorecard.")
 		res.State = scapiv1alpha2.FailState
 	}
 	return res


### PR DESCRIPTION


**Description of the change:**

with this change, the scorecard basic test (updatecr) will add PATCH to the list of http methods checked from the proxy log, previously only PUT and POST were checked and if found would cause the scorecard test to pass.


**Motivation for the change:**

this issue arises when you have an operator that is NOT written with the SDK AND when you want that operator to pass the scorecard basic-test UpdateCR test.  With this change, the proxy when it logs a PATCH http method, will cause the operator basic test (update cr) to detect the PATCH and pass the test.  

