### PR TITLE
added alpha scorecard config struct

### DIFF
--- a/internal/scorecard/alpha/config.go
+++ b/internal/scorecard/alpha/config.go
@@ -1,0 +1,43 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alpha
+
+import (
+	"log"
+
+	"gopkg.in/yaml.v2"
+)
+
+type ScorecardTest struct {
+	Image       string            `yaml:"image"`                // The container image name
+	Entrypoint  string            `yaml:"entrypoint,omitempty"` // An optional entrypoint passed to the test image
+	Labels      map[string]string `yaml:"labels"`               // User defined labels which are used by scorecard to filter tests
+	Description string            `yaml:"description"`          // User readable test description
+}
+
+// ScorecardConfig represents the set of test configurations which scorecard
+// would run based on user input
+type ScorecardConfig struct {
+	Tests []ScorecardTest `yaml:"tests"`
+}
+
+// String returns the yaml text representation of the ScorecardConfig
+func (c ScorecardConfig) String() string {
+	s, err := yaml.Marshal(&c)
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+	return string(s)
+}

--- a/internal/scorecard/alpha/config.go
+++ b/internal/scorecard/alpha/config.go
@@ -16,7 +16,6 @@ package alpha
 
 type ScorecardTest struct {
 	Name        string            `yaml:"name"`                 // The container test name
-	Parallel    bool              `yaml:"parallel"`             // Specifies if this test can be run in parallel
 	Image       string            `yaml:"image"`                // The container image name
 	Entrypoint  string            `yaml:"entrypoint,omitempty"` // An optional entrypoint passed to the test image
 	Labels      map[string]string `yaml:"labels"`               // User defined labels used to filter tests

--- a/internal/scorecard/alpha/config.go
+++ b/internal/scorecard/alpha/config.go
@@ -14,13 +14,9 @@
 
 package alpha
 
-import (
-	"log"
-
-	"gopkg.in/yaml.v2"
-)
-
 type ScorecardTest struct {
+	Name        string            `yaml:"name"`                 // The container test name
+	Parallel    bool              `yaml:"parallel"`             // Specifies if this test can be run in parallel
 	Image       string            `yaml:"image"`                // The container image name
 	Entrypoint  string            `yaml:"entrypoint,omitempty"` // An optional entrypoint passed to the test image
 	Labels      map[string]string `yaml:"labels"`               // User defined labels which are used by scorecard to filter tests
@@ -31,13 +27,4 @@ type ScorecardTest struct {
 // would run based on user input
 type ScorecardConfig struct {
 	Tests []ScorecardTest `yaml:"tests"`
-}
-
-// String returns the yaml text representation of the ScorecardConfig
-func (c ScorecardConfig) String() string {
-	s, err := yaml.Marshal(&c)
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
-	return string(s)
 }

--- a/internal/scorecard/alpha/config.go
+++ b/internal/scorecard/alpha/config.go
@@ -19,7 +19,7 @@ type ScorecardTest struct {
 	Parallel    bool              `yaml:"parallel"`             // Specifies if this test can be run in parallel
 	Image       string            `yaml:"image"`                // The container image name
 	Entrypoint  string            `yaml:"entrypoint,omitempty"` // An optional entrypoint passed to the test image
-	Labels      map[string]string `yaml:"labels"`               // User defined labels which are used by scorecard to filter tests
+	Labels      map[string]string `yaml:"labels"`               // User defined labels used to filter tests
 	Description string            `yaml:"description"`          // User readable test description
 }
 


### PR DESCRIPTION


**Description of the change:**

this PR is for the alpha scorecard implementation, it contains the configuration Struct for the scorecard.  This configuration file defines the test configurations scorecard will process.  

Scorecard users will create a YAML configuration file that will map to this Struct and scorecard will
read this configuration file when executed.  Here is a sample snippet of the ScorecardConfig yaml text representation:
```
tests:
- image: quay.io/jemccorm/customtest1:v0.0.1
  labels:
    suite: custom
    test: customtest1
  description: an ISV custom test that does...
- image: quay.io/jemccorm/customtest2:v0.0.1
  labels:
    suite: custom
    test: customtest2
  description: an ISV custom test that does...
- image: quay.io/redhat/basictests:v0.0.1
  entrypoint: basic-check-spec
  labels:
    suite: basic
    test: basic-check-spec-test
  description: check the spec test
```

**Motivation for the change:**

part of the new alpha scorecard implementation.
