### PR TITLE
Add to migration doc steps regards changes over metrics to the scaffolded files.

### DIFF
--- a/doc/migration/version-upgrade-guide.md
+++ b/doc/migration/version-upgrade-guide.md
@@ -814,7 +814,7 @@ See the [CHANGELOG](https://github.com/operator-framework/operator-sdk/blob/mast
 
 ### Bug Fixes and Improvements for Metrics
 
-Some changes were performed in the default implementation regards the default metrics export.  In this way, update the  `cmd/main.go` file as follows. 
+There were some changes to the default implementation of the metrics export. These changes require the `cmd/main.go` be updated as follows.
 
 Replace:
 

--- a/doc/migration/version-upgrade-guide.md
+++ b/doc/migration/version-upgrade-guide.md
@@ -814,7 +814,7 @@ See the [CHANGELOG](https://github.com/operator-framework/operator-sdk/blob/mast
 
 ### Bug Fixes and Improvements for Metrics
 
-Some changes were performed in the default implementation regards the default metrics export.  In this way, update the  `cmd/main.go` file as follows.
+Some changes were performed in the default implementation regards the default metrics export.  In this way, update the  `cmd/main.go` file as follows. 
 
 Replace:
 
@@ -834,17 +834,22 @@ func main() {
 	addMetrics(ctx, cfg)
 ``` 
 
-And then, replace the default implementation of `addMetrics` and `serveCRMetrics` method with:
+And then, update the default implementation of `addMetrics` and `serveCRMetrics` with:
 
 ```go
 // addMetrics will create the Services and Service Monitors to allow the operator export the metrics by using
 // the Prometheus operator
 func addMetrics(ctx context.Context, cfg *rest.Config) {
-	if err := serveCRMetrics(cfg); err != nil {
+	// Get the namespace the operator is currently deployed in.
+	operatorNs, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
 		if errors.Is(err, k8sutil.ErrRunLocal) {
 			log.Info("Skipping CR metrics server creation; not running in a cluster.")
 			return
 		}
+	}
+
+	if err := serveCRMetrics(cfg, operatorNs); err != nil {
 		log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
 	}
 
@@ -864,13 +869,6 @@ func addMetrics(ctx context.Context, cfg *rest.Config) {
 	// necessary to configure Prometheus to scrape metrics from this operator.
 	services := []*v1.Service{service}
 
-	// Get the namespace the operator is currently deployed in.
-	operatorNs, err := k8sutil.GetOperatorNamespace()
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-
 	// The ServiceMonitor is created in the same namespace where the operator is deployed
 	_, err = metrics.CreateServiceMonitors(cfg, operatorNs, services)
 	if err != nil {
@@ -885,32 +883,22 @@ func addMetrics(ctx context.Context, cfg *rest.Config) {
 
 // serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
 // It serves those metrics on "http://metricsHost:operatorMetricsPort".
-func serveCRMetrics(cfg *rest.Config) error {
-	// Below function returns filtered operator/CustomResource specific GVKs.
-	// For more control override the below GVK list with your own custom logic.
+func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
+	// The function below returns a list of filtered operator/CR specific GVKs. For more control, override the GVK list below
+	// with your own custom logic. Note that if you are adding third party API schemas, probably you will need to
+	// customize this implementation to avoid permissions issues.
 	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
 	if err != nil {
 		return err
 	}
-	// Get the namespace the operator is currently deployed in.
-	operatorNs, err := k8sutil.GetOperatorNamespace()
-	if err != nil {
-		return err
-	}
-	// To generate metrics in other namespaces, add the values below.
 
-	// Get the value from WATCH_NAMESPACES
-	watchNamespace, err := k8sutil.GetWatchNamespace()
+	// The metrics will be generated from the namespaces which are returned here.
+	// NOTE that passing nil or an empty list of namespaces in GenerateAndServeCRMetrics will result in an error.
+	ns, err := getNamespacesForMetrics(operatorNs)
 	if err != nil {
 		return err
 	}
-	//The metrics will be generated from the namespaces which are in ns
-	//NOTE that passing nil or an empty list of namespaces will result in an error.
-	ns := []string{operatorNs}
-	// To generate metrics from WATCH_NAMESPACES values if it be as for example ns1,ns2
-	if strings.Contains(watchNamespace, ",") {
-		ns = strings.Split(watchNamespace, ",")
-	}
+
 	// Generate and serve custom resource specific metrics.
 	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
 	if err != nil {
@@ -918,7 +906,26 @@ func serveCRMetrics(cfg *rest.Config) error {
 	}
 	return nil
 }
+
+// getNamespacesForMetrics wil return all namespaces which will be used to export the metrics
+func getNamespacesForMetrics(operatorNs string) ([]string, error) {
+	ns := []string{operatorNs}
+
+	// Get the value from WATCH_NAMESPACES
+	watchNamespace, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate metrics from the WATCH_NAMESPACES value if it contains multiple namespaces
+	if strings.Contains(watchNamespace, ",") {
+		ns = strings.Split(watchNamespace, ",")
+	}
+	return ns, nil
+}
 ```
+
+**NOTE**: For further and detailed information check the PRs which are responsible for the above changes [#2606](https://github.com/operator-framework/operator-sdk/pull/2606),[#2603](https://github.com/operator-framework/operator-sdk/pull/2603) #2603 and [#2601](https://github.com/operator-framework/operator-sdk/pull/2601).
 
 ### Breaking changes
 

--- a/doc/migration/version-upgrade-guide.md
+++ b/doc/migration/version-upgrade-guide.md
@@ -894,7 +894,7 @@ func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
 
 	// The metrics will be generated from the namespaces which are returned here.
 	// NOTE that passing nil or an empty list of namespaces in GenerateAndServeCRMetrics will result in an error.
-	ns, err := getNamespacesForMetrics(operatorNs)
+	ns, err := kubemetrics.GetNamespacesForMetrics(operatorNs)
 	if err != nil {
 		return err
 	}
@@ -905,23 +905,6 @@ func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
 		return err
 	}
 	return nil
-}
-
-// getNamespacesForMetrics wil return all namespaces which will be used to export the metrics
-func getNamespacesForMetrics(operatorNs string) ([]string, error) {
-	ns := []string{operatorNs}
-
-	// Get the value from WATCH_NAMESPACES
-	watchNamespace, err := k8sutil.GetWatchNamespace()
-	if err != nil {
-		return nil, err
-	}
-
-	// Generate metrics from the WATCH_NAMESPACES value if it contains multiple namespaces
-	if strings.Contains(watchNamespace, ",") {
-		ns = strings.Split(watchNamespace, ",")
-	}
-	return ns, nil
 }
 ```
 

--- a/doc/migration/version-upgrade-guide.md
+++ b/doc/migration/version-upgrade-guide.md
@@ -925,7 +925,7 @@ func getNamespacesForMetrics(operatorNs string) ([]string, error) {
 }
 ```
 
-**NOTE**: For further and detailed information check the PRs which are responsible for the above changes [#2606](https://github.com/operator-framework/operator-sdk/pull/2606),[#2603](https://github.com/operator-framework/operator-sdk/pull/2603) #2603 and [#2601](https://github.com/operator-framework/operator-sdk/pull/2601).
+**NOTE**: For further and detailed information check the PRs which are responsible for the above changes [#2606](https://github.com/operator-framework/operator-sdk/pull/2606),[#2603](https://github.com/operator-framework/operator-sdk/pull/2603) and [#2601](https://github.com/operator-framework/operator-sdk/pull/2601).
 
 ### Breaking changes
 

--- a/doc/migration/version-upgrade-guide.md
+++ b/doc/migration/version-upgrade-guide.md
@@ -908,7 +908,7 @@ func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
 }
 ```
 
-**NOTE**: For further and detailed information check the PRs which are responsible for the above changes [#2606](https://github.com/operator-framework/operator-sdk/pull/2606),[#2603](https://github.com/operator-framework/operator-sdk/pull/2603) and [#2601](https://github.com/operator-framework/operator-sdk/pull/2601).
+**NOTE**: For more information check the PRs which are responsible for the above changes [#2606](https://github.com/operator-framework/operator-sdk/pull/2606),[#2603](https://github.com/operator-framework/operator-sdk/pull/2603) and [#2601](https://github.com/operator-framework/operator-sdk/pull/2601).
 
 ### Breaking changes
 


### PR DESCRIPTION
**Description of the change:**
- Add info over changes in the default scaffold in the main.go file to address bug fixes and improvements. 

NOTE: It can just be merged after we merge: https://github.com/operator-framework/operator-sdk/pull/2606, https://github.com/operator-framework/operator-sdk/pull/2603, https://github.com/operator-framework/operator-sdk/pull/2601




