### PR TITLE
Add skip-cleanup-on-errors option to `test local` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add Prometheus metrics support to Ansible-based operators. ([#2179](https://github.com/operator-framework/operator-sdk/pull/2179))
 - On `generate csv`, populate a CSV manifest’s `spec.icon`, `spec.keywords`, and `spec.mantainers` fields with empty values to better inform users how to add data. ([#2521](https://github.com/operator-framework/operator-sdk/pull/2521))
 - Scaffold code in `cmd/manager/main.go` for Go operators and add logic to Ansible/Helm operators to handle [multinamespace caching](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder) if `WATCH_NAMESPACE` contains multiple namespaces. ([#2522](https://github.com/operator-framework/operator-sdk/pull/2522))
+- Add a new flag option (`--skip-cleanup-error`) to the test framework to allow skip the function which will remove all artefacts when an error be faced to perform this operation.   ([#2512](https://github.com/operator-framework/operator-sdk/pull/2512))
 
 ### Changed
 - Ansible scaffolding has been rewritten to be simpler and make use of newer features of Ansible and Molecule.

--- a/cmd/operator-sdk/test/local.go
+++ b/cmd/operator-sdk/test/local.go
@@ -48,11 +48,12 @@ type testLocalConfig struct {
 	goTestFlags        string
 	moleculeTestFlags  string
 	namespace          string
+	image              string
+	localOperatorFlags string
 	upLocal            bool
 	noSetup            bool
 	debug              bool
-	image              string
-	localOperatorFlags string
+	skipCleanupOnError bool
 }
 
 var tlConfig testLocalConfig
@@ -82,6 +83,9 @@ func newTestLocalCmd() *cobra.Command {
 		"Use a different operator image from the one specified in the namespaced manifest")
 	testCmd.Flags().StringVar(&tlConfig.localOperatorFlags, "local-operator-flags", "",
 		"The flags that the operator needs (while using --up-local). Example: \"--flag1 value1 --flag2=value2\"")
+	testCmd.Flags().BoolVar(&tlConfig.skipCleanupOnError, "skip-cleanup-error", false,
+		"If set as true, the cleanup function responsible to remove all artifacts "+
+			"will be skipped if an error is faced.")
 
 	return testCmd
 }
@@ -227,6 +231,7 @@ func testLocalGoFunc(cmd *cobra.Command, args []string) error {
 			testArgs = append(testArgs, "-"+test.LocalOperatorArgs, tlConfig.localOperatorFlags)
 		}
 	}
+	testArgs = append(testArgs, fmt.Sprintf("-%s=%t", test.SkipCleanupOnErrorFlag, tlConfig.skipCleanupOnError))
 	opts := projutil.GoTestOptions{
 		GoCmdOptions: projutil.GoCmdOptions{
 			PackagePath: args[0] + "/...",

--- a/doc/cli/operator-sdk_test_local.md
+++ b/doc/cli/operator-sdk_test_local.md
@@ -24,6 +24,7 @@ operator-sdk test local <path to tests directory> [flags]
       --namespace string              If non-empty, single namespace to run tests in
       --namespaced-manifest string    Path to manifest for per-test, namespaced resources (e.g. RBAC and Operator manifest)
       --no-setup                      Disable test resource creation
+      --skip-cleanup-error            If set as true, the cleanup function responsible to remove all artifacts will be skipped if an error is faced.
       --up-local                      Enable running operator locally with go run instead of as an image in the cluster
 ```
 

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -274,6 +274,18 @@ $ operator-sdk test local ./test/e2e --namespace operator-test --no-setup
 
 For more documentation on the `operator-sdk test local` command, see the [SDK CLI Reference][sdk-cli-ref] doc.
 
+### Skip-Cleanup-Error Flag
+
+If the tests encounter an error, it is possible to tell the framework not to delete the resources. This behavior is enabled with the `--skip-cleanup-error` flag:
+
+```shell
+$ operator-sdk test local ./test/e2e --skip-cleanup-error
+```
+
+This is useful if after the error happens, you need to inspect the resources that were created in the test or if you have automated scripts that download all the logs from the pods at the end of the test run.
+
+**NOTE**: The created resources will be deleted if the tests pass.
+
 ### Running Go Test Directly (Not Recommended)
 
 For advanced use cases, it is possible to run the tests via `go test` directly. As long as all flags defined

--- a/pkg/test/framework.go
+++ b/pkg/test/framework.go
@@ -71,6 +71,7 @@ type Framework struct {
 	schemeMutex         sync.Mutex
 	LocalOperator       bool
 	singleNamespaceMode bool
+	skipCleanupOnError  bool
 }
 
 type frameworkOpts struct {
@@ -78,19 +79,21 @@ type frameworkOpts struct {
 	kubeconfigPath      string
 	globalManPath       string
 	namespacedManPath   string
+	localOperatorArgs   string
 	singleNamespaceMode bool
 	isLocalOperator     bool
-	localOperatorArgs   string
+	skipCleanupOnError  bool
 }
 
 const (
-	ProjRootFlag          = "root"
-	KubeConfigFlag        = "kubeconfig"
-	NamespacedManPathFlag = "namespacedMan"
-	GlobalManPathFlag     = "globalMan"
-	SingleNamespaceFlag   = "singleNamespace"
-	LocalOperatorFlag     = "localOperator"
-	LocalOperatorArgs     = "localOperatorArgs"
+	ProjRootFlag           = "root"
+	KubeConfigFlag         = "kubeconfig"
+	NamespacedManPathFlag  = "namespacedMan"
+	GlobalManPathFlag      = "globalMan"
+	SingleNamespaceFlag    = "singleNamespace"
+	LocalOperatorFlag      = "localOperator"
+	LocalOperatorArgs      = "localOperatorArgs"
+	SkipCleanupOnErrorFlag = "skipCleanupOnError"
 
 	TestNamespaceEnv = "TEST_NAMESPACE"
 )
@@ -105,6 +108,9 @@ func (opts *frameworkOpts) addToFlagSet(flagset *flag.FlagSet) {
 	flagset.BoolVar(&opts.singleNamespaceMode, SingleNamespaceFlag, false, "enable single namespace mode")
 	flagset.StringVar(&opts.localOperatorArgs, LocalOperatorArgs, "",
 		"flags that the operator needs (while using --up-local). example: \"--flag1 value1 --flag2=value2\"")
+	flagset.BoolVar(&opts.skipCleanupOnError, SkipCleanupOnErrorFlag, false,
+		"If set as true, the cleanup function responsible to remove all artifacts "+
+			"will be skipped if an error is faced.")
 }
 
 func newFramework(opts *frameworkOpts) (*Framework, error) {
@@ -157,6 +163,7 @@ func newFramework(opts *frameworkOpts) (*Framework, error) {
 		localOperatorArgs:   opts.localOperatorArgs,
 		kubeconfigPath:      opts.kubeconfigPath,
 		restMapper:          restMapper,
+		skipCleanupOnError:  opts.skipCleanupOnError,
 	}
 	return framework, nil
 }


### PR DESCRIPTION
**Description of the change:**
This flag (which is `false` by default) tells the framework whether to
skip the clean up (or do it) if the test encountered errors.

**Motivation for the change:**

With the current behavior, the framework will always clean up the
resources it created. This is fine in most cases, however, in CI,
whenever there's an error, we might not get the logs of the workloads
and operator after the cleanup. So this option enables those resources
to linger until the logs have been acquired.