### PR TITLE
fix: CR has not error faced in the task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Fixed a regression in the `operator-sdk run` command that caused `--local` flags to be ignored ([#2478](https://github.com/operator-framework/operator-sdk/issues/2478))
 - Fix command `operator-sdk run --local` which was not working on Windows. ([#2481](https://github.com/operator-framework/operator-sdk/pull/2481))
 - Fix `ServiceMonitor` creation when the operator is cluster-scoped and the environment variable `WATCH_NAMESPACE` has a different value than the namespace where the operator is deployed. ([#2601](https://github.com/operator-framework/operator-sdk/pull/2601))
+- Fix missing error status when the error faced in the Ansible do not return an event status. ([#2661](https://github.com/operator-framework/operator-sdk/pull/2661))
 
 ## v0.15.2
 

--- a/pkg/ansible/controller/reconcile.go
+++ b/pkg/ansible/controller/reconcile.go
@@ -201,6 +201,10 @@ func (r *AnsibleOperatorReconciler) Reconcile(request reconcile.Request) (reconc
 		eventErr := errors.New("did not receive playbook_on_stats event")
 		stdout, err := result.Stdout()
 		if err != nil {
+			errmark := r.markError(u, request.NamespacedName, "Failed to get ansible-runner stdout")
+			if errmark != nil {
+				logger.Error(errmark, "Unable to mark error to run reconciliation")
+			}
 			logger.Error(err, "Failed to get ansible-runner stdout")
 			return reconcileResult, err
 		}

--- a/pkg/ansible/controller/reconcile_test.go
+++ b/pkg/ansible/controller/reconcile_test.go
@@ -458,6 +458,22 @@ func TestReconcile(t *testing.T) {
 					"apiVersion": "operator-sdk/v1beta1",
 					"kind":       "Testing",
 					"spec":       map[string]interface{}{},
+					"status": map[string]interface{}{
+						"conditions": []interface{}{
+							map[string]interface{}{
+								"status": "True",
+								"type":   "Running",
+								"ansibleResult": map[string]interface{}{
+									"changed":    int64(0),
+									"failures":   int64(0),
+									"ok":         int64(0),
+									"skipped":    int64(0),
+									"completion": eventTime.Format("2006-01-02T15:04:05.99999999"),
+								},
+								"message": "Failed to get ansible-runner stdout",
+							},
+						},
+					},
 				},
 			}),
 			Result: reconcile.Result{


### PR DESCRIPTION
**Description of the change:**
The reconcile was not marking the CR status when no event status is returned.  

**Motivation for the change:**

Closes #2565

**Local Test**
<img width="774" alt="Screenshot 2020-03-16 at 16 46 02" src="https://user-images.githubusercontent.com/7708031/76781068-06878c00-67a6-11ea-8d47-86910fa42b86.png">

