### PR TITLE
deprecate extensions for scorecard config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 ### Deprecated
 
 - The additional of the dependency `inotify-tools` on Ansible based-operator images. ([#2586](https://github.com/operator-framework/operator-sdk/pull/2586))
--  **Breaking Change:** The scorecard feature now only supports YAML config files. So, any config file with other extension is deprecated and should be changed for the YAML format. For further information see [`scorecard config file`](./doc/test-framework/scorecard.md#config-file) ([#](https://github.com/operator-framework/operator-sdk/pull/))
+-  **Breaking Change:** The scorecard feature now only supports YAML config files. So, any config file with other extension is deprecated and should be changed for the YAML format. For further information see [`scorecard config file`](./doc/test-framework/scorecard.md#config-file) ([#2591](https://github.com/operator-framework/operator-sdk/pull/2591))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Deprecated
 
 - The additional of the dependency `inotify-tools` on Ansible based-operator images. ([#2586](https://github.com/operator-framework/operator-sdk/pull/2586))
+-  **Breaking Change:** The scorecard feature now only supports YAML config files. So, any config file with other extension is deprecated and should be changed for the YAML format. For further information see [`scorecard config file`](./doc/test-framework/scorecard.md#config-file) ([#](https://github.com/operator-framework/operator-sdk/pull/))
 
 ### Removed
 

--- a/cmd/operator-sdk/scorecard/cmd.go
+++ b/cmd/operator-sdk/scorecard/cmd.go
@@ -125,7 +125,7 @@ func initConfig() (*viper.Viper, error) {
 		// these other formats are deprecated in the SDK.
 		// By using SetConfigName allows users to use  diff extensions.
 		// todo(camilamacedo86): Check if we can replace this configuration and make the things easier for the future
-		// versions since from 0.16 we will need just support the YAML format. 
+		// versions since from 0.16 we will need just support the YAML format.
 		viper.SetConfigName(scorecard.DefaultConfigFile)
 	}
 

--- a/cmd/operator-sdk/scorecard/cmd.go
+++ b/cmd/operator-sdk/scorecard/cmd.go
@@ -121,9 +121,11 @@ func initConfig() (*viper.Viper, error) {
 		viper.SetConfigFile(viper.GetString(configOpt))
 	} else {
 		viper.AddConfigPath(projutil.MustGetwd())
-		// Note that viper allows other extensions as  .json, or .toml file, however,
-		// this other formats are deprecated in the tool.
-		// using SetConfigName allows users to use a .yaml
+		// Note that viper allows other extensions as  .json, or .toml file as well, however,
+		// these other formats are deprecated in the SDK.
+		// By using SetConfigName allows users to use  diff extensions.
+		// todo(camilamacedo86): Check if we can replace this configuration and make the things easier for the future
+		// versions since from 0.16 we will need just support the YAML format. 
 		viper.SetConfigName(scorecard.DefaultConfigFile)
 	}
 

--- a/cmd/operator-sdk/scorecard/cmd.go
+++ b/cmd/operator-sdk/scorecard/cmd.go
@@ -114,7 +114,7 @@ func NewCmd() *cobra.Command {
 	return scorecardCmd
 }
 
-func initConfig()(*viper.Viper, error) {
+func initConfig() (*viper.Viper, error) {
 	// viper/cobra already has flags parsed at this point; we can check if a config file flag is set
 	if viper.GetString(configOpt) != "" {
 		// Use config file from the flag.

--- a/doc/cli/operator-sdk_scorecard.md
+++ b/doc/cli/operator-sdk_scorecard.md
@@ -15,7 +15,7 @@ operator-sdk scorecard [flags]
 
 ```
   -b, --bundle string       OLM bundle directory path, when specified runs bundle validation
-      --config string       config file (default is '<project_dir>/.osdk-scorecard'; the config file's extension and format can be .yaml, .json, or .toml)
+      --config string       config file (default is '<project_dir>/.osdk-scorecard.yaml'; the config file's extension and format must be .yaml
   -h, --help                help for scorecard
       --kubeconfig string   Path to kubeconfig of custom resource created in cluster
   -L, --list                If true, only print the test names that would be run based on selector filtering

--- a/doc/test-framework/scorecard.md
+++ b/doc/test-framework/scorecard.md
@@ -46,7 +46,7 @@ Following are some requirements for the operator project which would be  checked
 
 ## Running the Scorecard
 
-1. Setup the `.osdk-scorecard.yaml` configuration file in your project.. See [Config file](#config-file)
+1. Setup the `.osdk-scorecard.yaml` configuration file in your project. See [Config file](#config-file)
 2. Create the namespace defined in the RBAC files(`role_binding`)
 3. Then, run the scorecard, for example `$ operator-sdk scorecard`. See the [Command args](#command-args) to check its options.
 
@@ -58,7 +58,7 @@ The scorecard is configured by a config file that allows configuring internal pl
 
 ### Config File
 
-To use scorecard, you need to create a config file which by default will be `<project_dir>/.osdk-scorecard.*`. The following is an example of what a YAML formatted config file may look like:
+To use scorecard, you need to create a config file which by default will be `<project_dir>/.osdk-scorecard.yaml`. The following is an example over how the config file may look like:
 
 ```yaml
 scorecard:
@@ -92,7 +92,7 @@ While most configuration is done via a config file, there are a few important ar
 | Flag        | Type   | Description   |
 | --------    | -------- | -------- |
 | `--bundle`, `-b`  | string |  The path to a bundle directory used for the bundle validation test. |
-| `--config`  | string | Path to config file (default `<project_dir>/.osdk-scorecard`; file type and extension can be any of `.yaml`, `.json`, or `.toml`). If a config file is not provided and a config file is not found at the default location, the scorecard will exit with an error. |
+| `--config`  | string | Path to config file (default `<project_dir>/.osdk-scorecard.yaml`; file type and extension must be `.yaml`). If a config file is not provided and a config file is not found at the default location, the scorecard will exit with an error. |
 | `--output`, `-o`  | string | Output format. Valid options are: `text` and `json`. The default format is `text`, which is designed to be a simpler human readable format. The `json` format uses the JSON schema output format used for plugins defined later in this document. |
 | `--kubeconfig`, `-o`  | string |  path to kubeconfig. It sets the kubeconfig internally for internal plugins. |
 | `--version`  | string |  The version of scorecard to run, v1alpha2 is the default, valid values are v1alpha2. |

--- a/doc/test-framework/scorecard.md
+++ b/doc/test-framework/scorecard.md
@@ -58,7 +58,7 @@ The scorecard is configured by a config file that allows configuring internal pl
 
 ### Config File
 
-To use scorecard, you need to create a config file which by default will be `<project_dir>/.osdk-scorecard.yaml`. The following is an example over how the config file may look like:
+To use scorecard, you need to create a config file which by default will be `<project_dir>/.osdk-scorecard.yaml`.The following is an example of how the config file may look:
 
 ```yaml
 scorecard:


### PR DESCRIPTION
**Description of the change:**
- Deprecated other extensions for the scorecard config file. We will just support YAML. 
- Update flags, errors and docs to make clear that the SDK will be looking for scorecard.yaml file. 

Error now: 
<img width="1514" alt="Screenshot 2020-02-24 at 20 30 23" src="https://user-images.githubusercontent.com/7708031/75189672-935e9d00-5746-11ea-9761-d04ff704c665.png">

Help:
<img width="1337" alt="Screenshot 2020-02-24 at 20 46 28" src="https://user-images.githubusercontent.com/7708031/75189748-c2750e80-5746-11ea-9fb3-e69f6d7f6a7b.png">
