### PR TITLE
docs: fixed a bunch of things in the docs

### DIFF
--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -88,7 +88,7 @@ An example Watches file:
   group: baz.example.com
   kind: Baz
   playbook: /opt/ansible/baz.yml
-  reconcilePeriod: 0
+  reconcilePeriod: 0s
   manageStatus: false
   vars:
     foo: bar
@@ -206,7 +206,6 @@ Modify `roles/memcached/tasks/main.yml` to look like the following:
               image: "docker.io/memcached:1.4.36-alpine"
               ports:
                 - containerPort: 11211
-
 ```
 
 It is important to note that we used the `size` variable to control how many
@@ -241,7 +240,10 @@ $ docker push quay.io/example/memcached-operator:v0.0.1
 
 Kubernetes deployment manifests are generated in `deploy/operator.yaml`. The
 deployment image in this file needs to be modified from the placeholder
-`REPLACE_IMAGE` to the previous built image. To do this run:
+`REPLACE_IMAGE` to the previous built image.
+**NOTE** Also, we recommend keeping the `imagePullPolicy` as `Always` because it makes easier for testing.
+
+To do the above run:
 ```
 $ sed -i 's|{{ REPLACE_IMAGE }}|quay.io/example/memcached-operator:v0.0.1|g' deploy/operator.yaml
 ```


### PR DESCRIPTION
**Description of the change:**
- `reconcilePeriod` must have a time unit, added the same in the example
- `deploy/operator.yaml` - Fixed the sed commands to replace values of `image` and `imagePullPolicy`
- `roles/memcached/tasks/main.yml` - Replaced `community.kubernetes.k8s:` with `k8s:` as the former throws below error
```sh
 ERROR! couldn't resolve module/action 'community.kubernetes.k8s'. This often indicates a misspelling, missing collection, or incorrect module path.                                                                                                      │
│ The error appears to be in '/opt/ansible/roles/memcached/tasks/main.yml': line 2, column 3, but may                                                                                                                                                      │
│ be elsewhere in the file depending on the exact syntax problem.                                                                                                                                                                                          │
│ The offending line appears to be:                                                                                                                                                                                                                        │
│ ---                                                                                                                                                                                                                                                      │
│ - name: start memcached                                                                                                                                                                                                                                  │
│   ^ here
```

<!--
Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
Note: Make sure your branch is rebased to the latest upstream master.
-->


**Motivation for the change:**

I want to fix the bugs and make it easier for users to follow the user guide
