### PR TITLE
Fix exec in proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 ### Bug Fixes
 
+- The Ansible Operator proxy server now properly supports the Pod `exec` API ([#2716](https://github.com/operator-framework/operator-sdk/pull/2716))
+
 ## v0.16.0
 
 ### Added

--- a/pkg/ansible/proxy/kubectl.go
+++ b/pkg/ansible/proxy/kubectl.go
@@ -46,7 +46,7 @@ const (
 	// DefaultPathAcceptRE is the default path to accept.
 	DefaultPathAcceptRE = "^.*"
 	// DefaultPathRejectRE is the default set of paths to reject.
-	DefaultPathRejectRE = "^/api/.*/pods/.*/exec,^/api/.*/pods/.*/attach"
+	DefaultPathRejectRE = "^$"
 	// DefaultMethodRejectRE is the set of HTTP methods to reject by default.
 	DefaultMethodRejectRE = "^$"
 )

--- a/pkg/ansible/proxy/proxy.go
+++ b/pkg/ansible/proxy/proxy.go
@@ -44,7 +44,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-const AutoSkipCacheRE = "^/api/.*/pods/.*/exec,^/api/.*/pods/.*/attach"
+const AutoSkipCacheREList = "^/api/.*/pods/.*/exec,^/api/.*/pods/.*/attach"
 
 // RequestLogHandler - log the requests that come through the proxy.
 func RequestLogHandler(h http.Handler) http.Handler {
@@ -160,7 +160,7 @@ func Run(done chan error, o Options) error {
 		server.Handler = RequestLogHandler(server.Handler)
 	}
 	if !o.DisableCache {
-		autoSkipCacheRegexp, err := MakeRegexpArray(AutoSkipCacheRE)
+		autoSkipCacheRegexp, err := MakeRegexpArray(AutoSkipCacheREList)
 		if err != nil {
 			log.Error(err, "Failed to parse cache skip regular expression")
 		}

--- a/test/ansible/deploy/crds/test.example.com_collectiontests_crd.yaml
+++ b/test/ansible/deploy/crds/test.example.com_collectiontests_crd.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: collectiontests.test.example.com
+spec:
+  group: test.example.com
+  names:
+    kind: CollectionTest
+    listKind: CollectionTestList
+    plural: collectiontests
+    singular: collectiontest
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/test/ansible/deploy/crds/test.example.com_exectests_crd.yaml
+++ b/test/ansible/deploy/crds/test.example.com_exectests_crd.yaml
@@ -1,14 +1,14 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: collections.test.example.com
+  name: exectests.test.example.com
 spec:
   group: test.example.com
   names:
-    kind: Collection
-    listKind: CollectionList
-    plural: collections
-    singular: collection
+    kind: ExecTest
+    listKind: ExecTestList
+    plural: exectests
+    singular: exectest
   scope: Namespaced
   subresources:
     status: {}

--- a/test/ansible/deploy/crds/test.example.com_inventorytests_crd.yaml
+++ b/test/ansible/deploy/crds/test.example.com_inventorytests_crd.yaml
@@ -1,14 +1,14 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: inventories.test.example.com
+  name: inventorytests.test.example.com
 spec:
   group: test.example.com
   names:
-    kind: Inventory
-    listKind: InventoryList
-    plural: inventories
-    singular: inventory
+    kind: InventoryTest
+    listKind: InventoryTestList
+    plural: inventorytests
+    singular: inventorytest
   scope: Namespaced
   subresources:
     status: {}

--- a/test/ansible/deploy/crds/test.example.com_v1alpha1_inventorytest_cr.yaml
+++ b/test/ansible/deploy/crds/test.example.com_v1alpha1_inventorytest_cr.yaml
@@ -1,5 +1,5 @@
 apiVersion: test.example.com/v1alpha1
-kind: Inventory
+kind: InventoryTest
 metadata:
   name: example-inventory
   annotations:

--- a/test/ansible/deploy/role.yaml
+++ b/test/ansible/deploy/role.yaml
@@ -8,6 +8,8 @@ rules:
   - ""
   resources:
   - pods
+  - pods/exec
+  - pods/log
   - services
   - services/finalizers
   - endpoints

--- a/test/ansible/molecule/cluster/tasks/collections_test.yml
+++ b/test/ansible/molecule/cluster/tasks/collections_test.yml
@@ -1,11 +1,11 @@
 ---
-- name: Create the test.example.com/v1alpha1.Collection
+- name: Create the test.example.com/v1alpha1.CollectionTest
   k8s:
     state: present
     namespace: '{{ namespace }}'
     definition:
       apiVersion: test.example.com/v1alpha1
-      kind: Collection
+      kind: CollectionTest
       metadata:
         name: collection-test
     wait: yes

--- a/test/ansible/molecule/cluster/tasks/exec_test.yml
+++ b/test/ansible/molecule/cluster/tasks/exec_test.yml
@@ -1,0 +1,27 @@
+---
+- name: Create the test.example.com/v1alpha1.ExecTest
+  k8s:
+    state: present
+    definition:
+      apiVersion: test.example.com/v1alpha1
+      kind: ExecTest
+      metadata:
+        name: exec-test
+        namespace: '{{ namespace }}'
+      spec:
+        execCommand: "echo 'hello world'"
+    wait: yes
+    wait_timeout: 300
+    wait_condition:
+      type: Running
+      reason: Successful
+      status: "True"
+  register: exec_test
+
+- debug: var=exec_test
+
+- name: Assert stdout and stderr are properly set in status
+  assert:
+    that:
+      - exec_test.result.status.execCommandStderr == ""
+      - exec_test.result.status.execCommandStdout == "hello world"

--- a/test/ansible/molecule/cluster/tasks/inventory_test.yml
+++ b/test/ansible/molecule/cluster/tasks/inventory_test.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create the test.example.com/v1alpha1.Inventory
+- name: Create the test.example.com/v1alpha1.InventoryTest
   k8s:
     state: present
     namespace: '{{ namespace }}'
@@ -11,7 +11,7 @@
       reason: Successful
       status: "True"
   vars:
-    custom_resource: "{{ lookup('template', '/'.join([deploy_dir, 'crds/test.example.com_v1alpha1_inventory_cr.yaml'])) | from_yaml }}"
+    custom_resource: "{{ lookup('template', '/'.join([deploy_dir, 'crds/test.example.com_v1alpha1_inventorytest_cr.yaml'])) | from_yaml }}"
 
 - name: Assert sentinel ConfigMap has been created for Molecule Test
   assert:

--- a/test/ansible/molecule/templates/operator.yaml.j2
+++ b/test/ansible/molecule/templates/operator.yaml.j2
@@ -12,6 +12,9 @@ spec:
     metadata:
       labels:
         name: ansible
+{% if hash is defined %}
+        image_hash: "{{ hash }}"
+{% endif %}
     spec:
       serviceAccountName: ansible
       containers:
@@ -37,6 +40,8 @@ spec:
               value: explicit
             - name: ANSIBLE_INVENTORY
               value: /opt/ansible/inventory
+            - name: ANSIBLE_DEBUG_LOGS
+              value: "TRUE"
       volumes:
         - name: runner
           emptyDir: {}

--- a/test/ansible/molecule/test-local/playbook.yml
+++ b/test/ansible/molecule/test-local/playbook.yml
@@ -1,6 +1,7 @@
 ---
 - name: Build Operator in Kubernetes docker container
   hosts: k8s
+  gather_facts: no
   collections:
     - community.kubernetes
 
@@ -14,6 +15,7 @@
       register: prev_hash_raw
       changed_when: false
 
+
     - name: Build Operator Image
       command: docker build -f /build/build/Dockerfile -t {{ image }} /build
       register: build_cmd
@@ -21,6 +23,17 @@
       vars:
         hash: '{{ prev_hash_raw.stdout }}'
         cmd_out: '{{ "".join(build_cmd.stdout_lines[-2:]) }}'
+
+    - name: Get new image hash
+      command: docker images -q {{ image }}
+      register: hash_raw
+      changed_when: false
+
+    - name: Set localhost hash fact
+      set_fact:
+        hash: '{{ hash_raw.stdout }}'
+      delegate_to: localhost
+      delegate_facts: true
 
 - name: Converge
   hosts: localhost

--- a/test/ansible/playbooks/exec.yml
+++ b/test/ansible/playbooks/exec.yml
@@ -1,0 +1,44 @@
+---
+- hosts: localhost
+  gather_facts: no
+  collections:
+    - community.kubernetes
+    - operator_sdk.util
+
+  tasks:
+    - name: Deploy busybox pod
+      k8s:
+        definition:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: '{{ meta.name }}-busybox'
+            namespace: '{{ meta.namespace }}'
+          spec:
+            containers:
+              - image: busybox
+                name: sleep
+                args:
+                  - "/bin/sh"
+                  - "-c"
+                  - "while true;do date;sleep 5;done"
+        wait: yes
+
+    - name: Execute command in busybox pod
+      k8s_exec:
+        namespace: '{{ meta.namespace }}'
+        pod: '{{ meta.name }}-busybox'
+        command: '{{ exec_command }}'
+      register: exec_result
+
+    - debug: var=exec_result
+
+    - name: Write result to resource status
+      k8s_status:
+        api_version: test.example.com/v1alpha1
+        kind: ExecTest
+        name: '{{ meta.name }}'
+        namespace: '{{ meta.namespace }}'
+        status:
+          execCommandStdout: '{{ exec_result.stdout.strip() }}'
+          execCommandStderr: '{{ exec_result.stderr.strip() }}'

--- a/test/ansible/watches.yaml
+++ b/test/ansible/watches.yaml
@@ -1,10 +1,15 @@
 ---
 - version: v1alpha1
   group: test.example.com
-  kind: Inventory
-  playbook: /opt/ansible/playbooks/inventory.yml
+  kind: InventoryTest
+  playbook: playbooks/inventory.yml
 
 - version: v1alpha1
   group: test.example.com
-  kind: Collection
+  kind: CollectionTest
   role: operator_sdk.test_fixtures.dummy
+
+- version: v1alpha1
+  group: test.example.com
+  kind: ExecTest
+  playbook: playbooks/exec.yml


### PR DESCRIPTION
**Description of the change:**
Allows exec requests to go through the proxy without error

**Motivation for the change:**
It was impossible to make exec requests from Ansible code without circumventing the proxy

fixes #2204 