### PR TITLE
CSV Generation: support path detection for arrayFieldGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 ### Bug Fixes
 
+- Fixed issue in CSV generation that caused an incorrect path to be generated for descriptors on types that are fields in array elements. ([#2721](https://github.com/operator-framework/operator-sdk/pull/2721))
+
 ## v0.16.0
 
 ### Added

--- a/internal/scaffold/olm-catalog/descriptor/descriptor_test.go
+++ b/internal/scaffold/olm-catalog/descriptor/descriptor_test.go
@@ -55,11 +55,11 @@ func TestGetKindTypeForAPI(t *testing.T) {
 	}{
 		{
 			"Find types successfully",
-			testFrameworkPackage, "Dummy", 21, false,
+			testFrameworkPackage, "Dummy", 22, false,
 		},
 		{
 			"Find types with error from wrong kind",
-			testFrameworkPackage, "NotFound", 21, true,
+			testFrameworkPackage, "NotFound", 22, true,
 		},
 	}
 	wd, err := os.Getwd()
@@ -148,6 +148,13 @@ func TestGetCRDDescriptionForGVK(t *testing.T) {
 				SpecDescriptors: []olmapiv1alpha1.SpecDescriptor{
 					{Path: "size", DisplayName: "dummy-pods", Description: "Should be in spec",
 						XDescriptors: xdescsFor("size")},
+					{Path: "wheels", DisplayName: "Wheels", Description: "Should be in spec, but should not have array index in path",
+						XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:text"}},
+					{Path: "wheels[0].type", DisplayName: "Wheel Type", Description: "Type should be in spec with path equal to wheels[0].type",
+						XDescriptors: []string{
+							"urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:wheels",
+							"urn:alm:descriptor:com.tectonic.ui:text",
+						}},
 				},
 				StatusDescriptors: []olmapiv1alpha1.StatusDescriptor{
 					{Path: "hog.engine", DisplayName: "boss-hog-engine",

--- a/internal/scaffold/olm-catalog/descriptor/descriptor_test.go
+++ b/internal/scaffold/olm-catalog/descriptor/descriptor_test.go
@@ -150,7 +150,8 @@ func TestGetCRDDescriptionForGVK(t *testing.T) {
 						XDescriptors: xdescsFor("size")},
 					{Path: "wheels", DisplayName: "Wheels", Description: "Should be in spec, but should not have array index in path",
 						XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:text"}},
-					{Path: "wheels[0].type", DisplayName: "Wheel Type", Description: "Type should be in spec with path equal to wheels[0].type",
+					{Path: "wheels[0].type", DisplayName: "Wheel Type",
+						Description: "Type should be in spec with path equal to wheels[0].type",
 						XDescriptors: []string{
 							"urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:wheels",
 							"urn:alm:descriptor:com.tectonic.ui:text",

--- a/internal/scaffold/olm-catalog/descriptor/search.go
+++ b/internal/scaffold/olm-catalog/descriptor/search.go
@@ -54,7 +54,7 @@ func newTypeTreeFromRoot(root *types.Type) (typeTree, error) {
 				if err != nil {
 					return nil, fmt.Errorf("error parsing %s type member %s JSON tags: %v", child.member.Type.Name, cm.Name, err)
 				}
-				node.pathSegments = append(child.pathSegments, path)
+				node.pathSegments = getPathSegments(child, path)
 				if hasAnnotations(cm) {
 					tree.annotated = append(tree.annotated, node)
 				}
@@ -129,6 +129,19 @@ func getUnderlyingType(t *types.Type) *types.Type {
 		t = t.Underlying
 	}
 	return t
+}
+
+func getPathSegments(parent *tnode, path string) []string {
+	childPathSegments := make([]string, len(parent.pathSegments)+1)
+	copy(childPathSegments, parent.pathSegments)
+
+	// If the parent is a slice, include an array
+	// index on the parent's path segment.
+	if parent.member.Type.Kind == types.Slice {
+		childPathSegments[len(childPathSegments)-2] += "[0]"
+	}
+	childPathSegments[len(childPathSegments)-1] = path
+	return childPathSegments
 }
 
 func hasAnnotations(m types.Member) bool {

--- a/test/test-framework/deploy/crds/cache.example.com_dummys_crd.yaml
+++ b/test/test-framework/deploy/crds/cache.example.com_dummys_crd.yaml
@@ -34,8 +34,20 @@ spec:
               description: Should be in spec
               format: int32
               type: integer
+            wheels:
+              description: Should be in spec, but should not have array index in path
+              items:
+                properties:
+                  type:
+                    description: Type should be in spec with path equal to wheels[0].type
+                    type: string
+                required:
+                - type
+                type: object
+              type: array
           required:
           - size
+          - wheels
           type: object
         status:
           properties:

--- a/test/test-framework/pkg/apis/cache/v1alpha1/dummy_types.go
+++ b/test/test-framework/pkg/apis/cache/v1alpha1/dummy_types.go
@@ -46,6 +46,11 @@ type DummySpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="dummy-pods"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:podCount"
 	Size int32 `json:"size"`
+	// Should be in spec, but should not have array index in path
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Wheels"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:text"
+	Wheels []Wheel `json:"wheels"`
 }
 
 // +k8s:deepcopy-gen=false
@@ -100,6 +105,16 @@ type notExported struct {
 type Engine struct {
 	// Should not be included, no annotations.
 	Pistons []string `json:"pistons"`
+}
+
+// +k8s:deepcopy-gen=false
+// +k8s:openapi-gen=false
+type Wheel struct {
+	// Type should be in spec with path equal to wheels[0].type
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Wheel Type"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:wheels,urn:alm:descriptor:com.tectonic.ui:text"
+	Type string `json:"type"`
 }
 
 // +k8s:deepcopy-gen=false


### PR DESCRIPTION
**Description of the change:**
Add support for path detection of arrayFieldGroup spec descriptors during CSV generation

**Motivation for the change:**
Closes #2700 
