### PR TITLE
Improve Ansible User Guide memcached-operator example (#2774)

### DIFF
--- a/doc/ansible/user-guide.md
+++ b/doc/ansible/user-guide.md
@@ -256,23 +256,37 @@ Once this is done, there are two ways to run the operator:
 
 Running as a pod inside a Kubernetes cluster is preferred for production use.
 
+Setup the DOCKER_IMAGE environment variable corresponding to your quay registry:
+```
+$ export QUAY_USERNAME="put your quay username here"
+$ export DOCKER_IMAGE="quay.io/${QUAY_USERNAME}/memcached-operator:v0.0.1"
+```
+
 Build the memcached-operator image and push it to a registry:
+
 ```
-$ operator-sdk build quay.io/example/memcached-operator:v0.0.1
-$ docker push quay.io/example/memcached-operator:v0.0.1
+$ operator-sdk build $DOCKER_IMAGE
+$ docker login quay.io
+$ docker create $DOCKER_IMAGE
+$ docker push $DOCKER_IMAGE
 ```
+
+**Note**
+You will need to set the quay memcached-operator repository's "Repository Visibility" to public in order to pull the
+image in subsequent steps.
+
 
 Kubernetes deployment manifests are generated in `deploy/operator.yaml`. The
 deployment image in this file needs to be modified from the placeholder
 `REPLACE_IMAGE` to the previous built image. To do this run:
 ```
-$ sed -i 's|REPLACE_IMAGE|quay.io/example/memcached-operator:v0.0.1|g' deploy/operator.yaml
+$ sed -i "s|REPLACE_IMAGE|${DOCKER_IMAGE}|g" deploy/operator.yaml
 ```
 
 **Note**
 If you are performing these steps on OSX, use the following `sed` commands instead:
 ```
-$ sed -i "" 's|REPLACE_IMAGE|quay.io/example/memcached-operator:v0.0.1|g' deploy/operator.yaml
+$ sed -i "" "s|REPLACE_IMAGE|${DOCKER_IMAGE}|g" deploy/operator.yaml
 ```
 
 Deploy the memcached-operator:


### PR DESCRIPTION
Improves the Ansible Operator SDK User Guide to improve usability.
This change to the documentation instructs the user to abstract an
environment variable, DOCKER_IMAGE, which stores the path to the
quay.io docker image.  Furthermore, the user is instructed to create
the DOCKER_IMAGE value based on his or her QUAY_USERNAME.  Although
this might seem implicit, I failed to recognize the importance of
using my own quay.io repository the first time, as I quickly
copied/pasted.

Lastly, the user guide was updated to instruct the user that the
memcached-operator repository should be made public.  Beginners,
such as myself, will benefit from this knowledge as without
changing the "Repository Visibility", the kubernetes deployment will
fail with an ImagePullError.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
