### PR TITLE
Scorecard - add proxy port configuration setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add event stats output to the operator logs for Ansible based-operators. ([2580](https://github.com/operator-framework/operator-sdk/pull/2580))
 - Improve Ansible logs by allowing output the full Ansible result for Ansible based-operators configurable by environment variable. ([2589](https://github.com/operator-framework/operator-sdk/pull/2589))
 - Add the --max-workers flag to the commands operator-sdk exec-entrypoint and operator-sdk run --local for Helm based-operators with the purpose of controling the number of concurrent reconcile workers. ([2607](https://github.com/operator-framework/operator-sdk/pull/2607))
+- Add the --proxy-port flag to the operator-sdk scorecard command allowing users to override the default proxy port value (8889). ([2634](https://github.com/operator-framework/operator-sdk/pull/2634))
 
 ### Changed
 - Ansible scaffolding has been rewritten to be simpler and make use of newer features of Ansible and Molecule.

--- a/doc/test-framework/scorecard.md
+++ b/doc/test-framework/scorecard.md
@@ -129,6 +129,7 @@ The `basic` and `olm` internal plugins have the same configuration fields:
 | `crds-dir` | string | path to directory containing CRDs that must be deployed to the cluster |
 | `namespaced-manifest` | string | manifest file with all resources that run within a namespace. By default, the scorecard will combine `service_account.yaml`, `role.yaml`, `role_binding.yaml`, and `operator.yaml` from the `deploy` directory into a temporary manifest to use as the namespaced manifest |
 | `global-manifest` | string | manifest containing required resources that run globally (not namespaced). By default, the scorecard will combine all CRDs in the `crds-dir` directory into a temporary manifest to use as the global manifest |
+| `proxy-port` | int | port for scorecard-proxy to listen to, default is port 8889 |
 
 ## Tests Performed
 

--- a/internal/scorecard/interfaces.go
+++ b/internal/scorecard/interfaces.go
@@ -76,6 +76,9 @@ func setConfigDefaults(config *scplugins.BasicAndOLMPluginConfig, kubeconfig str
 		config.ProxyImage = fmt.Sprintf("quay.io/operator-framework/scorecard-proxy:%s",
 			strings.TrimSuffix(version.Version, "+git"))
 	}
+	if config.ProxyPort == 0 {
+		config.ProxyPort = 8889
+	}
 	if config.ProxyPullPolicy == "" {
 		config.ProxyPullPolicy = v1.PullAlways
 	}

--- a/internal/scorecard/plugins/config.go
+++ b/internal/scorecard/plugins/config.go
@@ -31,6 +31,7 @@ type BasicAndOLMPluginConfig struct {
 	CRManifest         []string        `mapstructure:"cr-manifest"`
 	CSVManifest        string          `mapstructure:"csv-path"`
 	ProxyImage         string          `mapstructure:"proxy-image"`
+	ProxyPort          int             `mapstructure:"proxy-port"`
 	ProxyPullPolicy    v1.PullPolicy   `mapstructure:"proxy-pull-policy"`
 	CRDsDir            string          `mapstructure:"crds-dir"`
 	DeployDir          string          `mapstructure:"deploy-dir"`

--- a/internal/scorecard/plugins/plugin_runner.go
+++ b/internal/scorecard/plugins/plugin_runner.go
@@ -401,17 +401,15 @@ func runTests(csv *olmapiv1alpha1.ClusterServiceVersion, pluginType PluginType, 
 	log.Printf("Running for cr: %s", cr)
 
 	if !cfg.OLMDeployed {
-		if err := createFromYAMLFile(cfg.Namespace, cfg.GlobalManifest, cfg.ProxyImage,
-			cfg.ProxyPullPolicy, cfg.InitTimeout, cfg.ProxyPort); err != nil {
+		if err := createFromYAMLFile(cfg, cfg.GlobalManifest); err != nil {
 			return testResults, "", fmt.Errorf("failed to create global resources: %v", err)
 		}
-		if err := createFromYAMLFile(cfg.Namespace, cfg.NamespacedManifest, cfg.ProxyImage,
-			cfg.ProxyPullPolicy, cfg.InitTimeout, cfg.ProxyPort); err != nil {
+		if err := createFromYAMLFile(cfg, cfg.NamespacedManifest); err != nil {
 			return testResults, "", fmt.Errorf("failed to create namespaced resources: %v", err)
 		}
 	}
 
-	if err := createFromYAMLFile(cfg.Namespace, cr, cfg.ProxyImage, cfg.ProxyPullPolicy, cfg.InitTimeout, cfg.ProxyPort); err != nil {
+	if err := createFromYAMLFile(cfg, cr); err != nil {
 		return testResults, "", fmt.Errorf("failed to create cr resource: %v", err)
 	}
 

--- a/internal/scorecard/plugins/plugin_runner.go
+++ b/internal/scorecard/plugins/plugin_runner.go
@@ -402,16 +402,16 @@ func runTests(csv *olmapiv1alpha1.ClusterServiceVersion, pluginType PluginType, 
 
 	if !cfg.OLMDeployed {
 		if err := createFromYAMLFile(cfg.Namespace, cfg.GlobalManifest, cfg.ProxyImage,
-			cfg.ProxyPullPolicy, cfg.InitTimeout); err != nil {
+			cfg.ProxyPullPolicy, cfg.InitTimeout, cfg.ProxyPort); err != nil {
 			return testResults, "", fmt.Errorf("failed to create global resources: %v", err)
 		}
 		if err := createFromYAMLFile(cfg.Namespace, cfg.NamespacedManifest, cfg.ProxyImage,
-			cfg.ProxyPullPolicy, cfg.InitTimeout); err != nil {
+			cfg.ProxyPullPolicy, cfg.InitTimeout, cfg.ProxyPort); err != nil {
 			return testResults, "", fmt.Errorf("failed to create namespaced resources: %v", err)
 		}
 	}
 
-	if err := createFromYAMLFile(cfg.Namespace, cr, cfg.ProxyImage, cfg.ProxyPullPolicy, cfg.InitTimeout); err != nil {
+	if err := createFromYAMLFile(cfg.Namespace, cr, cfg.ProxyImage, cfg.ProxyPullPolicy, cfg.InitTimeout, cfg.ProxyPort); err != nil {
 		return testResults, "", fmt.Errorf("failed to create cr resource: %v", err)
 	}
 

--- a/internal/scorecard/plugins/resource_handler.go
+++ b/internal/scorecard/plugins/resource_handler.go
@@ -219,7 +219,8 @@ func getPodFromDeployment(depName, namespace string) (pod *v1.Pod, err error) {
 // the kubeconfig for communicating with the proxy
 func createKubeconfigSecret(namespace string, initTimeout int, proxyPort int) error {
 	kubeconfigMap := make(map[string][]byte)
-	kc, err := proxyConf.Create(metav1.OwnerReference{Name: "scorecard"}, "http://localhost:"+strconv.Itoa(proxyPort), namespace)
+	proxyURL := fmt.Sprintf("http://localhost:%d", proxyPort)
+	kc, err := proxyConf.Create(metav1.OwnerReference{Name: "scorecard"}, proxyURL, namespace)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

**Description of the change:**
this change adds a proxy-port configuration setting for the scorecard

**Motivation for the change:**

scorecard users can use a port other than the default, 8889, if they set the proxy-port configuration setting for the scorecard.