### PR TITLE
Scaffold code in `cmd/manager/main.go` for Go operators and add logic to Ansible/Helm operators to handle [multinamespace caching]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added support for relative Ansible roles and playbooks paths in the Ansible operator's file. ([#2273](https://github.com/operator-framework/operator-sdk/pull/2273))
 - Add Prometheus metrics support to Ansible-based operators. ([#2179](https://github.com/operator-framework/operator-sdk/pull/2179))
 - On `generate csv`, populate a CSV manifest’s `spec.icon`, `spec.keywords`, and `spec.mantainers` fields with empty values to better inform users how to add data. ([#2521](https://github.com/operator-framework/operator-sdk/pull/2521))
+- Scaffold code in `cmd/manager/main.go` for Go operators and add logic to Ansible/Helm operators to handle [multinamespace caching](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder) if `WATCH_NAMESPACE` contains multiple namespaces. ([#2522](https://github.com/operator-framework/operator-sdk/pull/2522))
 
 ### Changed
 - Ansible scaffolding has been rewritten to be simpler and make use of newer features of Ansible and Molecule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - Added support for relative Ansible roles and playbooks paths in the Ansible operator's file. ([#2273](https://github.com/operator-framework/operator-sdk/pull/2273))
 - Add Prometheus metrics support to Ansible-based operators. ([#2179](https://github.com/operator-framework/operator-sdk/pull/2179))
 - On `generate csv`, populate a CSV manifest’s `spec.icon`, `spec.keywords`, and `spec.mantainers` fields with empty values to better inform users how to add data. ([#2521](https://github.com/operator-framework/operator-sdk/pull/2521))
-- Scaffold code in `cmd/manager/main.go` for Go operators and add logic to Ansible/Helm operators to handle [multinamespace caching](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder) if `WATCH_NAMESPACE` contains multiple namespaces. ([#2522](https://github.com/operator-framework/operator-sdk/pull/2522))
 
 ### Changed
 - Ansible scaffolding has been rewritten to be simpler and make use of newer features of Ansible and Molecule.

--- a/internal/scaffold/cmd.go
+++ b/internal/scaffold/cmd.go
@@ -140,9 +140,8 @@ func main() {
 	// Also note that you may face performance issues when using this with a high number of namespaces.
 	// More Info: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder
 	if strings.Contains(namespace, ",") {
-		multiNamespace := strings.Split(namespace, ",")
 		options.Namespace = ""
-		options.NewCache = cache.MultiNamespacedCacheBuilder(multiNamespace)
+		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(namespace, ","))
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components

--- a/internal/scaffold/cmd.go
+++ b/internal/scaffold/cmd.go
@@ -49,7 +49,6 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"{{ .Repo }}/pkg/apis"
 	"{{ .Repo }}/pkg/controller"
@@ -60,11 +59,11 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
-	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -133,7 +132,6 @@ func main() {
 	// Set default manager options
 	options := manager.Options{
 		Namespace:          namespace,
-		MapperProvider:     restmapper.NewDynamicRESTMapper,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	}
 
@@ -141,8 +139,8 @@ func main() {
 	// Note that this is not intended to be used for excluding namespaces, this is better done via a Predicate 
 	// Also note that you may face performance issues when using this with a high number of namespaces.
 	// More Info: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder
-	multiNamespace := strings.Split(namespace, ",")
-	if len(multiNamespace) > 1 {
+	if strings.Contains(namespace, ",") {
+		multiNamespace := strings.Split(namespace, ",")
 		options.Namespace = ""
 		options.NewCache = cache.MultiNamespacedCacheBuilder(multiNamespace)
 	}

--- a/internal/scaffold/cmd.go
+++ b/internal/scaffold/cmd.go
@@ -144,7 +144,7 @@ func main() {
 		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(namespace, ","))
 	}
 
-	// Create a new Cmd to provide shared dependencies and start components
+	// Create a new manager to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, options)
 	if err != nil {
 		log.Error(err, "")

--- a/internal/scaffold/cmd_test.go
+++ b/internal/scaffold/cmd_test.go
@@ -143,7 +143,7 @@ func main() {
 		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(namespace, ","))
 	}
 
-	// Create a new Cmd to provide shared dependencies and start components
+	// Create a new manager to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, options)
 	if err != nil {
 		log.Error(err, "")

--- a/internal/scaffold/cmd_test.go
+++ b/internal/scaffold/cmd_test.go
@@ -48,7 +48,6 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/example-inc/app-operator/pkg/apis"
 	"github.com/example-inc/app-operator/pkg/controller"
@@ -59,11 +58,11 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
-	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -132,7 +131,6 @@ func main() {
 	// Set default manager options
 	options := manager.Options{
 		Namespace:          namespace,
-		MapperProvider:     restmapper.NewDynamicRESTMapper,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	}
 
@@ -140,8 +138,8 @@ func main() {
 	// Note that this is not intended to be used for excluding namespaces, this is better done via a Predicate
 	// Also note that you may face performance issues when using this with a high number of namespaces.
 	// More Info: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder
-	multiNamespace := strings.Split(namespace, ",")
-	if len(multiNamespace) > 1 {
+	if strings.Contains(namespace, ",") {
+		multiNamespace := strings.Split(namespace, ",")
 		options.Namespace = ""
 		options.NewCache = cache.MultiNamespacedCacheBuilder(multiNamespace)
 	}

--- a/internal/scaffold/cmd_test.go
+++ b/internal/scaffold/cmd_test.go
@@ -43,10 +43,12 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/example-inc/app-operator/pkg/apis"
 	"github.com/example-inc/app-operator/pkg/controller"
@@ -57,6 +59,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
+	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
@@ -126,11 +129,25 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create a new Cmd to provide shared dependencies and start components
-	mgr, err := manager.New(cfg, manager.Options{
+	// Set default manager options
+	options := manager.Options{
 		Namespace:          namespace,
+		MapperProvider:     restmapper.NewDynamicRESTMapper,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
-	})
+	}
+
+	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)
+	// Note that this is not intended to be used for excluding namespaces, this is better done via a Predicate
+	// Also note that you may face performance issues when using this with a high number of namespaces.
+	// More Info: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder
+	multiNamespace := strings.Split(namespace, ",")
+	if len(multiNamespace) > 1 {
+		options.Namespace = ""
+		options.NewCache = cache.MultiNamespacedCacheBuilder(multiNamespace)
+	}
+
+	// Create a new Cmd to provide shared dependencies and start components
+	mgr, err := manager.New(cfg, options)
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)

--- a/internal/scaffold/cmd_test.go
+++ b/internal/scaffold/cmd_test.go
@@ -139,9 +139,8 @@ func main() {
 	// Also note that you may face performance issues when using this with a high number of namespaces.
 	// More Info: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder
 	if strings.Contains(namespace, ",") {
-		multiNamespace := strings.Split(namespace, ",")
 		options.Namespace = ""
-		options.NewCache = cache.MultiNamespacedCacheBuilder(multiNamespace)
+		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(namespace, ","))
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components

--- a/pkg/ansible/run.go
+++ b/pkg/ansible/run.go
@@ -65,12 +65,6 @@ func printVersion() {
 func Run(flags *aoflags.AnsibleOperatorFlags) error {
 	printVersion()
 
-	cfg, err := config.GetConfig()
-	if err != nil {
-		log.Error(err, "Failed to get config.")
-		return err
-	}
-
 	namespace, found := os.LookupEnv(k8sutil.WatchNamespaceEnvVar)
 	var multiNamespace []string
 	log = log.WithValues("Namespace", namespace)
@@ -80,7 +74,7 @@ func Run(flags *aoflags.AnsibleOperatorFlags) error {
 		} else {
 			multiNamespace = strings.Split(namespace, ",")
 			if len(multiNamespace) > 1 {
-				log.Info("Watching multiNamespace.")
+				log.Info("Watching multiple namespaces.")
 			} else {
 				log.Info("Watching single namespace.")
 			}
@@ -89,6 +83,12 @@ func Run(flags *aoflags.AnsibleOperatorFlags) error {
 		log.Info(fmt.Sprintf("%v environment variable not set. Watching all namespaces.",
 			k8sutil.WatchNamespaceEnvVar))
 		namespace = metav1.NamespaceAll
+	}
+
+	cfg, err := config.GetConfig()
+	if err != nil {
+		log.Error(err, "Failed to get config.")
+		return err
 	}
 
 	// Set default manager options

--- a/pkg/ansible/run.go
+++ b/pkg/ansible/run.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/operator-framework/operator-sdk/pkg/ansible/controller"
 	aoflags "github.com/operator-framework/operator-sdk/pkg/ansible/flags"
@@ -64,23 +65,34 @@ func printVersion() {
 func Run(flags *aoflags.AnsibleOperatorFlags) error {
 	printVersion()
 
-	namespace, found := os.LookupEnv(k8sutil.WatchNamespaceEnvVar)
-	log = log.WithValues("Namespace", namespace)
-	if found {
-		log.Info("Watching namespace.")
-	} else {
-		log.Info(fmt.Sprintf("%v environment variable not set. This operator is watching all namespaces.",
-			k8sutil.WatchNamespaceEnvVar))
-		namespace = metav1.NamespaceAll
-	}
-
 	cfg, err := config.GetConfig()
 	if err != nil {
 		log.Error(err, "Failed to get config.")
 		return err
 	}
+
+	namespace, found := os.LookupEnv(k8sutil.WatchNamespaceEnvVar)
+	var multiNamespace []string
+	log = log.WithValues("Namespace", namespace)
+	if found {
+		if namespace == metav1.NamespaceAll {
+			log.Info("Watching all namespaces.")
+		} else {
+			multiNamespace = strings.Split(namespace, ",")
+			if len(multiNamespace) > 1 {
+				log.Info("Watching multiNamespace.")
+			}
+			log.Info("Watching single namespace.")
+		}
+	} else {
+		log.Info(fmt.Sprintf("%v environment variable not set. Watching all namespaces.",
+			k8sutil.WatchNamespaceEnvVar))
+		namespace = metav1.NamespaceAll
+	}
+
+	// Set default manager options
 	// TODO: probably should expose the host & port as an environment variables
-	mgr, err := manager.New(cfg, manager.Options{
+	options := manager.Options{
 		Namespace:          namespace,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 		NewClient: func(cache cache.Cache, config *rest.Config, options client.Options) (client.Client, error) {
@@ -94,7 +106,16 @@ func Run(flags *aoflags.AnsibleOperatorFlags) error {
 				StatusClient: c,
 			}, nil
 		},
-	})
+	}
+
+	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)
+	if len(multiNamespace) > 1 {
+		options.Namespace = ""
+		options.NewCache = cache.MultiNamespacedCacheBuilder(multiNamespace)
+	}
+
+	// Create a new Cmd to provide shared dependencies and start components
+	mgr, err := manager.New(cfg, options)
 	if err != nil {
 		log.Error(err, "Failed to create a new manager.")
 		return err

--- a/pkg/ansible/run.go
+++ b/pkg/ansible/run.go
@@ -81,8 +81,9 @@ func Run(flags *aoflags.AnsibleOperatorFlags) error {
 			multiNamespace = strings.Split(namespace, ",")
 			if len(multiNamespace) > 1 {
 				log.Info("Watching multiNamespace.")
+			} else {
+				log.Info("Watching single namespace.")
 			}
-			log.Info("Watching single namespace.")
 		}
 	} else {
 		log.Info(fmt.Sprintf("%v environment variable not set. Watching all namespaces.",

--- a/pkg/ansible/run.go
+++ b/pkg/ansible/run.go
@@ -109,7 +109,7 @@ func Run(flags *aoflags.AnsibleOperatorFlags) error {
 		options.Namespace = metav1.NamespaceAll
 	}
 
-	// Create a new Cmd to provide shared dependencies and start components
+	// Create a new manager to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, options)
 	if err != nil {
 		log.Error(err, "Failed to create a new manager.")

--- a/pkg/helm/run.go
+++ b/pkg/helm/run.go
@@ -71,7 +71,7 @@ func Run(flags *hoflags.HelmOperatorFlags) error {
 		} else {
 			multiNamespace = strings.Split(namespace, ",")
 			if len(multiNamespace) > 1 {
-				log.Info("Watching multiNamespace.")
+				log.Info("Watching multiple namespaces.")
 			} else {
 				log.Info("Watching single namespace.")
 			}

--- a/pkg/helm/run.go
+++ b/pkg/helm/run.go
@@ -72,8 +72,9 @@ func Run(flags *hoflags.HelmOperatorFlags) error {
 			multiNamespace = strings.Split(namespace, ",")
 			if len(multiNamespace) > 1 {
 				log.Info("Watching multiNamespace.")
+			} else {
+				log.Info("Watching single namespace.")
 			}
-			log.Info("Watching single namespace.")
 		}
 	} else {
 		log.Info(fmt.Sprintf("%v environment variable not set. Watching all namespaces.",

--- a/test/test-framework/cmd/manager/main.go
+++ b/test/test-framework/cmd/manager/main.go
@@ -102,7 +102,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Create a new Cmd to provide shared dependencies and start components
+	// Create a new manager to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
 		Namespace:          namespace,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),


### PR DESCRIPTION
**Description of the change:**
- Add native support to MultiNamespace. More Info: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder

**Motivation for the change:**
- Integration with OLM: See that OLM allows and config the MultiNamespace via the option  `targetNamespaces` via the OperatorGroup. We are also in the olm commands setting these values in the WATCH-NAMESPACE EnvVar. 

- Address the requirements requested in tasks such as https://github.com/operator-framework/operator-sdk/issues/2494, https://github.com/operator-framework/operator-sdk/pull/2078, (which are a very common scenario in the channels: I as an operator dev, would like to deploy the operator in the nsA and WATCH the resources in the nsB and do not all cluster ), 

Closes #2361
