### PR TITLE
Deprecated test.TestCtx in order to rename test.TestCtx to test.Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Changed the scorecard basic test, `Writing into CRs has an effect`, to include the http.MethodPatch as part of its test criteria alongside http.MethodPut and http.MethodPost. ([#2509](https://github.com/operator-framework/operator-sdk/pull/2509))
 
 ### Deprecated
+- The type name `TestCtx` in `pkg/test` has been deprecated and renamed to `Context`. It now exists only as a type alias to maintain backwards compatibility. Users of the e2e framework should migrate to use the new name, `Context`. The `TestCtx` alias will be removed in a future version. ([2549](https://github.com/operator-framework/operator-sdk/pull/2549))
 
 - The additional of the dependency `inotify-tools` on Ansible based-operator images. ([#2586](https://github.com/operator-framework/operator-sdk/pull/2586))
 

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -10,7 +10,7 @@ as standard go tests.
 ## Components
 
 The test framework includes a few components. The most important to talk
-about are Framework and TestCtx.
+about are Framework and Context.
 
 ### Framework
 
@@ -18,11 +18,11 @@ about are Framework and TestCtx.
 scheme, and dynamic client (provided via the controller-runtime project).
 It is initialized by MainEntry and can be used anywhere in the tests.
 
-### TestCtx
+### Context
 
-[TestCtx][testctx-link] is a local context that stores important information for each test, such
+[Context][context-link] is a local context that stores important information for each test, such
 as the namespace for that test and the cleanup functions. By handling
-namespace and resource initialization through TestCtx, we can make sure that all
+namespace and resource initialization through Context, we can make sure that all
 resources are properly handled and removed after the test finishes.
 
 ## Walkthrough: Writing Tests
@@ -96,11 +96,11 @@ timeout after 5 seconds, returning an error if the mappings were not discovered 
 The next step is to create a TestCtx for the current test and defer its cleanup function:
 
 ```go
-ctx := framework.NewTestCtx(t)
+ctx := framework.NewContext(t)
 defer ctx.Cleanup()
 ```
 
-Now that there is a `TestCtx`, the test's Kubernetes resources (specifically the test namespace,
+Now that there is a `Context`, the test's Kubernetes resources (specifically the test namespace,
 Service Account, RBAC, and Operator deployment in `local` testing; just the Operator deployment
 in `cluster` testing) can be initialized:
 
@@ -211,8 +211,8 @@ if err != nil {
 }
 ```
 
-Once the end of the function is reached, the TestCtx's cleanup
-functions will automatically be run since they were deferred when the TestCtx was created.
+Once the end of the function is reached, the Context's cleanup
+functions will automatically be run since they were deferred when the Context was created.
 
 ## Running the Tests
 
@@ -341,7 +341,7 @@ $ kubectl delete -f deploy/crds/cache.example.com_memcacheds_crd.yaml
 
 [memcached-sample]:https://github.com/operator-framework/operator-sdk-samples/tree/master/go/memcached-operator
 [framework-link]:https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/framework.go
-[testctx-link]:https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/context.go
+[context-link]:https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/context.go
 [e2eutil-link]:https://github.com/operator-framework/operator-sdk/tree/master/pkg/test/e2eutil
 [memcached-test-link]:https://github.com/operator-framework/operator-sdk-samples/blob/master/go/memcached-operator/test/e2e/memcached_test.go
 [scheme-link]:https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/framework.go#L109

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -93,7 +93,7 @@ timeout after 5 seconds, returning an error if the mappings were not discovered 
 
 #### 3. Setup the test context and resources
 
-The next step is to create a TestCtx for the current test and defer its cleanup function:
+The next step is to create a Context for the current test and defer its cleanup function:
 
 ```go
 ctx := framework.NewContext(t)

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -75,7 +75,7 @@ func (f *Framework) newContext(t *testing.T) *Context {
 // Deprecated: NewTestCtx exists for historical compatibility
 // You should use NewContext instead of.
 // todo(camilamacedo86): remove before 1.0.0
-func NewTestCtx(t *testing.T) *Context {
+func NewTestCtx(t *testing.T) *TestCtx {
 	return Global.newContext(t)
 }
 

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -40,8 +40,7 @@ type Context struct {
 // todo(camilamacedo86): Remove the following line just added for we are able to deprecated TestCtx
 // need to be done before: 1.0.0
 
-// Deprecated: Context exists for historical compatibility
-// Yoou should use Context instead of.
+// Deprecated: Context exists for historical compatibility. Use Context instead.
 type TestCtx = Context //nolint:golint
 
 type CleanupOptions struct {
@@ -69,12 +68,12 @@ func (f *Framework) newContext(t *testing.T) *Context {
 		client:            f.Client,
 		kubeclient:        f.KubeClient,
 		restMapper:        f.restMapper,
+		skipCleanupOnError: f.skipCleanupOnError,
 	}
 }
 
-// Deprecated: NewTestCtx exists for historical compatibility
-// You should use NewContext instead of.
 // todo(camilamacedo86): remove before 1.0.0
+// Deprecated: NewTestCtx exists for historical compatibility. Use NewContext instead.
 func NewTestCtx(t *testing.T) *TestCtx {
 	return Global.newContext(t)
 }

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -40,7 +40,7 @@ type Context struct {
 // todo(camilamacedo86): Remove the following line just added for we are able to deprecated TestCtx
 // need to be done before: 1.0.0
 
-// Deprecated: Context exists for historical compatibility. Use Context instead.
+// Deprecated: TestCtx exists for historical compatibility. Use Context instead.
 type TestCtx = Context //nolint:golint
 
 type CleanupOptions struct {

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -24,11 +24,7 @@ import (
 	"k8s.io/client-go/restmapper"
 )
 
-type TestCtx struct { //nolint:golint
-	// todo(camilamacedo86): The no lint here is for type name will be used as test.TestCtx by other packages, and
-	//  that stutters; consider calling this Ctx (golint)
-	// However, was decided to not move forward with it now in order to not introduce breakchanges with the task to
-	// add the linter. We should to do it after.
+type Context struct {
 	id         string
 	cleanupFns []cleanupFn
 	namespace  string
@@ -41,43 +37,57 @@ type TestCtx struct { //nolint:golint
 	skipCleanupOnError bool
 }
 
+// todo(camilamacedo86): Remove the following line just added for we are able to deprecated TestCtx
+// need to be done before: 1.0.0
+
+// Deprecated: Context exists for historical compatibility
+// Yoou should use Context instead of.
+type TestCtx = Context //nolint:golint
+
 type CleanupOptions struct {
-	TestContext   *TestCtx
+	TestContext   *Context
 	Timeout       time.Duration
 	RetryInterval time.Duration
 }
 
 type cleanupFn func() error
 
-func (f *Framework) newTestCtx(t *testing.T) *TestCtx {
-	// TestCtx is used among others for namespace names where '/' is forbidden and must be 63 characters or less
+func (f *Framework) newContext(t *testing.T) *Context {
+
+	// Context is used among others for namespace names where '/' is forbidden and must be 63 characters or less
 	id := "osdk-e2e-" + uuid.New()
 
 	var namespace string
 	if f.singleNamespaceMode {
 		namespace = f.Namespace
 	}
-	return &TestCtx{
-		id:                 id,
-		t:                  t,
-		namespace:          namespace,
-		namespacedManPath:  *f.NamespacedManPath,
-		client:             f.Client,
-		kubeclient:         f.KubeClient,
-		restMapper:         f.restMapper,
-		skipCleanupOnError: f.skipCleanupOnError,
+	return &Context{
+		id:                id,
+		t:                 t,
+		namespace:         namespace,
+		namespacedManPath: *f.NamespacedManPath,
+		client:            f.Client,
+		kubeclient:        f.KubeClient,
+		restMapper:        f.restMapper,
 	}
 }
 
-func NewTestCtx(t *testing.T) *TestCtx {
-	return Global.newTestCtx(t)
+// Deprecated: NewTestCtx exists for historical compatibility
+// You should use NewContext instead of.
+// todo(camilamacedo86): remove before 1.0.0
+func NewTestCtx(t *testing.T) *Context {
+	return Global.newContext(t)
 }
 
-func (ctx *TestCtx) GetID() string {
+func NewContext(t *testing.T) *Context {
+	return Global.newContext(t)
+}
+
+func (ctx *Context) GetID() string {
 	return ctx.id
 }
 
-func (ctx *TestCtx) Cleanup() {
+func (ctx *Context) Cleanup() {
 	if ctx.t != nil {
 		// The cleanup function will be skipped
 		if ctx.t.Failed() && ctx.skipCleanupOnError {
@@ -103,6 +113,6 @@ func (ctx *TestCtx) Cleanup() {
 	}
 }
 
-func (ctx *TestCtx) AddCleanupFn(fn cleanupFn) {
+func (ctx *Context) AddCleanupFn(fn cleanupFn) {
 	ctx.cleanupFns = append(ctx.cleanupFns, fn)
 }

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -61,13 +61,13 @@ func (f *Framework) newContext(t *testing.T) *Context {
 		namespace = f.Namespace
 	}
 	return &Context{
-		id:                id,
-		t:                 t,
-		namespace:         namespace,
-		namespacedManPath: *f.NamespacedManPath,
-		client:            f.Client,
-		kubeclient:        f.KubeClient,
-		restMapper:        f.restMapper,
+		id:                 id,
+		t:                  t,
+		namespace:          namespace,
+		namespacedManPath:  *f.NamespacedManPath,
+		client:             f.Client,
+		kubeclient:         f.KubeClient,
+		restMapper:         f.restMapper,
 		skipCleanupOnError: f.skipCleanupOnError,
 	}
 }

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -72,7 +72,6 @@ func (f *Framework) newContext(t *testing.T) *Context {
 	}
 }
 
-// todo(camilamacedo86): remove before 1.0.0
 // Deprecated: NewTestCtx exists for historical compatibility. Use NewContext instead.
 func NewTestCtx(t *testing.T) *TestCtx {
 	return Global.newContext(t)

--- a/pkg/test/context_test.go
+++ b/pkg/test/context_test.go
@@ -21,13 +21,13 @@ import (
 	"github.com/pborman/uuid"
 )
 
-func TestNewTestCtxCreatesID(t *testing.T) {
+func TestNewContextCreatesID(t *testing.T) {
 	fakeNamespacedManPath := "fakePath"
 	Global = &Framework{
 		NamespacedManPath: &fakeNamespacedManPath,
 	}
 
-	ctx := NewTestCtx(t)
+	ctx := NewContext(t)
 
 	if strings.Index(ctx.GetID(), "osdk-e2e-") != 0 {
 		t.Error("ID should start with osdk-e2e-")

--- a/pkg/test/framework.go
+++ b/pkg/test/framework.go
@@ -217,7 +217,7 @@ func (f *Framework) addToScheme(addToScheme addToSchemeFunc, obj runtime.Object)
 
 func (f *Framework) runM(m *testing.M) (int, error) {
 	// setup context to use when setting up crd
-	ctx := f.newTestCtx(nil)
+	ctx := f.newContext(nil)
 	defer ctx.Cleanup()
 
 	// go test always runs from the test directory; change to project root

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-func (ctx *TestCtx) GetNamespace() (string, error) {
+func (ctx *Context) GetNamespace() (string, error) {
 	if ctx.namespace != "" {
 		return ctx.namespace, nil
 	}
@@ -48,7 +48,7 @@ func (ctx *TestCtx) GetNamespace() (string, error) {
 	return ctx.namespace, nil
 }
 
-func (ctx *TestCtx) createFromYAML(yamlFile []byte, skipIfExists bool, cleanupOptions *CleanupOptions) error {
+func (ctx *Context) createFromYAML(yamlFile []byte, skipIfExists bool, cleanupOptions *CleanupOptions) error {
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
 		return err
@@ -101,7 +101,7 @@ func (ctx *TestCtx) createFromYAML(yamlFile []byte, skipIfExists bool, cleanupOp
 	return nil
 }
 
-func (ctx *TestCtx) InitializeClusterResources(cleanupOptions *CleanupOptions) error {
+func (ctx *Context) InitializeClusterResources(cleanupOptions *CleanupOptions) error {
 	// create namespaced resources
 	namespacedYAML, err := ioutil.ReadFile(ctx.namespacedManPath)
 	if err != nil {

--- a/test/e2e/_incluster-test-code/memcached_test.go
+++ b/test/e2e/_incluster-test-code/memcached_test.go
@@ -65,7 +65,7 @@ func TestMemcached(t *testing.T) {
 	})
 }
 
-func memcachedLeaderTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
+func memcachedLeaderTest(t *testing.T, f *framework.Framework, ctx *framework.Context) error {
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
 		return err
@@ -160,7 +160,7 @@ func verifyLeader(t *testing.T, namespace string, f *framework.Framework, labels
 	return nil, fmt.Errorf("did not find operator pod that was referenced by configmap")
 }
 
-func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, fromReplicas, toReplicas int) error {
+func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Context, fromReplicas, toReplicas int) error {
 	name := "example-memcached"
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
@@ -177,7 +177,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 			Size: int32(fromReplicas),
 		},
 	}
-	// use TestCtx's create helper to create the object and add a cleanup function for the new object
+	// use Context's create helper to create the object and add a cleanup function for the new object
 	err = f.Client.Create(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		return fmt.Errorf("could no create CR: %v", err)
@@ -211,7 +211,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 
 func MemcachedLocal(t *testing.T) {
 	// get global framework variables
-	ctx := framework.NewTestCtx(t)
+	ctx := framework.NewContext(t)
 	defer ctx.Cleanup()
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
@@ -265,7 +265,7 @@ func MemcachedLocal(t *testing.T) {
 
 func MemcachedCluster(t *testing.T) {
 	// get global framework variables
-	ctx := framework.NewTestCtx(t)
+	ctx := framework.NewContext(t)
 	defer ctx.Cleanup()
 
 	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
@@ -305,7 +305,7 @@ func MemcachedCluster(t *testing.T) {
 	t.Log("Completed memcached custom resource metrics test")
 }
 
-func memcachedMetricsTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
+func memcachedMetricsTest(t *testing.T, f *framework.Framework, ctx *framework.Context) error {
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
 		return err
@@ -347,7 +347,7 @@ func memcachedMetricsTest(t *testing.T, f *framework.Framework, ctx *framework.T
 	return nil
 }
 
-func memcachedOperatorMetricsTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
+func memcachedOperatorMetricsTest(t *testing.T, f *framework.Framework, ctx *framework.Context) error {
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
 		return err

--- a/test/e2e/tls_util_test.go
+++ b/test/e2e/tls_util_test.go
@@ -82,7 +82,7 @@ func init() {
 // and CA TLS assets exist in the k8s cluster for a given cr,
 // the GenerateCert() simply returns those to the caller.
 func TestBothAppAndCATLSAssetsExist(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
+	ctx := framework.NewContext(t)
 	defer ctx.Cleanup()
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
@@ -127,7 +127,7 @@ func TestBothAppAndCATLSAssetsExist(t *testing.T) {
 // it won't verify the existing application TLS cert. Therefore, CertGenerator can't proceed
 // and returns an error to the caller.
 func TestOnlyAppSecretExist(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
+	ctx := framework.NewContext(t)
 	defer ctx.Cleanup()
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
@@ -153,7 +153,7 @@ func TestOnlyAppSecretExist(t *testing.T) {
 // TestOnlyCAExist tests the case where only the CA exists in the cluster;
 // GenerateCert can retrieve the CA and uses it to create a new application secret.
 func TestOnlyCAExist(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
+	ctx := framework.NewContext(t)
 	defer ctx.Cleanup()
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
@@ -182,7 +182,7 @@ func TestOnlyCAExist(t *testing.T) {
 // TestNoneOfCaAndAppSecretExist ensures that when none of the CA and Application TLS assets
 // exist, GenerateCert() creates both and put them into the k8s cluster.
 func TestNoneOfCaAndAppSecretExist(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
+	ctx := framework.NewContext(t)
 	defer ctx.Cleanup()
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
@@ -204,7 +204,7 @@ func TestNoneOfCaAndAppSecretExist(t *testing.T) {
 // TestCustomCA ensures that if a user provides a custom Key and Cert and the CA and Application TLS assets
 // do not exist, the GenerateCert method can use the custom CA to generate the TLS assest.
 func TestCustomCA(t *testing.T) {
-	ctx := framework.NewTestCtx(t)
+	ctx := framework.NewContext(t)
 	defer ctx.Cleanup()
 	namespace, err := ctx.GetNamespace()
 	if err != nil {

--- a/test/test-framework/test/e2e/memcached_test.go
+++ b/test/test-framework/test/e2e/memcached_test.go
@@ -50,7 +50,7 @@ func TestMemcached(t *testing.T) {
 	})
 }
 
-func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx, fromReplicas, toReplicas int) error {
+func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Context, fromReplicas, toReplicas int) error {
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
 		return fmt.Errorf("could not get namespace: %v", err)
@@ -66,7 +66,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 		},
 	}
 	key := types.NamespacedName{Name: exampleMemcached.GetName(), Namespace: exampleMemcached.GetNamespace()}
-	// use TestCtx's create helper to create the object and add a cleanup function for the new object
+	// use Context's create helper to create the object and add a cleanup function for the new object
 	err = f.Client.Create(goctx.TODO(), exampleMemcached, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		return fmt.Errorf("could not create %q: %v", key, err)
@@ -100,7 +100,7 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 
 func MemcachedCluster(t *testing.T) {
 	t.Parallel()
-	ctx := framework.NewTestCtx(t)
+	ctx := framework.NewContext(t)
 	defer ctx.Cleanup()
 	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {


### PR DESCRIPTION
**Description of the change:**
- Deprecated `test.TestCtx` in order to rename test.TestCtx to test.Context

**Motivation for the change:**
- Following the good practices since we should not have `test.Test`;
- Be able to rename the API before 1.0.0
- Solve tech-debts