### PR TITLE
Add Skeleton Command for Scorecard 2

### DIFF
--- a/cmd/operator-sdk/alpha/cmd.go
+++ b/cmd/operator-sdk/alpha/cmd.go
@@ -16,6 +16,7 @@ package alpha
 
 import (
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/alpha/kubebuilder"
+	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/alpha/scorecard"
 
 	"github.com/spf13/cobra"
 )
@@ -28,6 +29,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		kubebuilder.NewCmd(),
+		scorecard.NewCmd(),
 	)
 	return cmd
 }

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package scorecard2
+package scorecard
 
 import (
 	log "github.com/sirupsen/logrus"
@@ -25,7 +25,6 @@ var (
 	selector string
 )
 
-//scorecard2 alpha command stub
 func NewCmd() *cobra.Command {
 	scorecardCmd := &cobra.Command{
 		Use:    "scorecard",
@@ -39,7 +38,7 @@ func NewCmd() *cobra.Command {
 
 	scorecardCmd.Flags().StringVar(&dsl, "dsl", "", "path to a new to be defined DSL yaml formatted file that configures what tests get executed")
 	scorecardCmd.Flags().StringVar(&bundle, "bundle", "", "path to the operator bundle contents on disk")
-	scorecardCmd.Flags().StringVar(&selector, "selector", "", "label selector to determine which tests are run")
+	scorecardCmd.Flags().StringVarP(&selector, "selector", "l", "", "label selector to determine which tests are run")
 
 	return scorecardCmd
 }

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -20,9 +20,10 @@ import (
 )
 
 var (
-	dsl      string
+	config   string
 	bundle   string
 	selector string
+	listAll  bool
 )
 
 func NewCmd() *cobra.Command {
@@ -36,9 +37,11 @@ func NewCmd() *cobra.Command {
 		},
 	}
 
-	scorecardCmd.Flags().StringVar(&dsl, "dsl", "", "path to a new to be defined DSL yaml formatted file that configures what tests get executed")
+	scorecardCmd.Flags().StringVarP(&config, "config", "c", "",
+		"path to a new to be defined DSL yaml formatted file that configures what tests get executed")
 	scorecardCmd.Flags().StringVar(&bundle, "bundle", "", "path to the operator bundle contents on disk")
 	scorecardCmd.Flags().StringVarP(&selector, "selector", "l", "", "label selector to determine which tests are run")
+	scorecardCmd.Flags().BoolVarP(&listAll, "list", "L", false, "option to enable listing which tests are run")
 
 	return scorecardCmd
 }

--- a/cmd/operator-sdk/alpha/scorecard2/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard2/cmd.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Operator-SDK Authors
+// Copyright 2020 The Operator-SDK Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/operator-sdk/alpha/scorecard2/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard2/cmd.go
@@ -28,9 +28,10 @@ var (
 //scorecard2 alpha command stub
 func NewCmd() *cobra.Command {
 	scorecardCmd := &cobra.Command{
-		Use:   "scorecard",
-		Short: "Runs scorecard",
-		Long:  `Has flags to configure dsl, bundle, and selector.`,
+		Use:    "scorecard",
+		Short:  "Runs scorecard",
+		Long:   `Has flags to configure dsl, bundle, and selector.`,
+		Hidden: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			log.Info("TODO")
 		},

--- a/cmd/operator-sdk/alpha/scorecard2/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard2/cmd.go
@@ -20,10 +20,9 @@ import (
 )
 
 var (
-	dsl         string
-	bundle      string
-	bundleImage string
-	selector    string
+	dsl      string
+	bundle   string
+	selector string
 )
 
 //scorecard2 alpha command stub
@@ -31,7 +30,7 @@ func NewCmd() *cobra.Command {
 	scorecardCmd := &cobra.Command{
 		Use:   "scorecard",
 		Short: "Runs scorecard",
-		Long:  `Has flags to configure dsl, bundle, bundle-image, and selector.`,
+		Long:  `Has flags to configure dsl, bundle, and selector.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			log.Info("TODO")
 		},
@@ -39,7 +38,6 @@ func NewCmd() *cobra.Command {
 
 	scorecardCmd.Flags().StringVar(&dsl, "dsl", "", "path to a new to be defined DSL yaml formatted file that configures what tests get executed")
 	scorecardCmd.Flags().StringVar(&bundle, "bundle", "", "path to the operator bundle contents on disk")
-	scorecardCmd.Flags().StringVar(&bundleImage, "bundle-image", "", "name of a bundle image not on disk but in a registry")
 	scorecardCmd.Flags().StringVar(&selector, "selector", "", "label selector to determine which tests are run")
 
 	return scorecardCmd

--- a/cmd/operator-sdk/alpha/scorecard2/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard2/cmd.go
@@ -1,0 +1,46 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorecard2
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	dsl         string
+	bundle      string
+	bundleImage string
+	selector    string
+)
+
+//scorecard2 alpha command stub
+func NewCmd() *cobra.Command {
+	scorecardCmd := &cobra.Command{
+		Use:   "scorecard",
+		Short: "Runs scorecard",
+		Long:  `Has flags to configure dsl, bundle, bundle-image, and selector.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			log.Info("TODO")
+		},
+	}
+
+	scorecardCmd.Flags().StringVar(&dsl, "dsl", "", "path to a new to be defined DSL yaml formatted file that configures what tests get executed")
+	scorecardCmd.Flags().StringVar(&bundle, "bundle", "", "path to the operator bundle contents on disk")
+	scorecardCmd.Flags().StringVar(&bundleImage, "bundle-image", "", "name of a bundle image not on disk but in a registry")
+	scorecardCmd.Flags().StringVar(&selector, "selector", "", "label selector to determine which tests are run")
+
+	return scorecardCmd
+}


### PR DESCRIPTION
**Description of the change:**
Adds hidden skeleton command and needed flags for the updated scorecard system to the alpha commands group.
