### PR TITLE
Update client.md incorrect patch examples

### DIFF
--- a/doc/user/client.md
+++ b/doc/user/client.md
@@ -275,9 +275,9 @@ func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, e
 	...
 
 	ctx := context.TODO()
-	dep.Spec.Selector.MatchLabels["is_running"] = "true"
 	// A merge patch will preserve other fields modified at runtime.
-	patch := client.MergeFrom(dep)
+	patch := client.MergeFrom(dep.DeepCopy())
+	dep.Spec.Selector.MatchLabels["is_running"] = "true"
 	err := r.client.Patch(ctx, dep, patch)
 
 	...
@@ -326,7 +326,8 @@ func (r *ReconcileApp) Reconcile(request reconcile.Request) (reconcile.Result, e
 	...
 
 	// Patch
-	patch := client.MergeFrom(mem)
+	patch := client.MergeFrom(mem.DeepCopy())
+	mem.Status.Nodes = []string{"pod1", "pod2", "pod3"}
 	err := r.client.Status().Patch(ctx, mem, patch)
 
 	...


### PR DESCRIPTION
**Description of the change:**
Update the patch examples in order to function as expected.

**Motivation for the change:**
With current the patch examples provided, no changes would actually occur when patching because the patch was being applied to the modified object instead of a copy of the original.
