### PR TITLE
rename wachFlags for Flags

### DIFF
--- a/internal/flags/watch/flags.go
+++ b/internal/flags/watch/flags.go
@@ -23,7 +23,7 @@ import (
 
 // Flags provides flag for configuration of a controller's reconcile period and for a
 // watches.yaml file, which is used to configure dynamic operators (e.g. Ansible and Helm).
-type Flags struct { //nolint:golint
+type Flags struct {
 	ReconcilePeriod time.Duration
 	WatchesFile     string
 }

--- a/internal/flags/watch/flags.go
+++ b/internal/flags/watch/flags.go
@@ -21,25 +21,16 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// WatchFlags provides flag for configuration of a controller's reconcile period and for a
+// Flags provides flag for configuration of a controller's reconcile period and for a
 // watches.yaml file, which is used to configure dynamic operators (e.g. Ansible and Helm).
-type WatchFlags struct { //nolint:golint
-	/*
-		The nolint is regards to: type name will be used as watch.WatchFlags by other packages, and that stutters;
-		consider calling this Flags (golint)
-		todo(camilamacedo86): Note that we decided to not introduce breakchanges to add the linters
-		and it should be done after.
-		From @joelanford: Even though watch.WatchFlags is an internal type, it is embedded in exported types,
-		which means that changing it to watch.Flags is a breaking change.
-	*/
-
+type Flags struct { //nolint:golint
 	ReconcilePeriod time.Duration
 	WatchesFile     string
 }
 
 // AddTo - Add the reconcile period and watches file flags to the the flagset
 // helpTextPrefix will allow you add a prefix to default help text. Joined by a space.
-func (f *WatchFlags) AddTo(flagSet *pflag.FlagSet, helpTextPrefix ...string) {
+func (f *Flags) AddTo(flagSet *pflag.FlagSet, helpTextPrefix ...string) {
 	flagSet.DurationVar(&f.ReconcilePeriod,
 		"reconcile-period",
 		time.Minute,

--- a/pkg/ansible/flags/flag.go
+++ b/pkg/ansible/flags/flag.go
@@ -24,7 +24,7 @@ import (
 
 // AnsibleOperatorFlags - Options to be used by an ansible operator
 type AnsibleOperatorFlags struct {
-	watch.WatchFlags
+	watch.Flags
 	InjectOwnerRef   bool
 	MaxWorkers       int
 	AnsibleVerbosity int
@@ -37,7 +37,7 @@ const AnsibleRolesPathEnvVar = "ANSIBLE_ROLES_PATH"
 // helpTextPrefix will allow you add a prefix to default help text. Joined by a space.
 func AddTo(flagSet *pflag.FlagSet, helpTextPrefix ...string) *AnsibleOperatorFlags {
 	aof := &AnsibleOperatorFlags{}
-	aof.WatchFlags.AddTo(flagSet, helpTextPrefix...)
+	aof.Flags.AddTo(flagSet, helpTextPrefix...)
 	flagSet.AddFlagSet(zap.FlagSet())
 	flagSet.BoolVar(&aof.InjectOwnerRef,
 		"inject-owner-ref",

--- a/pkg/helm/flags/flag.go
+++ b/pkg/helm/flags/flag.go
@@ -22,14 +22,14 @@ import (
 
 // HelmOperatorFlags - Options to be used by a helm operator
 type HelmOperatorFlags struct {
-	watch.WatchFlags
+	watch.Flags
 }
 
 // AddTo - Add the helm operator flags to the the flagset
 // helpTextPrefix will allow you add a prefix to default help text. Joined by a space.
 func AddTo(flagSet *pflag.FlagSet, helpTextPrefix ...string) *HelmOperatorFlags {
 	hof := &HelmOperatorFlags{}
-	hof.WatchFlags.AddTo(flagSet, helpTextPrefix...)
+	hof.Flags.AddTo(flagSet, helpTextPrefix...)
 	flagSet.AddFlagSet(zap.FlagSet())
 	return hof
 }


### PR DESCRIPTION
**Description of the change:**
- rename wachFlags for Flags

**Motivation for the change:**

Was decide not to do this change in the same pr where the lint was introduced. Even though watch.WatchFlags is an internal type, it is embedded in exported types, which means that changing it to watch.Flags is a breaking change which will not affect users since it is not used/exported to them.
