### PR TITLE
Add error context to log messages

### DIFF
--- a/pkg/ansible/proxy/cache_response.go
+++ b/pkg/ansible/proxy/cache_response.go
@@ -81,7 +81,7 @@ func (c *cacheResponseHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 		k, err := getGVKFromRequestInfo(r, c.restMapper)
 		if err != nil {
 			// break here in case resource doesn't exist in cache
-			log.Info("Cache miss, can not find in rest mapper")
+			log.Error(err, "Cache miss, can not find in rest mapper")
 			break
 		}
 
@@ -94,7 +94,7 @@ func (c *cacheResponseHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 		isVR, err := c.apiResources.IsVirtualResource(k)
 		if err != nil {
 			// break here in case we can not understand if virtual resource or not
-			log.Info("Unable to determine if virtual resource", "gvk", k)
+			log.Error(err, "Unable to determine if virtual resource", "gvk", k)
 			break
 		}
 

--- a/pkg/ansible/proxy/inject_owner.go
+++ b/pkg/ansible/proxy/inject_owner.go
@@ -74,7 +74,7 @@ func (i *injectOwnerReferenceHandler) ServeHTTP(w http.ResponseWriter, req *http
 		k, err := getGVKFromRequestInfo(r, i.restMapper)
 		if err != nil {
 			// break here in case resource doesn't exist in cache
-			log.Info("Cache miss, can not find in rest mapper")
+			log.Error(err, "Cache miss, can not find in rest mapper")
 			break
 		}
 
@@ -82,7 +82,7 @@ func (i *injectOwnerReferenceHandler) ServeHTTP(w http.ResponseWriter, req *http
 		isVR, err := i.apiResources.IsVirtualResource(k)
 		if err != nil {
 			// break here in case we can not understand if virtual resource or not
-			log.Info("Unable to determine if virtual resource", "gvk", k)
+			log.Error(err, "Unable to determine if virtual resource", "gvk", k)
 			break
 		}
 


### PR DESCRIPTION
**Description of the change:**

Some of the logging messages do not have any error context included, I added that in.
No change in the logic.

**Motivation for the change:**
Related https://github.com/operator-framework/operator-sdk/issues/2623

In looking at the issue, I noticed that we were missing the error contexts for these log messages.
