### PR TITLE
Add `--olm-namespace` flag to OLM related subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Add the --proxy-port flag to the operator-sdk scorecard command allowing users to override the default proxy port value (8889). ([2634](https://github.com/operator-framework/operator-sdk/pull/2634))
 - Add support for Metrics with MultiNamespace scenario. ([#2603](https://github.com/operator-framework/operator-sdk/pull/2603))
 - Add Prometheus metrics support to Helm-based operators. ([#2603](https://github.com/operator-framework/operator-sdk/pull/2603))
+- Add a new flag option `--olm-namespace` to `operator-sdk run --olm`, `operator-sdk cleanup --olm` and `operator-sdk olm status` command, which allows specifying the namespace in which OLM is installed. ([#2613](https://github.com/operator-framework/operator-sdk/pull/2613))
 
 ### Changed
 - The base image now includes version 0.10.3 of the OpenShift Python client. This should fix hanging in Python3

--- a/cmd/operator-sdk/new/cmd.go
+++ b/cmd/operator-sdk/new/cmd.go
@@ -52,49 +52,49 @@ generates a default directory layout based on the input <project-name>.
 
 <project-name> is the project name of the new operator. (e.g app-operator)
 `,
-		Example: `# Create a new project directory
-		$ mkdir $HOME/projects/example.com/
-		$ cd $HOME/projects/example.com/
+		Example: `  # Create a new project directory
+  $ mkdir $HOME/projects/example.com/
+  $ cd $HOME/projects/example.com/
 
-		# Go project
-		$ operator-sdk new app-operator
+  # Go project
+  $ operator-sdk new app-operator
 
-		# Ansible project
-		$ operator-sdk new app-operator --type=ansible \
-				--api-version=app.example.com/v1alpha1 \
-				--kind=AppService
+  # Ansible project
+  $ operator-sdk new app-operator --type=ansible \
+    --api-version=app.example.com/v1alpha1 \
+    --kind=AppService
 
-		# Helm project
-		$ operator-sdk new app-operator --type=helm \
-		    --api-version=app.example.com/v1alpha1 \
-		    --kind=AppService
+  # Helm project
+  $ operator-sdk new app-operator --type=helm \
+  --api-version=app.example.com/v1alpha1 \
+  --kind=AppService
 
-		$ operator-sdk new app-operator --type=helm \
-		    --api-version=app.example.com/v1alpha1 \
-		    --kind=AppService \
-		    --helm-chart=myrepo/app
+  $ operator-sdk new app-operator --type=helm \
+  --api-version=app.example.com/v1alpha1 \
+  --kind=AppService \
+  --helm-chart=myrepo/app
 
-		$ operator-sdk new app-operator --type=helm \
-		    --helm-chart=myrepo/app
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=myrepo/app
 
-		$ operator-sdk new app-operator --type=helm \
-		    --helm-chart=myrepo/app \
-		    --helm-chart-version=1.2.3
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=myrepo/app \
+  --helm-chart-version=1.2.3
 
-		$ operator-sdk new app-operator --type=helm \
-		    --helm-chart=app \
-		    --helm-chart-repo=https://charts.mycompany.com/
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=app \
+  --helm-chart-repo=https://charts.mycompany.com/
 
-		$ operator-sdk new app-operator --type=helm \
-		    --helm-chart=app \
-		    --helm-chart-repo=https://charts.mycompany.com/ \
-		    --helm-chart-version=1.2.3
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=app \
+  --helm-chart-repo=https://charts.mycompany.com/ \
+  --helm-chart-version=1.2.3
 
-		$ operator-sdk new app-operator --type=helm \
-		    --helm-chart=/path/to/local/chart-directories/app/
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=/path/to/local/chart-directories/app/
 
-		$ operator-sdk new app-operator --type=helm \
-		    --helm-chart=/path/to/local/chart-archives/app-1.2.3.tgz
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=/path/to/local/chart-archives/app-1.2.3.tgz
 `,
 		RunE: newFunc,
 	}

--- a/cmd/operator-sdk/olm/status.go
+++ b/cmd/operator-sdk/olm/status.go
@@ -34,6 +34,7 @@ func newStatusCmd() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVar(&mgr.OLMNamespace, "olm-namespace", olm.DefaultOLMNamespace, "namespace where OLM is installed")
 	mgr.AddToFlagSet(cmd.Flags())
 	return cmd
 }

--- a/doc/cli/operator-sdk_cleanup.md
+++ b/doc/cli/operator-sdk_cleanup.md
@@ -16,6 +16,7 @@ operator-sdk cleanup [flags]
       --kubeconfig string           The file path to kubernetes configuration file. Defaults to location specified by $KUBECONFIG, or to default file rules if not set
       --namespace string            (Deprecated: use --operator-namespace instead.) The namespace from which operator and namespacesresources are cleaned up
       --olm                         The operator to be cleaned up is managed by OLM in a cluster. Cannot be set with another cleanup-type flag (default true)
+      --olm-namespace string        [olm only] The namespace where OLM is installed (default "olm")
       --operator-namespace string   [olm only] The namespace where operator resources are created in --olm mode. It must already exist in the cluster or be defined in a manifest passed to IncludePaths.
       --manifests string            [olm only] Directory containing package manifest and operator bundles.
       --operator-version string     [olm only] Version of operator to deploy

--- a/doc/cli/operator-sdk_new.md
+++ b/doc/cli/operator-sdk_new.md
@@ -17,49 +17,49 @@ operator-sdk new <project-name> [flags]
 ### Examples
 
 ```
-# Create a new project directory
-		$ mkdir $HOME/projects/example.com/
-		$ cd $HOME/projects/example.com/
+  # Create a new project directory
+  $ mkdir $HOME/projects/example.com/
+  $ cd $HOME/projects/example.com/
 
-		# Go project
-		$ operator-sdk new app-operator
+  # Go project
+  $ operator-sdk new app-operator
 
-		# Ansible project
-		$ operator-sdk new app-operator --type=ansible \
-				--api-version=app.example.com/v1alpha1 \
-				--kind=AppService
+  # Ansible project
+  $ operator-sdk new app-operator --type=ansible \
+    --api-version=app.example.com/v1alpha1 \
+    --kind=AppService
 
-		# Helm project
-		$ operator-sdk new app-operator --type=helm \
-		    --api-version=app.example.com/v1alpha1 \
-		    --kind=AppService
+  # Helm project
+  $ operator-sdk new app-operator --type=helm \
+  --api-version=app.example.com/v1alpha1 \
+  --kind=AppService
 
-		$ operator-sdk new app-operator --type=helm \
-		    --api-version=app.example.com/v1alpha1 \
-		    --kind=AppService \
-		    --helm-chart=myrepo/app
+  $ operator-sdk new app-operator --type=helm \
+  --api-version=app.example.com/v1alpha1 \
+  --kind=AppService \
+  --helm-chart=myrepo/app
 
-		$ operator-sdk new app-operator --type=helm \
-		    --helm-chart=myrepo/app
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=myrepo/app
 
-		$ operator-sdk new app-operator --type=helm \
-		    --helm-chart=myrepo/app \
-		    --helm-chart-version=1.2.3
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=myrepo/app \
+  --helm-chart-version=1.2.3
 
-		$ operator-sdk new app-operator --type=helm \
-		    --helm-chart=app \
-		    --helm-chart-repo=https://charts.mycompany.com/
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=app \
+  --helm-chart-repo=https://charts.mycompany.com/
 
-		$ operator-sdk new app-operator --type=helm \
-		    --helm-chart=app \
-		    --helm-chart-repo=https://charts.mycompany.com/ \
-		    --helm-chart-version=1.2.3
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=app \
+  --helm-chart-repo=https://charts.mycompany.com/ \
+  --helm-chart-version=1.2.3
 
-		$ operator-sdk new app-operator --type=helm \
-		    --helm-chart=/path/to/local/chart-directories/app/
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=/path/to/local/chart-directories/app/
 
-		$ operator-sdk new app-operator --type=helm \
-		    --helm-chart=/path/to/local/chart-archives/app-1.2.3.tgz
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=/path/to/local/chart-archives/app-1.2.3.tgz
 
 ```
 

--- a/doc/cli/operator-sdk_olm_status.md
+++ b/doc/cli/operator-sdk_olm_status.md
@@ -13,8 +13,9 @@ operator-sdk olm status [flags]
 ### Options
 
 ```
-  -h, --help               help for status
-      --timeout duration   time to wait for the command to complete before failing (default 2m0s)
+  -h, --help                   help for status
+      --olm-namespace string   namespace where OLM is installed (default "olm")
+      --timeout duration       time to wait for the command to complete before failing (default 2m0s)
 ```
 
 ### SEE ALSO

--- a/doc/cli/operator-sdk_run.md
+++ b/doc/cli/operator-sdk_run.md
@@ -16,6 +16,7 @@ operator-sdk run [flags]
       --kubeconfig string           The file path to kubernetes configuration file. Defaults to location specified by $KUBECONFIG, or to default file rules if not set
       --namespace string            (Deprecated: use --watch-namespace instead.)The namespace where the operator watches for changes.
       --olm                         The operator to be run will be managed by OLM in a cluster. Cannot be set with another run-type flag
+      --olm-namespace string        [olm only] The namespace where OLM is installed (default "olm")
       --operator-namespace string   [olm only] The namespace where operator resources are created in --olm mode. It must already exist in the cluster or be defined in a manifest passed to IncludePaths.
       --manifests string            [olm only] Directory containing package manifest and operator bundles.
       --operator-version string     [olm only] Version of operator to deploy

--- a/internal/olm/client/client.go
+++ b/internal/olm/client/client.go
@@ -42,8 +42,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
-const OLMNamespace = "olm"
-
 var ErrOLMNotInstalled = errors.New("no existing installation found")
 
 var Scheme = scheme.Scheme
@@ -211,14 +209,15 @@ func (c Client) DoCSVWait(ctx context.Context, key types.NamespacedName) error {
 	return wait.PollImmediateUntil(time.Second, csvPhaseSucceeded, ctx.Done())
 }
 
-func (c Client) GetInstalledVersion(ctx context.Context) (string, error) {
-	opts := client.InNamespace(OLMNamespace)
+// GetInstalledVersion returns the OLM version installed in the namespace informed.
+func (c Client) GetInstalledVersion(ctx context.Context, namespace string) (string, error) {
+	opts := client.InNamespace(namespace)
 	csvs := &olmapiv1alpha1.ClusterServiceVersionList{}
 	if err := c.KubeClient.List(ctx, csvs, opts); err != nil {
 		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 			return "", ErrOLMNotInstalled
 		}
-		return "", fmt.Errorf("failed to list CSVs in namespace %q: %v", OLMNamespace, err)
+		return "", fmt.Errorf("failed to list CSVs in namespace %q: %v", namespace, err)
 	}
 	var pkgServerCSV *olmapiv1alpha1.ClusterServiceVersion
 	for _, csv := range csvs.Items {

--- a/internal/olm/manager.go
+++ b/internal/olm/manager.go
@@ -28,14 +28,16 @@ import (
 const (
 	DefaultVersion = "latest"
 	DefaultTimeout = time.Minute * 2
+	// DefaultOLMNamespace is the namespace where OLM is installed
+	DefaultOLMNamespace = "olm"
 )
 
 type Manager struct {
-	Client  *Client
-	Version string
-	Timeout time.Duration
-
-	once sync.Once
+	Client       *Client
+	Version      string
+	Timeout      time.Duration
+	OLMNamespace string
+	once         sync.Once
 }
 
 func (m *Manager) initialize() (err error) {
@@ -60,6 +62,9 @@ func (m *Manager) initialize() (err error) {
 		if m.Timeout <= 0 {
 			m.Timeout = DefaultTimeout
 		}
+		if m.OLMNamespace == "" {
+			m.OLMNamespace = DefaultOLMNamespace
+		}
 	})
 	return err
 }
@@ -72,7 +77,7 @@ func (m *Manager) Install() error {
 	ctx, cancel := context.WithTimeout(context.Background(), m.Timeout)
 	defer cancel()
 
-	status, err := m.Client.InstallVersion(ctx, m.Version)
+	status, err := m.Client.InstallVersion(ctx, m.OLMNamespace, m.Version)
 	if err != nil {
 		return err
 	}
@@ -91,12 +96,12 @@ func (m *Manager) Uninstall() error {
 	ctx, cancel := context.WithTimeout(context.Background(), m.Timeout)
 	defer cancel()
 
-	version, err := m.Client.GetInstalledVersion(ctx)
+	version, err := m.Client.GetInstalledVersion(ctx, m.OLMNamespace)
 	if err != nil {
 		return err
 	}
 
-	if err := m.Client.UninstallVersion(ctx, version); err != nil {
+	if err := m.Client.UninstallVersion(ctx, m.OLMNamespace, version); err != nil {
 		return err
 	}
 
@@ -112,12 +117,12 @@ func (m *Manager) Status() error {
 	ctx, cancel := context.WithTimeout(context.Background(), m.Timeout)
 	defer cancel()
 
-	version, err := m.Client.GetInstalledVersion(ctx)
+	version, err := m.Client.GetInstalledVersion(ctx, m.OLMNamespace)
 	if err != nil {
 		return err
 	}
 
-	status, err := m.Client.GetStatus(ctx, version)
+	status, err := m.Client.GetStatus(ctx, m.OLMNamespace, version)
 	if err != nil {
 		return err
 	}

--- a/internal/olm/operator/operator.go
+++ b/internal/olm/operator/operator.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/operator-framework/operator-sdk/internal/olm"
+
 	"github.com/spf13/pflag"
 )
 
@@ -73,6 +75,8 @@ type OLMCmd struct { // nolint:golint
 	// OperatorNamespace must already exist in the cluster or be defined in
 	// a manifest passed to IncludePaths.
 	OperatorNamespace string
+	// OLMNamespace is the namespace in which OLM is installed.
+	OLMNamespace string
 	// Timeout dictates how long to wait for a REST call to complete. A call
 	// exceeding Timeout will generate an error.
 	Timeout time.Duration
@@ -86,6 +90,8 @@ var installModeFormat = "InstallModeType=[ns1,ns2[, ...]]"
 
 func (c *OLMCmd) AddToFlagSet(fs *pflag.FlagSet) {
 	prefix := "[olm only] "
+	fs.StringVar(&c.OLMNamespace, "olm-namespace", olm.DefaultOLMNamespace,
+		prefix+"The namespace where OLM is installed")
 	fs.StringVar(&c.OperatorNamespace, "operator-namespace", "",
 		prefix+"The namespace where operator resources are created in --olm mode. It "+
 			"must already exist in the cluster or be defined in"+

--- a/test/integration/operator_olm_test.go
+++ b/test/integration/operator_olm_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/operator-framework/operator-sdk/internal/olm"
 	operator "github.com/operator-framework/operator-sdk/internal/olm/operator"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 
@@ -91,6 +92,7 @@ func SingleOperator(t *testing.T) {
 		OperatorVersion: operatorVersion,
 		KubeconfigPath:  kubeconfigPath,
 		Timeout:         defaultTimeout,
+		OLMNamespace:    olm.DefaultOLMNamespace,
 	}
 	// Cleanup.
 	defer func() {

--- a/website/content/en/docs/cli/operator-sdk_cleanup.md
+++ b/website/content/en/docs/cli/operator-sdk_cleanup.md
@@ -16,6 +16,7 @@ operator-sdk cleanup [flags]
       --kubeconfig string           The file path to kubernetes configuration file. Defaults to location specified by $KUBECONFIG, or to default file rules if not set
       --namespace string            (Deprecated: use --operator-namespace instead.) The namespace from which operator and namespacesresources are cleaned up
       --olm                         The operator to be cleaned up is managed by OLM in a cluster. Cannot be set with another cleanup-type flag (default true)
+      --olm-namespace string        [olm only] The namespace where OLM is installed (default "olm")
       --operator-namespace string   [olm only] The namespace where operator resources are created in --olm mode. It must already exist in the cluster or be defined in a manifest passed to IncludePaths.
       --manifests string            [olm only] Directory containing package manifest and operator bundles.
       --operator-version string     [olm only] Version of operator to deploy

--- a/website/content/en/docs/cli/operator-sdk_new.md
+++ b/website/content/en/docs/cli/operator-sdk_new.md
@@ -9,16 +9,58 @@ generates a default directory layout based on the input <project-name>.
 
 <project-name> is the project name of the new operator. (e.g app-operator)
 
-For example:
-
-	$ mkdir $HOME/projects/example.com/
-	$ cd $HOME/projects/example.com/
-	$ operator-sdk new app-operator
-generates a skeletal app-operator application in $HOME/projects/example.com/app-operator.
-
 
 ```
 operator-sdk new <project-name> [flags]
+```
+
+### Examples
+
+```
+  # Create a new project directory
+  $ mkdir $HOME/projects/example.com/
+  $ cd $HOME/projects/example.com/
+
+  # Go project
+  $ operator-sdk new app-operator
+
+  # Ansible project
+  $ operator-sdk new app-operator --type=ansible \
+    --api-version=app.example.com/v1alpha1 \
+    --kind=AppService
+
+  # Helm project
+  $ operator-sdk new app-operator --type=helm \
+  --api-version=app.example.com/v1alpha1 \
+  --kind=AppService
+
+  $ operator-sdk new app-operator --type=helm \
+  --api-version=app.example.com/v1alpha1 \
+  --kind=AppService \
+  --helm-chart=myrepo/app
+
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=myrepo/app
+
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=myrepo/app \
+  --helm-chart-version=1.2.3
+
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=app \
+  --helm-chart-repo=https://charts.mycompany.com/
+
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=app \
+  --helm-chart-repo=https://charts.mycompany.com/ \
+  --helm-chart-version=1.2.3
+
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=/path/to/local/chart-directories/app/
+
+  $ operator-sdk new app-operator --type=helm \
+  --helm-chart=/path/to/local/chart-archives/app-1.2.3.tgz
+
 ```
 
 ### Options

--- a/website/content/en/docs/cli/operator-sdk_olm_status.md
+++ b/website/content/en/docs/cli/operator-sdk_olm_status.md
@@ -13,8 +13,9 @@ operator-sdk olm status [flags]
 ### Options
 
 ```
-  -h, --help               help for status
-      --timeout duration   time to wait for the command to complete before failing (default 2m0s)
+  -h, --help                   help for status
+      --olm-namespace string   namespace where OLM is installed (default "olm")
+      --timeout duration       time to wait for the command to complete before failing (default 2m0s)
 ```
 
 ### SEE ALSO

--- a/website/content/en/docs/cli/operator-sdk_run.md
+++ b/website/content/en/docs/cli/operator-sdk_run.md
@@ -16,6 +16,7 @@ operator-sdk run [flags]
       --kubeconfig string           The file path to kubernetes configuration file. Defaults to location specified by $KUBECONFIG, or to default file rules if not set
       --namespace string            (Deprecated: use --watch-namespace instead.)The namespace where the operator watches for changes.
       --olm                         The operator to be run will be managed by OLM in a cluster. Cannot be set with another run-type flag
+      --olm-namespace string        [olm only] The namespace where OLM is installed (default "olm")
       --operator-namespace string   [olm only] The namespace where operator resources are created in --olm mode. It must already exist in the cluster or be defined in a manifest passed to IncludePaths.
       --manifests string            [olm only] Directory containing package manifest and operator bundles.
       --operator-version string     [olm only] Version of operator to deploy


### PR DESCRIPTION
**Description of the change:**

- Add `--olm-namespace` flag to to `operator-sdk run --olm` command
- Add `--olm-namespace` flag to `operator-sdk olm status` command
- Add `--olm-namespace` flag to `operator-sdk cleanup` command

**Motivation for the change:**

This fixes the bug where running these commands against a openshift 4.x cluster would fail because in those clusters the OLM is installed in `namesapce: openshift-operator-lifecycle-manager` and the code always defaulted to default `namespace: olm`. Its now fixed by adding a new flag `--olm-namespace` that allows to override the default namespace(olm).

Closes: https://github.com/operator-framework/operator-sdk/issues/2595

**Example usage**

```
# get OLM installation status
$ operator-sdk olm status --olm-namespace openshift-operator-lifecycle-manager

# run locally with OLM
$ operator-sdk run --olm \
--operator-version 0.1.0 \
--manifests sample-operator/deploy/olm-catalog/sample-operator \
--olm-namespace openshift-operator-lifecycle-manager

# cleanup
$ operator-sdk cleanup --olm \
--operator-version 0.1.0 \
--manifests sample-operator/deploy/olm-catalog/sample-operator \
--olm-namespace openshift-operator-lifecycle-manager
```


