### PR TITLE
Add guide explaining how to use webhooks with Ansible-based Operators

### DIFF
--- a/pkg/ansible/proxy/cache_response.go
+++ b/pkg/ansible/proxy/cache_response.go
@@ -142,6 +142,7 @@ func (c *cacheResponseHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 		}
 
 		// Return so that request isn't passed along to APIserver
+		log.Info("Read object from cache", "resource", r)
 		return
 	}
 	c.next.ServeHTTP(w, req)
@@ -156,28 +157,29 @@ func (c *cacheResponseHandler) skipCacheLookup(r *requestfactory.RequestInfo, gv
 		log.Error(err, "Could not get owner reference from proxy.")
 		return false
 	}
-	ownerGV, err := schema.ParseGroupVersion(owner.APIVersion)
-	if err != nil {
-		m := fmt.Sprintf("Could not get group version for: %v.", owner)
-		log.Error(err, m)
-		return false
-	}
-	ownerGVK := schema.GroupVersionKind{
-		Group:   ownerGV.Group,
-		Version: ownerGV.Version,
-		Kind:    owner.Kind,
-	}
+	if owner != nil {
+		ownerGV, err := schema.ParseGroupVersion(owner.APIVersion)
+		if err != nil {
+			m := fmt.Sprintf("Could not get group version for: %v.", owner)
+			log.Error(err, m)
+			return false
+		}
+		ownerGVK := schema.GroupVersionKind{
+			Group:   ownerGV.Group,
+			Version: ownerGV.Version,
+			Kind:    owner.Kind,
+		}
 
-	relatedController, ok := c.cMap.Get(ownerGVK)
-	if !ok {
-		log.Info("Could not find controller for gvk.", "ownerGVK:", ownerGVK)
-		return false
+		relatedController, ok := c.cMap.Get(ownerGVK)
+		if !ok {
+			log.Info("Could not find controller for gvk.", "ownerGVK:", ownerGVK)
+			return false
+		}
+		if relatedController.Blacklist[gvk] {
+			log.Info("Skipping, because gvk is blacklisted", "GVK", gvk)
+			return true
+		}
 	}
-	if relatedController.Blacklist[gvk] {
-		log.Info("Skipping, because gvk is blacklisted", "GVK", gvk)
-		return true
-	}
-
 	// check if resource doesn't exist in watched namespaces
 	// if watchedNamespaces[""] exists then we are watching all namespaces
 	// and want to continue
@@ -202,10 +204,14 @@ func (c *cacheResponseHandler) recoverDependentWatches(req *http.Request, un *un
 		log.Error(err, "Could not get ownerRef from proxy")
 		return
 	}
+	// This happens when a request unrelated to reconciliation hits the proxy
+	if ownerRef == nil {
+		return
+	}
 
 	for _, oRef := range un.GetOwnerReferences() {
 		if oRef.APIVersion == ownerRef.APIVersion && oRef.Kind == ownerRef.Kind {
-			err := addWatchToController(ownerRef, c.cMap, un, c.restMapper, true)
+			err := addWatchToController(*ownerRef, c.cMap, un, c.restMapper, true)
 			if err != nil {
 				log.Error(err, "Could not recover dependent resource watch", "owner", ownerRef)
 				return
@@ -220,7 +226,7 @@ func (c *cacheResponseHandler) recoverDependentWatches(req *http.Request, un *un
 			return
 		}
 		if typeString == fmt.Sprintf("%v.%v", ownerRef.Kind, ownerGV.Group) {
-			err := addWatchToController(ownerRef, c.cMap, un, c.restMapper, false)
+			err := addWatchToController(*ownerRef, c.cMap, un, c.restMapper, false)
 			if err != nil {
 				log.Error(err, "Could not recover dependent resource watch", "owner", ownerRef)
 				return

--- a/pkg/ansible/proxy/proxy.go
+++ b/pkg/ansible/proxy/proxy.go
@@ -269,17 +269,17 @@ func removeAuthorizationHeader(h http.Handler) http.Handler {
 }
 
 // Helper function used by recovering dependent watches and owner ref injection.
-func getRequestOwnerRef(req *http.Request) (kubeconfig.NamespacedOwnerReference, error) {
+func getRequestOwnerRef(req *http.Request) (*kubeconfig.NamespacedOwnerReference, error) {
 	owner := kubeconfig.NamespacedOwnerReference{}
 	user, _, ok := req.BasicAuth()
 	if !ok {
-		return owner, errors.New("basic auth header not found")
+		return nil, nil
 	}
 	authString, err := base64.StdEncoding.DecodeString(user)
 	if err != nil {
 		m := "Could not base64 decode username"
 		log.Error(err, m)
-		return owner, err
+		return &owner, err
 	}
 	// Set owner to NamespacedOwnerReference, which has metav1.OwnerReference
 	// as a subset along with the Namespace of the owner. Please see the
@@ -288,9 +288,9 @@ func getRequestOwnerRef(req *http.Request) (kubeconfig.NamespacedOwnerReference,
 	if err := json.Unmarshal(authString, &owner); err != nil {
 		m := "Could not unmarshal auth string"
 		log.Error(err, m)
-		return owner, err
+		return &owner, err
 	}
-	return owner, err
+	return &owner, err
 }
 
 func getGVKFromRequestInfo(r *k8sRequest.RequestInfo, restMapper meta.RESTMapper) (schema.GroupVersionKind, error) {

--- a/website/content/en/docs/ansible/dev/webhooks.md
+++ b/website/content/en/docs/ansible/dev/webhooks.md
@@ -1,0 +1,166 @@
+# Adding Admission Webhooks to an Ansible-based Operator
+
+## Background
+
+For general background on what admission webhooks are, why to use them, and how to build them,
+please refer to the official Kubernetes documentation:
+https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
+
+This guide will assume that you understand the above content, and that you have an existing admission
+webhook server. You will likely need to make a few modifications to the webhook server container.
+
+When integrating an admission webhook server into your Ansible-based Operator, we recommend that you
+deploy it as a sidecar container alongside your operator. This allows you to make use of the proxy
+server that the operator deploys, as well as the cache that backs it.
+
+## Ensuring the webhook server uses the caching proxy
+
+When an Ansible-based Operator runs, it creates a Kubernetes proxy server and serves it on
+`http://localhost:8888`. This proxy server does not require any authorization, so all you need to
+do to make use of the proxy is ensure that your Kubernetes client is pointing at `http://localhost:8888`
+and that it does not attempt to verify SSL. If you use the default in-cluster configuration, you will
+be hitting the real API server and will not get caching for free.
+
+## Deploying the webhook server
+
+To deploy the webhook server as a sidecar alongside your operator, all you need to do is add the container
+specification to your `deploy/operator.yaml`. You may also need to add a volume for mounting in TLS secrets,
+as your webhook server is required to have a valid SSL configuration. Below is a sample updated container
+specification that deploys a webhook:
+
+```yaml
+      containers:
+        - name: my-operator
+          # Replace this with the built image name
+          image: "REPLACE_IMAGE"
+          imagePullPolicy: "Always"
+          volumeMounts:
+          - mountPath: /tmp/ansible-operator/runner
+            name: runner
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "validating-operator"
+            - name: ANSIBLE_GATHERING
+              value: explicit
+        # This deploys the webhook
+        - name: webhook
+          # Replace this with the built image name
+          image: "REPLACE_WEBHOOK_IMAGE"
+          imagePullPolicy: "Always"
+          volumeMounts:
+          - mountPath: /etc/tls/
+            name: webhook-cert
+      volumes:
+        - name: runner
+          emptyDir: {}
+        # This assumes there is a secret called webhook-cert containing TLS certificates
+        # Projects like cert-manager can create these certificates
+        - name: webhook-cert
+          secret:
+            secretName: webhook-cert
+```
+
+This will run your webhook server alongside the operator, but Kubernetes will not yet call the webhooks before
+resources can be created. In order to let Kubernetes know about your webhooks, you must create specific API resources.
+
+## Making Kubernetes call your webhooks
+
+In order to make your webhooks callable at all, first you must create a `Service` that points at your
+webhook server. Below is a sample service that creates a `Service` named `my-operator-webhook`, that will
+send traffic on port `443` to port `5000` in a `Pod` that matches the selector `name=my-operator`. Modify these
+values to match your environment.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-operator-webhook
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    protocol: TCP
+    # Change targetPort to match the port your server is listening on
+    targetPort: 5000
+  selector:
+    # Change this selector to match the labels on your operator pod
+    name: my-operator
+  type: ClusterIP
+```
+
+Now that you have a `Service` directing traffic to your webhook server, you will need to create
+`MutatingWebhookConfiguration` or `ValidatingWebhookConfiguration` objects (depending on what type of webhook you have deployed), which will tell Kubernetes
+to send certain API requests through your webhooks before writing to etcd.
+
+Below are examples of both `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` objects,
+which will tell Kubernetes to call the `my-operator-webhook` service when `samples.example.com Example` resources
+are created. The mutating webhook is served on the `/mutating` path in my example webhook server, and the validating webhook is served on `/validating`. Update these values as needed to reflect your environment
+and desired behavior. These objects are thoroughly documented in the official Kubernetes documentation:
+https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
+
+```yaml
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating.example.com
+webhooks:
+- name: "mutating.example.com"
+  rules:
+  - apiGroups:   ["samples.example.com"]
+    apiVersions: ["*"]
+    operations:  ["CREATE"]
+    resources:   ["examples"]
+    scope:       "Namespaced"
+  clientConfig:
+    service:
+      # Replace this with the namespace your service is in
+      namespace: REPLACE_NAMESPACE
+      name: my-operator-webhook
+      path: /mutating
+  admissionReviewVersions: ["v1"]
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating.example.com
+webhooks:
+- name: validating.example.com
+  rules:
+  - apiGroups:   ["samples.example.com"]
+    apiVersions: ["*"]
+    operations:  ["CREATE"]
+    resources:   ["examples"]
+    scope:       "Namespaced"
+  clientConfig:
+    service:
+      # Replace this with the namespace your service is in
+      namespace: REPLACE_NAMESPACE
+      name: my-operator-webhook
+      path: /validating
+  admissionReviewVersions: ["v1"]
+  failurePolicy: Fail
+  sideEffects: None
+```
+
+If these resources are configured properly you will now have an admissions webhook that can reject or mutate
+incoming resources before they are written to the Kubernetes database.
+
+## Summary
+
+To deploy an existing admissions webhook to validate or mutate your Kubernetes resources alongside an 
+Ansible-based Operator, you must
+1. Configure your admissions webhook to use the proxy server running on `http://localhost:8888` in the operator pod
+1. Add the webhook container to your operator deployment
+1. Create a `Service` pointing to your webhook
+1. Make sure your webhook is reachable via the `Service` over `https`
+1. Create `MutatingWebhookConfiguration` or `ValidatingWebhookConfiguration` mapping the resource you want to mutate/validate to the `Service` you created

--- a/website/content/en/docs/ansible/dev/webhooks.md
+++ b/website/content/en/docs/ansible/dev/webhooks.md
@@ -11,7 +11,19 @@ webhook server. You will likely need to make a few modifications to the webhook 
 
 When integrating an admission webhook server into your Ansible-based Operator, we recommend that you
 deploy it as a sidecar container alongside your operator. This allows you to make use of the proxy
-server that the operator deploys, as well as the cache that backs it.
+server that the operator deploys, as well as the cache that backs it. The sidecar will be defined in the `deploy/operator.yaml` and it will look like:
+
+```yaml
+...
+# This deploys the webhook
+        - name: webhook
+          # Replace this with the built image name
+          image: "REPLACE_WEBHOOK_IMAGE"
+          imagePullPolicy: "Always"
+          volumeMounts:
+          - mountPath: /etc/tls/
+            name: webhook-cert
+...            
 
 ## Ensuring the webhook server uses the caching proxy
 

--- a/website/content/en/docs/ansible/dev/webhooks.md
+++ b/website/content/en/docs/ansible/dev/webhooks.md
@@ -3,8 +3,7 @@
 ## Background
 
 For general background on what admission webhooks are, why to use them, and how to build them,
-please refer to the official Kubernetes documentation:
-https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
+please refer to the official Kubernetes documentation on [Extensible Admission Controllers][admission-controllers]
 
 This guide will assume that you understand the above content, and that you have an existing admission
 webhook server. You will likely need to make a few modifications to the webhook server container.
@@ -109,14 +108,13 @@ spec:
 ```
 
 Now that you have a `Service` directing traffic to your webhook server, you will need to create
-`MutatingWebhookConfiguration` or `ValidatingWebhookConfiguration` objects (depending on what type of webhook you have deployed), which will tell Kubernetes
+[`MutatingWebhookConfiguration`][mutating-webhook] or [`ValidatingWebhookConfiguration`][validating-webhook] objects (depending on what type of webhook you have deployed), which will tell Kubernetes
 to send certain API requests through your webhooks before writing to etcd.
 
-Below are examples of both `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` objects,
+Below are examples of both [`MutatingWebhookConfiguration`][mutating-webhook] and [`ValidatingWebhookConfiguration`][validating-webhook] objects,
 which will tell Kubernetes to call the `my-operator-webhook` service when `samples.example.com Example` resources
 are created. The mutating webhook is served on the `/mutating` path in my example webhook server, and the validating webhook is served on `/validating`. Update these values as needed to reflect your environment
-and desired behavior. These objects are thoroughly documented in the official Kubernetes documentation:
-https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
+and desired behavior. These objects are thoroughly documented in the official Kubernetes documentation on [Extensible Admission Controllers][admission-controllers]
 
 ```yaml
 ---
@@ -175,4 +173,9 @@ Ansible-based Operator, you must
 1. Add the webhook container to your operator deployment
 1. Create a `Service` pointing to your webhook
 1. Make sure your webhook is reachable via the `Service` over `https`
-1. Create `MutatingWebhookConfiguration` or `ValidatingWebhookConfiguration` mapping the resource you want to mutate/validate to the `Service` you created
+1. Create [`MutatingWebhookConfiguration`][mutating-webhook] or [`ValidatingWebhookConfiguration`][validating-webhook] mapping the resource you want to mutate/validate to the `Service` you created
+
+
+[admission-controllers]:https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
+[validating-webhook]:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#validatingwebhookconfiguration-v1-admissionregistration-k8s-io
+[mutating-webhook]:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#mutatingwebhookconfiguration-v1-admissionregistration-k8s-io


### PR DESCRIPTION
**Description of the change:**
Adds documentation explaining how to use a webhook with an Ansible-based Operator.

Also fixes the proxy so that it can be used by sidecar containers

**Motivation for the change:**
https://github.com/operator-framework/operator-sdk/issues/1658

