### PR TITLE
doc(migration guide) :add info regards 0.16 sdk version

### DIFF
--- a/doc/migration/version-upgrade-guide.md
+++ b/doc/migration/version-upgrade-guide.md
@@ -842,7 +842,7 @@ See the [CHANGELOG](https://github.com/operator-framework/operator-sdk/blob/mast
 
 ### modules
 
-- Ensure the the following `require` modules and `replace` directives with the specific versions are present in your `go.mod` file:
+- Ensure that the following `require` modules and `replace` directives with the specific versions are present in your `go.mod` file:
 
 ```
 require (
@@ -998,7 +998,7 @@ The scorecard feature now only supports YAML config files. Any config file with 
 
 #### Remove Ansible container sidecar 
 
-The Ansible logs are now are outputted in the operator container and has no long need for the Ansible container sidecar. To reflect this change, update the `deploy/operator.yaml` file as follows. 
+The Ansible logs are now outputted in the operator container, and has no need for the Ansible container sidecar. To reflect this change, update the `deploy/operator.yaml` file as follows. 
 
 Remove:
 

--- a/doc/migration/version-upgrade-guide.md
+++ b/doc/migration/version-upgrade-guide.md
@@ -988,7 +988,7 @@ func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
 
 #### Scorecard only supports YAML config files
   
-The scorecard feature now only supports YAML config files. So, any config file with other extension is deprecated and should be changed for the YAML format. For further information see [`scorecard config file`](./doc/test-framework/scorecard.md#config-file)
+The scorecard feature now only supports YAML config files. So, any config file with other extension is deprecated and should be changed for the YAML format. For further information see [`scorecard config file`](https://github.com/operator-framework/operator-sdk/blob/v0.16.x/doc/test-framework/scorecard.md#config-file)
   
 ### Breaking Changes for Ansible 
 

--- a/doc/migration/version-upgrade-guide.md
+++ b/doc/migration/version-upgrade-guide.md
@@ -881,7 +881,7 @@ replace github.com/openshift/api => github.com/openshift/api v0.0.0-201909241025
 
 ### Bug Fixes and Improvements for Metrics
 
-There were some changes to the default implementation of the metrics export. These changes require the `cmd/main.go` be updated as follows.
+There are changes to the default implementation of the metrics export. These changes require `cmd/main.go to be updated as follows.
 
 Replace:
 
@@ -980,21 +980,21 @@ func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
 ### Breaking changes
 
 #### `TestCtx` in `pkg/test` has been deprecated
-
- The type name `TestCtx` in `pkg/test` has been deprecated and renamed to `Context`. Users of the e2e framework should: 
+ 
+ The type name `TestCtx` in `pkg/test` has been deprecated and renamed to `Context`. Users of the e2e framework should do the following:
  
  - Replace `TestCtx` with `Context`
  - Replace `NewTestCtx` with `NewContext`
 
 #### Scorecard only supports YAML config files
   
-The scorecard feature now only supports YAML config files. So, any config file with other extension is deprecated and should be changed for the YAML format. For further information see [`scorecard config file`](https://github.com/operator-framework/operator-sdk/blob/v0.16.x/doc/test-framework/scorecard.md#config-file)
+The scorecard feature now only supports YAML config files. Any config file with other extension is deprecated and should be changed for the YAML format. For further information see [`scorecard config file`](https://github.com/operator-framework/operator-sdk/blob/v0.16.x/doc/test-framework/scorecard.md#config-file)
   
 ### Breaking Changes for Ansible 
 
 #### Remove Ansible container sidecar 
 
-The additional of the dependency `inotify-tools` on Ansible based-operator images is deprecated and it will be removed in the next versions. In this way, update the `deploy/operator.yaml` file as follows.
+The Ansible logs are now are outputted in the operator container and has no long need for the Ansible container sidecar. To reflect this change, update the `deploy/operator.yaml` file as follows. 
 
 Remove:
 
@@ -1024,6 +1024,8 @@ With:
 ```yaml
 - name: {{your operator name which is the value of metadata.name in this file}}
 ```
+
+**NOTE** The dependency `inotify-tools` on Ansible based-operator images has been deprecated since its usage was required just because of this container sidecar. It will be removed for the next versions. 
 
 #### Migration to Ansible collections
 

--- a/doc/migration/version-upgrade-guide.md
+++ b/doc/migration/version-upgrade-guide.md
@@ -879,6 +879,10 @@ replace github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503
 replace github.com/openshift/api => github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad // Required until https://github.com/operator-framework/operator-lifecycle-manager/pull/1241 is resolved
 ```
 
+- Run `go mod tidy` to update the project modules
+- Run the command `operator-sdk generate k8s` to ensure that your resources will be updated
+- Run the command `operator-sdk generate crds` to regenerate CRDs
+
 ### Bug Fixes and Improvements for Metrics
 
 There are changes to the default implementation of the metrics export. These changes require `cmd/main.go to be updated as follows.
@@ -1055,7 +1059,25 @@ RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible
 ```
 
-## Unreleased (Master branch)
+## Unreleased (Master Branch)
+
+### Breaking changes
+
+#### In the test-framework
+
+The methods `ctx.GetOperatorNamespace()` and `ctx.GetWatchNamespace()` was added pkg/test in order to replace `ctx.GetNamespace()` which is deprecated. In this way replace the use of `ctx.GetNamespace()` in your project with `ctx.GetOperatorNamespace()`
+
+### Breaking Changes on Commands
+
+This release contains breaking changes in some commands.
+
+- The --namespace flag from `operator-sdk run --local` command, `operator-sdk test --local` command and `operator-sdk cleanup` command was deprecated and was replaced by --watch-namespace and --operator-namespace .
+
+Note that --watch-namespace can be used to set the namespace(s) which the operator will watch for changes. It will set the environment variable WATCH_NAMESPACE. Use explicitly an empty string to watch all namespaces or inform a List of namespaces such as "ns1,ns2" when the operator is cluster-scoped. If you use a List, then it needs contains the namespace where the operator is "deployed" in since the default metrics implementation will manage resources in the Operator's namespace. By default, it will be the Operator Namespace.
+
+Then, use the flag --operator-namespace to inform the namespace where the Operator will be "deployed" in and then, it will set the environment variable OPERATOR_NAMESPACE. If this value is not set, then it will be the namespace defined as default in the Kubeconfig.
+
+NOTE: For more information check the PRs which are responsible for the above changes [#2617](https://github.com/operator-framework/operator-sdk/pull/2617).
 
 [legacy-kubebuilder-doc-crd]: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 [v0.8.2-go-mod]: https://github.com/operator-framework/operator-sdk/blob/28bd2b0d4fd25aa68e15d928ae09d3c18c3b51da/internal/pkg/scaffold/go_mod.go#L40-L94

--- a/doc/migration/version-upgrade-guide.md
+++ b/doc/migration/version-upgrade-guide.md
@@ -992,13 +992,13 @@ func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
 
 #### Scorecard only supports YAML config files
   
-The scorecard feature now only supports YAML config files. Any config file with other extension is deprecated and should be changed for the YAML format. For further information see [`scorecard config file`](https://github.com/operator-framework/operator-sdk/blob/v0.16.x/doc/test-framework/scorecard.md#config-file)
+The scorecard feature now only supports YAML config files. Config files with other extensions are no longer supported and should be changed to the YAML format. For further information see [`scorecard config file`](https://github.com/operator-framework/operator-sdk/blob/v0.16.x/doc/test-framework/scorecard.md#config-file)
   
 ### Breaking Changes for Ansible 
 
 #### Remove Ansible container sidecar 
 
-The Ansible logs are now outputted in the operator container, and has no need for the Ansible container sidecar. To reflect this change, update the `deploy/operator.yaml` file as follows. 
+The Ansible logs are now output in the operator container, so there is no longer a need for the Ansible container sidecar. To reflect this change, update the `deploy/operator.yaml` file as follows. 
 
 Remove:
 
@@ -1037,9 +1037,6 @@ By default the full Ansible logs will not be output, however, you can setup it v
   value: "True"
 ...
 ```
-
-**NOTE:** The dependency `inotify-tools` on Ansible based-operator images has been deprecated since its usage was required just because of this container sidecar. It will be removed for the next versions. 
-- Now, you can use the environmentt 
 
 #### Migration to Ansible collections
 

--- a/doc/migration/version-upgrade-guide.md
+++ b/doc/migration/version-upgrade-guide.md
@@ -1025,7 +1025,17 @@ With:
 - name: {{your operator name which is the value of metadata.name in this file}}
 ```
 
-**NOTE** The dependency `inotify-tools` on Ansible based-operator images has been deprecated since its usage was required just because of this container sidecar. It will be removed for the next versions. 
+By default the full Ansible logs will not be output, however, you can setup it via the `ANSIBLE_DEBUG_LOGS` environment variable in the `deploy/operator.yaml` file. See:
+
+```
+...
+- name: ANSIBLE_DEBUG_LOGS
+  value: "True"
+...
+```
+
+**NOTE:** The dependency `inotify-tools` on Ansible based-operator images has been deprecated since its usage was required just because of this container sidecar. It will be removed for the next versions. 
+- Now, you can use the environmentt 
 
 #### Migration to Ansible collections
 

--- a/website/content/en/docs/migration/version-upgrade-guide.md
+++ b/website/content/en/docs/migration/version-upgrade-guide.md
@@ -842,7 +842,7 @@ See the [CHANGELOG](https://github.com/operator-framework/operator-sdk/blob/mast
 
 ### modules
 
-- Ensure the the following `require` modules and `replace` directives with the specific versions are present in your `go.mod` file:
+- Ensure that the following `require` modules and `replace` directives with the specific versions are present in your `go.mod` file:
 
 ```
 require (
@@ -998,7 +998,7 @@ The scorecard feature now only supports YAML config files. Any config file with 
 
 #### Remove Ansible container sidecar 
 
-The Ansible logs are now are outputted in the operator container and has no long need for the Ansible container sidecar. To reflect this change, update the `deploy/operator.yaml` file as follows. 
+The Ansible logs are now outputted in the operator container, and has no need for the Ansible container sidecar. To reflect this change, update the `deploy/operator.yaml` file as follows. 
 
 Remove:
 

--- a/website/content/en/docs/migration/version-upgrade-guide.md
+++ b/website/content/en/docs/migration/version-upgrade-guide.md
@@ -992,13 +992,13 @@ func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
 
 #### Scorecard only supports YAML config files
   
-The scorecard feature now only supports YAML config files. Any config file with other extension is deprecated and should be changed for the YAML format. For further information see [`scorecard config file`](https://github.com/operator-framework/operator-sdk/blob/v0.16.x/doc/test-framework/scorecard.md#config-file)
+The scorecard feature now only supports YAML config files. Config files with other extensions are no longer supported and should be changed to the YAML format. For further information see [`scorecard config file`](https://github.com/operator-framework/operator-sdk/blob/v0.16.x/doc/test-framework/scorecard.md#config-file)
   
 ### Breaking Changes for Ansible 
 
 #### Remove Ansible container sidecar 
 
-The Ansible logs are now outputted in the operator container, and has no need for the Ansible container sidecar. To reflect this change, update the `deploy/operator.yaml` file as follows. 
+The Ansible logs are now output in the operator container, so there is no longer a need for the Ansible container sidecar. To reflect this change, update the `deploy/operator.yaml` file as follows. 
 
 Remove:
 
@@ -1037,9 +1037,6 @@ By default the full Ansible logs will not be output, however, you can setup it v
   value: "True"
 ...
 ```
-
-**NOTE:** The dependency `inotify-tools` on Ansible based-operator images has been deprecated since its usage was required just because of this container sidecar. It will be removed for the next versions. 
-- Now, you can use the environmentt 
 
 #### Migration to Ansible collections
 


### PR DESCRIPTION
**Description of the change:**
- Add missing info for 0.16 migration guide (breaking changes emerge before the agreement to started to update it with the prs + module)

