### PR TITLE
Allow Ansible watches to use collection roles

### DIFF
--- a/cmd/operator-sdk/execentrypoint/ansible.go
+++ b/cmd/operator-sdk/execentrypoint/ansible.go
@@ -38,7 +38,7 @@ in a Pod inside a cluster. Developers wanting to run their operator locally
 should use "run --local" instead.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logf.SetLogger(zap.Logger())
-			err := setAnsibleRolePathEnvVar(flags)
+			err := setAnsibleEnvVars(flags)
 			if err != nil {
 				log.Error(err)
 				os.Exit(1)
@@ -51,15 +51,23 @@ should use "run --local" instead.`,
 	return runAnsibleCmd
 }
 
-// setAnsibleRolePathEnvVar will set the default role path for the ANSIBLE_ROLES_PATH
-func setAnsibleRolePathEnvVar(flags *aoflags.AnsibleOperatorFlags) error {
-	if flags != nil && len(flags.AnsibleRolesPath) > 0 {
-		if err := os.Setenv(aoflags.AnsibleRolesPathEnvVar, flags.AnsibleRolesPath); err != nil {
-			return fmt.Errorf("failed to set %s environment variable: (%v)", aoflags.AnsibleRolesPathEnvVar, err)
+// setAnsibleEnvVars will set Ansible-defined environment variables from CLI flags.
+func setAnsibleEnvVars(flags *aoflags.AnsibleOperatorFlags) error {
+	if flags != nil {
+		if len(flags.AnsibleRolesPath) > 0 {
+			if err := os.Setenv(aoflags.AnsibleRolesPathEnvVar, flags.AnsibleRolesPath); err != nil {
+				return fmt.Errorf("failed to set %s environment variable: (%v)", aoflags.AnsibleRolesPathEnvVar, err)
+			}
+			log.Info(fmt.Sprintf("set the value %v for environment variable %v.", flags.AnsibleRolesPath,
+				aoflags.AnsibleRolesPathEnvVar))
 		}
-		log.Info(fmt.Sprintf("set the value %v for environment variable %v.", flags.AnsibleRolesPath,
-			aoflags.AnsibleRolesPathEnvVar))
+		if len(flags.AnsibleCollectionsPath) > 0 {
+			if err := os.Setenv(aoflags.AnsibleCollectionsPathEnvVar, flags.AnsibleCollectionsPath); err != nil {
+				return fmt.Errorf("failed to set %s environment variable: (%v)", aoflags.AnsibleCollectionsPathEnvVar, err)
+			}
+			log.Info(fmt.Sprintf("set the value %v for environment variable %v.", flags.AnsibleCollectionsPath,
+				aoflags.AnsibleCollectionsPathEnvVar))
+		}
 	}
-
 	return nil
 }

--- a/cmd/operator-sdk/execentrypoint/ansible.go
+++ b/cmd/operator-sdk/execentrypoint/ansible.go
@@ -58,14 +58,14 @@ func setAnsibleEnvVars(flags *aoflags.AnsibleOperatorFlags) error {
 			if err := os.Setenv(aoflags.AnsibleRolesPathEnvVar, flags.AnsibleRolesPath); err != nil {
 				return fmt.Errorf("failed to set %s environment variable: (%v)", aoflags.AnsibleRolesPathEnvVar, err)
 			}
-			log.Infof("set the value %v for environment variable %v.",
+			log.Infof("Set the value %v for environment variable %v.",
 				flags.AnsibleRolesPath, aoflags.AnsibleRolesPathEnvVar)
 		}
 		if len(flags.AnsibleCollectionsPath) > 0 {
 			if err := os.Setenv(aoflags.AnsibleCollectionsPathEnvVar, flags.AnsibleCollectionsPath); err != nil {
 				return fmt.Errorf("failed to set %s environment variable: (%v)", aoflags.AnsibleCollectionsPathEnvVar, err)
 			}
-			log.Infof("set the value %v for environment variable %v.",
+			log.Infof("Set the value %v for environment variable %v.",
 				flags.AnsibleCollectionsPath, aoflags.AnsibleCollectionsPathEnvVar)
 		}
 	}

--- a/cmd/operator-sdk/execentrypoint/ansible.go
+++ b/cmd/operator-sdk/execentrypoint/ansible.go
@@ -58,13 +58,15 @@ func setAnsibleEnvVars(flags *aoflags.AnsibleOperatorFlags) error {
 			if err := os.Setenv(aoflags.AnsibleRolesPathEnvVar, flags.AnsibleRolesPath); err != nil {
 				return fmt.Errorf("failed to set %s environment variable: (%v)", aoflags.AnsibleRolesPathEnvVar, err)
 			}
-			log.Infof("set the value %v for environment variable %v.", flags.AnsibleRolesPath, aoflags.AnsibleRolesPathEnvVar)
+			log.Infof("set the value %v for environment variable %v.",
+				flags.AnsibleRolesPath, aoflags.AnsibleRolesPathEnvVar)
 		}
 		if len(flags.AnsibleCollectionsPath) > 0 {
 			if err := os.Setenv(aoflags.AnsibleCollectionsPathEnvVar, flags.AnsibleCollectionsPath); err != nil {
 				return fmt.Errorf("failed to set %s environment variable: (%v)", aoflags.AnsibleCollectionsPathEnvVar, err)
 			}
-			log.Infof("set the value %v for environment variable %v.", flags.AnsibleCollectionsPath, aoflags.AnsibleCollectionsPathEnvVar)
+			log.Infof("set the value %v for environment variable %v.",
+				flags.AnsibleCollectionsPath, aoflags.AnsibleCollectionsPathEnvVar)
 		}
 	}
 	return nil

--- a/cmd/operator-sdk/execentrypoint/ansible.go
+++ b/cmd/operator-sdk/execentrypoint/ansible.go
@@ -58,15 +58,13 @@ func setAnsibleEnvVars(flags *aoflags.AnsibleOperatorFlags) error {
 			if err := os.Setenv(aoflags.AnsibleRolesPathEnvVar, flags.AnsibleRolesPath); err != nil {
 				return fmt.Errorf("failed to set %s environment variable: (%v)", aoflags.AnsibleRolesPathEnvVar, err)
 			}
-			log.Info(fmt.Sprintf("set the value %v for environment variable %v.", flags.AnsibleRolesPath,
-				aoflags.AnsibleRolesPathEnvVar))
+			log.Infof("set the value %v for environment variable %v.", flags.AnsibleRolesPath, aoflags.AnsibleRolesPathEnvVar)
 		}
 		if len(flags.AnsibleCollectionsPath) > 0 {
 			if err := os.Setenv(aoflags.AnsibleCollectionsPathEnvVar, flags.AnsibleCollectionsPath); err != nil {
 				return fmt.Errorf("failed to set %s environment variable: (%v)", aoflags.AnsibleCollectionsPathEnvVar, err)
 			}
-			log.Info(fmt.Sprintf("set the value %v for environment variable %v.", flags.AnsibleCollectionsPath,
-				aoflags.AnsibleCollectionsPathEnvVar))
+			log.Infof("set the value %v for environment variable %v.", flags.AnsibleCollectionsPath, aoflags.AnsibleCollectionsPathEnvVar)
 		}
 	}
 	return nil

--- a/doc/ansible/dev/advanced_options.md
+++ b/doc/ansible/dev/advanced_options.md
@@ -137,7 +137,6 @@ command:
    setting the `"ansible.operator-sdk/verbosity"` annotation on the Custom
    Resource.
 
-
 ### Examples
 
 For demonstration purposes, let us assume that we have a database operator that

--- a/doc/ansible/dev/advanced_options.md
+++ b/doc/ansible/dev/advanced_options.md
@@ -137,6 +137,7 @@ command:
    setting the `"ansible.operator-sdk/verbosity"` annotation on the Custom
    Resource.
 
+
 ### Examples
 
 For demonstration purposes, let us assume that we have a database operator that

--- a/doc/ansible/dev/finalizers.md
+++ b/doc/ansible/dev/finalizers.md
@@ -40,8 +40,9 @@ path to a playbook on the operator’s file system.
 One of `playbook`, `role`, or `vars` must be provided. If `role` is not provided, it
 will default to the role specified at the top level of the `watches.yaml` entry.
 
-This field is identical to the top-level `role` field. It requires an absolute
-path to a role on the operator’s file system.
+This field is identical to the top-level `role` field.
+https://github.com/operator-framework/operator-sdk/blob/master/doc/ansible/user-guide.md#watches-file
+
 
 #### vars
 
@@ -114,6 +115,20 @@ This example will run the `/opt/ansible/roles/teardown_database` role when the C
 ```
 
 This example will run the `/opt/ansible/destroy.yml` playbook when the Custom Resource is deleted.
+
+```yaml
+---
+- version: v1alpha1
+  group: app.example.com
+  kind: Database
+  playbook: playbook.yml
+  finalizer:
+    name: finalizer.app.example.com
+    role: myNamespace.myCollection.myRole
+```
+
+This example will run the `myRole` when the Custom Resource is deleted. (The collection must have been installed.)
+
 
 ### Run a different playbook or role with vars
 

--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -51,7 +51,7 @@ be monitored for updates and cached.
 * **group**:  The group of the Custom Resource that you will be watching.
 * **version**:  The version of the Custom Resource that you will be watching.
 * **kind**:  The kind of the Custom Resource that you will be watching.
-* **role** (default): Speficies a role to be executed. This field is mutually exclusive with the
+* **role** (default): Specifies a role to be executed. This field is mutually exclusive with the
   "playbook" field. This field can be:
   * an absolute path to a role directory.
   * a relative path within one of the directories specified by `ANSIBLE_ROLES_PATH` environment variable or `ansible-roles-path` flag.
@@ -61,8 +61,8 @@ be monitored for updates and cached.
     use the `ANSIBLE_COLLECTIONS_PATH` environment variable or the `ansible-collections-path` flag
 * **playbook**: This is the playbook name that you have added to the
   container. This playbook is expected to be simply a way to call roles. This
-  field is mutually exclusive with the "role" field. Also, when it is running locally it looking for the playbook in the
-  current project directory in the local machine.
+  field is mutually exclusive with the "role" field. When running locally, the playbook is expected to be in the
+  current project directory.
 * **vars**: This is an arbitrary map of key-value pairs. The contents will be
   passed as `extra_vars` to the playbook or role specified for this watch.
 * **reconcilePeriod** (optional): The reconciliation interval, how often the

--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -51,15 +51,17 @@ be monitored for updates and cached.
 * **group**:  The group of the Custom Resource that you will be watching.
 * **version**:  The version of the Custom Resource that you will be watching.
 * **kind**:  The kind of the Custom Resource that you will be watching.
-* **role** (default): This is the name of the role that you have added to the
-  container. This field is mutually exclusive with the
-  "playbook" field. If the path is relative, it is relative to the `roles` directory in the current working directory 
-  which in the image by default is `/opt/ansible/roles`. Also, when it is running locally it is by default the directory 
-  `roles` in the current project directory in the local machine. Note that it can be customized by using the flag 
-  `ansible-roles-path` or the envinroment variable `ANSIBLE_ROLES_PATH`. 
+* **role** (default): Speficies a role to be executed. This field is mutually exclusive with the
+  "playbook" field. This field can be:
+  * an absolute path to a role directory.
+  * a relative path within one of the directories specified by `ANSIBLE_ROLES_PATH` environment variable or `ansible-roles-path` flag.
+  * a relative path within the current working directory, which defaults to `/opt/ansible/roles`.
+  * a fully qualified collection name of an installed Ansible collection. Ansible collections are installed to
+    `~/.ansible/collections` or `/usr/share/ansible/collections` by default. If they are installed elsewhere, 
+    use the `ANSIBLE_COLLECTIONS_PATH` environment variable or the `ansible-collections-path` flag
 * **playbook**: This is the playbook name that you have added to the
   container. This playbook is expected to be simply a way to call roles. This
-  field is mutually exclusive with the "role" field. Also, when it is running locally it looking for the playbook in the 
+  field is mutually exclusive with the "role" field. Also, when it is running locally it looking for the playbook in the
   current project directory in the local machine.
 * **vars**: This is an arbitrary map of key-value pairs. The contents will be
   passed as `extra_vars` to the playbook or role specified for this watch.
@@ -107,6 +109,12 @@ An example Watches file:
     - group: ""
       version: v1
       kind: ConfigMap
+
+# Example usage with a role from an installed Ansible collection 
+- version: v1alpha1
+  group: bar.example.com
+  kind: Bar
+  role: myNamespace.myCollection.myRole
 ```
 
 ## Customize the operator logic

--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -57,7 +57,7 @@ be monitored for updates and cached.
   * a relative path within one of the directories specified by `ANSIBLE_ROLES_PATH` environment variable or `ansible-roles-path` flag.
   * a relative path within the current working directory, which defaults to `/opt/ansible/roles`.
   * a fully qualified collection name of an installed Ansible collection. Ansible collections are installed to
-    `~/.ansible/collections` or `/usr/share/ansible/collections` by default. If they are installed elsewhere, 
+    `~/.ansible/collections` or `/usr/share/ansible/collections` by default. If they are installed elsewhere,
     use the `ANSIBLE_COLLECTIONS_PATH` environment variable or the `ansible-collections-path` flag
 * **playbook**: This is the playbook name that you have added to the
   container. This playbook is expected to be simply a way to call roles. This
@@ -69,7 +69,7 @@ be monitored for updates and cached.
   role/playbook is run, for a given CR.
 * **manageStatus** (optional): When true (default), the operator will manage
   the status of the CR generically. Set to false, the status of the CR is
-  managed elsewhere, by the specified role/playbook or in a separate controller. 
+  managed elsewhere, by the specified role/playbook or in a separate controller.
 * **blacklist**: A list of child resources (by GVK) that will not be watched or cached.
 
 An example Watches file:
@@ -110,7 +110,7 @@ An example Watches file:
       version: v1
       kind: ConfigMap
 
-# Example usage with a role from an installed Ansible collection 
+# Example usage with a role from an installed Ansible collection
 - version: v1alpha1
   group: bar.example.com
   kind: Bar
@@ -368,10 +368,10 @@ In order to see the logs from a particular you can run:
 kubectl logs deployment/memcached-operator
 ```
 
-The logs contain the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks. 
+The logs contain the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks.
 Note that the logs will contain much more detailed information about the Ansible Operator's internals and interface with Kubernetes as well.
 
-Also, you can use the environment variable `ANSIBLE_DEBUG_LOGS` set as `True` to check the full Ansible result in the logs in order to be able to debug it. 
+Also, you can use the environment variable `ANSIBLE_DEBUG_LOGS` set as `True` to check the full Ansible result in the logs in order to be able to debug it.
 
 **Example**
 

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -54,7 +54,7 @@ header_text "Test local"
 pushd memcached-operator
 sed -i".bak" -E -e 's/(FROM quay.io\/operator-framework\/ansible-operator)(:.*)?/\1:dev/g' build/Dockerfile; rm -f build/Dockerfile.bak
 OPERATORDIR="$(pwd)"
-TEST_CLUSTER_PORT=24443 operator-sdk test local --namespace default
+# TEST_CLUSTER_PORT=24443 operator-sdk test local --namespace default
 
 remove_prereqs
 
@@ -67,6 +67,6 @@ DEST_IMAGE="quay.io/example/ansible-test-operator:v0.0.1"
 sed -i".bak" -E -e 's/(FROM quay.io\/operator-framework\/ansible-operator)(:.*)?/\1:dev/g' build/Dockerfile; rm -f build/Dockerfile.bak
 operator-sdk build "$DEST_IMAGE"
 load_image_if_kind "$DEST_IMAGE"
-OPERATOR_PULL_POLICY=Never OPERATOR_IMAGE=${DEST_IMAGE} TEST_CLUSTER_PORT=24443 TEST_NAMESPACE=osdk-test molecule test --all
+OPERATOR_PULL_POLICY=Never OPERATOR_IMAGE=${DEST_IMAGE} TEST_CLUSTER_PORT=24443 TEST_NAMESPACE=osdk-test molecule test -s cluster
 
 popd

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -65,7 +65,7 @@ header_text "Test Ansible Molecule scenarios"
 pushd "${ROOTDIR}/test/ansible"
 DEST_IMAGE="quay.io/example/ansible-test-operator:v0.0.1"
 sed -i".bak" -E -e 's/(FROM quay.io\/operator-framework\/ansible-operator)(:.*)?/\1:dev/g' build/Dockerfile; rm -f build/Dockerfile.bak
-operator-sdk build "$DEST_IMAGE"
+operator-sdk build "$DEST_IMAGE" --image-build-args="--no-cache"
 load_image_if_kind "$DEST_IMAGE"
 OPERATOR_PULL_POLICY=Never OPERATOR_IMAGE=${DEST_IMAGE} TEST_CLUSTER_PORT=24443 TEST_NAMESPACE=osdk-test molecule test --all
 

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -54,7 +54,7 @@ header_text "Test local"
 pushd memcached-operator
 sed -i".bak" -E -e 's/(FROM quay.io\/operator-framework\/ansible-operator)(:.*)?/\1:dev/g' build/Dockerfile; rm -f build/Dockerfile.bak
 OPERATORDIR="$(pwd)"
-# TEST_CLUSTER_PORT=24443 operator-sdk test local --namespace default
+TEST_CLUSTER_PORT=24443 operator-sdk test local --namespace default
 
 remove_prereqs
 
@@ -67,6 +67,6 @@ DEST_IMAGE="quay.io/example/ansible-test-operator:v0.0.1"
 sed -i".bak" -E -e 's/(FROM quay.io\/operator-framework\/ansible-operator)(:.*)?/\1:dev/g' build/Dockerfile; rm -f build/Dockerfile.bak
 operator-sdk build "$DEST_IMAGE"
 load_image_if_kind "$DEST_IMAGE"
-OPERATOR_PULL_POLICY=Never OPERATOR_IMAGE=${DEST_IMAGE} TEST_CLUSTER_PORT=24443 TEST_NAMESPACE=osdk-test molecule test -s cluster
+OPERATOR_PULL_POLICY=Never OPERATOR_IMAGE=${DEST_IMAGE} TEST_CLUSTER_PORT=24443 TEST_NAMESPACE=osdk-test molecule test --all
 
 popd

--- a/pkg/ansible/flags/flag.go
+++ b/pkg/ansible/flags/flag.go
@@ -72,8 +72,10 @@ func AddTo(flagSet *pflag.FlagSet, helpTextPrefix ...string) *AnsibleOperatorFla
 		"ansible-collections-path",
 		"",
 		strings.Join(append(helpTextPrefix,
-			"Path to installed Ansible Collections. If set, collections should be located in {{value}}/ansible_collections/. If unset, collections are assumed to be in ~/.ansible/collections or /usr/share/ansible/collections."),
-			" "),
+			`Path to installed Ansible Collections. If set, collections should be
+			located in {{value}}/ansible_collections/. If unset, collections are
+			assumed to be in ~/.ansible/collections or
+			/usr/share/ansible/collections.`), " "),
 	)
 	return aof
 }

--- a/pkg/ansible/flags/flag.go
+++ b/pkg/ansible/flags/flag.go
@@ -25,13 +25,15 @@ import (
 // AnsibleOperatorFlags - Options to be used by an ansible operator
 type AnsibleOperatorFlags struct {
 	watch.WatchFlags
-	InjectOwnerRef   bool
-	MaxWorkers       int
-	AnsibleVerbosity int
-	AnsibleRolesPath string
+	InjectOwnerRef         bool
+	MaxWorkers             int
+	AnsibleVerbosity       int
+	AnsibleRolesPath       string
+	AnsibleCollectionsPath string
 }
 
 const AnsibleRolesPathEnvVar = "ANSIBLE_ROLES_PATH"
+const AnsibleCollectionsPathEnvVar = "ANSIBLE_COLLECTIONS_PATH"
 
 // AddTo - Add the ansible operator flags to the the flagset
 // helpTextPrefix will allow you add a prefix to default help text. Joined by a space.
@@ -63,7 +65,14 @@ func AddTo(flagSet *pflag.FlagSet, helpTextPrefix ...string) *AnsibleOperatorFla
 		"ansible-roles-path",
 		"",
 		strings.Join(append(helpTextPrefix,
-			"Ansible Roles Path. By default, it will be {{CWD}}/roles."),
+			"Ansible Roles Path. If unset, roles are assumed to be in {{CWD}}/roles."),
+			" "),
+	)
+	flagSet.StringVar(&aof.AnsibleCollectionsPath,
+		"ansible-collections-path",
+		"",
+		strings.Join(append(helpTextPrefix,
+			"Path to installed Ansible Collections. If set, collections should be located in {{value}}/ansible_collections/. If unset, collections are assumed to be in ~/.ansible/collections or /usr/share/ansible/collections."),
 			" "),
 	)
 	return aof

--- a/pkg/ansible/watches/testdata/invalid_collection.yaml
+++ b/pkg/ansible/watches/testdata/invalid_collection.yaml
@@ -1,0 +1,5 @@
+---
+- version: v1alpha1
+  group: app.example.com
+  kind: SanityUnconfirmed
+  role: nameSpace.collection.someRole

--- a/pkg/ansible/watches/testdata/valid.yaml.tmpl
+++ b/pkg/ansible/watches/testdata/valid.yaml.tmpl
@@ -87,3 +87,7 @@
   role: {{ .ValidRole }}
   vars:
     sentinel: reconciling
+- version: v1alpha1
+  group: app.example.com
+  kind: AnsibleCollectionEnvTest
+  role: nameSpace.collection.someRole

--- a/pkg/ansible/watches/watches.go
+++ b/pkg/ansible/watches/watches.go
@@ -149,17 +149,34 @@ func (w *Watch) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // addRolePlaybookPaths will add the full path based on the current dir
 func (w *Watch) addRolePlaybookPaths() {
-	w.Playbook = getFullPath(w.Playbook)
-	w.Role = getFullRolePath(w.Role)
+	if len(w.Playbook) > 0 {
+		w.Playbook = getFullPath(w.Playbook)
+	}
+
+	if len(w.Role) > 0 {
+		possibleRolePaths := getPossibleRolePaths(w.Role)
+		for _, possiblePath := range possibleRolePaths {
+			if _, err := os.Stat(possiblePath); err == nil {
+				w.Role = possiblePath
+				break
+			}
+		}
+	}
 	if w.Finalizer != nil && len(w.Finalizer.Role) > 0 {
-		w.Finalizer.Role = getFullRolePath(w.Finalizer.Role)
+		possibleRolePaths := getPossibleRolePaths(w.Finalizer.Role)
+		for _, possiblePath := range possibleRolePaths {
+			if _, err := os.Stat(possiblePath); err == nil {
+				w.Finalizer.Role = possiblePath
+				break
+			}
+		}
 	}
 	if w.Finalizer != nil && len(w.Finalizer.Playbook) > 0 {
 		w.Finalizer.Playbook = getFullPath(w.Finalizer.Playbook)
 	}
 }
 
-// getFullPath will return a valid full path for the playbook
+// getFullPath returns an absolute path for the playbook
 func getFullPath(path string) string {
 	if len(path) > 0 && !filepath.IsAbs(path) {
 		return filepath.Join(projutil.MustGetwd(), path)
@@ -167,32 +184,41 @@ func getFullPath(path string) string {
 	return path
 }
 
-// getFullRolePath will return a valid full path for the role
-func getFullRolePath(path string) string {
-	if len(path) > 0 && !filepath.IsAbs(path) {
-		envVar, ok := os.LookupEnv("ANSIBLE_ROLES_PATH")
-		if ok && len(envVar) > 0 {
-			// Check all values informed (e.g. path1/roles:path2/roles:/absolute/path3/roles)
-			result := strings.Split(envVar, ":")
-			for i := range result {
-				// Check if the role can be found in the envVar + role path
-				infoPath := filepath.Join(result[i], path)
-				if _, err := os.Stat(infoPath); err == nil {
-					return infoPath
-				}
-
-				// Check if the role can be found in the envVar + roles + role path
-				infoPathWithRolesDir := filepath.Join(result[i], "roles", path)
-				if _, err := os.Stat(infoPathWithRolesDir); err == nil {
-					return infoPathWithRolesDir
-				}
+// getFullRolePath returns a full path to the role directory
+func getPossibleRolePaths(path string) []string {
+	possibleRolePaths := []string{}
+	if filepath.IsAbs(path) || len(path) == 0 {
+		return append(possibleRolePaths, path)
+	}
+	fqcn := strings.Split(path, ".")
+	// If fqcn is a valid fully qualified collection name, it is <namespace>.<collectionName>.<roleName>
+	if len(fqcn) == 3 {
+		ansibleCollectionsPathEnv, ok := os.LookupEnv("ANSIBLE_COLLECTIONS_PATH")
+		if !ok || len(ansibleCollectionsPathEnv) == 0 {
+			ansibleCollectionsPathEnv = "/usr/share/ansible/collections"
+			home, err := os.UserHomeDir()
+			if err == nil {
+				homeCollections := filepath.Join(home, ".ansible/collections")
+				ansibleCollectionsPathEnv = ansibleCollectionsPathEnv + ":" + homeCollections
 			}
 		}
-		// If the flag and/or env var ANSIBLE_ROLES_PATH was not set or no roles were informed in the path then, it will
-		// be the current directory concat with roles.
-		return getFullPath(filepath.Join("roles", path))
+		for _, possiblePathParent := range strings.Split(ansibleCollectionsPathEnv, ":") {
+			possibleRolePaths = append(possibleRolePaths, filepath.Join(possiblePathParent, "ansible_collections", fqcn[0], fqcn[1], "roles", fqcn[2]))
+		}
 	}
-	return path
+
+	// Check for the role where Ansible would. If it exists, use it.
+	ansibleRolesPathEnv, ok := os.LookupEnv("ANSIBLE_ROLES_PATH")
+	if ok && len(ansibleRolesPathEnv) > 0 {
+		for _, possiblePathParent := range strings.Split(ansibleRolesPathEnv, ":") {
+			// "roles" is optionally a part of the path. Check with, and without.
+			// TODO(asmacdo) ^This might not be true. https://github.com/operator-framework/operator-sdk/pull/2273#discussion_r374946618
+			possibleRolePaths = append(possibleRolePaths, filepath.Join(possiblePathParent, path))
+			possibleRolePaths = append(possibleRolePaths, filepath.Join(possiblePathParent, "roles", path))
+		}
+	}
+	// Roles can also live in the current working directory.
+	return append(possibleRolePaths, getFullPath(filepath.Join("roles", path)))
 }
 
 // Validate - ensures that a Watch is valid
@@ -297,13 +323,11 @@ func verifyGVK(gvk schema.GroupVersionKind) error {
 func verifyAnsiblePath(playbook string, role string) error {
 	switch {
 	case playbook != "":
-		playbookPath := getFullPath(playbook)
-		if _, err := os.Stat(playbookPath); err != nil {
+		if _, err := os.Stat(playbook); err != nil {
 			return fmt.Errorf("playbook: %v was not found", playbook)
 		}
 	case role != "":
-		rolePath := getFullRolePath(role)
-		if _, err := os.Stat(rolePath); err != nil {
+		if _, err := os.Stat(role); err != nil {
 			return fmt.Errorf("role: %v was not found", role)
 		}
 	default:

--- a/pkg/ansible/watches/watches.go
+++ b/pkg/ansible/watches/watches.go
@@ -161,6 +161,14 @@ func (w *Watch) addRolePlaybookPaths() {
 				break
 			}
 		}
+		fmt.Println("OH NOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")
+		fmt.Println("OH NOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")
+		fmt.Println("OH NOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")
+		fmt.Println("OH NOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")
+		fmt.Println("OH NOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")
+		for _, possiblePath := range possibleRolePaths {
+			fmt.Println(possiblePath)
+		}
 	}
 	if w.Finalizer != nil && len(w.Finalizer.Role) > 0 {
 		possibleRolePaths := getPossibleRolePaths(w.Finalizer.Role)

--- a/pkg/ansible/watches/watches.go
+++ b/pkg/ansible/watches/watches.go
@@ -203,7 +203,8 @@ func getPossibleRolePaths(path string) []string {
 			}
 		}
 		for _, possiblePathParent := range strings.Split(ansibleCollectionsPathEnv, ":") {
-			possibleRolePaths = append(possibleRolePaths, filepath.Join(possiblePathParent, "ansible_collections", fqcn[0], fqcn[1], "roles", fqcn[2]))
+			possiblePath := filepath.Join(possiblePathParent, "ansible_collections", fqcn[0], fqcn[1], "roles", fqcn[2])
+			possibleRolePaths = append(possibleRolePaths, possiblePath)
 		}
 	}
 
@@ -212,7 +213,6 @@ func getPossibleRolePaths(path string) []string {
 	if ok && len(ansibleRolesPathEnv) > 0 {
 		for _, possiblePathParent := range strings.Split(ansibleRolesPathEnv, ":") {
 			// "roles" is optionally a part of the path. Check with, and without.
-			// TODO(asmacdo) ^This might not be true. https://github.com/operator-framework/operator-sdk/pull/2273#discussion_r374946618
 			possibleRolePaths = append(possibleRolePaths, filepath.Join(possiblePathParent, path))
 			possibleRolePaths = append(possibleRolePaths, filepath.Join(possiblePathParent, "roles", path))
 		}

--- a/pkg/ansible/watches/watches.go
+++ b/pkg/ansible/watches/watches.go
@@ -184,7 +184,7 @@ func getFullPath(path string) string {
 	return path
 }
 
-// getFullRolePath returns a full path to the role directory
+// getPossibleRolePaths returns list of possible absolute paths derived from a user provided value.
 func getPossibleRolePaths(path string) []string {
 	possibleRolePaths := []string{}
 	if filepath.IsAbs(path) || len(path) == 0 {

--- a/pkg/ansible/watches/watches.go
+++ b/pkg/ansible/watches/watches.go
@@ -161,14 +161,6 @@ func (w *Watch) addRolePlaybookPaths() {
 				break
 			}
 		}
-		fmt.Println("OH NOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")
-		fmt.Println("OH NOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")
-		fmt.Println("OH NOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")
-		fmt.Println("OH NOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")
-		fmt.Println("OH NOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")
-		for _, possiblePath := range possibleRolePaths {
-			fmt.Println(possiblePath)
-		}
 	}
 	if w.Finalizer != nil && len(w.Finalizer.Role) > 0 {
 		possibleRolePaths := getPossibleRolePaths(w.Finalizer.Role)

--- a/pkg/ansible/watches/watches_test.go
+++ b/pkg/ansible/watches/watches_test.go
@@ -391,7 +391,7 @@ func TestLoad(t *testing.T) {
 			shouldError: true,
 		},
 		{
-			name:        "if collection is not installed, fail",
+			name:        "if collection env var is not set and collection is not installed to the default locations, fail",
 			path:        "testdata/invalid_collection.yaml",
 			shouldError: true,
 		},

--- a/test/ansible-memcached/molecule.yml
+++ b/test/ansible-memcached/molecule.yml
@@ -10,7 +10,7 @@ platforms:
 - name: kind-test-local
   groups:
   - k8s
-  image: bsycorp/kind:latest-1.15
+  image: bsycorp/kind:latest-1.16
   privileged: True
   override_command: no
   exposed_ports:

--- a/test/ansible/build/Dockerfile
+++ b/test/ansible/build/Dockerfile
@@ -1,9 +1,11 @@
 FROM quay.io/operator-framework/ansible-operator:dev
 
 COPY ansible.cfg /etc/ansible/ansible.cfg
+COPY requirements.yml ${HOME}/requirements.yml
 COPY watches.yaml ${HOME}/watches.yaml
 
 COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/playbooks/
 COPY inventory/ ${HOME}/inventory/
 COPY plugins/ ${HOME}/plugins/
+RUN ansible-galaxy collection install -r ${HOME}/requirements.yml

--- a/test/ansible/build/Dockerfile
+++ b/test/ansible/build/Dockerfile
@@ -1,11 +1,15 @@
 FROM quay.io/operator-framework/ansible-operator:dev
 
 COPY ansible.cfg /etc/ansible/ansible.cfg
-COPY requirements.yml ${HOME}/requirements.yml
 COPY watches.yaml ${HOME}/watches.yaml
 
 COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/playbooks/
 COPY inventory/ ${HOME}/inventory/
 COPY plugins/ ${HOME}/plugins/
-RUN ansible-galaxy collection install -r ${HOME}/requirements.yml
+COPY fixture_collection/ /tmp/fixture_collection/
+USER root
+RUN chmod -R ug+rwx /tmp/fixture_collection
+USER 1001
+RUN ansible-galaxy collection build /tmp/fixture_collection/ --output-path /tmp/fixture_collection/
+RUN ansible-galaxy collection install /tmp/fixture_collection/operator_sdk-test_fixtures-0.0.0.tar.gz

--- a/test/ansible/deploy/crds/test.example.com_collections_crd.yaml
+++ b/test/ansible/deploy/crds/test.example.com_collections_crd.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: collections.test.example.com
+spec:
+  group: test.example.com
+  names:
+    kind: Collection
+    listKind: CollectionList
+    plural: collections
+    singular: collection
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/test/ansible/fixture_collection/galaxy.yml
+++ b/test/ansible/fixture_collection/galaxy.yml
@@ -1,0 +1,57 @@
+### REQUIRED
+
+# The namespace of the collection. This can be a company/brand/organization or product namespace under which all
+# content lives. May only contain alphanumeric characters and underscores. Additionally namespaces cannot start with
+# underscores or numbers and cannot contain consecutive underscores
+namespace: operator_sdk
+
+# The name of the collection. Has the same character restrictions as 'namespace'
+name: test_fixtures
+
+# The version of the collection. Must be compatible with semantic versioning
+version: 0.0.0
+
+# The path to the Markdown (.md) readme file. This path is relative to the root of the collection
+readme: README.md
+
+# A list of the collection's content authors. Can be just the name or in the format 'Full Name <email> (url)
+# @nicks:irc/im.site#channel'
+authors:
+- your name <example@domain.com>
+
+
+### OPTIONAL but strongly recommended
+
+# A short summary description of the collection
+description: your collection description
+
+# Either a single license or a list of licenses for content inside of a collection. Ansible Galaxy currently only
+# accepts L(SPDX,https://spdx.org/licenses/) licenses. This key is mutually exclusive with 'license_file'
+license:
+- GPL-2.0-or-later
+
+# The path to the license file for the collection. This path is relative to the root of the collection. This key is
+# mutually exclusive with 'license'
+license_file: ''
+
+# A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
+# requirements as 'namespace' and 'name'
+tags: []
+
+# Collections that this collection requires to be installed for it to be usable. The key of the dict is the
+# collection label 'namespace.name'. The value is a version range
+# L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
+# range specifiers can be set and are separated by ','
+dependencies: {}
+
+# The URL of the originating SCM repository
+repository: http://example.com/repository
+
+# The URL to any online docs
+documentation: http://docs.example.com
+
+# The URL to the homepage of the collection/project
+homepage: http://example.com
+
+# The URL to the collection issue tracker
+issues: http://example.com/issue/tracker

--- a/test/ansible/fixture_collection/galaxy.yml
+++ b/test/ansible/fixture_collection/galaxy.yml
@@ -1,57 +1,6 @@
-### REQUIRED
-
-# The namespace of the collection. This can be a company/brand/organization or product namespace under which all
-# content lives. May only contain alphanumeric characters and underscores. Additionally namespaces cannot start with
-# underscores or numbers and cannot contain consecutive underscores
 namespace: operator_sdk
-
-# The name of the collection. Has the same character restrictions as 'namespace'
 name: test_fixtures
-
-# The version of the collection. Must be compatible with semantic versioning
 version: 0.0.0
-
-# The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
-
-# A list of the collection's content authors. Can be just the name or in the format 'Full Name <email> (url)
-# @nicks:irc/im.site#channel'
 authors:
 - your name <example@domain.com>
-
-
-### OPTIONAL but strongly recommended
-
-# A short summary description of the collection
-description: your collection description
-
-# Either a single license or a list of licenses for content inside of a collection. Ansible Galaxy currently only
-# accepts L(SPDX,https://spdx.org/licenses/) licenses. This key is mutually exclusive with 'license_file'
-license:
-- GPL-2.0-or-later
-
-# The path to the license file for the collection. This path is relative to the root of the collection. This key is
-# mutually exclusive with 'license'
-license_file: ''
-
-# A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
-# requirements as 'namespace' and 'name'
-tags: []
-
-# Collections that this collection requires to be installed for it to be usable. The key of the dict is the
-# collection label 'namespace.name'. The value is a version range
-# L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
-# range specifiers can be set and are separated by ','
-dependencies: {}
-
-# The URL of the originating SCM repository
-repository: http://example.com/repository
-
-# The URL to any online docs
-documentation: http://docs.example.com
-
-# The URL to the homepage of the collection/project
-homepage: http://example.com
-
-# The URL to the collection issue tracker
-issues: http://example.com/issue/tracker

--- a/test/ansible/fixture_collection/roles/dummy/tasks/main.yml
+++ b/test/ansible/fixture_collection/roles/dummy/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Create ConfigMap
+  k8s:
+    definition:
+      kind: ConfigMap
+      apiVersion: v1
+      metadata:
+        name: test-this-collection
+        namespace: "{{ meta.namespace }}"
+      data:
+        did_it_work: "indeed"
+    state: present

--- a/test/ansible/molecule/cluster/tasks/collections_test.yml
+++ b/test/ansible/molecule/cluster/tasks/collections_test.yml
@@ -1,0 +1,17 @@
+- name: Create the test.example.com/v1alpha1.Collection
+  k8s:
+    state: present
+    definition:
+      apiVersion:
+      kind: Collection
+      metadata:
+        name: collection-test
+        namespace: '{{ namespace }}'
+      spec:
+        arbitrary: data
+
+- name: Assert sentinel ConfigMap has been created for Molecule Test
+  assert:
+    that: cm.data.did_this_work == 'yes'
+  vars:
+    cm: "{{ q('k8s', api_version='v1', kind='ConfigMap', namespace=namespace, resource_name='test-this-collection').0 }}"

--- a/test/ansible/molecule/cluster/tasks/collections_test.yml
+++ b/test/ansible/molecule/cluster/tasks/collections_test.yml
@@ -15,7 +15,7 @@
       reason: Successful
       status: "True"
 
-- name: Assert sentinel ConfigMap has been created for Molecule Test
+- name: Assert ConfigMap has been created by collection Role
   assert:
     that: cm.data.did_it_work == 'indeed'
   vars:

--- a/test/ansible/molecule/cluster/tasks/collections_test.yml
+++ b/test/ansible/molecule/cluster/tasks/collections_test.yml
@@ -1,17 +1,22 @@
+---
 - name: Create the test.example.com/v1alpha1.Collection
   k8s:
     state: present
+    namespace: '{{ namespace }}'
     definition:
-      apiVersion:
+      apiVersion: test.example.com/v1alpha1
       kind: Collection
       metadata:
         name: collection-test
-        namespace: '{{ namespace }}'
-      spec:
-        arbitrary: data
+    wait: yes
+    wait_timeout: 300
+    wait_condition:
+      type: Running
+      reason: Successful
+      status: "True"
 
 - name: Assert sentinel ConfigMap has been created for Molecule Test
   assert:
-    that: cm.data.did_this_work == 'yes'
+    that: cm.data.did_it_work == 'indeed'
   vars:
     cm: "{{ q('k8s', api_version='v1', kind='ConfigMap', namespace=namespace, resource_name='test-this-collection').0 }}"

--- a/test/ansible/molecule/cluster/verify.yml
+++ b/test/ansible/molecule/cluster/verify.yml
@@ -6,3 +6,4 @@
   tasks:
     - import_tasks: tasks/inventory_test.yml
     - import_tasks: tasks/servicemonitor_test.yml
+    - import_tasks: tasks/collections_test.yml

--- a/test/ansible/requirements.yml
+++ b/test/ansible/requirements.yml
@@ -1,3 +1,0 @@
----
-collections:
-  - asmacdo.fixture_collection

--- a/test/ansible/requirements.yml
+++ b/test/ansible/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - asmacdo.fixture_collection

--- a/test/ansible/watches.yaml
+++ b/test/ansible/watches.yaml
@@ -6,5 +6,5 @@
 
 - version: v1alpha1
   group: test.example.com
-  kind: CollectionTest
+  kind: Collection
   role: asmacdo.fixture_collection.dummy

--- a/test/ansible/watches.yaml
+++ b/test/ansible/watches.yaml
@@ -7,4 +7,4 @@
 - version: v1alpha1
   group: test.example.com
   kind: Collection
-  role: asmacdo.fixture_collection.dummy
+  role: operator_sdk.test_fixtures.dummy

--- a/test/ansible/watches.yaml
+++ b/test/ansible/watches.yaml
@@ -3,3 +3,8 @@
   group: test.example.com
   kind: Inventory
   playbook: /opt/ansible/playbooks/inventory.yml
+
+- version: v1alpha1
+  group: test.example.com
+  kind: CollectionTest
+  role: asmacdo.fixture_collection.dummy


### PR DESCRIPTION
~Just a POC at the moment, roles only, no playbooks.~ Note: Playbooks are not yet fully supported within collections.

Allow Ansible watches to use collection roles

Ansible-based operators can now specify roles in `watches.yaml` by their
fully qualified collection name, ie `myNamespace.myCollection.myRole`.