### PR TITLE
[fix]: include filename in the error returned by generate-csv command

### DIFF
--- a/cmd/operator-sdk/generate/csv.go
+++ b/cmd/operator-sdk/generate/csv.go
@@ -199,7 +199,7 @@ func writeCRDsToDir(crdPaths []string, toDir string) error {
 		}
 		typeMeta, err := k8sutil.GetTypeMetaFromBytes(b)
 		if err != nil {
-			return err
+			return fmt.Errorf("error in %s : %v", p, err)
 		}
 		if typeMeta.Kind != "CustomResourceDefinition" {
 			continue


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Modify error message by including the file path.

**Motivation for the change:**
 Currently, if there is error during unmarshalling of crds in the
deploy/crds folder, the error returned by generate-csv command
is unclear as it does not include any filename. This PR modifies
the error message to include the filepath.
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #2583 

-->
