### PR TITLE
doc : update docs regards  break changing in the run command

### DIFF
--- a/doc/migration/version-upgrade-guide.md
+++ b/doc/migration/version-upgrade-guide.md
@@ -806,7 +806,35 @@ This release contains breaking changes in some commands.
 - The `operator-sdk olm-catalog gen-csv` was replaced by `operator-sdk generate csv`
 - The `operator-sdk up local` is now `operator-sdk run --local`. However, all functionality of this command is retained.
 - And then, the `operator-sdk alpha olm [sub-commands] [flags]` was moved from `alpha` to its own sub-command. However, all functionality of this command is retained. To check run; `operator-sdk olm --help`.
-- **(Useful for Ansible and Helm based-operators only)** The `operator-sdk run ansible/helm` are now hidden commands in `exec-entrypoint ansible/helm`. However, all functionality of each sub-command is still the same.
+
+### Breaking Changes for Helm and Ansible 
+
+The `operator-sdk run ansible/helm` are now hidden commands in `exec-entrypoint ansible/helm`. However, all functionality of each sub-command is still the same.  So, if you are using this feature then you will need replace the `run` for `exec-entrypoint` as the following examples.
+
+Replace:
+
+```
+oprator-sdk run ansible --watches-file=/opt/ansible/watches.yaml 
+```
+
+With: 
+
+```
+oprator-sdk exec-entrypoint ansible --watches-file=/opt/ansible/watches.yaml
+```
+
+
+Replace:
+
+```
+oprator-sdk run helm --watches-file=$HOME/watches.yaml
+```
+
+With: 
+
+```
+oprator-sdk run exec-entrypoint helm --watches-file=$HOME/watches.yaml
+```
 
 See the [CHANGELOG](https://github.com/operator-framework/operator-sdk/blob/master/CHANGELOG.md#v0151) for details of the release.
 

--- a/doc/migration/version-upgrade-guide.md
+++ b/doc/migration/version-upgrade-guide.md
@@ -809,7 +809,7 @@ This release contains breaking changes in some commands.
 
 ### Breaking Changes for Helm and Ansible 
 
-The `operator-sdk run ansible/helm` are now hidden commands in `exec-entrypoint ansible/helm`. However, all functionality of each sub-command is still the same.  So, if you are using this feature then you will need replace the `run` for `exec-entrypoint` as the following examples.
+The `operator-sdk run ansible/helm` are now hidden commands in `exec-entrypoint ansible/helm`. However, all functionality of each sub-command is still the same. If you are using this feature then you will need to replace the `run` for `exec-entrypoint` as the following examples.
 
 Replace:
 

--- a/doc/sdk-cli-reference.md
+++ b/doc/sdk-cli-reference.md
@@ -414,13 +414,6 @@ should use `up local` instead.
 #### Flags
 
 * `--reconcile-period` string - Default reconcile period for controllers (default 1m0s)
-* `--watches-file` string - Path to the watches file to use (default "./watches.yaml")
-
-#### Example
-
-```console
-$ operator-sdk run ansible --watches-file=/opt/ansible/watches.yaml --reconcile-period=30s
-```
 
 ### helm
 
@@ -431,13 +424,6 @@ should use `up local` instead.
 #### Flags
 
 * `--reconcile-period` string - Default reconcile period for controllers (default 1m0s)
-* `--watches-file` string - Path to the watches file to use (default "./watches.yaml")
-
-#### Example
-
-```console
-$ operator-sdk run helm --watches-file=/opt/helm/watches.yaml --reconcile-period=30s
-```
 
 ## scorecard
 


### PR DESCRIPTION

**Description of the change:**
- Remove `--watches-file` and its example for the command `run` from sdk cli doc since it is outdated. 
- Add further information in the migration doc over break changing in the run command. 

**Motivation for the change:**

Closes #2615

