### PR TITLE
Add docs about needed cluster roles for e2e operator tests

### DIFF
--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -282,9 +282,9 @@ you are using, this may require some manual setup. For example, OpenShift users 
 to manually add permissions to access these resources.
 
 The simplest way to accomplish this is to bind the cluster-admin Cluster Role to the Service Account you will run the test under. 
-If you are unable or unwilling to grant such access, a more limited Cluster Role such as this testuser can be created and bound 
-to the Service Account you are using.
-
+If you are unable or unwilling to grant such access, a more limited permission set can be created and bound to your Service Account.
+A good place to start would be the Role bound to your operator itself, such as [this role for the memcached operator example][memcached-role].
+In addition, you might have to create a Cluster Role to allow your tests to create namespaces, like so:
 ```
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -293,15 +293,8 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - apiextensions.k8s.io
-  - cache.example.com # the api space your tests are created in
-  - apps
   resources:
-  - memcacheds # the type(s) of the CRD in your operator
   - namespaces
-  - customresourcedefinitions
-  - deployments
-  - pods
   verbs:
   - create
   - delete
@@ -310,6 +303,8 @@ rules:
   - watch
   - update
 ```
+
+Note that this isn't an exhaustive permission set, and the e2e tests you write might require more or less access.
 
 For more documentation on the `operator-sdk test local` command, see the [SDK CLI Reference][cli-test-local] doc.
 
@@ -386,3 +381,4 @@ $ kubectl delete -f deploy/crds/cache.example.com_memcacheds_crd.yaml
 [scheme-link]:https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/framework.go#L109
 [cli-test-local]:https://github.com/operator-framework/operator-sdk/blob/master/doc/cli/operator-sdk_test_local.md
 [main-entry-link]:https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/main_entry.go#L25
+[memcached-role]:https://github.com/operator-framework/operator-sdk-samples/blob/master/go/memcached-operator/deploy/role.yaml

--- a/doc/test-framework/writing-e2e-tests.md
+++ b/doc/test-framework/writing-e2e-tests.md
@@ -275,6 +275,42 @@ $ kubectl create -f deploy/operator.yaml --namespace operator-test
 $ operator-sdk test local ./test/e2e --namespace operator-test --no-setup
 ```
 
+### Test Permissions
+
+Executing e2e tests requires the permission to access, create, and delete resources on your cluster. Depending on what kind of Kubernetes cluster
+you are using, this may require some manual setup. For example, OpenShift users are not created with cluster-admin access by default, so you would have
+to manually add permissions to access these resources.
+
+The simplest way to accomplish this is to bind the cluster-admin Cluster Role to the Service Account you will run the test under. 
+If you are unable or unwilling to grant such access, a more limited Cluster Role such as this testuser can be created and bound 
+to the Service Account you are using.
+
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: testuser
+rules:
+- apiGroups:
+  - ""
+  - apiextensions.k8s.io
+  - cache.example.com # the api space your tests are created in
+  - apps
+  resources:
+  - memcacheds # the type(s) of the CRD in your operator
+  - namespaces
+  - customresourcedefinitions
+  - deployments
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+  - update
+```
+
 For more documentation on the `operator-sdk test local` command, see the [SDK CLI Reference][cli-test-local] doc.
 
 ### Skip-Cleanup-Error Flag

--- a/website/content/en/docs/test-framework/writing-e2e-tests.md
+++ b/website/content/en/docs/test-framework/writing-e2e-tests.md
@@ -275,6 +275,37 @@ $ kubectl create -f deploy/operator.yaml --namespace operator-test
 $ operator-sdk test local ./test/e2e --namespace operator-test --no-setup
 ```
 
+### Test Permissions
+
+Executing e2e tests requires the permission to access, create, and delete resources on your cluster. Depending on what kind of Kubernetes cluster
+you are using, this may require some manual setup. For example, OpenShift users are not created with cluster-admin access by default, so you would have
+to manually add permissions to access these resources.
+
+The simplest way to accomplish this is to bind the cluster-admin Cluster Role to the Service Account you will run the test under. 
+If you are unable or unwilling to grant such access, a more limited permission set can be created and bound to your Service Account.
+A good place to start would be the Role bound to your operator itself, such as [this role for the memcached operator example][memcached-role].
+In addition, you might have to create a Cluster Role to allow your tests to create namespaces, like so:
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: testuser
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+  - update
+```
+
+Note that this isn't an exhaustive permission set, and the e2e tests you write might require more or less access.
+
 For more documentation on the `operator-sdk test local` command, see the [SDK CLI Reference][cli-test-local] doc.
 
 ### Skip-Cleanup-Error Flag
@@ -350,3 +381,4 @@ $ kubectl delete -f deploy/crds/cache.example.com_memcacheds_crd.yaml
 [scheme-link]:https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/framework.go#L109
 [cli-test-local]:https://github.com/operator-framework/operator-sdk/blob/master/doc/cli/operator-sdk_test_local.md
 [main-entry-link]:https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/main_entry.go#L25
+[memcached-role]:https://github.com/operator-framework/operator-sdk-samples/blob/master/go/memcached-operator/deploy/role.yaml


### PR DESCRIPTION
**Description of the change:**
Add docs about the needed permissions for running e2e operator tests.

**Motivation for the change:**
As discussed in #1082 this is useful information for users in environments where they might not be running as cluster-admin by default.

Closes #1082
