### PR TITLE
Upgrade ansible kind from 1.16 to 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Upgrade `prometheus-operator` version from `v0.34.0` to `v0.38.0`. ([#2715](https://github.com/operator-framework/operator-sdk/pull/2715))
 - Upgrade `operator-registry` version from `v1.5.7`to `v1.6.2`. ([#2715](https://github.com/operator-framework/operator-sdk/pull/2715))
 - **Breaking Change:** [`operator-sdk bundle create`](./doc/cli/operator-sdk_bundle_create.md) now creates a `manifests/` directory under the parent directory of the argument passed to `--directory`, and setting `--generate-only=true` writes a Dockerfile to `<project-root>/bundle.Dockerfile` that copies bundle manifests from that `manifests/` directory. ([#2715](https://github.com/operator-framework/operator-sdk/pull/2715))
+- Upgrade Kind used for tests for Ansible based-operators from `1.16` to `1.17`. ([#2753](https://github.com/operator-framework/operator-sdk/pull/2715))
 
 ### Deprecated
 

--- a/doc/ansible/dev/testing_guide.md
+++ b/doc/ansible/dev/testing_guide.md
@@ -92,7 +92,7 @@ The options supported by the default scenario are:
 
 | Environment variable | Default | Purpose |
 | :---                 | :---    | :---    |
-| KUBE_VERSION | 1.16 | The Kubernetes version to deploy |
+| KUBE_VERSION | 1.17 | The Kubernetes version to deploy |
 | TEST_CLUSTER_PORT | 9443 | The port on the host to expose the Kubernetes API |
 | TEST_OPERATOR_NAMESPACE | osdk-test | The namespace to run your role against |
 
@@ -191,7 +191,7 @@ The options supported by the default scenario are:
 
 | Environment variable | Default | Purpose |
 | :---                 | :---    | :---    |
-| KUBE_VERSION | 1.16 | The Kubernetes version to deploy |
+| KUBE_VERSION | 1.17 | The Kubernetes version to deploy |
 | TEST_CLUSTER_PORT | 10443 | The port on the host to expose the Kubernetes API |
 | TEST_OPERATOR_NAMESPACE | osdk-test | The namespace to deploy the operator and associated resources |
 

--- a/internal/scaffold/ansible/molecule_default_molecule.go
+++ b/internal/scaffold/ansible/molecule_default_molecule.go
@@ -52,7 +52,7 @@ platforms:
 - name: kind-default
   groups:
   - k8s
-  image: bsycorp/kind:latest-${KUBE_VERSION:-1.16}
+  image: bsycorp/kind:latest-${KUBE_VERSION:-1.17}
   privileged: True
   override_command: no
   exposed_ports:

--- a/internal/scaffold/ansible/molecule_test_local_molecule.go
+++ b/internal/scaffold/ansible/molecule_test_local_molecule.go
@@ -52,7 +52,7 @@ platforms:
   - name: kind-test-local
     groups:
       - k8s
-    image: bsycorp/kind:latest-${KUBE_VERSION:-1.16}
+    image: bsycorp/kind:latest-${KUBE_VERSION:-1.17}
     privileged: true
     override_command: false
     exposed_ports:

--- a/test/ansible-memcached/molecule.yml
+++ b/test/ansible-memcached/molecule.yml
@@ -10,7 +10,7 @@ platforms:
 - name: kind-test-local
   groups:
   - k8s
-  image: bsycorp/kind:latest-1.16
+  image: bsycorp/kind:latest-1.17
   privileged: True
   override_command: no
   exposed_ports:

--- a/test/ansible/molecule/test-local/molecule.yml
+++ b/test/ansible/molecule/test-local/molecule.yml
@@ -13,7 +13,7 @@ platforms:
   - name: kind-test-local
     groups:
       - k8s
-    image: bsycorp/kind:latest-${KUBE_VERSION:-1.16}
+    image: bsycorp/kind:latest-${KUBE_VERSION:-1.17}
     privileged: true
     override_command: false
     exposed_ports:

--- a/website/content/en/docs/ansible/testing-guide.md
+++ b/website/content/en/docs/ansible/testing-guide.md
@@ -96,7 +96,7 @@ The options supported by the default scenario are:
 
 | Environment variable | Default | Purpose |
 | :---                 | :---    | :---    |
-| KUBE_VERSION | 1.16 | The Kubernetes version to deploy |
+| KUBE_VERSION | 1.17 | The Kubernetes version to deploy |
 | TEST_CLUSTER_PORT | 9443 | The port on the host to expose the Kubernetes API |
 | TEST_OPERATOR_NAMESPACE | osdk-test | The namespace to run your role against |
 
@@ -195,7 +195,7 @@ The options supported by the default scenario are:
 
 | Environment variable | Default | Purpose |
 | :---                 | :---    | :---    |
-| KUBE_VERSION | 1.16 | The Kubernetes version to deploy |
+| KUBE_VERSION | 1.17 | The Kubernetes version to deploy |
 | TEST_CLUSTER_PORT | 10443 | The port on the host to expose the Kubernetes API |
 | TEST_OPERATOR_NAMESPACE | osdk-test | The namespace to deploy the operator and associated resources |
 


### PR DESCRIPTION
**Description of the change:**
Upgrade Kind used for tests for Ansible based-operators from `1.16` to `1.17`.

**Motivation for the change:**

Closes #2665

