### PR TITLE
upgrade minimal required cluster version

### DIFF
--- a/website/content/en/docs/test-framework/scorecard.md
+++ b/website/content/en/docs/test-framework/scorecard.md
@@ -40,7 +40,7 @@ The scorecard also supports plugins which allows to extend the functionality of 
 
 Following are some requirements for the operator project which would be  checked by the scorecard.
 
-- Access to a Kubernetes v1.11.3+ cluster
+- Access to a Kubernetes v1.14.3+ cluster.
 
 **For non-SDK operators:**
 

--- a/website/content/en/docs/user-guide.md
+++ b/website/content/en/docs/user-guide.md
@@ -9,7 +9,7 @@ This guide walks through an example of building a simple memcached-operator usin
 - [mercurial][mercurial_tool] version 3.9+
 - [docker][docker_tool] version 17.03+.
 - [kubectl][kubectl_tool] version v1.11.3+.
-- Access to a Kubernetes v1.11.3+ cluster.
+- Access to a Kubernetes v1.14.3+ cluster.
 
 **Note**: This guide uses [minikube][minikube_tool] version v0.25.0+ as the local Kubernetes cluster and [quay.io][quay_link] for the public registry.
 


### PR DESCRIPTION
**Description**

Upgrade minimal required cluster version to 1.14+

**Motivation**
It is the minimal k8s api version supported. See https://kubernetes.io/docs/home/supported-doc-versions/. Also, kubebuilder do not do tests using the previous versions as well. 