### PR TITLE
Properly handle resources with '-' in the group name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 ### Bug Fixes
 
+- Resources that use '-' in the APIGroup name can now be directly accessed by Ansible. ([#2712](https://github.com/operator-framework/operator-sdk/pull/2712))
+
 ## v0.16.0
 
 ### Added

--- a/pkg/ansible/runner/runner.go
+++ b/pkg/ansible/runner/runner.go
@@ -310,8 +310,7 @@ func (r *runner) makeParameters(u *unstructured.Unstructured) map[string]interfa
 	parameters := paramconv.MapToSnake(spec)
 	parameters["meta"] = map[string]string{"namespace": u.GetNamespace(), "name": u.GetName()}
 
-	objKey := fmt.Sprintf("_%v_%v", strings.ReplaceAll(strings.ReplaceAll(r.GVK.Group, ".", "_"), "-", "_"),
-		strings.ToLower(r.GVK.Kind))
+	objKey := escapeAnsibleKey(fmt.Sprintf("_%v_%v", r.GVK.Group, strings.ToLower(r.GVK.Kind)))
 	parameters[objKey] = u.Object
 
 	specKey := fmt.Sprintf("%s_spec", objKey)
@@ -326,6 +325,16 @@ func (r *runner) makeParameters(u *unstructured.Unstructured) map[string]interfa
 		}
 	}
 	return parameters
+}
+
+// escapeAnsibleKey - replaces characters that would result in an inaccessible Ansible parameter with underscores
+// ie, _cert-manager.k8s.io would be converted to _cert_manager_k8s_io
+func escapeAnsibleKey(key string) string {
+	disallowed := []string{".", "-"}
+	for _, c := range disallowed {
+		key = strings.ReplaceAll(key, c, "_")
+	}
+	return key
 }
 
 func (r *runner) GetFinalizer() (string, bool) {

--- a/pkg/ansible/runner/runner.go
+++ b/pkg/ansible/runner/runner.go
@@ -310,7 +310,7 @@ func (r *runner) makeParameters(u *unstructured.Unstructured) map[string]interfa
 	parameters := paramconv.MapToSnake(spec)
 	parameters["meta"] = map[string]string{"namespace": u.GetNamespace(), "name": u.GetName()}
 
-	objKey := fmt.Sprintf("_%v_%v", strings.Replace(r.GVK.Group, ".", "_", -1),
+	objKey := fmt.Sprintf("_%v_%v", strings.ReplaceAll(strings.ReplaceAll(r.GVK.Group, ".", "_"), "-", "_"),
 		strings.ToLower(r.GVK.Kind))
 	parameters[objKey] = u.Object
 

--- a/pkg/ansible/runner/runner_test.go
+++ b/pkg/ansible/runner/runner_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/operator-framework/operator-sdk/pkg/ansible/watches"
@@ -57,12 +58,13 @@ func TestNew(t *testing.T) {
 	validPlaybook := filepath.Join(cwd, "testdata", "playbook.yml")
 	validRole := filepath.Join(cwd, "testdata", "roles", "role")
 	testCases := []struct {
-		name      string
-		gvk       schema.GroupVersionKind
-		playbook  string
-		role      string
-		vars      map[string]interface{}
-		finalizer *watches.Finalizer
+		name             string
+		gvk              schema.GroupVersionKind
+		playbook         string
+		role             string
+		vars             map[string]interface{}
+		finalizer        *watches.Finalizer
+		desiredObjectKey string
 	}{
 		{
 			name: "basic runner with playbook",
@@ -141,6 +143,16 @@ func TestNew(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "basic runner with a dash in the group name",
+			gvk: schema.GroupVersionKind{
+				Group:   "operator-with-dash.example.com",
+				Version: "v1alpha1",
+				Kind:    "Example",
+			},
+			playbook:         validPlaybook,
+			desiredObjectKey: "_operator_with_dash_example_com_example",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -165,6 +177,15 @@ func TestNew(t *testing.T) {
 				if testRunnerStruct.Path != testWatch.Role {
 					t.Fatalf("Unexpected path %v expected path %v", testRunnerStruct.Path, testWatch.Role)
 				}
+			}
+
+			// check that the group + kind are properly formatted into a parameter
+			if tc.desiredObjectKey != "" {
+				parameters := testRunnerStruct.makeParameters(&unstructured.Unstructured{})
+				if _, ok := parameters[tc.desiredObjectKey]; !ok {
+					t.Fatalf("Did not find expected objKey %v in parameters %+v", tc.desiredObjectKey, parameters)
+				}
+
 			}
 
 			if testRunnerStruct.GVK != testWatch.GroupVersionKind {


### PR DESCRIPTION
Resources with '-' in the APIGroup now are properly formatted when
passed to Ansible. For example

```
apiVersion: cert-manager.io/v1alpha2
kind: Certificate
```

will now result in a variabled called
`_cert_manager_io_certificaterequest`
instead of
`_cert-manager_io_certificaterequest`

Fixes #2486

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
