### PR TITLE
operator-sdk add api for Ansible/Helm operators.

### DIFF
--- a/changelog/fragments/helm-ansible-add-api.yaml
+++ b/changelog/fragments/helm-ansible-add-api.yaml
@@ -1,0 +1,3 @@
+entries:
+    - description: Add support for additional API creation for Anisble/Helm based operators.
+      kind: "addition"

--- a/cmd/operator-sdk/add/api.go
+++ b/cmd/operator-sdk/add/api.go
@@ -20,90 +20,270 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/internal/genutil"
-	gencrd "github.com/operator-framework/operator-sdk/internal/generate/crd"
-	"github.com/operator-framework/operator-sdk/internal/scaffold"
-	"github.com/operator-framework/operator-sdk/internal/scaffold/input"
-	"github.com/operator-framework/operator-sdk/internal/util/projutil"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+	"k8s.io/client-go/discovery"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/internal/genutil"
+	apiflags "github.com/operator-framework/operator-sdk/internal/flags/apiflags"
+	"github.com/operator-framework/operator-sdk/internal/scaffold"
+	"github.com/operator-framework/operator-sdk/internal/scaffold/ansible"
+	"github.com/operator-framework/operator-sdk/internal/scaffold/helm"
+	"github.com/operator-framework/operator-sdk/internal/scaffold/input"
+	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 )
 
-var (
-	apiVersion     string
-	kind           string
-	skipGeneration bool
-	crdVersion     string
-)
+var apiFlags apiflags.APIFlags
 
 func newAddAPICmd() *cobra.Command {
 	apiCmd := &cobra.Command{
 		Use:   "api",
 		Short: "Adds a new api definition under pkg/apis",
-		Long: `operator-sdk add api --kind=<kind> --api-version=<group/version> creates
-the api definition for a new custom resource under pkg/apis. This command
-must be run from the project root directory. If the api already exists at
-pkg/apis/<group>/<version> then the command will not overwrite and return
-an error.
+		Long: `operator-sdk add api --kind=<kind> --api-version<group/version> 
+creates an API definition for a new custom resource.
+This command must be run from the project root directory.
 
-By default, this command runs Kubernetes deepcopy and CRD generators on
-tagged types in all paths under pkg/apis. Go code is generated under
-pkg/apis/<group>/<version>/zz_generated.deepcopy.go. CRD's are generated,
-or updated if they exist for a particular group + version + kind, under
+For Go-based operators:
+
+  - Creates the api definition for a new custom resource under pkg/apis.
+  - By default, this command runs Kubernetes deepcopy and CRD generators on
+  tagged types in all paths under pkg/apis. Go code is generated under
+  pkg/apis/<group>/<version>/zz_generated.deepcopy.go. Generation can be disabled with the
+  --skip-generation flag for Go-based operators.
+
+For Ansible-based operators:
+
+  - Creates resource folder under /roles.
+  - watches.yaml is updated with new resource.
+  - deploy/role.yaml will be updated with apiGroup for new API.
+
+For Helm-based operators:
+  - Creates resource folder under /helm-charts.
+  - watches.yaml is updated with new resource.
+  - deploy/role.yaml will be updated to reflact new rules for the incoming API.
+
+CRD's are generated, or updated if they exist for a particular group + version + kind, under
 deploy/crds/<full group>_<resource>_crd.yaml; OpenAPI V3 validation YAML
-is generated as a 'validation' object. Generation can be disabled with the
---skip-generation flag.
+is generated as a 'validation' object.`,
+		Example: `  # Create a new API, under an existing project. This command must be run from the project root directory.
+# Go Example:
+  $ operator-sdk add api --api-version=app.example.com/v1alpha1 --kind=AppService
 
-Example:
+# Ansible Example
+  $ operator-sdk add api  \
+  --api-version=app.example.com/v1alpha1 \
+  --kind=AppService
 
-	$ operator-sdk add api --api-version=app.example.com/v1alpha1 --kind=AppService
-	$ tree pkg/apis
-	pkg/apis/
-	├── addtoscheme_app_appservice.go
-	├── apis.go
-	└── app
-		└── v1alpha1
-			├── doc.go
-			├── register.go
-			├── appservice_types.go
-			├── zz_generated.deepcopy.go
-	$ tree deploy/crds
-	├── deploy/crds/app.example.com_v1alpha1_appservice_cr.yaml
-	├── deploy/crds/app.example.com_appservices_crd.yaml
+# Helm Example:
+  $ operator-sdk add api \
+  --api-version=app.example.com/v1alpha1 \
+  --kind=AppService
+
+  $ operator-sdk add api \
+  --api-version=app.example.com/v1alpha1 \
+  --kind=AppService
+  --helm-chart=myrepo/app
+
+  $ operator-sdk add api \
+  --helm-chart=myrepo/app
+
+  $ operator-sdk add api \
+  --helm-chart=myrepo/app \
+  --helm-chart-version=1.2.3
+
+  $ operator-sdk add api \
+  --helm-chart=app \
+  --helm-chart-repo=https://charts.mycompany.com/
+
+  $ operator-sdk add api \
+  --helm-chart=app \
+  --helm-chart-repo=https://charts.mycompany.com/ \
+  --helm-chart-version=1.2.3
+
+  $ operator-sdk add api \
+  --helm-chart=/path/to/local/chart-directories/app/
+
+  $ operator-sdk add api \
+  --helm-chart=/path/to/local/chart-archives/app-1.2.3.tgz
 `,
 		RunE: apiRun,
 	}
 
-	apiCmd.Flags().StringVar(&apiVersion, "api-version", "",
-		"Kubernetes APIVersion that has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)")
-	if err := apiCmd.MarkFlagRequired("api-version"); err != nil {
-		log.Fatalf("Failed to mark `api-version` flag for `add api` subcommand as required")
-	}
-	apiCmd.Flags().StringVar(&kind, "kind", "", "Kubernetes resource Kind name. (e.g AppService)")
-	if err := apiCmd.MarkFlagRequired("kind"); err != nil {
-		log.Fatalf("Failed to mark `kind` flag for `add api` subcommand as required")
-	}
-	apiCmd.Flags().BoolVar(&skipGeneration, "skip-generation", false,
-		"Skip generation of deepcopy and OpenAPI code and OpenAPI CRD specs")
-	apiCmd.Flags().StringVar(&crdVersion, "crd-version", gencrd.DefaultCRDVersion,
-		"CRD version to generate")
+	// Initialize flagSet struct with command flags
+	apiFlags.AddTo(apiCmd.Flags())
 
 	return apiCmd
 }
 
 func apiRun(cmd *cobra.Command, args []string) error {
+
 	projutil.MustInProjectRoot()
 
-	// Only Go projects can add apis.
-	if err := projutil.CheckGoProjectCmd(cmd); err != nil {
+	operatorType := projutil.GetOperatorType()
+	if operatorType == projutil.OperatorTypeUnknown {
+		return projutil.ErrUnknownOperatorType{}
+	}
+	// Verify the incoming flags.
+	if err := apiFlags.VerifyCommonFlags(operatorType); err != nil {
 		return err
 	}
 
-	log.Infof("Generating api version %s for kind %s.", apiVersion, kind)
+	log.Infof("Generating api version %s for kind %s.", apiFlags.APIVersion, apiFlags.Kind)
+
+	switch operatorType {
+	case projutil.OperatorTypeGo:
+		if err := doGoAPIScaffold(); err != nil {
+			return err
+		}
+	case projutil.OperatorTypeAnsible:
+		if err := doAnsibleAPIScaffold(); err != nil {
+			return err
+		}
+	case projutil.OperatorTypeHelm:
+		if err := doHelmAPIScaffold(); err != nil {
+			return err
+		}
+	}
+	log.Info("API generation complete.")
+	return nil
+}
+
+// TODO
+// Consolidate scaffold func to be used by both "new" and "add api" commands.
+func doAnsibleAPIScaffold() error {
+	// Create and validate new resource.
+	r, err := scaffold.NewResource(apiFlags.APIVersion, apiFlags.Kind)
+	if err != nil {
+		return fmt.Errorf("invalid apiVersion and kind: %v", err)
+	}
+	absProjectPath := projutil.MustGetwd()
+	cfg := &input.Config{
+		AbsProjectPath: absProjectPath,
+	}
+	roleFiles := ansible.RolesFiles{Resource: *r}
+	roleTemplates := ansible.RolesTemplates{Resource: *r}
+
+	// update watch.yaml for the given resource r.
+	if err := ansible.UpdateAnsibleWatchForResource(r, absProjectPath); err != nil {
+		return fmt.Errorf("failed to update the Watch manifest for the resource (%v, %v): (%v)",
+			r.APIVersion, r.Kind, err)
+	}
+
+	s := &scaffold.Scaffold{}
+	err = s.Execute(cfg,
+		&scaffold.CR{Resource: r},
+		&ansible.RolesReadme{Resource: *r},
+		&ansible.RolesMetaMain{Resource: *r},
+		&roleFiles,
+		&roleTemplates,
+		&ansible.RolesVarsMain{Resource: *r},
+		&ansible.RolesDefaultsMain{Resource: *r},
+		&ansible.RolesTasksMain{Resource: *r},
+		&ansible.RolesHandlersMain{Resource: *r},
+	)
+	if err != nil {
+		return fmt.Errorf("new ansible api scaffold failed: %v", err)
+	}
+	if err = genutil.GenerateCRDNonGo("", *r, apiFlags.CrdVersion); err != nil {
+		return err
+	}
+
+	// Remove placeholders from empty directories
+	err = os.Remove(filepath.Join(s.AbsProjectPath, roleFiles.Path))
+	if err != nil {
+		return fmt.Errorf("new ansible api scaffold failed: %v", err)
+	}
+	err = os.Remove(filepath.Join(s.AbsProjectPath, roleTemplates.Path))
+	if err != nil {
+		return fmt.Errorf("new ansible api scaffold failed: %v", err)
+	}
+
+	// update deploy/role.yaml for the given resource r.
+	if err := scaffold.UpdateRoleForResource(r, absProjectPath); err != nil {
+		return fmt.Errorf("failed to update the RBAC manifest for the resource (%v, %v): (%v)",
+			r.APIVersion, r.Kind, err)
+	}
+	return nil
+}
+
+// TODO
+// Consolidate scaffold func to be used by both "new" and "add api" commands.
+func doHelmAPIScaffold() error {
+
+	absProjectPath := projutil.MustGetwd()
+	projectName := filepath.Base(absProjectPath)
+	cfg := &input.Config{
+		AbsProjectPath: absProjectPath,
+		ProjectName:    projectName,
+	}
+
+	createOpts := helm.CreateChartOptions{
+		ResourceAPIVersion: apiFlags.APIVersion,
+		ResourceKind:       apiFlags.Kind,
+		Chart:              apiFlags.HelmChartRef,
+		Version:            apiFlags.HelmChartVersion,
+		Repo:               apiFlags.HelmChartRepo,
+	}
+
+	r, chart, err := helm.CreateChart(cfg.AbsProjectPath, createOpts)
+	if err != nil {
+		return fmt.Errorf("failed to create helm chart: %v", err)
+	}
+
+	valuesPath := filepath.Join("<project_dir>", helm.HelmChartsDir, chart.Name(), "values.yaml")
+
+	rawValues, err := yaml.Marshal(chart.Values)
+	if err != nil {
+		return fmt.Errorf("failed to get raw chart values: %v", err)
+	}
+	crSpec := fmt.Sprintf("# Default values copied from %s\n\n%s", valuesPath, rawValues)
+
+	// update watch.yaml for the given resource r.
+	if err := helm.UpdateHelmWatchForResource(r, absProjectPath, chart.Name()); err != nil {
+		return fmt.Errorf("failed to update the Watch manifest for the resource (%v, %v): (%v)",
+			r.APIVersion, r.Kind, err)
+	}
+
+	s := &scaffold.Scaffold{}
+	err = s.Execute(cfg,
+		&scaffold.CR{
+			Resource: r,
+			Spec:     crSpec,
+		},
+	)
+	if err != nil {
+		log.Fatalf("API scaffold failed: %v", err)
+	}
+	if err = genutil.GenerateCRDNonGo("", *r, apiFlags.CrdVersion); err != nil {
+		return err
+	}
+
+	roleScaffold := helm.DefaultRoleScaffold
+
+	if k8sCfg, err := config.GetConfig(); err != nil {
+		log.Warnf("Using default RBAC rules: failed to get Kubernetes config: %s", err)
+	} else if dc, err := discovery.NewDiscoveryClientForConfig(k8sCfg); err != nil {
+		log.Warnf("Using default RBAC rules: failed to create Kubernetes discovery client: %s", err)
+	} else {
+		roleScaffold = helm.GenerateRoleScaffold(dc, chart)
+	}
+
+	if err = scaffold.MergeRoleForResource(r, absProjectPath, roleScaffold); err != nil {
+		return fmt.Errorf("failed to merge rules in the RBAC manifest for resource (%v, %v): %v",
+			r.APIVersion, r.Kind, err)
+	}
+
+	return nil
+}
+
+// TODO
+// Consolidate scaffold func to be used by both "new" and "add api" commands.
+func doGoAPIScaffold() error {
 
 	// Create and validate new resource.
-	r, err := scaffold.NewResource(apiVersion, kind)
+	r, err := scaffold.NewResource(apiFlags.APIVersion, apiFlags.Kind)
 	if err != nil {
 		return err
 	}
@@ -140,14 +320,14 @@ func apiRun(cmd *cobra.Command, args []string) error {
 			r.APIVersion, r.Kind, err)
 	}
 
-	if !skipGeneration {
+	if !apiFlags.SkipGeneration {
 		// Run k8s codegen for deepcopy
 		if err := genutil.K8sCodegen(); err != nil {
 			log.Fatal(err)
 		}
 
 		// Generate a validation spec for the new CRD.
-		if err := genutil.CRDGen(crdVersion); err != nil {
+		if err := genutil.CRDGen(apiFlags.CrdVersion); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/cmd/operator-sdk/add/controller.go
+++ b/cmd/operator-sdk/add/controller.go
@@ -23,7 +23,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var customAPIImport string
+var (
+	customAPIImport string
+	apiVersion      string
+	kind            string
+	crdVersion      string
+)
 
 //nolint:lll
 func newAddControllerCmd() *cobra.Command {

--- a/cmd/operator-sdk/add/crd.go
+++ b/cmd/operator-sdk/add/crd.go
@@ -107,7 +107,7 @@ func crdFunc(cmd *cobra.Command, args []string) error {
 		CRDVersion:   crdVersion,
 	}
 	if err := crd.Generate(); err != nil {
-		log.Fatalf("Error generating CRD for %s: %w", resource, err)
+		log.Fatalf("Error generating CRD for %s: %v", resource, err)
 	}
 
 	// update deploy/role.yaml for the given resource r.

--- a/cmd/operator-sdk/internal/genutil/crds.go
+++ b/cmd/operator-sdk/internal/genutil/crds.go
@@ -16,6 +16,7 @@ package genutil
 
 import (
 	"fmt"
+	"path/filepath"
 
 	gencrd "github.com/operator-framework/operator-sdk/internal/generate/crd"
 	"github.com/operator-framework/operator-sdk/internal/scaffold"
@@ -39,5 +40,20 @@ func CRDGen(crdVersion string) error {
 	}
 
 	log.Info("CRD generation complete.")
+	return nil
+}
+
+// GenerateCRDNonGo generates CRDs for Non-Go APIs(Eg., Ansible,Helm)
+func GenerateCRDNonGo(projectName string, resource scaffold.Resource, crdVersion string) error {
+	crdsDir := filepath.Join(projectName, scaffold.CRDsDir)
+	gcfg := gen.Config{
+		Inputs:    map[string]string{gencrd.CRDsDirKey: crdsDir},
+		OutputDir: crdsDir,
+	}
+	crd := gencrd.NewCRDNonGo(gcfg, resource, crdVersion)
+	if err := crd.Generate(); err != nil {
+		return fmt.Errorf("error generating CRD for %s: %w", resource, err)
+	}
+	log.Info("Generated CustomResourceDefinition manifests.")
 	return nil
 }

--- a/cmd/operator-sdk/internal/genutil/crds.go
+++ b/cmd/operator-sdk/internal/genutil/crds.go
@@ -46,11 +46,13 @@ func CRDGen(crdVersion string) error {
 // GenerateCRDNonGo generates CRDs for Non-Go APIs(Eg., Ansible,Helm)
 func GenerateCRDNonGo(projectName string, resource scaffold.Resource, crdVersion string) error {
 	crdsDir := filepath.Join(projectName, scaffold.CRDsDir)
-	gcfg := gen.Config{
-		Inputs:    map[string]string{gencrd.CRDsDirKey: crdsDir},
-		OutputDir: crdsDir,
+	crd := gencrd.Generator{
+		CRDsDir:      crdsDir,
+		OutputDir:    crdsDir,
+		CRDVersion:   crdVersion,
+		Resource:     resource,
+		IsOperatorGo: false,
 	}
-	crd := gencrd.NewCRDNonGo(gcfg, resource, crdVersion)
 	if err := crd.Generate(); err != nil {
 		return fmt.Errorf("error generating CRD for %s: %w", resource, err)
 	}

--- a/cmd/operator-sdk/new/cmd.go
+++ b/cmd/operator-sdk/new/cmd.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/internal/genutil"
 	"github.com/operator-framework/operator-sdk/internal/flags/apiflags"
-	gencrd "github.com/operator-framework/operator-sdk/internal/generate/crd"
 	"github.com/operator-framework/operator-sdk/internal/scaffold"
 	"github.com/operator-framework/operator-sdk/internal/scaffold/ansible"
 	"github.com/operator-framework/operator-sdk/internal/scaffold/helm"
@@ -407,22 +406,6 @@ func doHelmScaffold() error {
 		return fmt.Errorf("failed to update the RBAC manifest for resource (%v, %v): %v",
 			resource.APIVersion, resource.Kind, err)
 	}
-	return nil
-}
-
-func generateCRDNonGo(projectName string, resource scaffold.Resource, crdVersion string) error {
-	crdsDir := filepath.Join(projectName, scaffold.CRDsDir)
-	crd := gencrd.Generator{
-		CRDsDir:      crdsDir,
-		OutputDir:    crdsDir,
-		CRDVersion:   crdVersion,
-		Resource:     resource,
-		IsOperatorGo: false,
-	}
-	if err := crd.Generate(); err != nil {
-		return fmt.Errorf("error generating CRD for %s: %w", resource, err)
-	}
-	log.Info("Generated CustomResourceDefinition manifests.")
 	return nil
 }
 

--- a/cmd/operator-sdk/new/cmd.go
+++ b/cmd/operator-sdk/new/cmd.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/internal/genutil"
+	"github.com/operator-framework/operator-sdk/internal/flags/apiflags"
 	gencrd "github.com/operator-framework/operator-sdk/internal/generate/crd"
 	"github.com/operator-framework/operator-sdk/internal/scaffold"
 	"github.com/operator-framework/operator-sdk/internal/scaffold/ansible"
@@ -97,11 +99,6 @@ generates a default directory layout based on the input <project-name>.
 `,
 		RunE: newFunc,
 	}
-
-	newCmd.Flags().StringVar(&apiVersion, "api-version", "", "Kubernetes apiVersion and has"+
-		" a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1) - used with \"ansible\" or \"helm\" types")
-	newCmd.Flags().StringVar(&kind, "kind", "",
-		"Kubernetes CustomResourceDefintion kind. (e.g AppService) - used with \"ansible\" or \"helm\" types")
 	newCmd.Flags().StringVar(&operatorType, "type", "go",
 		"Type of operator to initialize (choices: \"go\", \"ansible\" or \"helm\")")
 	newCmd.Flags().StringVar(&repo, "repo", "",
@@ -116,21 +113,15 @@ generates a default directory layout based on the input <project-name>.
 		"Do not validate the resulting project's structure and dependencies. (Only used for --type go)")
 	newCmd.Flags().BoolVar(&generatePlaybook, "generate-playbook", false,
 		"Generate a playbook skeleton. (Only used for --type ansible)")
-	newCmd.Flags().StringVar(&helmChartRef, "helm-chart", "",
-		"Initialize helm operator with existing helm chart (<URL>, <repo>/<name>, or local path)")
-	newCmd.Flags().StringVar(&helmChartVersion, "helm-chart-version", "",
-		"Specific version of the helm chart (default is latest version)")
-	newCmd.Flags().StringVar(&helmChartRepo, "helm-chart-repo", "",
-		"Chart repository URL for the requested helm chart")
-	newCmd.Flags().StringVar(&crdVersion, "crd-version", gencrd.DefaultCRDVersion,
-		"CRD version to generate (Only used for --type=ansible|helm)")
+
+	// Initialize flagSet struct with common flags
+	apiFlags.AddTo(newCmd.Flags())
 
 	return newCmd
 }
 
 var (
-	apiVersion       string
-	kind             string
+	apiFlags         apiflags.APIFlags
 	operatorType     string
 	projectName      string
 	headerFile       string
@@ -139,12 +130,6 @@ var (
 	makeVendor       bool
 	skipValidation   bool
 	generatePlaybook bool
-
-	helmChartRef     string
-	helmChartVersion string
-	helmChartRepo    string
-
-	crdVersion string
 )
 
 func newFunc(cmd *cobra.Command, args []string) error {
@@ -271,7 +256,7 @@ func doAnsibleScaffold() error {
 		ProjectName:    projectName,
 	}
 
-	resource, err := scaffold.NewResource(apiVersion, kind)
+	resource, err := scaffold.NewResource(apiFlags.APIVersion, apiFlags.Kind)
 	if err != nil {
 		return fmt.Errorf("invalid apiVersion and kind: %v", err)
 	}
@@ -324,7 +309,7 @@ func doAnsibleScaffold() error {
 		return fmt.Errorf("new ansible scaffold failed: %v", err)
 	}
 
-	if err = generateCRDNonGo(projectName, *resource, crdVersion); err != nil {
+	if err = genutil.GenerateCRDNonGo(projectName, *resource, apiFlags.CrdVersion); err != nil {
 		return err
 	}
 
@@ -365,11 +350,11 @@ func doHelmScaffold() error {
 	}
 
 	createOpts := helm.CreateChartOptions{
-		ResourceAPIVersion: apiVersion,
-		ResourceKind:       kind,
-		Chart:              helmChartRef,
-		Version:            helmChartVersion,
-		Repo:               helmChartRepo,
+		ResourceAPIVersion: apiFlags.APIVersion,
+		ResourceKind:       apiFlags.Kind,
+		Chart:              apiFlags.HelmChartRef,
+		Version:            apiFlags.HelmChartVersion,
+		Repo:               apiFlags.HelmChartRepo,
 	}
 
 	resource, chart, err := helm.CreateChart(cfg.AbsProjectPath, createOpts)
@@ -414,7 +399,7 @@ func doHelmScaffold() error {
 		return fmt.Errorf("new helm scaffold failed: %v", err)
 	}
 
-	if err = generateCRDNonGo(projectName, *resource, crdVersion); err != nil {
+	if err = genutil.GenerateCRDNonGo(projectName, *resource, apiFlags.CrdVersion); err != nil {
 		return err
 	}
 
@@ -450,19 +435,8 @@ func verifyFlags() error {
 	if operatorType != projutil.OperatorTypeAnsible && generatePlaybook {
 		return fmt.Errorf("value of --generate-playbook can only be used with --type `ansible`")
 	}
-
-	if len(helmChartRef) != 0 {
-		if operatorType != projutil.OperatorTypeHelm {
-			return fmt.Errorf("value of --helm-chart can only be used with --type=helm")
-		}
-	} else if len(helmChartRepo) != 0 {
-		return fmt.Errorf("value of --helm-chart-repo can only be used with --type=helm and --helm-chart")
-	} else if len(helmChartVersion) != 0 {
-		return fmt.Errorf("value of --helm-chart-version can only be used with --type=helm and --helm-chart")
-	}
-
 	if operatorType == projutil.OperatorTypeGo {
-		if len(apiVersion) != 0 || len(kind) != 0 {
+		if len(apiFlags.APIVersion) != 0 || len(apiFlags.Kind) != 0 {
 			return fmt.Errorf("operators of type Go do not use --api-version or --kind")
 		}
 
@@ -470,27 +444,8 @@ func verifyFlags() error {
 			return err
 		}
 	}
-
-	// --api-version and --kind are required with --type=ansible and --type=helm, with one exception.
-	//
-	// If --type=helm and --helm-chart is set, --api-version and --kind are optional. If left unset,
-	// sane defaults are used when the specified helm chart is created.
-	if operatorType == projutil.OperatorTypeAnsible || operatorType == projutil.OperatorTypeHelm &&
-		len(helmChartRef) == 0 {
-		if len(apiVersion) == 0 {
-			return fmt.Errorf("value of --api-version must not have empty value")
-		}
-		if len(kind) == 0 {
-			return fmt.Errorf("value of --kind must not have empty value")
-		}
-		kindFirstLetter := string(kind[0])
-		if kindFirstLetter != strings.ToUpper(kindFirstLetter) {
-			return fmt.Errorf("value of --kind must start with an uppercase letter")
-		}
-		if strings.Count(apiVersion, "/") != 1 {
-			return fmt.Errorf("value of --api-version has wrong format (%v);"+
-				" format must be $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)", apiVersion)
-		}
+	if err := apiFlags.VerifyCommonFlags(operatorType); err != nil {
+		return err
 	}
 
 	return nil

--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -440,7 +440,6 @@ $ kubectl delete -f deploy/crds/cache.example.com_memcacheds_crd.yaml
 ```
 
 **NOTE** Additional CR/CRD's can be added to the project by running, for example, the command :`operator-sdk add api --api-version=cache.example.com/v1alpha1 --kind=AppService`
-For more information, refer [cli][addcli] doc.
 
 [operator-scope]:./../operator-scope.md
 [install-guide]: ../user/install-operator-sdk.md
@@ -455,4 +454,3 @@ For more information, refer [cli][addcli] doc.
 [ansible-runner-tool]:https://ansible-runner.readthedocs.io/en/latest/install.html
 [ansible-runner-http-plugin]:https://github.com/ansible/ansible-runner-http
 [quay-link]:https://quay.io
-[addcli]: https://operator-sdk.netlify.com/docs/cli/operator-sdk_add_api/

--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -439,7 +439,8 @@ $ kubectl delete -f deploy/service_account.yaml
 $ kubectl delete -f deploy/crds/cache.example.com_memcacheds_crd.yaml
 ```
 
-**NOTE** Additional CR/CRD's can be added to the project by running, for example, the command :`operator-sdk new api --api-version=cache.example.com/v1alpha1 --kind=AppService --type=ansible`
+**NOTE** Additional CR/CRD's can be added to the project by running, for example, the command :`operator-sdk add api --api-version=cache.example.com/v1alpha1 --kind=AppService`
+For more information, refer [cli][addcli] doc.
 
 [operator-scope]:./../operator-scope.md
 [install-guide]: ../user/install-operator-sdk.md
@@ -454,3 +455,4 @@ $ kubectl delete -f deploy/crds/cache.example.com_memcacheds_crd.yaml
 [ansible-runner-tool]:https://ansible-runner.readthedocs.io/en/latest/install.html
 [ansible-runner-http-plugin]:https://github.com/ansible/ansible-runner-http
 [quay-link]:https://quay.io
+[addcli]: https://operator-sdk.netlify.com/docs/cli/operator-sdk_add_api/

--- a/doc/helm/user-guide.md
+++ b/doc/helm/user-guide.md
@@ -309,6 +309,8 @@ kubectl delete -f deploy/role.yaml
 kubectl delete -f deploy/service_account.yaml
 kubectl delete -f deploy/crds/example.com_nginxes_crd.yaml
 ```
+**NOTE** Additional CR/CRD's can be added to the project by running, for example, the command :`operator-sdk add api --api-version=cache.example.com/v1alpha1 --kind=AppService`
+For more information, refer [cli][addcli] doc.
 
 ## Advanced features
 
@@ -429,3 +431,4 @@ spec:
 [helm-charts]:https://helm.sh/docs/topics/charts/
 [helm-values]:https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing
 [quay-link]:https://quay.io
+[addcli]: https://operator-sdk.netlify.com/docs/cli/operator-sdk_add_api/

--- a/internal/flags/apiflags/flags.go
+++ b/internal/flags/apiflags/flags.go
@@ -1,0 +1,97 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiflags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+
+	gencrd "github.com/operator-framework/operator-sdk/internal/generate/crd"
+	"github.com/operator-framework/operator-sdk/internal/util/projutil"
+)
+
+type APIFlags struct {
+	SkipGeneration   bool
+	APIVersion       string
+	Kind             string
+	CrdVersion       string
+	HelmChartRef     string
+	HelmChartVersion string
+	HelmChartRepo    string
+}
+
+// AddTo - Add the reconcile period and watches file flags to the the flagset
+// helpTextPrefix will allow you add a prefix to default help text. Joined by a space.
+func (f *APIFlags) AddTo(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&f.APIVersion, "api-version", "",
+		"Kubernetes apiVersion and has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)")
+
+	flagSet.StringVar(&f.Kind, "kind", "",
+		"Kubernetes resource Kind name. (e.g AppService)")
+
+	flagSet.BoolVar(&f.SkipGeneration, "skip-generation", false,
+		"Skip generation of deepcopy and OpenAPI code and OpenAPI CRD specs")
+
+	flagSet.StringVar(&f.CrdVersion, "crd-version", gencrd.DefaultCRDVersion,
+		"CRD version to generate")
+
+	flagSet.StringVar(&f.HelmChartRef, "helm-chart", "",
+		"Initialize helm operator with existing helm chart (<URL>, <repo>/<name>, or local path). Valid only for --type helm")
+
+	flagSet.StringVar(&f.HelmChartVersion, "helm-chart-version", "",
+		"Specific version of the helm chart (default is latest version). Valid only for --type helm")
+
+	flagSet.StringVar(&f.HelmChartRepo, "helm-chart-repo", "",
+		"Chart repository URL for the requested helm chart, Valid only for --type helm")
+
+}
+
+// VerifyCommonFlags func is used to verify flags common to both "new" and "add api" commands.
+func (f *APIFlags) VerifyCommonFlags(operatorType string) error {
+
+	if len(f.HelmChartRef) != 0 {
+		if operatorType != projutil.OperatorTypeHelm {
+			return fmt.Errorf("value of --helm-chart can only be used with --type=helm")
+		}
+	} else if len(f.HelmChartRepo) != 0 {
+		return fmt.Errorf("value of --helm-chart-repo can only be used with --type=helm and --helm-chart")
+	} else if len(f.HelmChartVersion) != 0 {
+		return fmt.Errorf("value of --helm-chart-version can only be used with --type=helm and --helm-chart")
+	}
+
+	// --api-version and --kind are required with --type=ansible, --type=helm , with one exception.
+	// If --type=helm and --helm-chart is set, --api-version and --kind are optional. If left unset,
+	// sane defaults are used when the specified helm chart is created.
+	if (operatorType == projutil.OperatorTypeAnsible || operatorType == projutil.OperatorTypeHelm) &&
+		len(f.HelmChartRef) == 0 {
+		if len(f.APIVersion) == 0 {
+			return fmt.Errorf("value of --api-version must not have empty value")
+		}
+		if len(f.Kind) == 0 {
+			return fmt.Errorf("value of --kind must not have empty value")
+		}
+		kindFirstLetter := string(f.Kind[0])
+		if kindFirstLetter != strings.ToUpper(kindFirstLetter) {
+			return fmt.Errorf("value of --kind must start with an uppercase letter")
+		}
+		if strings.Count(f.APIVersion, "/") != 1 {
+			return fmt.Errorf("value of --api-version has wrong format (%v);"+
+				" format must be $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)", f.APIVersion)
+		}
+	}
+	return nil
+}

--- a/internal/flags/apiflags/flags_test.go
+++ b/internal/flags/apiflags/flags_test.go
@@ -1,0 +1,270 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiflags
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddTo(t *testing.T) {
+	testCases := []struct {
+		name     string
+		apiFlags APIFlags
+		validate func(APIFlags, *pflag.FlagSet) error
+	}{
+		{
+			// Populate FlagSet
+			name: "Populate FlagSet",
+			apiFlags: APIFlags{
+				APIVersion:       "app.example.com/v1alpha1",
+				Kind:             "AppService",
+				SkipGeneration:   false,
+				CrdVersion:       "v1",
+				HelmChartRef:     "stable/app",
+				HelmChartVersion: "1.0.0",
+				HelmChartRepo:    "https://charts.mycompany.com/",
+			},
+			validate: func(apiFlags APIFlags, flagSet *pflag.FlagSet) error {
+				val, err := flagSet.GetString("api-version")
+				if err != nil {
+					return err
+				}
+				if apiFlags.APIVersion != val {
+					return fmt.Errorf("apiVersion does not match")
+				}
+
+				val, err = flagSet.GetString("kind")
+				if err != nil {
+					return err
+				}
+				if apiFlags.Kind != val {
+					return fmt.Errorf("kind does not match")
+				}
+
+				boolVal, err := flagSet.GetBool("skip-generation")
+				if err != nil {
+					return err
+				}
+				if apiFlags.SkipGeneration != boolVal {
+					return fmt.Errorf("skipGeneration does not match")
+				}
+
+				val, err = flagSet.GetString("crd-version")
+				if err != nil {
+					return err
+				}
+				if apiFlags.CrdVersion != val {
+					return fmt.Errorf("crdVersion does not match")
+				}
+
+				val, err = flagSet.GetString("helm-chart-repo")
+				if err != nil {
+					return err
+				}
+				if apiFlags.HelmChartRepo != val {
+					return fmt.Errorf("helmChartRepo does not match")
+				}
+
+				val, err = flagSet.GetString("helm-chart-version")
+				if err != nil {
+					return err
+				}
+				if apiFlags.HelmChartVersion != val {
+					return fmt.Errorf("helmChartVersion does not match")
+				}
+
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		expFlags := &pflag.FlagSet{}
+		t.Run(tc.name, func(t *testing.T) {
+			tc.apiFlags.AddTo(expFlags)
+			if tc.validate != nil {
+				if err := tc.validate(tc.apiFlags, expFlags); err != nil {
+					t.Fatal("Unexpected error validating AddTo", err)
+				}
+			}
+		})
+	}
+}
+
+func TestVerifyCommonFlags(t *testing.T) {
+	testCases := []struct {
+		name         string
+		apiFlags     APIFlags
+		operatorType string
+		expError     string
+	}{
+		{
+			// Valid Go API Flags
+			name: "Valid Go API Flags",
+			apiFlags: APIFlags{
+				APIVersion:     "app.example.com/v1alpha1",
+				Kind:           "AppService",
+				SkipGeneration: false,
+			},
+			operatorType: "go",
+			expError:     "",
+		},
+		{
+			// Invalid Go API Flags
+			name: "Invalid Go API Flags-HelmChartRef",
+			apiFlags: APIFlags{
+				APIVersion:   "app.example.com/v1alpha1",
+				HelmChartRef: "stable/repo",
+			},
+			operatorType: "go",
+			expError:     "value of --helm-chart can only be used with --type=helm",
+		},
+		{
+			// Invalid Go API Flags
+			name: "Invalid Go API Flags-HelmChartRepo",
+			apiFlags: APIFlags{
+				APIVersion:    "app.example.com/v1alpha1",
+				HelmChartRepo: "https://charts.mycompany.com/",
+			},
+			operatorType: "go",
+			expError:     "value of --helm-chart-repo can only be used with --type=helm and --helm-chart",
+		},
+		{
+			// Invalid Go API Flags
+			name: "Invalid Go API Flags-HelmChartVersion",
+			apiFlags: APIFlags{
+				APIVersion:       "app.example.com/v1alpha1",
+				HelmChartVersion: "1.2.0",
+			},
+			operatorType: "go",
+			expError:     "value of --helm-chart-version can only be used with --type=helm and --helm-chart",
+		},
+		{
+			// Valid Ansible API Flags
+			name: "Valid Ansible API Flags",
+			apiFlags: APIFlags{
+				APIVersion: "app.example.com/v1alpha1",
+				Kind:       "App",
+				CrdVersion: "v1",
+			},
+			operatorType: "ansible",
+			expError:     "",
+		},
+		{
+			// Valid Ansible API Flags
+			name: "Valid Ansible API Flags-check dup",
+			apiFlags: APIFlags{
+				APIVersion: "app.example.com/v1alpha1",
+				Kind:       "App",
+			},
+			operatorType: "ansible",
+			expError:     "",
+		},
+		{
+			// Invalid Ansible API Flags
+			name: "Invalid Ansible API Flags-Kind not present",
+			apiFlags: APIFlags{
+				APIVersion: "app.example.com/v1alpha1",
+			},
+			operatorType: "ansible",
+			expError:     "value of --kind must not have empty value",
+		},
+		{
+			// Invalid Ansible API Flags
+			name: "Invalid Ansible API Flags-apiVersion not present",
+			apiFlags: APIFlags{
+				Kind: "App",
+			},
+			operatorType: "ansible",
+			expError:     "value of --api-version must not have empty value",
+		},
+		{
+			// Invalid Ansible API Flags
+			name: "Invalid Ansible API Flags-HelmChartVersion is used",
+			apiFlags: APIFlags{
+				APIVersion:       "app.example.com/v1alpha1",
+				Kind:             "App",
+				HelmChartVersion: "1.2.0",
+			},
+			operatorType: "ansible",
+			expError:     "value of --helm-chart-version can only be used with --type=helm and --helm-chart",
+		},
+		{
+			// Invalid Ansible API Flags
+			name: "Invalid Ansible API Flags-HelmChartRepo is used",
+			apiFlags: APIFlags{
+				APIVersion:    "app.example.com/v1alpha1",
+				Kind:          "App",
+				HelmChartRepo: "https://charts.mycompany.com/",
+			},
+			operatorType: "ansible",
+			expError:     "value of --helm-chart-repo can only be used with --type=helm and --helm-chart",
+		},
+		{
+			// Valid HELM API Flags
+			name: "Valid HELM API Flags",
+			apiFlags: APIFlags{
+				APIVersion:     "app.example.com/v1alpha1",
+				Kind:           "App",
+				SkipGeneration: true,
+			},
+			operatorType: "helm",
+			expError:     "",
+		},
+		{
+			// Valid HELM API Flags
+			name: "Valid HELM API Flags-Helmchart used",
+			apiFlags: APIFlags{
+				HelmChartRef: "stable/repo",
+			},
+			operatorType: "helm",
+			expError:     "",
+		},
+		{
+			// Valid HELM API Flags
+			name: "Valid HELM API Flags-Helm specific flags",
+			apiFlags: APIFlags{
+				HelmChartRef:     "stable/repo",
+				HelmChartRepo:    "https://charts.mycompany.com/",
+				HelmChartVersion: "1.2.0",
+			},
+			operatorType: "helm",
+			expError:     "",
+		},
+		{
+			// Invalid HELM API Flags
+			name: "Invalid HELM API Flags-no HelmChartRef provided",
+			apiFlags: APIFlags{
+				HelmChartRepo:    "https://charts.mycompany.com/",
+				HelmChartVersion: "1.2.0",
+			},
+			operatorType: "helm",
+			expError:     "value of --helm-chart-repo can only be used with --type=helm and --helm-chart",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var result string
+			if err := tc.apiFlags.VerifyCommonFlags(tc.operatorType); err != nil {
+				result = err.Error()
+			}
+			assert.Equal(t, tc.expError, result)
+		})
+	}
+}

--- a/internal/scaffold/ansible/testdata/invalid/invalid_watch/watches.yaml
+++ b/internal/scaffold/ansible/testdata/invalid/invalid_watch/watches.yaml
@@ -1,0 +1,4 @@
+---
+  version: v1alpha1
+  kind: App
+  role: app

--- a/internal/scaffold/ansible/testdata/valid1/validWatches.yaml
+++ b/internal/scaffold/ansible/testdata/valid1/validWatches.yaml
@@ -1,0 +1,10 @@
+---
+- version: v1alpha1
+  group: mykind.example.com
+  kind: MyKind
+  role: mykind
+
+- version: v1alpha1
+  group: app.example.com
+  kind: App
+  role: app

--- a/internal/scaffold/ansible/testdata/valid2/validWatches.yaml
+++ b/internal/scaffold/ansible/testdata/valid2/validWatches.yaml
@@ -1,0 +1,10 @@
+---
+- version: v1alpha1
+  group: mykind.example.com
+  kind: MyKind
+  playbook: playbook.yml
+
+- version: v1alpha1
+  group: app.example.com
+  kind: App
+  role: app

--- a/internal/scaffold/ansible/watches.go
+++ b/internal/scaffold/ansible/watches.go
@@ -25,6 +25,7 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/scaffold/input"
 	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
 	"github.com/operator-framework/operator-sdk/pkg/ansible/watches"
+
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -55,9 +56,6 @@ func UpdateAnsibleWatchForResource(r *scaffold.Resource, absProjectPath string) 
 	watchYAML, err := ioutil.ReadFile(watchFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to read watch manifest %v: %v", watchFilePath, err)
-	}
-	if len(watchYAML) == 0 {
-		return fmt.Errorf("empty watch File at: %v", absProjectPath)
 	}
 	var buf bytes.Buffer
 	watchList := []watches.Watch{}

--- a/internal/scaffold/ansible/watches.go
+++ b/internal/scaffold/ansible/watches.go
@@ -50,6 +50,7 @@ func (w *Watches) GetInput() (input.Input, error) {
 	return w.Input, nil
 }
 
+// TODO Extract adding watch resource into its own func.
 // UpdateAnsibleWatchForResource checks for duplicate GVK, and appends to existing Watch.yaml file.
 func UpdateAnsibleWatchForResource(r *scaffold.Resource, absProjectPath string) error {
 	watchFilePath := filepath.Join(absProjectPath, WatchesFile)

--- a/internal/scaffold/ansible/watches.go
+++ b/internal/scaffold/ansible/watches.go
@@ -15,8 +15,18 @@
 package ansible
 
 import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"path/filepath"
+
 	"github.com/operator-framework/operator-sdk/internal/scaffold"
 	"github.com/operator-framework/operator-sdk/internal/scaffold/input"
+	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
+	"github.com/operator-framework/operator-sdk/pkg/ansible/watches"
+	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const WatchesFile = "watches.yaml"
@@ -39,7 +49,76 @@ func (w *Watches) GetInput() (input.Input, error) {
 	return w.Input, nil
 }
 
+// UpdateAnsibleWatchForResource checks for duplicate GVK, and appends to existing Watch.yaml file.
+func UpdateAnsibleWatchForResource(r *scaffold.Resource, absProjectPath string) error {
+	watchFilePath := filepath.Join(absProjectPath, WatchesFile)
+	watchYAML, err := ioutil.ReadFile(watchFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read watch manifest %v: %v", watchFilePath, err)
+	}
+	if len(watchYAML) == 0 {
+		return fmt.Errorf("empty watch File at: %v", absProjectPath)
+	}
+	var buf bytes.Buffer
+	watchList := []watches.Watch{}
+	err = yaml.Unmarshal(watchYAML, &watchList)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal watch config %v ", err)
+	}
+
+	gvk := schema.GroupVersionKind{
+		Version: r.Version,
+		Group:   r.FullGroup,
+		Kind:    r.Kind,
+	}
+
+	for _, watch := range watchList {
+		if watch.GroupVersionKind == gvk {
+			// dupe detected
+			return fmt.Errorf("duplicate GVK: %v", watch.GroupVersionKind.String())
+		}
+	}
+	// Create new watch
+	watches := Watches{
+		GeneratePlaybook: false,
+		Resource: scaffold.Resource{
+			Kind:      r.Kind,
+			FullGroup: r.FullGroup,
+			Version:   r.Version,
+			LowerKind: r.LowerKind,
+		},
+	}
+	tmpl, err := template.New("watches").Delims("[[", "]]").Parse(updateWatchesAnsibleTmpl)
+	if err != nil {
+		panic(err)
+	}
+	err = tmpl.Execute(&buf, watches)
+	if err != nil {
+		panic(err)
+	}
+	// Append new Watch content existing watch.yaml
+	watchYAML = append(watchYAML, buf.Bytes()...)
+	if err := ioutil.WriteFile(watchFilePath, watchYAML, fileutil.DefaultFileMode); err != nil {
+		return fmt.Errorf("failed to update %v: %v", watchFilePath, err)
+	}
+	return nil
+}
+
+// TODO
+// Currently we are using string template for initial creation for watches.yaml and STRUCT/YAML for updating
+// new resources in watches.YAML.
+// Consolidate to use STRUCT/YAML Marshalling for creating and updating resources in watches.yaml
 const watchesAnsibleTmpl = `---
+- version: [[.Resource.Version]]
+  group: [[.Resource.FullGroup]]
+  kind: [[.Resource.Kind]]
+  [[- if .GeneratePlaybook ]]
+  playbook: playbook.yml
+  [[- else ]]
+  role: [[.Resource.LowerKind]]
+  [[- end ]]
+`
+const updateWatchesAnsibleTmpl = `
 - version: [[.Resource.Version]]
   group: [[.Resource.FullGroup]]
   kind: [[.Resource.Kind]]

--- a/internal/scaffold/ansible/watches_test.go
+++ b/internal/scaffold/ansible/watches_test.go
@@ -1,0 +1,177 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ansible
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/operator-framework/operator-sdk/internal/scaffold"
+	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
+)
+
+func TestUpdateAnsibleWatchForResource(t *testing.T) {
+
+	watchFilePath1 := "./testdata/valid1/watches.yaml"
+	if err := ioutil.WriteFile(watchFilePath1, []byte(sampleWatch1), fileutil.DefaultFileMode); err != nil {
+		fmt.Printf("failed to initiate sample watch %v", err)
+	}
+	defer remove(watchFilePath1)
+	watchFilePath2 := "./testdata/valid2/watches.yaml"
+	if err := ioutil.WriteFile(watchFilePath2, []byte(sampleWatch2), fileutil.DefaultFileMode); err != nil {
+		fmt.Printf("failed to initiate sample watch %v", err)
+	}
+	defer remove(watchFilePath2)
+
+	testCases := []struct {
+		name           string
+		r              *scaffold.Resource
+		absProjectPath string
+		expError       string
+		expWatchesFile string
+	}{
+
+		{
+			//Valid watch
+			name: "Basic Valid Watch",
+			r: &scaffold.Resource{
+				APIVersion: "app.example.com/v1alpha1",
+				Kind:       "App",
+				LowerKind:  "app",
+				FullGroup:  "app.example.com",
+				Version:    "v1alpha1",
+			},
+			absProjectPath: "./testdata/valid1",
+			expError:       "",
+			expWatchesFile: "./testdata/valid1/validWatches.yaml",
+		},
+		{
+			//Valid watch with playbbok
+			name: "Valid Watch With Playbook",
+			r: &scaffold.Resource{
+				APIVersion: "app.example.com/v1alpha1",
+				Kind:       "App",
+				LowerKind:  "app",
+				FullGroup:  "app.example.com",
+				Version:    "v1alpha1",
+			},
+			absProjectPath: "./testdata/valid2",
+			expError:       "",
+			expWatchesFile: "./testdata/valid2/validWatches.yaml",
+		},
+		{
+			//Invalid Watch
+			name: "Duplicate GVK",
+			r: &scaffold.Resource{
+				APIVersion: "app.example.com/v1alpha1",
+				Kind:       "App",
+				LowerKind:  "app",
+				FullGroup:  "app.example.com",
+				Version:    "v1alpha1",
+			},
+			absProjectPath: "./testdata/valid1",
+			expError:       "duplicate GVK: app.example.com/v1alpha1, Kind=App",
+		},
+		{
+			//Invalid Watch
+			name: "Empty WatchFile",
+			r: &scaffold.Resource{
+				APIVersion: "app.example.com/v1alpha1",
+				Kind:       "App",
+				LowerKind:  "app",
+				FullGroup:  "app.example.com",
+				Version:    "v1alpha1",
+			},
+			absProjectPath: "./testdata/invalid/emptywatchfile",
+			expError:       "empty watch File at: ./testdata/invalid/emptywatchfile",
+		},
+		{
+			//Invalid Watch
+			name: "Empty Directory",
+			r: &scaffold.Resource{
+				APIVersion: "app.example.com/v1alpha1",
+				Kind:       "App",
+				LowerKind:  "app",
+				FullGroup:  "app.example.com",
+				Version:    "v1alpha1",
+			},
+			absProjectPath: "./testdata",
+			expError: "failed to read watch manifest testdata/watches.yaml: " +
+				"open testdata/watches.yaml: no such file or directory",
+		},
+		{
+			//Invalid Watch
+			name: "Invalid Watch file",
+			r: &scaffold.Resource{
+				APIVersion: "app.example.com/v1alpha1",
+				Kind:       "App",
+				LowerKind:  "app",
+				FullGroup:  "app.example.com",
+				Version:    "v1alpha1",
+			},
+			absProjectPath: "./testdata/invalid/invalid_watch",
+			expError: "failed to unmarshal watch config yaml: unmarshal errors:" + "\n" +
+				"  line 2: cannot unmarshal !!map into []watches.Watch ",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var result string
+			if err := UpdateAnsibleWatchForResource(tc.r, tc.absProjectPath); err != nil {
+				result = err.Error()
+			}
+			assert.Equal(t, tc.expError, result)
+			// Check watchfile content
+			if tc.expError == "" {
+				actualFilePath := tc.absProjectPath + "/watches.yaml"
+				expectedWatchFile, err := ioutil.ReadFile(tc.expWatchesFile)
+				if err != nil {
+					fmt.Printf("failed to read expectedWatchFile  %v: %v", tc.expWatchesFile, err)
+				}
+				actualWatchFile, err := ioutil.ReadFile(actualFilePath)
+				if err != nil {
+					fmt.Printf("failed to read actualWatchFile  %v: %v", actualFilePath, err)
+				}
+				assert.Equal(t, expectedWatchFile, actualWatchFile)
+			}
+		})
+	}
+}
+
+// remove removes path from disk. Used in defer statements.
+func remove(path string) {
+	if err := os.RemoveAll(path); err != nil {
+		log.Fatal(err)
+	}
+}
+
+const sampleWatch1 = `---
+- version: v1alpha1
+  group: mykind.example.com
+  kind: MyKind
+  role: mykind
+`
+
+const sampleWatch2 = `---
+- version: v1alpha1
+  group: mykind.example.com
+  kind: MyKind
+  playbook: playbook.yml
+`

--- a/internal/scaffold/ansible/watches_test.go
+++ b/internal/scaffold/ansible/watches_test.go
@@ -91,19 +91,6 @@ func TestUpdateAnsibleWatchForResource(t *testing.T) {
 		},
 		{
 			//Invalid Watch
-			name: "Empty WatchFile",
-			r: &scaffold.Resource{
-				APIVersion: "app.example.com/v1alpha1",
-				Kind:       "App",
-				LowerKind:  "app",
-				FullGroup:  "app.example.com",
-				Version:    "v1alpha1",
-			},
-			absProjectPath: "./testdata/invalid/emptywatchfile",
-			expError:       "empty watch File at: ./testdata/invalid/emptywatchfile",
-		},
-		{
-			//Invalid Watch
 			name: "Empty Directory",
 			r: &scaffold.Resource{
 				APIVersion: "app.example.com/v1alpha1",

--- a/internal/scaffold/helm/testdata/testwatches/invalid/invalid_watch/watches.yaml
+++ b/internal/scaffold/helm/testdata/testwatches/invalid/invalid_watch/watches.yaml
@@ -1,0 +1,4 @@
+---
+  version: v1alpha1
+  kind: App
+  chart: helm-charts/app

--- a/internal/scaffold/helm/testdata/testwatches/valid-1/validWatches.yaml
+++ b/internal/scaffold/helm/testdata/testwatches/valid-1/validWatches.yaml
@@ -1,0 +1,9 @@
+- group: mykind.example.com
+  version: v1alpha1
+  kind: MyKind
+  chart: helm-charts/mykind
+  watchDependentResources: true
+- group: app.example.com
+  version: v1alpha1
+  kind: App
+  chart: helm-charts/app

--- a/internal/scaffold/helm/testdata/testwatches/valid-2/validWatches.yaml
+++ b/internal/scaffold/helm/testdata/testwatches/valid-2/validWatches.yaml
@@ -1,0 +1,9 @@
+- group: mykind.example.com
+  version: v1alpha1
+  kind: MyKind
+  chart: helm-charts/mykind
+  watchDependentResources: true
+- group: app.example.com
+  version: v1alpha1
+  kind: App
+  chart: helm-charts/appservice

--- a/internal/scaffold/helm/watches.go
+++ b/internal/scaffold/helm/watches.go
@@ -15,8 +15,17 @@
 package helm
 
 import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/operator-framework/operator-sdk/internal/scaffold"
 	"github.com/operator-framework/operator-sdk/internal/scaffold/input"
+	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
+	"github.com/operator-framework/operator-sdk/pkg/helm/watches"
 )
 
 const WatchesYamlFile = "watches.yaml"
@@ -43,6 +52,58 @@ func (s *WatchesYAML) GetInput() (input.Input, error) {
 	return s.Input, nil
 }
 
+// UpdateHelmWatchForResource checks for duplicate GVK, and appends to existing Watch.yaml file.
+func UpdateHelmWatchForResource(r *scaffold.Resource, absProjectPath string, chart string) error {
+	watchFilePath := filepath.Join(absProjectPath, WatchesYamlFile)
+	watchYAML, err := ioutil.ReadFile(watchFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read watch manifest %v: %v", watchFilePath, err)
+	}
+	if len(watchYAML) == 0 {
+		return fmt.Errorf("empty Watch File at: %v", absProjectPath)
+	}
+
+	watchList := []watches.Watch{}
+	err = yaml.Unmarshal(watchYAML, &watchList)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal watch config %v ", err)
+	}
+
+	gvk := schema.GroupVersionKind{
+		Version: r.Version,
+		Group:   r.FullGroup,
+		Kind:    r.Kind,
+	}
+
+	for _, watch := range watchList {
+		if watch.GroupVersionKind == gvk {
+			// dupe detected
+			return fmt.Errorf("duplicate GVK: %v", watch.GroupVersionKind.String())
+		}
+	}
+	if chart == "" {
+		chart = r.LowerKind
+	}
+	newWatch := watches.Watch{
+		GroupVersionKind: gvk,
+		ChartDir:         HelmChartsDir + "/" + chart,
+	}
+	watchList = append(watchList, newWatch)
+	data, err := yaml.Marshal(watchList)
+	if err != nil {
+		return fmt.Errorf("failed to marshal watch config: %v", err)
+	}
+
+	if err := ioutil.WriteFile(watchFilePath, data, fileutil.DefaultFileMode); err != nil {
+		return fmt.Errorf("failed to update %v: %v", watchFilePath, err)
+	}
+	return nil
+}
+
+// TODO
+// Currently we are using string template for initial creation for watches.yaml and STRUCT/YAML for updating
+// new resources in watches.YAML.
+// Consolidate to use STRUCT/YAML Marshalling for creating and updating resources in watched.yaml
 const watchesYAMLTmpl = `---
 - version: {{.Resource.Version}}
   group: {{.Resource.FullGroup}}

--- a/internal/scaffold/helm/watches.go
+++ b/internal/scaffold/helm/watches.go
@@ -52,6 +52,7 @@ func (s *WatchesYAML) GetInput() (input.Input, error) {
 	return s.Input, nil
 }
 
+// TODO Extract adding watch resource into its own func.
 // UpdateHelmWatchForResource checks for duplicate GVK, and appends to existing Watch.yaml file.
 func UpdateHelmWatchForResource(r *scaffold.Resource, absProjectPath string, chart string) error {
 	watchFilePath := filepath.Join(absProjectPath, WatchesYamlFile)

--- a/internal/scaffold/helm/watches.go
+++ b/internal/scaffold/helm/watches.go
@@ -59,9 +59,6 @@ func UpdateHelmWatchForResource(r *scaffold.Resource, absProjectPath string, cha
 	if err != nil {
 		return fmt.Errorf("failed to read watch manifest %v: %v", watchFilePath, err)
 	}
-	if len(watchYAML) == 0 {
-		return fmt.Errorf("empty Watch File at: %v", absProjectPath)
-	}
 
 	watchList := []watches.Watch{}
 	err = yaml.Unmarshal(watchYAML, &watchList)

--- a/internal/scaffold/helm/watches_test.go
+++ b/internal/scaffold/helm/watches_test.go
@@ -92,19 +92,6 @@ func TestUpdateHelmWatchForResource(t *testing.T) {
 		},
 		{
 			// Invalid Watch
-			name: "Empty WatchFile",
-			r: &scaffold.Resource{
-				APIVersion: "app.example.com/v1alpha1",
-				Kind:       "App",
-				LowerKind:  "app",
-				FullGroup:  "app.example.com",
-				Version:    "v1alpha1",
-			},
-			absProjectPath: "./testdata/testwatches/invalid/emptywatchfile",
-			expError:       "empty Watch File at: ./testdata/testwatches/invalid/emptywatchfile",
-		},
-		{
-			// Invalid Watch
 			name: "Empty Directory",
 			r: &scaffold.Resource{
 				APIVersion: "app.example.com/v1alpha1",

--- a/internal/scaffold/helm/watches_test.go
+++ b/internal/scaffold/helm/watches_test.go
@@ -1,0 +1,170 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/operator-framework/operator-sdk/internal/scaffold"
+	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
+)
+
+func TestUpdateHelmWatchForResource(t *testing.T) {
+	watchFilePath1 := "./testdata/testwatches/valid-1/watches.yaml"
+	if err := ioutil.WriteFile(watchFilePath1, []byte(sampleWatch), fileutil.DefaultFileMode); err != nil {
+		fmt.Printf("failed to write sample watch %v", err)
+	}
+	watchFilePath2 := "./testdata/testwatches/valid-2/watches.yaml"
+	if err := ioutil.WriteFile(watchFilePath2, []byte(sampleWatch), fileutil.DefaultFileMode); err != nil {
+		fmt.Printf("failed to write sample watch %v", err)
+	}
+
+	defer remove(watchFilePath1)
+	defer remove(watchFilePath2)
+
+	testCases := []struct {
+		name           string
+		r              *scaffold.Resource
+		absProjectPath string
+		chart          string
+		expError       string
+		expWatchesFile string
+	}{
+		{
+			// Valid watch without chart
+			name: "Valid watch without chart",
+			r: &scaffold.Resource{
+				APIVersion: "app.example.com/v1alpha1",
+				Kind:       "App",
+				LowerKind:  "app",
+				FullGroup:  "app.example.com",
+				Version:    "v1alpha1",
+			},
+			absProjectPath: "./testdata/testwatches/valid-1",
+			expError:       "",
+			expWatchesFile: "./testdata/testwatches/valid-1/validWatches.yaml",
+		},
+		{
+			// Valid watch with chart
+			name: "Valid watch with chart",
+			r: &scaffold.Resource{
+				APIVersion: "app.example.com/v1alpha1",
+				Kind:       "App",
+				LowerKind:  "app",
+				FullGroup:  "app.example.com",
+				Version:    "v1alpha1",
+			},
+			absProjectPath: "./testdata/testwatches/valid-2",
+			chart:          "appservice",
+			expError:       "",
+			expWatchesFile: "./testdata/testwatches/valid-2/validWatches.yaml",
+		},
+		{
+			// Invalid Watch
+			name: "Duplicate GVK",
+			r: &scaffold.Resource{
+				APIVersion: "app.example.com/v1alpha1",
+				Kind:       "App",
+				LowerKind:  "app",
+				FullGroup:  "app.example.com",
+				Version:    "v1alpha1",
+			},
+			absProjectPath: "./testdata/testwatches/valid-1",
+			expError:       "duplicate GVK: app.example.com/v1alpha1, Kind=App",
+		},
+		{
+			// Invalid Watch
+			name: "Empty WatchFile",
+			r: &scaffold.Resource{
+				APIVersion: "app.example.com/v1alpha1",
+				Kind:       "App",
+				LowerKind:  "app",
+				FullGroup:  "app.example.com",
+				Version:    "v1alpha1",
+			},
+			absProjectPath: "./testdata/testwatches/invalid/emptywatchfile",
+			expError:       "empty Watch File at: ./testdata/testwatches/invalid/emptywatchfile",
+		},
+		{
+			// Invalid Watch
+			name: "Empty Directory",
+			r: &scaffold.Resource{
+				APIVersion: "app.example.com/v1alpha1",
+				Kind:       "App",
+				LowerKind:  "app",
+				FullGroup:  "app.example.com",
+				Version:    "v1alpha1",
+			},
+			absProjectPath: "./testdata/testwatches/",
+			expError: "failed to read watch manifest testdata/testwatches/watches.yaml: " +
+				"open testdata/testwatches/watches.yaml: no such file or directory",
+		},
+		{
+			// Invalid Watch
+			name: "Invalid Watch file",
+			r: &scaffold.Resource{
+				APIVersion: "app.example.com/v1alpha1",
+				Kind:       "App",
+				LowerKind:  "app",
+				FullGroup:  "app.example.com",
+				Version:    "v1alpha1",
+			},
+			absProjectPath: "./testdata/testwatches/invalid/invalid_watch",
+			expError: "failed to unmarshal watch config yaml: unmarshal errors:" + "\n" +
+				"  line 2: cannot unmarshal !!map into []watches.Watch ",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var result string
+			if err := UpdateHelmWatchForResource(tc.r, tc.absProjectPath, tc.chart); err != nil {
+				result = err.Error()
+			}
+			assert.Equal(t, tc.expError, result)
+			// Check watchfile content
+			if tc.expError == "" {
+				actualFilePath := tc.absProjectPath + "/watches.yaml"
+				expectedWatchFile, err := ioutil.ReadFile(tc.expWatchesFile)
+				if err != nil {
+					fmt.Printf("failed to read expectedWatchFile  %v: %v", tc.expWatchesFile, err)
+				}
+				actualWatchFile, err := ioutil.ReadFile(actualFilePath)
+				if err != nil {
+					fmt.Printf("failed to read actualWatchFile  %v: %v", actualFilePath, err)
+				}
+				assert.Equal(t, expectedWatchFile, actualWatchFile)
+			}
+		})
+	}
+}
+
+// remove removes path from disk. Used in defer statements.
+func remove(path string) {
+	if err := os.RemoveAll(path); err != nil {
+		log.Fatal(err)
+	}
+}
+
+const sampleWatch = `---
+- group: mykind.example.com
+  version: v1alpha1
+  kind: MyKind
+  chart: helm-charts/mykind`

--- a/internal/scaffold/role.go
+++ b/internal/scaffold/role.go
@@ -176,21 +176,16 @@ func MergeRoleForResource(r *Resource, absProjectPath string, roleScaffold Role)
 		}
 		mergedRoleRules := mergeRules(role.Rules, roleScaffold)
 		role.Rules = mergedRoleRules
-
-		if err := updateRoleFile(&role, roleFilePath); err != nil {
-			return fmt.Errorf("failed to update for resource (%v, %v): %v",
-				r.APIVersion, r.Kind, err)
-		}
 	case *rbacv1.ClusterRole:
 		mergedClusterRoleRules := mergeRules(role.Rules, roleScaffold)
 		role.Rules = mergedClusterRoleRules
-
-		if err := updateRoleFile(&role, roleFilePath); err != nil {
-			return fmt.Errorf("failed to update for resource (%v, %v): %v",
-				r.APIVersion, r.Kind, err)
-		}
 	default:
 		log.Errorf("Failed to parse role.yaml as a role %v", err)
+	}
+
+	if err := updateRoleFile(obj, roleFilePath); err != nil {
+		return fmt.Errorf("failed to update for resource (%v, %v): %v",
+			r.APIVersion, r.Kind, err)
 	}
 
 	return UpdateRoleForResource(r, absProjectPath)

--- a/internal/scaffold/role.go
+++ b/internal/scaffold/role.go
@@ -20,14 +20,15 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-
-	"github.com/operator-framework/operator-sdk/internal/scaffold/input"
-	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
+	"sort"
 
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 	rbacv1 "k8s.io/api/rbac/v1"
 	cgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/operator-framework/operator-sdk/internal/scaffold/input"
+	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
 )
 
 const RoleYamlFile = "role.yaml"
@@ -61,9 +62,9 @@ func UpdateRoleForResource(r *Resource, absProjectPath string) error {
 		return fmt.Errorf("failed to decode role manifest %v: %v", roleFilePath, err)
 	}
 	switch role := obj.(type) {
-	// TODO: use rbac/v1.
 	case *rbacv1.Role:
 		pr := &rbacv1.PolicyRule{}
+
 		apiGroupFound := false
 		for i := range role.Rules {
 			if role.Rules[i].APIGroups[0] == r.FullGroup {
@@ -72,6 +73,7 @@ func UpdateRoleForResource(r *Resource, absProjectPath string) error {
 				break
 			}
 		}
+
 		// check if the resource already exists
 		for _, resource := range pr.Resources {
 			if resource == r.Resource {
@@ -143,6 +145,111 @@ func UpdateRoleForResource(r *Resource, absProjectPath string) error {
 	}
 }
 
+// MergeRoleForResource merges incoming new API resource rules with existing deploy/role.yaml
+func MergeRoleForResource(r *Resource, absProjectPath string, roleScaffold Role) error {
+	roleFilePath := filepath.Join(absProjectPath, DeployDir, RoleYamlFile)
+	roleYAML, err := ioutil.ReadFile(roleFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read role manifest %v: %v", roleFilePath, err)
+	}
+	// Check for existing role.yaml
+	if len(roleYAML) == 0 {
+		return fmt.Errorf("empty Role File at: %v", absProjectPath)
+	}
+	// Check for incoming new Role
+	if len(roleScaffold.CustomRules) == 0 {
+		return fmt.Errorf("customRules cannot be empty for new Role at: %v", r.APIVersion)
+	}
+
+	obj, _, err := cgoscheme.Codecs.UniversalDeserializer().Decode(roleYAML, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to decode role manifest %v: %v", roleFilePath, err)
+	}
+	switch role := obj.(type) {
+	case *rbacv1.Role:
+		// TODO: Add logic to merge Cluster scoped rules into existing Kind: Role scoped rules
+		// Error out for ClusterRole merging with existing Kind: Role
+		if roleScaffold.IsClusterScoped {
+			return fmt.Errorf("cannot Merge Cluster scoped rules with existing deploy/role.yaml. " +
+				"please modify existing deploy/role.yaml and deploy/role_binding.yaml " +
+				"to reflect Cluster scope and try again")
+		}
+		mergedRoleRules := mergeRules(role.Rules, roleScaffold)
+		role.Rules = mergedRoleRules
+
+		if err := updateRoleFile(&role, roleFilePath); err != nil {
+			return fmt.Errorf("failed to update for resource (%v, %v): %v",
+				r.APIVersion, r.Kind, err)
+		}
+	case *rbacv1.ClusterRole:
+		mergedClusterRoleRules := mergeRules(role.Rules, roleScaffold)
+		role.Rules = mergedClusterRoleRules
+
+		if err := updateRoleFile(&role, roleFilePath); err != nil {
+			return fmt.Errorf("failed to update for resource (%v, %v): %v",
+				r.APIVersion, r.Kind, err)
+		}
+	default:
+		log.Errorf("Failed to parse role.yaml as a role %v", err)
+	}
+
+	return UpdateRoleForResource(r, absProjectPath)
+}
+
+func ifMatches(pr []string, newPr []string) bool {
+
+	sort.Strings(pr)
+	sort.Strings(newPr)
+
+	if len(pr) != len(newPr) {
+		return false
+	}
+	for i, v := range pr {
+		if v != newPr[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func findResource(resources []string, search string) bool {
+	for _, r := range resources {
+		if r == search || r == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+func mergeRules(rules1 []rbacv1.PolicyRule, rules2 Role) []rbacv1.PolicyRule {
+	for j := range rules2.CustomRules {
+		ruleFound := false
+		prj := &rules2.CustomRules[j]
+	iLoop:
+		for i, pri := range rules1 {
+			// check if apiGroup, verbs, resourceName, and nonResourceURLS matches for new resource.
+			apiGroupsEqual := ifMatches(pri.APIGroups, prj.APIGroups)
+			verbsEqual := ifMatches(pri.Verbs, prj.Verbs)
+			resourceNamesEqual := ifMatches(pri.ResourceNames, prj.ResourceNames)
+			nonResourceURLsEqual := ifMatches(pri.NonResourceURLs, prj.NonResourceURLs)
+
+			if apiGroupsEqual && verbsEqual && resourceNamesEqual && nonResourceURLsEqual {
+				for _, newResource := range prj.Resources {
+					if !findResource(pri.Resources, newResource) {
+						// append rbac rule to deploy/role.yaml
+						rules1[i].Resources = append(rules1[i].Resources, newResource)
+					}
+				}
+				ruleFound = true
+				break iLoop
+			}
+		}
+		if !ruleFound {
+			rules1 = append(rules1, *prj)
+		}
+	}
+	return rules1
+}
 func updateRoleFile(role interface{}, roleFilePath string) error {
 	d, err := json.Marshal(&role)
 	if err != nil {

--- a/internal/scaffold/role_test.go
+++ b/internal/scaffold/role_test.go
@@ -15,9 +15,15 @@
 package scaffold
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/operator-framework/operator-sdk/internal/util/diffutil"
+	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -81,6 +87,809 @@ func TestRoleCustomRules(t *testing.T) {
 		t.Fatalf("Expected vs actual differs.\n%v", diffs)
 	}
 }
+
+func TestMergeRoleForResource(t *testing.T) {
+	clusterRoleFilePath1 := "./testdata/testroles/valid_clusterrole"
+	clusterRoleFile1 := clusterRoleFilePath1 + "/deploy/role.yaml"
+	if err := ioutil.WriteFile(clusterRoleFile1, []byte(clusterRole), fileutil.DefaultFileMode); err != nil {
+		fmt.Printf("failed to update %v: %v", clusterRoleFile1, err)
+	}
+	defer remove(clusterRoleFile1)
+
+	roleFilePath1 := "./testdata/testroles/valid_role1"
+	absRoleFile1 := roleFilePath1 + "/deploy/role.yaml"
+	if err := ioutil.WriteFile(absRoleFile1, []byte(roleFile1), fileutil.DefaultFileMode); err != nil {
+		fmt.Printf("failed to update %v: %v", absRoleFile1, err)
+	}
+	defer remove(absRoleFile1)
+
+	roleFilePath2 := "./testdata/testroles/valid_role2"
+	absRoleFile2 := roleFilePath2 + "/deploy/role.yaml"
+	if err := ioutil.WriteFile(absRoleFile2, []byte(roleFile2), fileutil.DefaultFileMode); err != nil {
+		fmt.Printf("failed to update %v: %v", absRoleFile2, err)
+	}
+	defer remove(absRoleFile2)
+
+	roleFilePath3 := "./testdata/testroles/valid_role3"
+	absRoleFile3 := roleFilePath3 + "/deploy/role.yaml"
+	if err := ioutil.WriteFile(absRoleFile3, []byte(roleFile3), fileutil.DefaultFileMode); err != nil {
+		fmt.Printf("failed to update %v: %v", absRoleFile3, err)
+	}
+	defer remove(absRoleFile3)
+
+	roleFilePath4 := "./testdata/testroles/valid_role4"
+	absRoleFile4 := roleFilePath4 + "/deploy/role.yaml"
+	if err := ioutil.WriteFile(absRoleFile4, []byte(roleFile3), fileutil.DefaultFileMode); err != nil {
+		fmt.Printf("failed to update %v: %v", absRoleFile4, err)
+	}
+	defer remove(absRoleFile4)
+
+	roleFilePath5 := "./testdata/testroles/valid_role5"
+	absRoleFile5 := roleFilePath5 + "/deploy/role.yaml"
+	if err := ioutil.WriteFile(absRoleFile5, []byte(roleFile3), fileutil.DefaultFileMode); err != nil {
+		fmt.Printf("failed to update %v: %v", absRoleFile5, err)
+	}
+	defer remove(absRoleFile5)
+
+	roleFilePath6 := "./testdata/testroles/valid_role6"
+	absRoleFile6 := roleFilePath6 + "/deploy/role.yaml"
+	if err := ioutil.WriteFile(absRoleFile6, []byte(roleFile3), fileutil.DefaultFileMode); err != nil {
+		fmt.Printf("failed to update %v: %v", absRoleFile6, err)
+	}
+	defer remove(absRoleFile6)
+
+	testCases := []struct {
+		name           string
+		absProjectPath string
+		r              *Resource
+		roleScaffold   *Role
+		expError       error
+		existingRole   string
+		mergedRole     string
+	}{
+		{
+			name:           "Valid Basic ClusterRole-1",
+			absProjectPath: clusterRoleFilePath1,
+			mergedRole:     clusterRoleFilePath1 + "/mergedRole.yaml",
+			r: &Resource{
+				APIVersion: "charts.helm.k8s.io/v1alpha1",
+				Kind:       "Memcached",
+				FullGroup:  "charts.helm.k8s.io",
+				LowerKind:  "memcached",
+				Resource:   "memcacheds",
+			},
+			roleScaffold: &Role{
+				IsClusterScoped:  false,
+				SkipDefaultRules: true,
+				CustomRules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"namespaces"},
+						Verbs:     []string{"get"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"configmaps", "secrets"},
+						Verbs:     []string{"*"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"events"},
+						Verbs:     []string{"create"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"services"},
+						Verbs:     []string{"*"},
+					},
+					{
+						APIGroups: []string{"apps"},
+						Resources: []string{"statefulsets"},
+						Verbs:     []string{"*"},
+					},
+				},
+			},
+		},
+		{
+			name:           "Valid Basic CustomRules-1",
+			absProjectPath: roleFilePath1,
+			mergedRole:     roleFilePath1 + "/mergedRole.yaml",
+			r: &Resource{
+				APIVersion: "charts.helm.k8s.io/v1alpha1",
+				Kind:       "Memcached",
+				FullGroup:  "charts.helm.k8s.io",
+				LowerKind:  "memcached",
+				Resource:   "memcacheds",
+			},
+			roleScaffold: &Role{
+				IsClusterScoped:  false,
+				SkipDefaultRules: true,
+				CustomRules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"namespaces"},
+						Verbs:     []string{"get"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"configmaps", "secrets"},
+						Verbs:     []string{"*"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"events"},
+						Verbs:     []string{"create"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"services"},
+						Verbs:     []string{"*"},
+					},
+					{
+						APIGroups: []string{"apps"},
+						Resources: []string{"statefulsets"},
+						Verbs:     []string{"*"},
+					},
+				},
+			},
+		},
+
+		{
+			name:           "Valid With Options CustomRules-2",
+			absProjectPath: roleFilePath2,
+			mergedRole:     roleFilePath2 + "/mergedRole.yaml",
+			r: &Resource{
+				APIVersion: "cache.example.com/v1alpha1",
+				Kind:       "Mykind",
+				FullGroup:  "cache.example.com",
+				LowerKind:  "mykind",
+				Resource:   "mykinds",
+			},
+			roleScaffold: &Role{
+				IsClusterScoped:  false,
+				SkipDefaultRules: true,
+				CustomRules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"namespaces"},
+						Verbs:     []string{"get"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"configmaps", "secrets"},
+						Verbs:     []string{"*"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"events"},
+						Verbs:     []string{"create"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"serviceaccounts", "services"},
+						Verbs:     []string{"*"},
+					},
+					{
+						APIGroups:       []string{"apps"},
+						Resources:       []string{"deployments"},
+						ResourceNames:   []string{"helm-demo"},
+						NonResourceURLs: []string{"/demos"},
+						Verbs:           []string{"*"},
+					},
+					{
+						APIGroups:       []string{"apps"},
+						Resources:       []string{"deamonsets"},
+						Verbs:           []string{"delete"},
+						ResourceNames:   []string{"helm-demo"},
+						NonResourceURLs: []string{"/demos", "/helm"},
+					},
+				},
+			},
+		},
+		{
+			name:           "Valid and differing APIGroups in CustomRules-3",
+			absProjectPath: roleFilePath3,
+			mergedRole:     roleFilePath3 + "/mergedRole.yaml",
+			r: &Resource{
+				APIVersion: "cache.example.com/v1alpha1",
+				Kind:       "Mykind",
+				FullGroup:  "cache.example.com",
+				LowerKind:  "mykind",
+				Resource:   "mykinds",
+			},
+			roleScaffold: &Role{
+				IsClusterScoped:  false,
+				SkipDefaultRules: true,
+				CustomRules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"namespaces"},
+						Verbs:     []string{"get"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"configmaps", "secrets"},
+						Verbs:     []string{"*"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"events"},
+						Verbs:     []string{"create"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"serviceaccounts", "services"},
+						Verbs:     []string{"*"},
+					},
+					// Testing vars which differ only in APIGroups with existing role.yaml
+					{
+						APIGroups:       []string{"apps"},
+						Resources:       []string{"replicasets", "deployments"},
+						ResourceNames:   []string{"helm-demo", "sample"},
+						NonResourceURLs: []string{"/demos", "/helm"},
+						Verbs:           []string{"create", "get"},
+					},
+				},
+			},
+		},
+		{
+			name:           "Valid and differing ResourceNames in CustomRules-4",
+			absProjectPath: roleFilePath4,
+			mergedRole:     roleFilePath4 + "/mergedRole.yaml",
+			r: &Resource{
+				APIVersion: "cache.example.com/v1alpha1",
+				Kind:       "Mykind",
+				FullGroup:  "cache.example.com",
+				LowerKind:  "mykind",
+				Resource:   "mykinds",
+			},
+			roleScaffold: &Role{
+				IsClusterScoped:  false,
+				SkipDefaultRules: true,
+				CustomRules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"namespaces"},
+						Verbs:     []string{"get"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"configmaps", "secrets"},
+						Verbs:     []string{"*"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"events"},
+						Verbs:     []string{"create"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"serviceaccounts", "services"},
+						Verbs:     []string{"*"},
+					},
+					// Testing vars which differ only in ResourceNames with existing role.yaml
+					{
+						APIGroups:       []string{"apps", "samples"},
+						Resources:       []string{"replicasets", "deployments"},
+						ResourceNames:   []string{"helm-demo"},
+						NonResourceURLs: []string{"/demos", "/helm"},
+						Verbs:           []string{"create", "get"},
+					},
+				},
+			},
+		},
+		{
+			name:           "Valid and differing NonResourceURLs in CustomRule-5",
+			absProjectPath: roleFilePath5,
+			mergedRole:     roleFilePath5 + "/mergedRole.yaml",
+			r: &Resource{
+				APIVersion: "cache.example.com/v1alpha1",
+				Kind:       "Mykind",
+				FullGroup:  "cache.example.com",
+				LowerKind:  "mykind",
+				Resource:   "mykinds",
+			},
+			roleScaffold: &Role{
+				IsClusterScoped:  false,
+				SkipDefaultRules: true,
+				CustomRules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"namespaces"},
+						Verbs:     []string{"get"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"configmaps", "secrets"},
+						Verbs:     []string{"*"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"events"},
+						Verbs:     []string{"create"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"serviceaccounts", "services"},
+						Verbs:     []string{"*"},
+					},
+					// Testing vars which differ only in NonResourceURLs with existing role.yaml
+					{
+						APIGroups:       []string{"apps", "samples"},
+						Resources:       []string{"replicasets", "deployments"},
+						ResourceNames:   []string{"helm-demo", "sample"},
+						NonResourceURLs: []string{"/demos"},
+						Verbs:           []string{"create", "get"},
+					},
+				},
+			},
+		},
+		{
+			name:           "Valid and differing Verbs in CustomRules-6",
+			absProjectPath: roleFilePath6,
+			mergedRole:     roleFilePath6 + "/mergedRole.yaml",
+			r: &Resource{
+				APIVersion: "cache.example.com/v1alpha1",
+				Kind:       "Mykind",
+				FullGroup:  "cache.example.com",
+				LowerKind:  "mykind",
+				Resource:   "mykinds",
+			},
+			roleScaffold: &Role{
+				IsClusterScoped:  false,
+				SkipDefaultRules: true,
+				CustomRules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"namespaces"},
+						Verbs:     []string{"get"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"configmaps", "secrets"},
+						Verbs:     []string{"*"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"events"},
+						Verbs:     []string{"create"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"serviceaccounts", "services"},
+						Verbs:     []string{"*"},
+					},
+					// Testing vars which differ only in Verbs with existing role.yaml
+					{
+						APIGroups:       []string{"apps", "samples"},
+						Resources:       []string{"replicasets", "deployments"},
+						ResourceNames:   []string{"helm-demo", "sample"},
+						NonResourceURLs: []string{"/demos", "/helm"},
+						Verbs:           []string{"create"},
+					},
+				},
+			},
+		},
+		{
+			name:           "Invalid ClusterRole",
+			absProjectPath: roleFilePath1,
+			r: &Resource{
+				APIVersion: "charts.helm.k8s.io/v1alpha1",
+				Kind:       "Nginxingress",
+				FullGroup:  "charts.helm.k8s.io",
+				LowerKind:  "nginx-ingress",
+				Resource:   "nginxingresses",
+			},
+			roleScaffold: &Role{
+				IsClusterScoped:  true,
+				SkipDefaultRules: true,
+				CustomRules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"namespaces"},
+						Verbs:     []string{"get"},
+					},
+					{
+						APIGroups: []string{""},
+						Resources: []string{"configmaps", "secrets"},
+						Verbs:     []string{"*"},
+					},
+				},
+			},
+		},
+		{
+			name:           "Empty CustomRules",
+			absProjectPath: "./testdata/testroles/invalid_role",
+			mergedRole:     "",
+			r: &Resource{
+				APIVersion: "cache.example.com/v1alpha1",
+				Kind:       "Mykind",
+				FullGroup:  "app.example.com",
+			},
+			roleScaffold: &Role{
+				IsClusterScoped:  false,
+				SkipDefaultRules: true,
+				CustomRules:      []rbacv1.PolicyRule{},
+			},
+		},
+		{
+			name:           "Empty role.yaml file",
+			absProjectPath: "./testdata/testroles/invalid_role",
+			mergedRole:     "",
+			r: &Resource{
+				APIVersion: "cache.example.com/v1alpha1",
+				Kind:       "Mykind",
+				FullGroup:  "app.example.com",
+			},
+			roleScaffold: &Role{
+				IsClusterScoped:  false,
+				SkipDefaultRules: true,
+				CustomRules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{""},
+						Resources: []string{"namespaces"},
+						Verbs:     []string{"get"},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualErr := MergeRoleForResource(tc.r, tc.absProjectPath, *tc.roleScaffold)
+			absFilePath := tc.absProjectPath + "/deploy/role.yaml"
+			actualMergedRoleYAML, err := ioutil.ReadFile(absFilePath)
+			if err != nil {
+				fmt.Printf("failed to read actualMergedrole  %v: %v", absFilePath, err)
+			}
+			expectedMergedRoleYAML, err := ioutil.ReadFile(tc.mergedRole)
+			if err != nil {
+				fmt.Printf("failed to read expectedMergedrole  %v: %v", tc.mergedRole, err)
+			}
+
+			if actualErr != nil {
+				assert.NotNil(t, actualErr)
+			} else {
+				assert.Equal(t, string(expectedMergedRoleYAML), string(actualMergedRoleYAML))
+			}
+		})
+	}
+}
+
+// remove removes path from disk. Used in defer statements.
+func remove(path string) {
+	if err := os.RemoveAll(path); err != nil {
+		log.Fatal(err)
+	}
+}
+
+const clusterRole = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: helm-demo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - secrets
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - helm-demo
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - charts.helm.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+`
+const roleFile3 = `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: helm-demo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - helm-demo
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  - samples
+  nonResourceURLs:
+  - /demos
+  - /helm
+  resourceNames:
+  - helm-demo
+  - sample 
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - charts.helm.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+`
+
+const roleFile1 = `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: helm-demo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - secrets
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - helm-demo
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - charts.helm.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+`
+const roleFile2 = `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: helm-demo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - helm-demo
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - charts.helm.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+`
 
 const roleExp = `kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/internal/scaffold/role_test.go
+++ b/internal/scaffold/role_test.go
@@ -92,49 +92,49 @@ func TestMergeRoleForResource(t *testing.T) {
 	clusterRoleFilePath1 := "./testdata/testroles/valid_clusterrole"
 	clusterRoleFile1 := clusterRoleFilePath1 + "/deploy/role.yaml"
 	if err := ioutil.WriteFile(clusterRoleFile1, []byte(clusterRole), fileutil.DefaultFileMode); err != nil {
-		fmt.Printf("failed to update %v: %v", clusterRoleFile1, err)
+		fmt.Printf("failed to instantiate %v: %v", clusterRoleFile1, err)
 	}
 	defer remove(clusterRoleFile1)
 
 	roleFilePath1 := "./testdata/testroles/valid_role1"
 	absRoleFile1 := roleFilePath1 + "/deploy/role.yaml"
 	if err := ioutil.WriteFile(absRoleFile1, []byte(roleFile1), fileutil.DefaultFileMode); err != nil {
-		fmt.Printf("failed to update %v: %v", absRoleFile1, err)
+		fmt.Printf("failed to instantiate %v: %v", absRoleFile1, err)
 	}
 	defer remove(absRoleFile1)
 
 	roleFilePath2 := "./testdata/testroles/valid_role2"
 	absRoleFile2 := roleFilePath2 + "/deploy/role.yaml"
 	if err := ioutil.WriteFile(absRoleFile2, []byte(roleFile2), fileutil.DefaultFileMode); err != nil {
-		fmt.Printf("failed to update %v: %v", absRoleFile2, err)
+		fmt.Printf("failed to instantiate %v: %v", absRoleFile2, err)
 	}
 	defer remove(absRoleFile2)
 
 	roleFilePath3 := "./testdata/testroles/valid_role3"
 	absRoleFile3 := roleFilePath3 + "/deploy/role.yaml"
 	if err := ioutil.WriteFile(absRoleFile3, []byte(roleFile3), fileutil.DefaultFileMode); err != nil {
-		fmt.Printf("failed to update %v: %v", absRoleFile3, err)
+		fmt.Printf("failed to instantiate %v: %v", absRoleFile3, err)
 	}
 	defer remove(absRoleFile3)
 
 	roleFilePath4 := "./testdata/testroles/valid_role4"
 	absRoleFile4 := roleFilePath4 + "/deploy/role.yaml"
 	if err := ioutil.WriteFile(absRoleFile4, []byte(roleFile3), fileutil.DefaultFileMode); err != nil {
-		fmt.Printf("failed to update %v: %v", absRoleFile4, err)
+		fmt.Printf("failed to instantiate %v: %v", absRoleFile4, err)
 	}
 	defer remove(absRoleFile4)
 
 	roleFilePath5 := "./testdata/testroles/valid_role5"
 	absRoleFile5 := roleFilePath5 + "/deploy/role.yaml"
 	if err := ioutil.WriteFile(absRoleFile5, []byte(roleFile3), fileutil.DefaultFileMode); err != nil {
-		fmt.Printf("failed to update %v: %v", absRoleFile5, err)
+		fmt.Printf("failed to instantiate %v: %v", absRoleFile5, err)
 	}
 	defer remove(absRoleFile5)
 
 	roleFilePath6 := "./testdata/testroles/valid_role6"
 	absRoleFile6 := roleFilePath6 + "/deploy/role.yaml"
 	if err := ioutil.WriteFile(absRoleFile6, []byte(roleFile3), fileutil.DefaultFileMode); err != nil {
-		fmt.Printf("failed to update %v: %v", absRoleFile6, err)
+		fmt.Printf("failed to instantiate %v: %v", absRoleFile6, err)
 	}
 	defer remove(absRoleFile6)
 

--- a/internal/scaffold/testdata/testroles/valid_clusterrole/mergedRole.yaml
+++ b/internal/scaffold/testdata/testroles/valid_clusterrole/mergedRole.yaml
@@ -1,0 +1,82 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: helm-demo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - secrets
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - helm-demo
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - charts.helm.k8s.io
+  resources:
+  - '*'
+  - memcacheds
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/internal/scaffold/testdata/testroles/valid_role1/mergedRole.yaml
+++ b/internal/scaffold/testdata/testroles/valid_role1/mergedRole.yaml
@@ -1,0 +1,82 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: helm-demo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - secrets
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - helm-demo
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - charts.helm.k8s.io
+  resources:
+  - '*'
+  - memcacheds
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/internal/scaffold/testdata/testroles/valid_role2/mergedRole.yaml
+++ b/internal/scaffold/testdata/testroles/valid_role2/mergedRole.yaml
@@ -1,0 +1,112 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: helm-demo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - apps
+  resourceNames:
+  - helm-demo
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - charts.helm.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  nonResourceURLs:
+  - /demos
+  resourceNames:
+  - helm-demo
+  resources:
+  - deployments
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  nonResourceURLs:
+  - /demos
+  - /helm
+  resourceNames:
+  - helm-demo
+  resources:
+  - deamonsets
+  verbs:
+  - delete
+- apiGroups:
+  - cache.example.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/internal/scaffold/testdata/testroles/valid_role3/mergedRole.yaml
+++ b/internal/scaffold/testdata/testroles/valid_role3/mergedRole.yaml
@@ -1,0 +1,113 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: helm-demo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - apps
+  resourceNames:
+  - helm-demo
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  - samples
+  nonResourceURLs:
+  - /demos
+  - /helm
+  resourceNames:
+  - helm-demo
+  - sample
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - charts.helm.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  nonResourceURLs:
+  - /demos
+  - /helm
+  resourceNames:
+  - helm-demo
+  - sample
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - cache.example.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/internal/scaffold/testdata/testroles/valid_role4/mergedRole.yaml
+++ b/internal/scaffold/testdata/testroles/valid_role4/mergedRole.yaml
@@ -1,0 +1,113 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: helm-demo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - apps
+  resourceNames:
+  - helm-demo
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  - samples
+  nonResourceURLs:
+  - /demos
+  - /helm
+  resourceNames:
+  - helm-demo
+  - sample
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - charts.helm.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  - samples
+  nonResourceURLs:
+  - /demos
+  - /helm
+  resourceNames:
+  - helm-demo
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - cache.example.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/internal/scaffold/testdata/testroles/valid_role5/mergedRole.yaml
+++ b/internal/scaffold/testdata/testroles/valid_role5/mergedRole.yaml
@@ -1,0 +1,113 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: helm-demo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - apps
+  resourceNames:
+  - helm-demo
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  - samples
+  nonResourceURLs:
+  - /demos
+  - /helm
+  resourceNames:
+  - helm-demo
+  - sample
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - charts.helm.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  - samples
+  nonResourceURLs:
+  - /demos
+  resourceNames:
+  - helm-demo
+  - sample
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - cache.example.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/internal/scaffold/testdata/testroles/valid_role6/mergedRole.yaml
+++ b/internal/scaffold/testdata/testroles/valid_role6/mergedRole.yaml
@@ -1,0 +1,113 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: helm-demo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - apps
+  resourceNames:
+  - helm-demo
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  - samples
+  nonResourceURLs:
+  - /demos
+  - /helm
+  resourceNames:
+  - helm-demo
+  - sample
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - charts.helm.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  - samples
+  nonResourceURLs:
+  - /demos
+  - /helm
+  resourceNames:
+  - helm-demo
+  - sample
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - create
+- apiGroups:
+  - cache.example.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/pkg/ansible/watches/watches.go
+++ b/pkg/ansible/watches/watches.go
@@ -51,8 +51,8 @@ type Watch struct {
 	WatchClusterScopedResources bool                      `yaml:"watchClusterScopedResources"`
 
 	// Not configurable via watches.yaml
-	MaxWorkers       int `yaml:"maxWorkers"`
-	AnsibleVerbosity int `yaml:"ansibleVerbosity"`
+	MaxWorkers       int `yaml:"-"`
+	AnsibleVerbosity int `yaml:"-"`
 }
 
 // Finalizer - Expose finalizer to be used by a user.
@@ -293,6 +293,7 @@ func Load(path string, maxWorkers, ansibleVerbosity int) ([]Watch, error) {
 		if _, ok := watchesMap[watch.GroupVersionKind]; ok {
 			return nil, fmt.Errorf("duplicate GVK: %v", watch.GroupVersionKind.String())
 		}
+
 		watchesMap[watch.GroupVersionKind] = true
 
 		err = watch.Validate()

--- a/pkg/helm/run.go
+++ b/pkg/helm/run.go
@@ -125,7 +125,7 @@ func Run(flags *hoflags.HelmOperatorFlags) error {
 			GVK:                     w.GroupVersionKind,
 			ManagerFactory:          release.NewManagerFactory(mgr, w.ChartDir),
 			ReconcilePeriod:         flags.ReconcilePeriod,
-			WatchDependentResources: w.WatchDependentResources,
+			WatchDependentResources: *w.WatchDependentResources,
 			OverrideValues:          w.OverrideValues,
 			MaxWorkers:              flags.MaxWorkers,
 		})

--- a/pkg/helm/watches/watches_test.go
+++ b/pkg/helm/watches/watches_test.go
@@ -152,19 +152,19 @@ foo: bar
 		t.Run(tc.name, func(t *testing.T) {
 			tmp, err := ioutil.TempFile("", "watches.yaml")
 			if err != nil {
-				t.Fatalf("Failed to create temporary watches.yaml file: %w", err)
+				t.Fatalf("Failed to create temporary watches.yaml file: %v", err)
 			}
 			defer func() { _ = os.Remove(tmp.Name()) }()
 			if _, err := tmp.WriteString(tc.data); err != nil {
-				t.Fatalf("Failed to write data to temporary watches.yaml file: %w", err)
+				t.Fatalf("Failed to write data to temporary watches.yaml file: %v", err)
 			}
 			if err := tmp.Close(); err != nil {
-				t.Fatalf("Failed to close temporary watches.yaml file: %w", err)
+				t.Fatalf("Failed to close temporary watches.yaml file: %v", err)
 			}
 
 			for k, v := range tc.env {
 				if err := os.Setenv(k, v); err != nil {
-					t.Fatalf("Failed to set environment variable %q: %w", k, err)
+					t.Fatalf("Failed to set environment variable %q: %v", k, err)
 				}
 			}
 
@@ -172,7 +172,7 @@ foo: bar
 
 			for k := range tc.env {
 				if err := os.Unsetenv(k); err != nil {
-					t.Fatalf("Failed to unset environment variable %q: %w", k, err)
+					t.Fatalf("Failed to unset environment variable %q: %v", k, err)
 				}
 			}
 		})
@@ -182,7 +182,7 @@ foo: bar
 func doTest(t *testing.T, tc testCase, watchesFile string) {
 	watches, err := Load(watchesFile)
 	if !tc.expectErr && err != nil {
-		t.Fatalf("Expected no error; got error: %w", err)
+		t.Fatalf("Expected no error; got error: %v", err)
 	} else if tc.expectErr && err == nil {
 		t.Fatalf("Expected error; got no error")
 	}

--- a/website/content/en/docs/ansible/quickstart.md
+++ b/website/content/en/docs/ansible/quickstart.md
@@ -354,7 +354,8 @@ $ kubectl delete -f deploy/service_account.yaml
 $ kubectl delete -f deploy/crds/cache.example.com_memcacheds_crd.yaml
 ```
 
-**NOTE** Additional CR/CRD's can be added to the project by running, for example, the command :`operator-sdk new api --api-version=cache.example.com/v1alpha1 --kind=AppService --type=ansible`
+**NOTE** Additional CR/CRD's can be added to the project by running, for example, the command :`operator-sdk add api --api-version=cache.example.com/v1alpha1 --kind=AppService`
+For more information, refer [cli][addcli] doc.
 
 [ansible-install-guide]: /docs/ansible/installation
 [ansible-runner-http-plugin]:https://github.com/ansible/ansible-runner-http
@@ -368,3 +369,4 @@ $ kubectl delete -f deploy/crds/cache.example.com_memcacheds_crd.yaml
 [go-tool]:https://golang.org/dl/
 [docker-tool]:https://docs.docker.com/install/
 [kubectl-tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
+[addcli]: /docs/cli/operator-sdk_add_api

--- a/website/content/en/docs/cli/operator-sdk_add_api.md
+++ b/website/content/en/docs/cli/operator-sdk_add_api.md
@@ -7,50 +7,94 @@ Adds a new api definition under pkg/apis
 
 ### Synopsis
 
-operator-sdk add api --kind=<kind> --api-version=<group/version> creates
-the api definition for a new custom resource under pkg/apis. This command
-must be run from the project root directory. If the api already exists at
-pkg/apis/<group>/<version> then the command will not overwrite and return
-an error.
+operator-sdk add api --kind=<kind> --api-version<group/version> 
+creates an API definition for a new custom resource.
+This command must be run from the project root directory.
 
-By default, this command runs Kubernetes deepcopy and CRD generators on
-tagged types in all paths under pkg/apis. Go code is generated under
-pkg/apis/<group>/<version>/zz_generated.deepcopy.go. CRD's are generated,
-or updated if they exist for a particular group + version + kind, under
+For Go-based operators:
+
+  - Creates the api definition for a new custom resource under pkg/apis.
+  - By default, this command runs Kubernetes deepcopy and CRD generators on
+  tagged types in all paths under pkg/apis. Go code is generated under
+  pkg/apis/<group>/<version>/zz_generated.deepcopy.go. Generation can be disabled with the
+  --skip-generation flag for Go-based operators.
+
+For Ansible-based operators:
+
+  - Creates resource folder under /roles.
+  - watches.yaml is updated with new resource.
+  - deploy/role.yaml will be updated with apiGroup for new API.
+
+For Helm-based operators:
+  - Creates resource folder under /helm-charts.
+  - watches.yaml is updated with new resource.
+  - deploy/role.yaml will be updated to reflact new rules for the incoming API.
+
+CRD's are generated, or updated if they exist for a particular group + version + kind, under
 deploy/crds/<full group>_<resource>_crd.yaml; OpenAPI V3 validation YAML
-is generated as a 'validation' object. Generation can be disabled with the
---skip-generation flag.
-
-Example:
-
-	$ operator-sdk add api --api-version=app.example.com/v1alpha1 --kind=AppService
-	$ tree pkg/apis
-	pkg/apis/
-	├── addtoscheme_app_appservice.go
-	├── apis.go
-	└── app
-		└── v1alpha1
-			├── doc.go
-			├── register.go
-			├── appservice_types.go
-			├── zz_generated.deepcopy.go
-	$ tree deploy/crds
-	├── deploy/crds/app.example.com_v1alpha1_appservice_cr.yaml
-	├── deploy/crds/app.example.com_appservices_crd.yaml
-
+is generated as a 'validation' object.
 
 ```
 operator-sdk add api [flags]
 ```
 
+### Examples
+
+```
+  # Create a new API, under an existing project. This command must be run from the project root directory.
+# Go Example:
+  $ operator-sdk add api --api-version=app.example.com/v1alpha1 --kind=AppService
+
+# Ansible Example
+  $ operator-sdk add api  \
+  --api-version=app.example.com/v1alpha1 \
+  --kind=AppService
+
+# Helm Example:
+  $ operator-sdk add api \
+  --api-version=app.example.com/v1alpha1 \
+  --kind=AppService
+
+  $ operator-sdk add api \
+  --api-version=app.example.com/v1alpha1 \
+  --kind=AppService
+  --helm-chart=myrepo/app
+
+  $ operator-sdk add api \
+  --helm-chart=myrepo/app
+
+  $ operator-sdk add api \
+  --helm-chart=myrepo/app \
+  --helm-chart-version=1.2.3
+
+  $ operator-sdk add api \
+  --helm-chart=app \
+  --helm-chart-repo=https://charts.mycompany.com/
+
+  $ operator-sdk add api \
+  --helm-chart=app \
+  --helm-chart-repo=https://charts.mycompany.com/ \
+  --helm-chart-version=1.2.3
+
+  $ operator-sdk add api \
+  --helm-chart=/path/to/local/chart-directories/app/
+
+  $ operator-sdk add api \
+  --helm-chart=/path/to/local/chart-archives/app-1.2.3.tgz
+
+```
+
 ### Options
 
 ```
-      --api-version string   Kubernetes APIVersion that has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)
-      --crd-version string   CRD version to generate (default "v1beta1")
-  -h, --help                 help for api
-      --kind string          Kubernetes resource Kind name. (e.g AppService)
-      --skip-generation      Skip generation of deepcopy and OpenAPI code and OpenAPI CRD specs
+      --api-version string          Kubernetes apiVersion and has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)
+      --crd-version string          CRD version to generate (default "v1beta1")
+      --helm-chart string           Initialize helm operator with existing helm chart (<URL>, <repo>/<name>, or local path). Valid only for --type helm
+      --helm-chart-repo string      Chart repository URL for the requested helm chart, Valid only for --type helm
+      --helm-chart-version string   Specific version of the helm chart (default is latest version). Valid only for --type helm
+  -h, --help                        help for api
+      --kind string                 Kubernetes resource Kind name. (e.g AppService)
+      --skip-generation             Skip generation of deepcopy and OpenAPI code and OpenAPI CRD specs
 ```
 
 ### SEE ALSO

--- a/website/content/en/docs/cli/operator-sdk_new.md
+++ b/website/content/en/docs/cli/operator-sdk_new.md
@@ -69,17 +69,18 @@ operator-sdk new <project-name> [flags]
 ### Options
 
 ```
-      --api-version string          Kubernetes apiVersion and has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1) - used with "ansible" or "helm" types
-      --crd-version string          CRD version to generate (Only used for --type=ansible|helm) (default "v1beta1")
+      --api-version string          Kubernetes apiVersion and has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)
+      --crd-version string          CRD version to generate (default "v1beta1")
       --generate-playbook           Generate a playbook skeleton. (Only used for --type ansible)
       --git-init                    Initialize the project directory as a git repository (default false)
       --header-file string          Path to file containing headers for generated Go files. Copied to hack/boilerplate.go.txt
-      --helm-chart string           Initialize helm operator with existing helm chart (<URL>, <repo>/<name>, or local path)
-      --helm-chart-repo string      Chart repository URL for the requested helm chart
-      --helm-chart-version string   Specific version of the helm chart (default is latest version)
+      --helm-chart string           Initialize helm operator with existing helm chart (<URL>, <repo>/<name>, or local path). Valid only for --type helm
+      --helm-chart-repo string      Chart repository URL for the requested helm chart, Valid only for --type helm
+      --helm-chart-version string   Specific version of the helm chart (default is latest version). Valid only for --type helm
   -h, --help                        help for new
-      --kind string                 Kubernetes CustomResourceDefintion kind. (e.g AppService) - used with "ansible" or "helm" types
+      --kind string                 Kubernetes resource Kind name. (e.g AppService)
       --repo string                 Project repository path for Go operators. Used as the project's Go import path. This must be set if outside of $GOPATH/src (e.g. github.com/example-inc/my-operator)
+      --skip-generation             Skip generation of deepcopy and OpenAPI code and OpenAPI CRD specs
       --skip-validation             Do not validate the resulting project's structure and dependencies. (Only used for --type go)
       --type string                 Type of operator to initialize (choices: "go", "ansible" or "helm") (default "go")
       --vendor                      Use a vendor directory for dependencies

--- a/website/content/en/docs/helm/quickstart.md
+++ b/website/content/en/docs/helm/quickstart.md
@@ -298,9 +298,12 @@ kubectl delete -f deploy/role.yaml
 kubectl delete -f deploy/service_account.yaml
 kubectl delete -f deploy/crds/example.com_nginxes_crd.yaml
 ```
+**NOTE** Additional CR/CRD's can be added to the project by running, for example, the command :`operator-sdk add api --api-version=cache.example.com/v1alpha1 --kind=AppService`
+For more information, refer [cli][addcli] doc.
 
 [operator-scope]: /docs/operator-scope
 [layout-doc]: /docs/helm/reference/scaffolding
 [helm-charts]:https://helm.sh/docs/topics/charts/
 [helm-values]:https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing
 [helm-official]:https://helm.sh/docs/
+[addcli]: /docs/cli/operator-sdk_add_api


### PR DESCRIPTION
**Description**: Enable Ansible/Helm operator developers to create additional APIs, through SDK CLI, using below command.
Ansible Example:
`operator-sdk add api --api-version=example.com/v1alpha1 --kind=Memcached`
Helm Example: (chart options being optional)
`operator-sdk add api --api-version=example.com/v1alpha1 --kind=Memcached --helm-chart=stable/memcached`
**Motivation**:
As of today, SDK CLI can be used only to add additonal APIs for Go based Operators. Ansible/Helm operator developers are not able to create additonal APIs via CLI, once the original project scaffolds. Today, developers have to manually add necessary files to the project scaffold.
For more information please refer [proposal](https://github.com/operator-framework/operator-sdk/blob/master/doc/proposals/ansible-helm-addapi.md).

