### PR TITLE
doc: fix typo in v0.16.x upgrade guide

### DIFF
--- a/doc/migration/version-upgrade-guide.md
+++ b/doc/migration/version-upgrade-guide.md
@@ -846,7 +846,7 @@ See the [CHANGELOG](https://github.com/operator-framework/operator-sdk/blob/mast
 
 ```
 require (
-	github.com/operator-framework/operator-sdk 0.16.0
+	github.com/operator-framework/operator-sdk v0.16.0
 	sigs.k8s.io/controller-runtime v0.4.0
 )
 

--- a/website/content/en/docs/migration/version-upgrade-guide.md
+++ b/website/content/en/docs/migration/version-upgrade-guide.md
@@ -846,7 +846,7 @@ See the [CHANGELOG](https://github.com/operator-framework/operator-sdk/blob/mast
 
 ```
 require (
-	github.com/operator-framework/operator-sdk 0.16.0
+	github.com/operator-framework/operator-sdk v0.16.0
 	sigs.k8s.io/controller-runtime v0.4.0
 )
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Fixes a small typo in the `v0.16.x` upgrade guide.

**Motivation for the change:**

While working through the upgrade to `v0.16.0` I encountered this issue and reported the bug.

Closes #2733
