### PR TITLE
update instructions for building operator-sdk

### DIFF
--- a/doc/dev/developer_guide.md
+++ b/doc/dev/developer_guide.md
@@ -4,7 +4,7 @@ This document explains how to setup your dev environment.
 
 ## Prerequisites
 - [git][git-tool]
-- [go][go-tool] version v1.12+
+- [go][go-tool] version v1.13+
 
 ## Download Operator SDK
 

--- a/doc/user/install-operator-sdk.md
+++ b/doc/user/install-operator-sdk.md
@@ -86,12 +86,15 @@ $ chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin && sudo mkdir -p 
 - [go][go_tool] version v1.13+.
 
 ```sh
-$ go get -d github.com/operator-framework/operator-sdk # This will download the git repository and not install it
-$ cd $GOPATH/src/github.com/operator-framework/operator-sdk
+$ git clone https://github.com/operator-framework/operator-sdk
+$ cd operator-sdk
 $ git checkout master
 $ make tidy
 $ make install
 ```
+
+**Note:** Ensure that your `GOPROXY` is set with its default value for Go
+versions 1.13+ which is `https://proxy.golang.org,direct`.
 
 [homebrew_tool]:https://brew.sh/
 [git_tool]:https://git-scm.com/downloads


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

this change updates the minimum required go lang version in one of the developer docs, and also changes the method for downloading the source code. it should produce fewer warnings for developers wishing to install operator-sdk from source. it also adds a note about needing GOPROXY set to its default.


**Motivation for the change:**

Inspired by warning messages found while investigating issue #2573, the proposed changes here produce fewer warnings during installation for developers.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
