### PR TITLE
Include error context when logging in proxy

### DIFF
--- a/pkg/ansible/proxy/inject_owner.go
+++ b/pkg/ansible/proxy/inject_owner.go
@@ -74,7 +74,7 @@ func (i *injectOwnerReferenceHandler) ServeHTTP(w http.ResponseWriter, req *http
 		k, err := getGVKFromRequestInfo(r, i.restMapper)
 		if err != nil {
 			// break here in case resource doesn't exist in cache
-			log.Info("Cache miss, can not find in rest mapper")
+			log.Info("Cache miss, can not find in rest mapper", "error", err.Error())
 			break
 		}
 
@@ -82,7 +82,7 @@ func (i *injectOwnerReferenceHandler) ServeHTTP(w http.ResponseWriter, req *http
 		isVR, err := i.apiResources.IsVirtualResource(k)
 		if err != nil {
 			// break here in case we can not understand if virtual resource or not
-			log.Info("Unable to determine if virtual resource", "gvk", k)
+			log.Info("Unable to determine if virtual resource", "gvk", k, "error", err.Error())
 			break
 		}
 


### PR DESCRIPTION
**Description of the change:**
Outputs error context when we fail to load an object from the cache or determine whether a resource is virtual

**Motivation for the change:**
Makes debugging errors in the proxy (ie https://github.com/operator-framework/operator-sdk/issues/2623) much easier. 
