### PR TITLE
Improve operator logs by adding the possibility to get the full Ansible logs on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Scaffold code in `cmd/manager/main.go` for Go operators and add logic to Ansible/Helm operators to handle [multinamespace caching](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder) if `WATCH_NAMESPACE` contains multiple namespaces. ([#2522](https://github.com/operator-framework/operator-sdk/pull/2522))
 - Add a new flag option (`--skip-cleanup-error`) to the test framework to allow skip the function which will remove all artefacts when an error be faced to perform this operation.   ([#2512](https://github.com/operator-framework/operator-sdk/pull/2512))
 - Add event stats output to the operator logs for Ansible based-operators. ([2580](https://github.com/operator-framework/operator-sdk/pull/2580))   
+- Improve Ansible logs by allowing output the full Ansible result for Ansible based-operators configurable by environment variable. ([2589](https://github.com/operator-framework/operator-sdk/pull/2589))   
 
 ### Changed
 - Ansible scaffolding has been rewritten to be simpler and make use of newer features of Ansible and Molecule.

--- a/doc/ansible/dev/developer_guide.md
+++ b/doc/ansible/dev/developer_guide.md
@@ -321,6 +321,18 @@ kubectl logs deployment/foo-operator
 The logs contain the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks. 
 Note that the logs will contain much more detailed information about the Ansible Operator's internals and interface with Kubernetes as well.
 
+Also, you can use the environment variable `ANSIBLE_DEBUG_LOGS` set as `True` to check the full Ansible result in the logs in order to be able to debug it. 
+
+**Example**
+
+In the `deploy/operator.yaml`:
+```yaml
+...
+- name: ANSIBLE_DEBUG_LOGS
+  value: "True"
+...
+```
+
 ## Custom Resource Status Management
 The operator will automatically update the CR's `status` subresource with
 generic information about the previous Ansible run. This includes the number of

--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -67,7 +67,7 @@ be monitored for updates and cached.
   role/playbook is run, for a given CR.
 * **manageStatus** (optional): When true (default), the operator will manage
   the status of the CR generically. Set to false, the status of the CR is
-  managed elsewhere, by the specified role/playbook or in a separate controller.
+  managed elsewhere, by the specified role/playbook or in a separate controller. 
 * **blacklist**: A list of child resources (by GVK) that will not be watched or cached.
 
 An example Watches file:
@@ -94,7 +94,7 @@ An example Watches file:
   kind: Baz
   playbook: baz.yml
   reconcilePeriod: 0
-  manageStatus: false
+  manageStatus: False
   vars:
     foo: bar
 
@@ -362,6 +362,18 @@ kubectl logs deployment/memcached-operator
 
 The logs contain the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks. 
 Note that the logs will contain much more detailed information about the Ansible Operator's internals and interface with Kubernetes as well.
+
+Also, you can use the environment variable `ANSIBLE_DEBUG_LOGS` set as `True` to check the full Ansible result in the logs in order to be able to debug it. 
+
+**Example**
+
+In the `deploy/operator.yaml`:
+```yaml
+...
+- name: ANSIBLE_DEBUG_LOGS
+  value: "True"
+...
+```
 
 ### Additional Ansible Debug
 

--- a/pkg/ansible/controller/controller.go
+++ b/pkg/ansible/controller/controller.go
@@ -45,6 +45,7 @@ type Options struct {
 	GVK                         schema.GroupVersionKind
 	ReconcilePeriod             time.Duration
 	ManageStatus                bool
+	AnsibleDebugLogs            bool
 	WatchDependentResources     bool
 	WatchClusterScopedResources bool
 	MaxWorkers                  int
@@ -60,13 +61,14 @@ func Add(mgr manager.Manager, options Options) *controller.Controller {
 	eventHandlers := append(options.EventHandlers, events.NewLoggingEventHandler(options.LoggingLevel))
 
 	aor := &AnsibleOperatorReconciler{
-		Client:          mgr.GetClient(),
-		GVK:             options.GVK,
-		Runner:          options.Runner,
-		EventHandlers:   eventHandlers,
-		ReconcilePeriod: options.ReconcilePeriod,
-		ManageStatus:    options.ManageStatus,
-		APIReader:       mgr.GetAPIReader(),
+		Client:           mgr.GetClient(),
+		GVK:              options.GVK,
+		Runner:           options.Runner,
+		EventHandlers:    eventHandlers,
+		ReconcilePeriod:  options.ReconcilePeriod,
+		ManageStatus:     options.ManageStatus,
+		AnsibleDebugLogs: options.AnsibleDebugLogs,
+		APIReader:        mgr.GetAPIReader(),
 	}
 
 	scheme := mgr.GetScheme()

--- a/pkg/ansible/events/log_events.go
+++ b/pkg/ansible/events/log_events.go
@@ -93,17 +93,20 @@ func (l loggingEventHandler) Handle(ident string, u *unstructured.Unstructured, 
 	// log everything else for the 'Everything' LogLevel
 	if l.LogLevel == Everything {
 		logger.Info("", "EventData", e.EventData)
+		l.logAnsibleStdOut(e)
 	}
 }
 
 // logAnsibleStdOut will print in the logs the Ansible Task Output formatted
 func (l loggingEventHandler) logAnsibleStdOut(e eventapi.JobEvent) {
-	fmt.Printf("\n--------------------------- Ansible Task StdOut -------------------------------\n")
-	if e.Event != eventapi.EventPlaybookOnTaskStart {
-		fmt.Printf("\n TASK [%v] ******************************** \n", e.EventData["task"])
+	if len(e.StdOut) > 0 {
+		fmt.Printf("\n--------------------------- Ansible Task StdOut -------------------------------\n")
+		if e.Event != eventapi.EventPlaybookOnTaskStart {
+			fmt.Printf("\n TASK [%v] ******************************** \n", e.EventData["task"])
+		}
+		fmt.Println(e.StdOut)
+		fmt.Printf("\n-------------------------------------------------------------------------------\n")
 	}
-	fmt.Println(e.StdOut)
-	fmt.Printf("\n-------------------------------------------------------------------------------\n")
 }
 
 // NewLoggingEventHandler - Creates a Logging Event Handler to log events.

--- a/pkg/ansible/run.go
+++ b/pkg/ansible/run.go
@@ -265,7 +265,7 @@ func getAnsibleDebugLog() bool {
 	val := false
 	if envVal, ok := os.LookupEnv(envVar); ok {
 		if i, err := strconv.ParseBool(envVal); err != nil {
-			log.Info("Could not parse environment variable as an integer; using default value",
+			log.Info("Could not parse environment variable as an boolean; using default value",
 				"envVar", envVar, "default", val)
 		} else {
 			val = i


### PR DESCRIPTION
**Description of the change:**

- Add full Ansible result output to the operator logs for Ansible based-operators configurable by EnvVar.

**Motivation for the change:**

Allow users to have the same full information that can be obtained until the version 0.15.x with the Ansible sidecar container in the operator logs. 

Note that we deprecated the inotify-tools and we will no longer scaffold the sidecar container. See https://github.com/operator-framework/operator-sdk/pull/2586. Also, we have been improving the operator logs in order to attend all needs. See: https://github.com/operator-framework/operator-sdk/pull/2580 and https://github.com/operator-framework/operator-sdk/pull/2321.

**Local Test**
Image: quay.io/camilamacedo86/ansible-operator:logs

See the output with the ENV VAR:

```
$ kubectl logs deployment.apps/testoperator  -n test
{"level":"info","ts":1582571464.3917449,"logger":"cmd","msg":"Go Version: go1.13.3"}
{"level":"info","ts":1582571464.39191,"logger":"cmd","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1582571464.3919568,"logger":"cmd","msg":"Version of operator-sdk: v0.15.0+git"}
{"level":"info","ts":1582571464.392188,"logger":"cmd","msg":"Watching single namespace.","Namespace":"test"}
{"level":"info","ts":1582571464.753258,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":"0.0.0.0:8383"}
{"level":"info","ts":1582571464.753604,"logger":"watches","msg":"Environment variable not set; using default value","envVar":"WORKER_TESTCR_GLOTHRIEL_COM","default":1}
{"level":"info","ts":1582571464.7536469,"logger":"watches","msg":"Environment variable not set; using default value","envVar":"ANSIBLE_VERBOSITY_TESTCR_GLOTHRIEL_COM","default":2}
{"level":"info","ts":1582571464.7537,"logger":"ansible-controller","msg":"Watching resource","Options.Group":"glothriel.com","Options.Version":"v1alpha1","Options.Kind":"TestCR"}
{"level":"info","ts":1582571464.7538302,"logger":"leader","msg":"Trying to become the leader."}
{"level":"info","ts":1582571465.1339865,"logger":"leader","msg":"No pre-existing lock was found."}
{"level":"info","ts":1582571465.140328,"logger":"leader","msg":"Became the leader."}
{"level":"info","ts":1582571465.8697152,"logger":"metrics","msg":"Metrics Service object created","Service.Name":"testoperator-metrics","Service.Namespace":"test"}
{"level":"info","ts":1582571466.225284,"logger":"cmd","msg":"Could not create ServiceMonitor object","Namespace":"test","error":"no ServiceMonitor registered with the API"}
{"level":"info","ts":1582571466.2253857,"logger":"cmd","msg":"Install prometheus-operator in your cluster to create ServiceMonitor objects","Namespace":"test","error":"no ServiceMonitor registered with the API"}
{"level":"info","ts":1582571466.2270525,"logger":"proxy","msg":"Starting to serve","Address":"127.0.0.1:8888"}
{"level":"info","ts":1582571466.2276838,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"testcr-controller","source":"kind source: glothriel.com/v1alpha1, Kind=TestCR"}
{"level":"info","ts":1582571466.2280617,"logger":"controller-runtime.controller","msg":"Starting Controller","controller":"testcr-controller"}
{"level":"info","ts":1582571466.230627,"logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
{"level":"info","ts":1582571466.3331325,"logger":"controller-runtime.controller","msg":"Starting workers","controller":"testcr-controller","worker count":1}

--------------------------- Ansible Task StdOut -------------------------------

{"level":"info","ts":1582571469.3538122,"logger":"logging_event_handler","msg":"[playbook task]","name":"example-testcr","namespace":"test","gvk":"glothriel.com/v1alpha1, Kind=TestCR","event_type":"playbook_on_task_start","job":"6129484611666145821","EventData.Name":"Gathering Facts"}
TASK [Gathering Facts] *********************************************************

-------------------------------------------------------------------------------
{"level":"info","ts":1582571470.7043462,"logger":"logging_event_handler","msg":"[playbook debug]","name":"example-testcr","namespace":"test","gvk":"glothriel.com/v1alpha1, Kind=TestCR","event_type":"runner_on_ok","job":"6129484611666145821","EventData.TaskArgs":""}

--------------------------- Ansible Task StdOut -------------------------------

 TASK [task A] ******************************** 
ok: [localhost] => {
    "msg": "Watch task!"
}

-------------------------------------------------------------------------------
{"level":"info","ts":1582571470.9242826,"logger":"runner","msg":"Ansible-runner exited successfully","job":"6129484611666145821","name":"example-testcr","namespace":"test"}

--------------------------- Ansible Task Status Event StdOut  -----------------

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


-------------------------------------------------------------------------------

--------------------------- Ansible Debug Result -----------------------------
ansible-playbook 2.9.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible/openshift']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 3.6.8 (default, Oct 11 2019, 15:04:54) [GCC 8.3.1 20190507 (Red Hat 8.3.1-4)]
Using /etc/ansible/ansible.cfg as config file

PLAYBOOK: 21675fce3ecd475c959ce73f9b02b655 *************************************
1 plays in /tmp/ansible-operator/runner/glothriel.com/v1alpha1/TestCR/test/example-testcr/project/21675fce3ecd475c959ce73f9b02b655

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]
META: ran handlers

TASK [testcr : task A] *********************************************************
task path: /opt/ansible/roles/testcr/tasks/main.yml:4
ok: [localhost] => {
    "msg": "Watch task!"
}
META: ran handlers
META: ran handlers
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   



-------------------------------------------------------------------------------
```
