### PR TITLE
doc: add info over openAPI validations for Ansible based operators

### DIFF
--- a/doc/ansible/dev/advanced_options.md
+++ b/doc/ansible/dev/advanced_options.md
@@ -173,3 +173,70 @@ metadata:
     "ansible.operator-sdk/verbosity": "5"
 spec: {}
 ```
+
+## Custom Resources with OpenApi Validation
+
+Currently, SDK tool does not support and will not generate automatically the CRD's using the [OpenAPI](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#validation) spec to perform validations. 
+
+However, it can be done manually by adding its validations as you can check in the following example.
+
+**Example**
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: memcacheds.cache.example.com
+spec:
+  group: cache.example.com
+  names:
+    kind: Memcached
+    listKind: MemcachedList
+    plural: memcacheds
+    singular: memcached
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Memcached is the Schema for the memcacheds API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: MemcachedSpec defines the desired state of Memcached
+          properties:
+            size:
+              description: Size is the size of the memcached deployment
+              format: int32
+              type: integer
+          required:
+          - size
+          type: object
+        status:
+          description: MemcachedStatus defines the observed state of Memcached
+          properties:
+            nodes:
+              description: Nodes are the names of the memcached pods
+              items:
+                type: string
+              type: array
+          required:
+          - nodes
+          type: object
+      type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+```


### PR DESCRIPTION
**Description of the change:**
Update doc with openAPI validations for Ansible based operators

**Motivation for the change:**

Closes #2036

