### PR TITLE
 Add event stats output to the operator logs for Ansible based-operators.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - On `generate csv`, populate a CSV manifest’s `spec.icon`, `spec.keywords`, and `spec.mantainers` fields with empty values to better inform users how to add data. ([#2521](https://github.com/operator-framework/operator-sdk/pull/2521))
 - Scaffold code in `cmd/manager/main.go` for Go operators and add logic to Ansible/Helm operators to handle [multinamespace caching](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder) if `WATCH_NAMESPACE` contains multiple namespaces. ([#2522](https://github.com/operator-framework/operator-sdk/pull/2522))
 - Add a new flag option (`--skip-cleanup-error`) to the test framework to allow skip the function which will remove all artefacts when an error be faced to perform this operation.   ([#2512](https://github.com/operator-framework/operator-sdk/pull/2512))
+- Add event stats output to the operator logs for Ansible based-operators. ([2580](https://github.com/operator-framework/operator-sdk/pull/2580))   
 
 ### Changed
 - Ansible scaffolding has been rewritten to be simpler and make use of newer features of Ansible and Molecule.

--- a/pkg/ansible/controller/reconcile.go
+++ b/pkg/ansible/controller/reconcile.go
@@ -176,10 +176,12 @@ func (r *AnsibleOperatorReconciler) Reconcile(request reconcile.Request) (reconc
 			// convert to StatusJobEvent; would love a better way to do this
 			data, err := json.Marshal(event)
 			if err != nil {
+				printEventStats(statusEvent)
 				return reconcile.Result{}, err
 			}
 			err = json.Unmarshal(data, &statusEvent)
 			if err != nil {
+				printEventStats(statusEvent)
 				return reconcile.Result{}, err
 			}
 		}
@@ -187,6 +189,10 @@ func (r *AnsibleOperatorReconciler) Reconcile(request reconcile.Request) (reconc
 			failureMessages = append(failureMessages, event.GetFailedPlaybookMessage())
 		}
 	}
+
+	// To print the stats of the task
+	printEventStats(statusEvent)
+
 	if statusEvent.Event == "" {
 		eventErr := errors.New("did not receive playbook_on_stats event")
 		stdout, err := result.Stdout()
@@ -247,6 +253,12 @@ func (r *AnsibleOperatorReconciler) Reconcile(request reconcile.Request) (reconc
 		return reconcileResult, errors.New("received failed task event")
 	}
 	return reconcileResult, nil
+}
+
+func printEventStats(statusEvent eventapi.StatusJobEvent) {
+	fmt.Printf("\n--------------------------- Ansible Task Status Event StdOut  -----------------\n")
+	fmt.Println(statusEvent.StdOut)
+	fmt.Printf("\n-------------------------------------------------------------------------------\n")
 }
 
 func (r *AnsibleOperatorReconciler) markRunning(u *unstructured.Unstructured,


### PR DESCRIPTION
**Description**
 Add event stats output to the operator logs for Ansible based-operators.

**Motivation**
Allow we remove the ansible container ( Related to #2007 )

