### PR TITLE
add info over how to gen others CR/CRDs for the Ansible operators

### DIFF
--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -419,6 +419,8 @@ $ kubectl delete -f deploy/service_account.yaml
 $ kubectl delete -f deploy/crds/cache.example.com_memcacheds_crd.yaml
 ```
 
+**NOTE** Additional CR/CRD's can be added to the project by running, for example, the command :`operator-sdk new api --api-version=cache.example.com/v1alpha1 --kind=AppService --type=ansible`
+
 [operator-scope]:./../operator-scope.md
 [install-guide]: ../user/install-operator-sdk.md
 [layout-doc]:./project_layout.md


### PR DESCRIPTION
**Description of the change:**
Add info over how to gen others CR/CRDs for the Ansible operators

**Motivation for the change:**
Make clear that users are able to use N CR/CRDS in the Ansible operators project as well.