### PR TITLE
fix ci for when just docs were updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,20 +36,17 @@ go:
 # so we can use it to create a bunch of common build step
 # YAML anchors which we use in our build jobs.
 x_base_steps:
-  # before_install for jobs that require go builds and do not run for doc-only changes
-  - &go_before_install
-    before_install:
-      # hack/ci/check-doc-only-update.sh needs to be sourced so
-      # that it can properly exit the test early with success
-      - source hack/ci/check-doc-only-update.sh
-      - travis_retry make tidy
-
   # Base go, ansbile, and helm job
   - &test
     stage: test
     env:
     - CLUSTER=k8s
-    <<: *go_before_install
+    # before_install for jobs that require go builds and do not run for doc-only changes
+    before_install:
+      # hack/ci/check-doc-only-update.sh needs to be sourced so
+      # that it can properly exit the test early with success
+      - source hack/ci/check-doc-only-update.sh
+      - travis_retry make tidy
     install:
       - make install
       - hack/ci/setup-${CLUSTER}.sh
@@ -67,7 +64,8 @@ x_base_steps:
   - &deploy
     stage: deploy
     if: type != pull_request AND ( tag IS present OR branch = master OR commit_message =~ /\[travis deploy\]/ )
-    <<: *go_before_install
+    before_install:
+      - travis_retry make tidy
     install: make install
     before_script:
       - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
@@ -155,8 +153,6 @@ jobs:
 
     # Build and deploy ppc64le helm-operator docker image
     - <<: *deploy
-      env:
-        - SKIP_DOC_CHECK=true
       name: Docker image for helm-operator (ppc64le)
       arch: ppc64le
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,6 +155,8 @@ jobs:
 
     # Build and deploy ppc64le helm-operator docker image
     - <<: *deploy
+      env:
+        - SKIP_DOC_CHECK=true
       name: Docker image for helm-operator (ppc64le)
       arch: ppc64le
       script:

--- a/hack/ci/check-doc-only-update.sh
+++ b/hack/ci/check-doc-only-update.sh
@@ -5,9 +5,10 @@ set -e
 # Make sure the TRAVIS_COMMIT_RANGE is valid, by catching any errors and exiting.
 if [ -z "$TRAVIS_COMMIT_RANGE" ] || ! git rev-list --quiet $TRAVIS_COMMIT_RANGE; then
   echo "Invalid commit range. Skipping check for doc only update"
-elif "$SKIP_DOC_CHECK" = "true"; then
-  echo "Skipping check for doc only update. Env Var SKIP_DOC_CHECK = true"
-elif ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md)|(\.MD)|(\.png)|(\.pdf)|^(doc/)|^(MAINTAINERS)|^(LICENSE)'; then
+  return 0
+fi
+
+if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md)|(\.MD)|(\.png)|(\.pdf)|^(doc/)|^(MAINTAINERS)|^(LICENSE)'; then
   echo "Only doc files were updated, not running the CI."
   exit 0
 fi

--- a/hack/ci/check-doc-only-update.sh
+++ b/hack/ci/check-doc-only-update.sh
@@ -5,10 +5,9 @@ set -e
 # Make sure the TRAVIS_COMMIT_RANGE is valid, by catching any errors and exiting.
 if [ -z "$TRAVIS_COMMIT_RANGE" ] || ! git rev-list --quiet $TRAVIS_COMMIT_RANGE; then
   echo "Invalid commit range. Skipping check for doc only update"
-  return 0
-fi
-
-if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md)|(\.MD)|(\.png)|(\.pdf)|^(doc/)|^(MAINTAINERS)|^(LICENSE)'; then
+elif "$SKIP_DOC_CHECK" = "true"; then
+  echo "Skipping check for doc only update. Env Var SKIP_DOC_CHECK = true"
+elif ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md)|(\.MD)|(\.png)|(\.pdf)|^(doc/)|^(MAINTAINERS)|^(LICENSE)'; then
   echo "Only doc files were updated, not running the CI."
   exit 0
 fi


### PR DESCRIPTION
**Description of the change:**
Fix ci for when just docs were updated by not calling the skip shell to deploy the images. 

**Motivation for the change:**

We merged a doc and the CI-job in the master to build `Docker image for helm-operator (ppc64le)` did not work. So, the change could not cause it. ( The issue is timeout in the process which is not returning a exit in 10 min . - any command execution which takes more than 10 min will be killed by Travis in the default config )

Here: https://travis-ci.org/operator-framework/operator-sdk/jobs/647499366

```
travis-ci.orgtravis-ci.org
Travis CI - Test and Deploy Your Code with Confidence
Travis CI enables your team to test and ship your apps with confidence. Easily sync your projects with Travis CI and you'll be testing your code in minutes.
11:56
$ gimme version
v1.5.3
$ go version
go version go1.13.7 linux/ppc64le
go.env
$ go env
$ source hack/ci/check-doc-only-update.sh
Only doc files were updated, not running the CI.
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
```

Note that the same job is done for another arch and works 100% well which proves that the root cause is with it.  See that it work perfectly all in all scenarios unless 1 one case where the arch: ppc64le`. So, with it, Travis is not getting the exit 0 from the shell. 

https://github.com/travis-ci/travis-ci/issues/10504