### PR TITLE
Add releases tab, point to current gh docs

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -32,16 +32,11 @@ pygmentsStyle = "tango"
 [permalinks]
 blog = "/:section/:year/:month/:day/:slug/"
 
-## Configuration for BlackFriday markdown parser: https://github.com/russross/blackfriday
+## Configuration for Goldmark markdown parser: https://github.com/yuin/goldmark
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
-# [blackfriday]
-# plainIDAnchors = true
-# hrefTargetBlank = true
-# angledQuotes = false
-# latexDashes = true
 
 # Image processing configuration.
 [imaging]
@@ -74,6 +69,13 @@ copyright = "The Operator SDK Authors"
 # Menu title if your navbar has a versions selector to access old versions of your site.
 # This menu appears only if you have at least one [params.versions] set.
 version_menu = "Releases"
+[[params.versions]]
+  version = "master"
+  url = "/docs"
+
+[[params.versions]]
+  version = "v0.16"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v0.16.x/doc"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 # github_repo = "https://github.com/operator-framework/operator-sdk"
@@ -96,7 +98,6 @@ breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
 sidebar_search_disable = false
 
-# TODO(asmacdo)
 #  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
 navbar_logo = true
 # Set to true to disable the About link in the site footer
@@ -120,7 +121,6 @@ no = 'Sorry to hear that. Please <a href="https://github.com/operator-framework/
 	icon = "fa fa-envelope"
         desc = "Discussion and help"
 
-# TODO(asmaco) file issue
 # [[params.links.user]]
 # 	name = "Stack Overflow"
 # 	url = "https://stackoverflow.com/questions/tagged/operator-sdk"


### PR DESCRIPTION
This PR does not solve https://github.com/operator-framework/operator-sdk/issues/2708, but does add a placeholder with value.

![Screenshot from 2020-03-24 09-05-31](https://user-images.githubusercontent.com/1028657/77428577-b06ea600-6dae-11ea-9593-d638c425ee97.png)

Master -> relative link, /docs
0.16 -> GitHub docs tree for 0.16.x branch