### PR TITLE
Adds --max-workers flag to the exec-entrypoint helm command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 - On `generate csv`, populate a CSV manifest’s `spec.icon`, `spec.keywords`, and `spec.mantainers` fields with empty values to better inform users how to add data. ([#2521](https://github.com/operator-framework/operator-sdk/pull/2521))
 - Scaffold code in `cmd/manager/main.go` for Go operators and add logic to Ansible/Helm operators to handle [multinamespace caching](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder) if `WATCH_NAMESPACE` contains multiple namespaces. ([#2522](https://github.com/operator-framework/operator-sdk/pull/2522))
 - Add a new flag option (`--skip-cleanup-error`) to the test framework to allow skip the function which will remove all artefacts when an error be faced to perform this operation.   ([#2512](https://github.com/operator-framework/operator-sdk/pull/2512))
-- Add event stats output to the operator logs for Ansible based-operators. ([2580](https://github.com/operator-framework/operator-sdk/pull/2580))   
-- Improve Ansible logs by allowing output the full Ansible result for Ansible based-operators configurable by environment variable. ([2589](https://github.com/operator-framework/operator-sdk/pull/2589))   
+- Add event stats output to the operator logs for Ansible based-operators. ([2580](https://github.com/operator-framework/operator-sdk/pull/2580))
+- Improve Ansible logs by allowing output the full Ansible result for Ansible based-operators configurable by environment variable. ([2589](https://github.com/operator-framework/operator-sdk/pull/2589))
+- Add the --max-workers flag to the commands operator-sdk exec-entrypoint and operator-sdk run --local for Helm based-operators with the purpose of controling the number of concurrent reconcile workers. ([2607](https://github.com/operator-framework/operator-sdk/pull/2607))
 
 ### Changed
 - Ansible scaffolding has been rewritten to be simpler and make use of newer features of Ansible and Molecule.

--- a/doc/helm/user-guide.md
+++ b/doc/helm/user-guide.md
@@ -391,6 +391,17 @@ Events:
 ```
 
 
+## Changing the concurrent worker count
+
+Depending on the number of CRs of the same type, a single reconciling worker may have issues keeping up. You can increase the number of workers by passing `--max-workers <number of workers>`.
+
+For example:
+
+```sh
+$ operator-sdk exec-entrypoint helm --max-workers 10
+```
+
+
 [operator-scope]:./../operator-scope.md
 [install-guide]: ../user/install-operator-sdk.md
 [layout-doc]:./project_layout.md

--- a/pkg/helm/controller/controller.go
+++ b/pkg/helm/controller/controller.go
@@ -70,7 +70,10 @@ func Add(mgr manager.Manager, options WatchOptions) error {
 	mgr.GetScheme().AddKnownTypeWithName(options.GVK, &unstructured.Unstructured{})
 	metav1.AddToGroupVersion(mgr.GetScheme(), options.GVK.GroupVersion())
 
-	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: options.MaxWorkers})
+	c, err := controller.New(controllerName, mgr, controller.Options{
+		Reconciler:              r,
+		MaxConcurrentReconciles: options.MaxWorkers,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/helm/controller/controller.go
+++ b/pkg/helm/controller/controller.go
@@ -50,6 +50,7 @@ type WatchOptions struct {
 	ReconcilePeriod         time.Duration
 	WatchDependentResources bool
 	OverrideValues          map[string]string
+	MaxWorkers              int
 }
 
 // Add creates a new helm operator controller and adds it to the manager
@@ -69,7 +70,7 @@ func Add(mgr manager.Manager, options WatchOptions) error {
 	mgr.GetScheme().AddKnownTypeWithName(options.GVK, &unstructured.Unstructured{})
 	metav1.AddToGroupVersion(mgr.GetScheme(), options.GVK.GroupVersion())
 
-	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 10})
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: options.MaxWorkers})
 	if err != nil {
 		return err
 	}

--- a/pkg/helm/controller/controller.go
+++ b/pkg/helm/controller/controller.go
@@ -69,7 +69,7 @@ func Add(mgr manager.Manager, options WatchOptions) error {
 	mgr.GetScheme().AddKnownTypeWithName(options.GVK, &unstructured.Unstructured{})
 	metav1.AddToGroupVersion(mgr.GetScheme(), options.GVK.GroupVersion())
 
-	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 10})
 	if err != nil {
 		return err
 	}

--- a/pkg/helm/flags/flag.go
+++ b/pkg/helm/flags/flag.go
@@ -15,6 +15,8 @@
 package flags
 
 import (
+	"strings"
+
 	"github.com/operator-framework/operator-sdk/internal/flags/watch"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/spf13/pflag"
@@ -23,6 +25,7 @@ import (
 // HelmOperatorFlags - Options to be used by a helm operator
 type HelmOperatorFlags struct {
 	watch.WatchFlags
+	MaxWorkers int
 }
 
 // AddTo - Add the helm operator flags to the the flagset
@@ -31,5 +34,12 @@ func AddTo(flagSet *pflag.FlagSet, helpTextPrefix ...string) *HelmOperatorFlags 
 	hof := &HelmOperatorFlags{}
 	hof.WatchFlags.AddTo(flagSet, helpTextPrefix...)
 	flagSet.AddFlagSet(zap.FlagSet())
+	flagSet.IntVar(&hof.MaxWorkers,
+		"max-workers",
+		1,
+		strings.Join(append(helpTextPrefix,
+			"Maximum number of workers to use."),
+			" "),
+	)
 	return hof
 }

--- a/pkg/helm/run.go
+++ b/pkg/helm/run.go
@@ -126,6 +126,7 @@ func Run(flags *hoflags.HelmOperatorFlags) error {
 			ReconcilePeriod:         flags.ReconcilePeriod,
 			WatchDependentResources: w.WatchDependentResources,
 			OverrideValues:          w.OverrideValues,
+			MaxWorkers:              flags.MaxWorkers,
 		})
 		if err != nil {
 			log.Error(err, "Failed to add manager factory to controller.")


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adds --max-workers flag to the exec-entrypoint helm command

**Motivation for the change:**
Currently the helm operator runs with just 1 worker. Reconciling helm releases can sometime take >1 second, using a single worker will not be able to keep up for more than 60 CRs of the same type. 

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
