### PR TITLE
hack: add sanity check for doc diffs

### DIFF
--- a/hack/check-doc-diffs.sh
+++ b/hack/check-doc-diffs.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+source ./hack/lib/common.sh
+
+header_text "Checking diff between ./doc and ./website..."
+
+COMMIT_RANGE="$TRAVIS_COMMIT_RANGE"
+if [ -z "$COMMIT_RANGE" ] || ! git rev-list --quiet $COMMIT_RANGE; then
+	# Assume comparing current branch to master if we don't have $TRAVIS_COMMIT_RANGE
+	COMMIT_RANGE="master"
+fi
+
+old_changes=$(git diff --name-only $COMMIT_RANGE -- ./doc | wc -l)
+new_changes=$(git diff --name-only $COMMIT_RANGE -- ./website | wc -l)
+
+if [[ "$old_changes" -ne 0 && "$new_changes" -eq 0 ]]; then
+  error_text "ERROR: Docs changes in ./doc not found in ./website"
+  echo ""
+  header_text "./doc changes:"
+  echo "$(git diff --name-only $COMMIT_RANGE -- ./doc)"
+  echo ""
+  header_text "./website changes:"
+  echo "$(git diff --name-only $COMMIT_RANGE -- ./website)"
+  exit 1
+fi
+
+header_text "OK"

--- a/hack/tests/sanity-check.sh
+++ b/hack/tests/sanity-check.sh
@@ -7,6 +7,7 @@ go fmt ./...
 
 ./hack/check-license.sh
 ./hack/check-error-log-msg-format.sh
+./hack/check-doc-diffs.sh
 ./hack/generate/gen-cli-doc.sh
 ./hack/generate/gen-test-framework.sh
 


### PR DESCRIPTION
**Description of the change:**
Adds a sanity check to compare diffs between `./doc` and `./website`. If there are changes to `./doc`, we expect _something_ to change in `./website`.

**Motivation for the change:**
While we're transitioning to a new docs site, we need to make sure that the docs stay in sync between the current GitHub-based docs in `./doc` and the new docs site docs in `./website`

