### PR TITLE
[helm-operator] Add annotation to use helm upgrade force 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 - The `--overwrite` flag instructs [`operator-sdk bundle create`](./website/content/en/docs/cli/operator-sdk_bundle_create.md) to overwrite metadata, manifests, and `bundle.Dockerfile`. ([#2715](https://github.com/operator-framework/operator-sdk/pull/2715))
 - [`operator-sdk bundle validate`](./website/content/en/docs/cli/operator-sdk_bundle_validate.md) now accepts either an image tag or a directory arg. If the arg is a directory, its children must contain a `manifests/` and a `metadata/` directory. ([#2737](https://github.com/operator-framework/operator-sdk/pull/2737))
 - Add support to release SDK arm64 binaries and images. ([#2742](https://github.com/operator-framework/operator-sdk/pull/2715))
- 
+- Add annotation `helm.operator-sdk/upgrade-force: "True"` to allow force resources replacement (`helm upgrade --force`) for Helm based-operators. ([#2773](https://github.com/operator-framework/operator-sdk/pull/2773))
+
 ### Changed
 
 - The scorecard when creating a Custom Resource, will produce a message to the user if that CR already exists. ([#2683](https://github.com/operator-framework/operator-sdk/pull/2683))

--- a/doc/helm/user-guide.md
+++ b/doc/helm/user-guide.md
@@ -400,6 +400,22 @@ For example:
 $ operator-sdk exec-entrypoint helm --max-workers 10
 ```
 
+## Use `helm upgrade --force` for deployment
+
+By adding the annotation `helm.operator-sdk/upgrade-force: "True"` to the deployed CR, the operator uses the `force` flag of helm to replace the rendered resources. For more info see the [Helm Upgrade documentation](https://helm.sh/docs/helm/helm_upgrade/).
+
+```yaml
+apiVersion: example.com/v1alpha1
+kind: Nginx
+metadata:
+  name: example-nginx
+  annotations:
+    helm.operator-sdk/upgrade-force: "True"
+spec:
+  replicaCount: 2
+  service:
+    port: 8080
+```
 
 [operator-scope]:./../operator-scope.md
 [install-guide]: ../user/install-operator-sdk.md

--- a/pkg/helm/release/manager.go
+++ b/pkg/helm/release/manager.go
@@ -46,10 +46,10 @@ type Manager interface {
 	IsInstalled() bool
 	IsUpdateRequired() bool
 	Sync(context.Context) error
-	InstallRelease(context.Context) (*rpb.Release, error)
-	UpdateRelease(context.Context) (*rpb.Release, *rpb.Release, error)
+	InstallRelease(context.Context, ...InstallOption) (*rpb.Release, error)
+	UpdateRelease(context.Context, ...UpdateOption) (*rpb.Release, *rpb.Release, error)
 	ReconcileRelease(context.Context) (*rpb.Release, error)
-	UninstallRelease(context.Context) (*rpb.Release, error)
+	UninstallRelease(context.Context, ...UninstallOption) (*rpb.Release, error)
 }
 
 type manager struct {
@@ -68,6 +68,10 @@ type manager struct {
 	deployedRelease  *rpb.Release
 	chart            *cpb.Chart
 }
+
+type InstallOption func(*action.Install) error
+type UpdateOption func(*action.Upgrade) error
+type UninstallOption func(*action.Uninstall) error
 
 // ReleaseName returns the name of the release.
 func (m manager) ReleaseName() string {
@@ -150,10 +154,15 @@ func (m manager) getCandidateRelease(namespace, name string, chart *cpb.Chart,
 }
 
 // InstallRelease performs a Helm release install.
-func (m manager) InstallRelease(ctx context.Context) (*rpb.Release, error) {
+func (m manager) InstallRelease(ctx context.Context, opts ...InstallOption) (*rpb.Release, error) {
 	install := action.NewInstall(m.actionConfig)
 	install.ReleaseName = m.releaseName
 	install.Namespace = m.namespace
+	for _, o := range opts {
+		if err := o(install); err != nil {
+			return nil, fmt.Errorf("failed to apply install option: %w", err)
+		}
+	}
 
 	installedRelease, err := install.Run(m.chart, m.values)
 	if err != nil {
@@ -179,10 +188,22 @@ func (m manager) InstallRelease(ctx context.Context) (*rpb.Release, error) {
 	return installedRelease, nil
 }
 
+func ForceUpdate(force bool) UpdateOption {
+	return func(u *action.Upgrade) error {
+		u.Force = force
+		return nil
+	}
+}
+
 // UpdateRelease performs a Helm release update.
-func (m manager) UpdateRelease(ctx context.Context) (*rpb.Release, *rpb.Release, error) {
+func (m manager) UpdateRelease(ctx context.Context, opts ...UpdateOption) (*rpb.Release, *rpb.Release, error) {
 	upgrade := action.NewUpgrade(m.actionConfig)
 	upgrade.Namespace = m.namespace
+	for _, o := range opts {
+		if err := o(upgrade); err != nil {
+			return nil, nil, fmt.Errorf("failed to apply upgrade option: %w", err)
+		}
+	}
 
 	updatedRelease, err := upgrade.Run(m.releaseName, m.chart, m.values)
 	if err != nil {
@@ -294,7 +315,7 @@ func generatePatch(existing, expected runtime.Object) ([]byte, error) {
 }
 
 // UninstallRelease performs a Helm release uninstall.
-func (m manager) UninstallRelease(ctx context.Context) (*rpb.Release, error) {
+func (m manager) UninstallRelease(ctx context.Context, opts ...UninstallOption) (*rpb.Release, error) {
 	// Get history of this release
 	h, err := m.storageBackend.History(m.releaseName)
 	if err != nil {
@@ -308,6 +329,11 @@ func (m manager) UninstallRelease(ctx context.Context) (*rpb.Release, error) {
 	}
 
 	uninstall := action.NewUninstall(m.actionConfig)
+	for _, o := range opts {
+		if err := o(uninstall); err != nil {
+			return nil, fmt.Errorf("failed to apply uninstall option: %w", err)
+		}
+	}
 	uninstallResponse, err := uninstall.Run(m.releaseName)
 	return uninstallResponse.Release, err
 }

--- a/website/content/en/docs/helm/reference/advanced_features.md
+++ b/website/content/en/docs/helm/reference/advanced_features.md
@@ -93,3 +93,20 @@ For example:
 ```sh
 $ operator-sdk exec-entrypoint helm --max-workers 10
 ```
+
+## Use `helm upgrade --force` for deployment
+
+By adding the annotation `helm.operator-sdk/upgrade-force: "True"` to the deployed CR, the operator uses the `force` flag of helm to replace the rendered resources. For more info see the [Helm Upgrade documentation](https://helm.sh/docs/helm/helm_upgrade/).
+
+```yaml
+apiVersion: example.com/v1alpha1
+kind: Nginx
+metadata:
+  name: example-nginx
+  annotations:
+    helm.operator-sdk/upgrade-force: "True"
+spec:
+  replicaCount: 2
+  service:
+    port: 8080
+```


### PR DESCRIPTION
This PR adds a new annotation to the CR for helm releases to use `helm
upgrade --force`.