### PR TITLE
add already exists check in object creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- The scorecard when creating a Custom Resource, will produce a message to the user if that CR already exists. ([#2683](https://github.com/operator-framework/operator-sdk/pull/2683))
+
 ### Deprecated
 
 ### Removed

--- a/internal/scorecard/plugins/resource_handler.go
+++ b/internal/scorecard/plugins/resource_handler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ghodss/yaml"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -129,7 +130,9 @@ func createFromYAMLFile(cfg BasicAndOLMPluginConfig, yamlPath string) error {
 			}
 		}
 		err = runtimeClient.Create(context.TODO(), obj)
-		if err != nil {
+		if errors.IsAlreadyExists(err) {
+			fmt.Printf("already exists, %s, not creating.", yamlPath)
+		} else if err != nil {
 			_, restErr := restMapper.RESTMappings(obj.GetObjectKind().GroupVersionKind().GroupKind())
 			if restErr == nil {
 				return err


### PR DESCRIPTION


**Description of the change:**
this PR fixes a situation where an operator being tested with scorecard, creates CRs in its implementation (seeded), this would cause scorecard to fail since it was trying to create the same CRs already seeded.  With this change, if a CR is already created, the scorecard will just print a message to the user to let them know when a CR already exists.

**Motivation for the change:**

 
Closes #2677 

