### PR TITLE
Deprecated `inotify-tools` on Ansible based-operator images and remove Ansible sidecar container.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@
 
 ### Deprecated
 
+- The additional of the dependency `inotify-tools` on Ansible based-operator images. ([#2586](https://github.com/operator-framework/operator-sdk/pull/2586))
+
 ### Removed
+
+-  **Breaking Change:** The additional Ansible sidecar container. ([#2586](https://github.com/operator-framework/operator-sdk/pull/2586))
 
 ### Bug Fixes
 

--- a/cmd/operator-sdk/migrate/cmd.go
+++ b/cmd/operator-sdk/migrate/cmd.go
@@ -127,6 +127,7 @@ func migrateAnsible() error {
 		&dockerfile,
 		&ansible.Entrypoint{},
 		&ansible.UserSetup{},
+		// todo(camilamacedo86): It is deprecated and should be removed before 1.0.0
 		&ansible.AoLogs{},
 	)
 	if err != nil {

--- a/doc/ansible/dev/developer_guide.md
+++ b/doc/ansible/dev/developer_guide.md
@@ -312,18 +312,14 @@ foo-operator       1         1         1            1           1m
 
 #### Viewing the Ansible logs
 
-The `foo-operator` deployment creates a Pod with two containers, `operator` and `ansible`.
-The `ansible` container exists only to expose the standard Ansible stdout logs that most Ansible
-users will be familiar with. In order to see the logs from a particular container, you can run
+In order to see the logs from a particular you can run:
 
 ```sh
-kubectl logs deployment/foo-operator -c ansible
-kubectl logs deployment/foo-operator -c operator
+kubectl logs deployment/foo-operator 
 ```
 
-The `ansible` logs contain all of the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks,
-whereas the `operator` logs will contain much more detailed information about the Ansible Operator's internals and interface with Kubernetes.
-
+The logs contain the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks. Note that the
+logs will contain much more detailed information about the Ansible Operator's internals and interface with Kubernetes as well.
 
 ## Custom Resource Status Management
 The operator will automatically update the CR's `status` subresource with

--- a/doc/ansible/dev/developer_guide.md
+++ b/doc/ansible/dev/developer_guide.md
@@ -318,8 +318,8 @@ In order to see the logs from a particular you can run:
 kubectl logs deployment/foo-operator 
 ```
 
-The logs contain the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks. Note that the
-logs will contain much more detailed information about the Ansible Operator's internals and interface with Kubernetes as well.
+The logs contain the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks. 
+Note that the logs will contain much more detailed information about the Ansible Operator's internals and interface with Kubernetes as well.
 
 ## Custom Resource Status Management
 The operator will automatically update the CR's `status` subresource with

--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -360,8 +360,8 @@ In order to see the logs from a particular you can run:
 kubectl logs deployment/memcached-operator
 ```
 
-The logs contain the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks. Note that the
-logs will contain much more detailed information about the Ansible Operator's internals and interface with Kubernetes as well.
+The logs contain the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks. 
+Note that the logs will contain much more detailed information about the Ansible Operator's internals and interface with Kubernetes as well.
 
 ### Additional Ansible Debug
 

--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -354,17 +354,14 @@ memcached-operator-7cc7cfdf86-vvjqk   2/2       Running   0          2m
 
 ### View the Ansible logs
 
-The `memcached-operator` deployment creates a Pod with two containers, `operator` and `ansible`.
-The `ansible` container exists only to expose the standard Ansible stdout logs that most Ansible
-users will be familiar with. In order to see the logs from a particular container, you can run
+In order to see the logs from a particular you can run:
 
 ```sh
-kubectl logs deployment/memcached-operator -c ansible
-kubectl logs deployment/memcached-operator -c operator
+kubectl logs deployment/memcached-operator
 ```
 
-The `ansible` logs contain all of the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks,
-whereas the `operator` logs will contain much more detailed information about the Ansible Operator's internals and interface with Kubernetes.
+The logs contain the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks. Note that the
+logs will contain much more detailed information about the Ansible Operator's internals and interface with Kubernetes as well.
 
 ### Additional Ansible Debug
 

--- a/doc/migration/version-upgrade-guide.md
+++ b/doc/migration/version-upgrade-guide.md
@@ -810,6 +810,43 @@ This release contains breaking changes in some commands.
 
 See the [CHANGELOG](https://github.com/operator-framework/operator-sdk/blob/master/CHANGELOG.md#v0151) for details of the release.
 
+## Unreleased
+
+### Breaking changes
+
+#### Remove Ansible container sidecar
+
+The additional of the dependency `inotify-tools` on Ansible based-operator images is deprecated and it will be removed in the next versions. In this way, update the `deploy/operator.yaml` file as follows.
+
+Remove:
+
+```
+- name: ansible
+  command:
+    - /usr/local/bin/ao-logs
+    - /tmp/ansible-operator/runner
+    - stdout
+  # Replace this with the built image name
+  image: "REPLACE_IMAGE"
+  imagePullPolicy: "Always"
+  volumeMounts:
+    - mountPath: /tmp/ansible-operator/runner
+    name: runner
+    readOnly: true
+```
+
+Replace:
+
+```yaml 
+- name: operator
+```
+
+With:
+
+```yaml 
+- name: {{your operator name which is the value of metadata.name in this file}}
+```
+
 [legacy-kubebuilder-doc-crd]: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 [v0.8.2-go-mod]: https://github.com/operator-framework/operator-sdk/blob/28bd2b0d4fd25aa68e15d928ae09d3c18c3b51da/internal/pkg/scaffold/go_mod.go#L40-L94
 [activating-modules]: https://github.com/golang/go/wiki/Modules#how-to-install-and-activate-module-support

--- a/hack/image/ansible/scaffold-ansible-image.go
+++ b/hack/image/ansible/scaffold-ansible-image.go
@@ -38,6 +38,7 @@ func main() {
 		&ansible.DockerfileHybrid{},
 		&ansible.Entrypoint{},
 		&ansible.UserSetup{},
+		// todo(camilamacedo86): It is deprecated and should be removed before 1.0.0
 		&ansible.AoLogs{},
 	)
 	if err != nil {

--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -40,9 +40,7 @@ operator_logs() {
     header_text "Getting events"
     kubectl get events
     header_text "Getting operator logs"
-    kubectl logs deployment/memcached-operator -c operator
-    header_text "Getting Ansible logs"
-    kubectl logs deployment/memcached-operator -c ansible
+    kubectl logs deployment/memcached-operator
 }
 
 test_operator() {
@@ -109,7 +107,7 @@ test_operator() {
     fi
 
     header_text "Verify that config map requests skip the cache."
-    if ! kubectl logs deployment/memcached-operator -c operator | grep -e "Skipping cache lookup\".*"Path\":\"\/api\/v1\/namespaces\/default\/configmaps\/test-blacklist-watches\";
+    if ! kubectl logs deployment/memcached-operator | grep -e "Skipping cache lookup\".*"Path\":\"\/api\/v1\/namespaces\/default\/configmaps\/test-blacklist-watches\";
     then
         error_text "FAIL: test-blacklist-watches should not be accessible with the cache."
         operator_logs
@@ -157,7 +155,7 @@ test_operator() {
     fi
 
     header_text "Ensure that no errors appear in the log"
-    if kubectl logs deployment/memcached-operator -c operator | grep -i error;
+    if kubectl logs deployment/memcached-operator| grep -i error;
     then
         error_text "FAIL: the operator log includes errors"
         operator_logs

--- a/internal/scaffold/ansible/ao_logs.go
+++ b/internal/scaffold/ansible/ao_logs.go
@@ -39,13 +39,14 @@ func (a *AoLogs) GetInput() (input.Input, error) {
 
 const aoLogsTmpl = `#!/bin/bash
 
+echo "WARN: This script is deprecated and will soon be removed"
+
 watch_dir=${1:-/tmp/ansible-operator/runner}
 filename=${2:-stdout}
 mkdir -p ${watch_dir}
 inotifywait -r -m -e close_write ${watch_dir} | while read dir op file
 do
   if [[ "${file}" = "${filename}" ]] ; then
-    echo "WARN: This script is deprecated and will soon be removed"
     echo "${dir}/${file}"
     cat ${dir}/${file}
   fi

--- a/internal/scaffold/ansible/ao_logs.go
+++ b/internal/scaffold/ansible/ao_logs.go
@@ -20,6 +20,8 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/scaffold/input"
 )
 
+// todo(camilamacedo86): Remove before 1.0.0
+// Deprecated : The dep inotify-tools will be removed and then, it will no long be required.
 //DockerfileHybrid - Dockerfile for a hybrid operator
 type AoLogs struct {
 	StaticInput
@@ -35,8 +37,6 @@ func (a *AoLogs) GetInput() (input.Input, error) {
 	return a.Input, nil
 }
 
-//TODO: Change this implementation for no longer use inotifywait.
-// More Info: https://github.com/operator-framework/operator-sdk/issues/2007
 const aoLogsTmpl = `#!/bin/bash
 
 watch_dir=${1:-/tmp/ansible-operator/runner}
@@ -45,6 +45,7 @@ mkdir -p ${watch_dir}
 inotifywait -r -m -e close_write ${watch_dir} | while read dir op file
 do
   if [[ "${file}" = "${filename}" ]] ; then
+    echo "WARN: This script is deprecated and will soon be removed"
     echo "${dir}/${file}"
     cat ${dir}/${file}
   fi

--- a/internal/scaffold/ansible/deploy_operator.go
+++ b/internal/scaffold/ansible/deploy_operator.go
@@ -55,19 +55,7 @@ spec:
     spec:
       serviceAccountName: [[.ProjectName]]
       containers:
-        - name: ansible
-          command:
-          - /usr/local/bin/ao-logs
-          - /tmp/ansible-operator/runner
-          - stdout
-          # Replace this with the built image name
-          image: "REPLACE_IMAGE"
-          imagePullPolicy: "Always"
-          volumeMounts:
-          - mountPath: /tmp/ansible-operator/runner
-            name: runner
-            readOnly: true
-        - name: operator
+        - name: [[.ProjectName]]
           # Replace this with the built image name
           image: "REPLACE_IMAGE"
           imagePullPolicy: "Always"

--- a/internal/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/scaffold/ansible/dockerfilehybrid.go
@@ -65,9 +65,11 @@ ENV OPERATOR=/usr/local/bin/ansible-operator \
 RUN yum clean all && rm -rf /var/cache/yum/* \
  && yum -y update \
  && yum install -y libffi-devel openssl-devel python36-devel gcc python3-pip python3-setuptools \
- # todo: remove inotify-tools. More info: See https://github.com/operator-framework/operator-sdk/issues/2007
+ # todo(camilamacedo) : remove the FEDORA and inotify-tools before 1.0.0 
+ # ---- The usage of inotify-tools here is deprecated
  && FEDORA=$(case $(arch) in ppc64le|s390x) echo -n fedora-secondary ;; *) echo -n fedora/linux ;; esac) \
  && yum install -y https://dl.fedoraproject.org/pub/$FEDORA/releases/30/Everything/$(arch)/os/Packages/i/inotify-tools-3.14-16.fc30.$(arch).rpm \
+ # ---- 
  && pip3 install --no-cache-dir --ignore-installed ipaddress \
       ansible-runner==1.3.4 \
       ansible-runner-http==1.0.0 \

--- a/internal/scaffold/ansible/molecule_templates_operator.go
+++ b/internal/scaffold/ansible/molecule_templates_operator.go
@@ -54,19 +54,7 @@ spec:
     spec:
       serviceAccountName: [[.ProjectName]]
       containers:
-        - name: ansible
-          command:
-          - /usr/local/bin/ao-logs
-          - /tmp/ansible-operator/runner
-          - stdout
-          # Replace this with the built image name
-          image: "{{ image }}"
-          imagePullPolicy: "{{ pull_policy }}"
-          volumeMounts:
-          - mountPath: /tmp/ansible-operator/runner
-            name: runner
-            readOnly: true
-        - name: operator
+        - name: [[.ProjectName]]
           # Replace this with the built image name
           image: "{{ image }}"
           imagePullPolicy: "{{ pull_policy }}"

--- a/test/ansible-memcached/verify.yml
+++ b/test/ansible-memcached/verify.yml
@@ -192,22 +192,12 @@
       - name: get operator logs
         ignore_errors: yes
         failed_when: false
-        command: kubectl logs deployment/{{ definition.metadata.name }} -n {{ namespace }} -c operator
+        command: kubectl logs deployment/{{ definition.metadata.name }} -n {{ namespace }}
         vars:
           definition: "{{ lookup('file', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
         register: log
 
       - debug: var=log.stdout_lines
-
-      - name: get ansible logs
-        ignore_errors: yes
-        failed_when: false
-        command: kubectl logs deployment/{{ definition.metadata.name }} -n {{ namespace }} -c ansible
-        vars:
-          definition: "{{ lookup('file', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
-        register: ansible_log
-
-      - debug: var=ansible_log.stdout_lines
 
       - fail:
           msg: "Failed in verify.yml"

--- a/test/ansible/deploy/operator.yaml
+++ b/test/ansible/deploy/operator.yaml
@@ -16,18 +16,6 @@ spec:
       serviceAccountName: ansible
       containers:
         - name: ansible
-          command:
-          - /usr/local/bin/ao-logs
-          - /tmp/ansible-operator/runner
-          - stdout
-          # Replace this with the built image name
-          image: "REPLACE_IMAGE"
-          imagePullPolicy: "Always"
-          volumeMounts:
-          - mountPath: /tmp/ansible-operator/runner
-            name: runner
-            readOnly: true
-        - name: operator
           # Replace this with the built image name
           image: "REPLACE_IMAGE"
           imagePullPolicy: "Always"

--- a/test/ansible/molecule/templates/operator.yaml.j2
+++ b/test/ansible/molecule/templates/operator.yaml.j2
@@ -15,18 +15,6 @@ spec:
     spec:
       serviceAccountName: ansible
       containers:
-        - name: ansible
-          command:
-          - /usr/local/bin/ao-logs
-          - /tmp/ansible-operator/runner
-          - stdout
-          # Replace this with the built image name
-          image: "{{ image }}"
-          imagePullPolicy: "{{ pull_policy }}"
-          volumeMounts:
-          - mountPath: /tmp/ansible-operator/runner
-            name: runner
-            readOnly: true
         - name: operator
           # Replace this with the built image name
           image: "{{ image }}"


### PR DESCRIPTION
**Description of the change:**
- Improve the log in the operator to add the event stats 
- Remove the ansible sidecar container used just to provide the Ansible logs. 
- deprecated the inotify-tools usage in order to be able to remove it before 1.0.0

**Motivation for the change:**

Closes #2007

