### PR TITLE
test framework: handle double-registered `--kubeconfig` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - The Ansible Operator proxy server now properly supports the Pod `exec` API ([#2716](https://github.com/operator-framework/operator-sdk/pull/2716))
 - Resources that use '-' in the APIGroup name can now be directly accessed by Ansible. ([#2712](https://github.com/operator-framework/operator-sdk/pull/2712))
 - Fixed issue in CSV generation that caused an incorrect path to be generated for descriptors on types that are fields in array elements. ([#2721](https://github.com/operator-framework/operator-sdk/pull/2721))
+- The test framework `pkg/test` no longer double-registers the `--kubeconfig` flag. Related bug: [kubernetes-sigs/controller-runtime#878](https://github.com/kubernetes-sigs/controller-runtime/issues/878). ([#2731](https://github.com/operator-framework/operator-sdk/pull/2731))
 
 ## v0.16.0
 

--- a/pkg/test/framework.go
+++ b/pkg/test/framework.go
@@ -102,7 +102,6 @@ func (opts *frameworkOpts) addToFlagSet(flagset *flag.FlagSet) {
 	flagset.StringVar(&opts.namespacedManPath, NamespacedManPathFlag, "", "path to rbac manifest")
 	flagset.BoolVar(&opts.isLocalOperator, LocalOperatorFlag, false,
 		"enable if operator is running locally (not in cluster)")
-	flagset.StringVar(&opts.kubeconfigPath, KubeConfigFlag, "", "path to kubeconfig")
 	flagset.StringVar(&opts.globalManPath, GlobalManPathFlag, "", "path to operator manifest")
 	flagset.StringVar(&opts.localOperatorArgs, LocalOperatorArgs, "",
 		"flags that the operator needs (while using --up-local). example: \"--flag1 value1 --flag2=value2\"")

--- a/pkg/test/main_entry.go
+++ b/pkg/test/main_entry.go
@@ -25,7 +25,21 @@ import (
 func MainEntry(m *testing.M) {
 	fopts := &frameworkOpts{}
 	fopts.addToFlagSet(flag.CommandLine)
+	// controller-runtime registers the --kubeconfig flag in client config
+	// package:
+	// https://github.com/kubernetes-sigs/controller-runtime/blob/v0.5.2/pkg/client/config/config.go#L39
+	//
+	// If this flag is not registered, do so. Otherwise retrieve its value.
+	kcFlag := flag.Lookup(KubeConfigFlag)
+	if kcFlag == nil {
+		flag.StringVar(&fopts.kubeconfigPath, KubeConfigFlag, "", "path to kubeconfig")
+	}
+
 	flag.Parse()
+
+	if kcFlag != nil {
+		fopts.kubeconfigPath = kcFlag.Value.String()
+	}
 
 	f, err := newFramework(fopts)
 	if err != nil {

--- a/test/e2e/_incluster-test-code/main_test.go
+++ b/test/e2e/_incluster-test-code/main_test.go
@@ -19,6 +19,10 @@ import (
 	"testing"
 
 	f "github.com/operator-framework/operator-sdk/pkg/test"
+
+	// This import tests double-registration of the --kubebuilder flag:
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/878
+	_ "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 type testArgs struct {


### PR DESCRIPTION
**Description of the change:**
* pkg/test: only register `--kubeconfig` if not registered, get value if already registered

**Motivation for the change:** controller-runtime currently adds the `--kubeconfig` flag if `pkg/client/config` is imported (set up in an `init()` function). The SDK's test framework also adds this flag, which will panic if both packages are imported and the test framework is initialized.

Closes: https://github.com/kubernetes-sigs/controller-runtime/issues/878

/cc @joelanford @camilamacedo86 @DirectXMan12 @akoserwal
/kind bug