### PR TITLE
Add docs about not running e2e testing m directly

### DIFF
--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -16,7 +16,10 @@ about are Framework and Context.
 
 [Framework][framework-link] contains all global variables, such as the kubeconfig, kubeclient,
 scheme, and dynamic client (provided via the controller-runtime project).
-It is initialized by MainEntry and can be used anywhere in the tests.
+It is initialized by the MainEntry function and can be used anywhere in the tests.
+
+**Note:** several required arguments are initialized and added by `MainEntry()`. Do not attempt to
+use `testing.M` directly.
 
 ### Context
 


### PR DESCRIPTION
**Description of the change:**
Add docs text explaining why e2e operator tests *must* use the testing framework's MainEntry function.

**Motivation for the change:**
e2e tests that do not use the framework MainEntry function cause confusing errors when attempting to run your test, the source of which is not obvious. See #1908.

Closes #1908 