### PR TITLE
cmd/operator-sdk/internal: explicitly set GOROOT

### DIFF
--- a/cmd/operator-sdk/internal/genutil/k8s.go
+++ b/cmd/operator-sdk/internal/genutil/k8s.go
@@ -35,14 +35,14 @@ import (
 func K8sCodegen() error {
 	projutil.MustInProjectRoot()
 
-	out, err := exec.Command("go", "env", "GOROOT").CombinedOutput()
+	goEnv, err := exec.Command("go", "env", "GOROOT").CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to GOROOT from go env")
+		return fmt.Errorf("failed to get GOROOT from go env: %w", err)
 	}
-	goRoot := strings.TrimSuffix(string(out), "\n")
+	goRoot := strings.TrimSuffix(string(goEnv), "\n")
 	log.Debugf("Setting GOROOT=%s", goRoot)
 	if err := os.Setenv("GOROOT", goRoot); err != nil {
-		return fmt.Errorf("failed to set env GOROOT=" + goRoot)
+		return fmt.Errorf("failed to set env GOROOT=%s: %w", goRoot, err)
 	}
 
 	repoPkg := projutil.GetGoPkg()

--- a/cmd/operator-sdk/internal/genutil/k8s.go
+++ b/cmd/operator-sdk/internal/genutil/k8s.go
@@ -17,6 +17,7 @@ package genutil
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -33,6 +34,16 @@ import (
 // pkg/apis.
 func K8sCodegen() error {
 	projutil.MustInProjectRoot()
+
+	out, err := exec.Command("go", "env", "GOROOT").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to GOROOT from go env")
+	}
+	goRoot := strings.TrimSuffix(string(out), "\n")
+	log.Debugf("Setting GOROOT=%s", goRoot)
+	if err := os.Setenv("GOROOT", goRoot); err != nil {
+		return fmt.Errorf("failed to set env GOROOT=" + goRoot)
+	}
 
 	repoPkg := projutil.GetGoPkg()
 


### PR DESCRIPTION
**Description of the change:**

If the user's `GOROOT` does not match the `GOROOT` used to build the binary, they would be required to explicitly set the `GOROOT` env variable:

```bash
export GOROOT=$(go env GOROOT)
```

To avoid this step for end-users we can explicitly pull the `GOROOT` from `go env` and explicitly set the `GOROOT` env variable prior to generation code executing.

**Motivation for the change:**

Closes #2744 
