### PR TITLE
fix: kclient.Discovery() deprecations

### DIFF
--- a/internal/scaffold/helm/role.go
+++ b/internal/scaffold/helm/role.go
@@ -37,7 +37,7 @@ import (
 // methods needed by the Helm role scaffold generator. Requiring just this
 // interface simplifies testing.
 type roleDiscoveryInterface interface {
-	ServerResources() ([]*metav1.APIResourceList, error)
+	ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error)
 }
 
 var DefaultRoleScaffold = scaffold.Role{
@@ -101,7 +101,7 @@ func GenerateRoleScaffold(dc roleDiscoveryInterface, chart *chart.Chart) scaffol
 
 func generateRoleRules(dc roleDiscoveryInterface, chart *chart.Chart) ([]rbacv1.PolicyRule,
 	[]rbacv1.PolicyRule, error) {
-	serverResources, err := dc.ServerResources()
+	_, serverResources, err := dc.ServerGroupsAndResources()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get server resources: %v", err)
 	}

--- a/internal/scaffold/helm/role_test.go
+++ b/internal/scaffold/helm/role_test.go
@@ -99,21 +99,9 @@ func simpleGroupList() []*metav1.APIGroup {
 	return []*metav1.APIGroup{
 		{
 			Name: "example",
-			Versions: []metav1.GroupVersionForDiscovery{
-				metav1.GroupVersionForDiscovery{
-					"v1",
-					"v1",
-				},
-			},
 		},
 		{
 			Name: "example2",
-			Versions: []metav1.GroupVersionForDiscovery{
-				metav1.GroupVersionForDiscovery{
-					"v2",
-					"v2",
-				},
-			},
 		},
 	}
 }

--- a/internal/scaffold/helm/role_test.go
+++ b/internal/scaffold/helm/role_test.go
@@ -28,11 +28,15 @@ import (
 
 func TestGenerateRoleScaffold(t *testing.T) {
 	validDiscoveryClient := &mockRoleDiscoveryClient{
-		serverResources: func() ([]*metav1.APIResourceList, error) { return simpleResourcesList(), nil },
+		serverGroupsAndResources: func() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+			return simpleGroupList(), simpleResourcesList(), nil
+		},
 	}
 
 	brokenDiscoveryClient := &mockRoleDiscoveryClient{
-		serverResources: func() ([]*metav1.APIResourceList, error) { return nil, errors.New("no server resources") },
+		serverGroupsAndResources: func() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+			return nil, nil, errors.New("no server resources")
+		},
 	}
 
 	testCases := []roleScaffoldTestCase{
@@ -84,11 +88,34 @@ func TestGenerateRoleScaffold(t *testing.T) {
 }
 
 type mockRoleDiscoveryClient struct {
-	serverResources func() ([]*metav1.APIResourceList, error)
+	serverGroupsAndResources func() ([]*metav1.APIGroup, []*metav1.APIResourceList, error)
 }
 
-func (dc *mockRoleDiscoveryClient) ServerResources() ([]*metav1.APIResourceList, error) {
-	return dc.serverResources()
+func (dc *mockRoleDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return dc.serverGroupsAndResources()
+}
+
+func simpleGroupList() []*metav1.APIGroup {
+	return []*metav1.APIGroup{
+		{
+			Name: "example",
+			Versions: []metav1.GroupVersionForDiscovery{
+				metav1.GroupVersionForDiscovery{
+					"v1",
+					"v1",
+				},
+			},
+		},
+		{
+			Name: "example2",
+			Versions: []metav1.GroupVersionForDiscovery{
+				metav1.GroupVersionForDiscovery{
+					"v2",
+					"v2",
+				},
+			},
+		},
+	}
 }
 
 func simpleResourcesList() []*metav1.APIResourceList {

--- a/pkg/ansible/proxy/proxy.go
+++ b/pkg/ansible/proxy/proxy.go
@@ -312,10 +312,7 @@ func (a *apiResources) resetResources() error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	// TODO(camilamacedo86): Fix deprecation
-	// SA1019: a.discoveryClient.ServerResources is deprecated: use ServerGroupsAndResources instead.  (staticcheck)
-	// nolint: staticcheck
-	apisResourceList, err := a.discoveryClient.ServerResources()
+	_, apisResourceList, err := a.discoveryClient.ServerGroupsAndResources()
 	if err != nil {
 		return err
 	}

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -91,10 +91,8 @@ func GetOperatorName() (string, error) {
 // ResourceExists returns true if the given resource kind exists
 // in the given api groupversion
 func ResourceExists(dc discovery.DiscoveryInterface, apiGroupVersion, kind string) (bool, error) {
-	// TODO(camilamacedo86): fix deprecation
-	// SA1019: dc.ServerResources is deprecated: use ServerGroupsAndResources instead.  (staticcheck)
-	// nolint:staticcheck
-	apiLists, err := dc.ServerResources()
+
+	_, apiLists, err := dc.ServerGroupsAndResources()
 	if err != nil {
 		return false, err
 	}

--- a/pkg/kube-metrics/uclient.go
+++ b/pkg/kube-metrics/uclient.go
@@ -57,10 +57,7 @@ func getAPIResource(cfg *rest.Config, apiVersion, kind string) (*metav1.APIResou
 		return nil, nil, err
 	}
 
-	// TODO(camilamacedo86): fix deprecation
-	// nolint:staticcheck
-	// SA1019: kclient.Discovery().ServerResources is deprecated: use ServerGroupsAndResources instead.  (staticcheck)
-	apiResourceLists, err := kclient.Discovery().ServerResources()
+	_, apiResourceLists, err := kclient.Discovery().ServerGroupsAndResources()
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
**Description**
- Replace the usage `ServerResource` by `ServerGroupsAndResources`
- Follow up it changes in the SDK internal API implemented to make easier the tests. (See @joelanford comment https://github.com/operator-framework/operator-sdk/pull/2541#pullrequestreview-356731570)

**Motivation**
- The `ServerResources` is deprecated and then is required to use instead of ServerGroupsAndResources instead.
- Solve technical debts in the project before 1.0.0

Note: deprecations occurred in client-go kubernetes-1.14.0.