### PR TITLE
Scorecard2 label processing

### DIFF
--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -25,10 +25,10 @@ import (
 
 func NewCmd() *cobra.Command {
 	var (
-		config   string
-		bundle   string // TODO - to be implemented
+		config string
+		//bundle   string // TODO - to be implemented
 		selector string
-		list     bool // TODO - to be implemented
+		//list     bool // TODO - to be implemented
 	)
 	scorecardCmd := &cobra.Command{
 		Use:    "scorecard",
@@ -60,9 +60,9 @@ func NewCmd() *cobra.Command {
 
 	scorecardCmd.Flags().StringVarP(&config, "config", "c", "",
 		"path to a new to be defined DSL yaml formatted file that configures what tests get executed")
-	scorecardCmd.Flags().StringVar(&bundle, "bundle", "", "path to the operator bundle contents on disk")
+	//	scorecardCmd.Flags().StringVar(&bundle, "bundle", "", "path to the operator bundle contents on disk")
 	scorecardCmd.Flags().StringVarP(&selector, "selector", "l", "", "label selector to determine which tests are run")
-	scorecardCmd.Flags().BoolVarP(&list, "list", "L", false, "option to enable listing which tests are run")
+	//	scorecardCmd.Flags().BoolVarP(&list, "list", "L", false, "option to enable listing which tests are run")
 
 	return scorecardCmd
 }

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -35,7 +35,7 @@ func NewCmd() *cobra.Command {
 		Short:  "Runs scorecard",
 		Long:   `Has flags to configure dsl, bundle, and selector.`,
 		Hidden: true,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 
 			var err error
 			o := scorecard.Options{}

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -26,9 +26,9 @@ import (
 func NewCmd() *cobra.Command {
 	var (
 		config   string
-		bundle   string
+		bundle   string // TODO - to be implemented
 		selector string
-		list     bool
+		list     bool // TODO - to be implemented
 	)
 	scorecardCmd := &cobra.Command{
 		Use:    "scorecard",
@@ -48,6 +48,8 @@ func NewCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("could not parse selector %s", err.Error())
 			}
+
+			// TODO - process list and output formatting here?
 
 			if err := scorecard.RunTests(o); err != nil {
 				log.Fatal(err)

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -15,32 +15,30 @@
 package scorecard
 
 import (
+	"log"
+
 	scorecard "github.com/operator-framework/operator-sdk/internal/scorecard/alpha"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-var (
-	config   string
-	bundle   string
-	selector string
-	listAll  bool
-)
-
 func NewCmd() *cobra.Command {
+	var (
+		config   string
+		bundle   string
+		selector string
+		list     bool
+	)
 	scorecardCmd := &cobra.Command{
 		Use:    "scorecard",
 		Short:  "Runs scorecard",
 		Long:   `Has flags to configure dsl, bundle, and selector.`,
 		Hidden: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			scorecardFlags := scorecard.ScorecardFlags{
-				Config:   config,
-				Bundle:   bundle,
-				Selector: selector,
-				ListAll:  listAll,
+			options, err := scorecard.GetOptions(config, selector)
+			if err != nil {
+				log.Fatal(err)
 			}
-			if err := scorecard.RunTests(scorecardFlags); err != nil {
+			if err := scorecard.RunTests(options); err != nil {
 				log.Fatal(err)
 			}
 		},
@@ -50,7 +48,7 @@ func NewCmd() *cobra.Command {
 		"path to a new to be defined DSL yaml formatted file that configures what tests get executed")
 	scorecardCmd.Flags().StringVar(&bundle, "bundle", "", "path to the operator bundle contents on disk")
 	scorecardCmd.Flags().StringVarP(&selector, "selector", "l", "", "label selector to determine which tests are run")
-	scorecardCmd.Flags().BoolVarP(&listAll, "list", "L", false, "option to enable listing which tests are run")
+	scorecardCmd.Flags().BoolVarP(&list, "list", "L", false, "option to enable listing which tests are run")
 
 	return scorecardCmd
 }

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -15,6 +15,7 @@
 package scorecard
 
 import (
+	scorecard "github.com/operator-framework/operator-sdk/internal/scorecard/alpha"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -33,7 +34,15 @@ func NewCmd() *cobra.Command {
 		Long:   `Has flags to configure dsl, bundle, and selector.`,
 		Hidden: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			log.Info("TODO")
+			scorecardFlags := scorecard.ScorecardFlags{
+				Config:   config,
+				Bundle:   bundle,
+				Selector: selector,
+				ListAll:  listAll,
+			}
+			if err := scorecard.RunTests(scorecardFlags); err != nil {
+				log.Fatal(err)
+			}
 		},
 	}
 

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -41,17 +41,18 @@ func NewCmd() *cobra.Command {
 			o := scorecard.Options{}
 			o.Config, err = scorecard.LoadConfig(config)
 			if err != nil {
-				log.Fatal(fmt.Errorf("could not find config file %s", err.Error()))
+				return fmt.Errorf("could not find config file %s", err.Error())
 			}
 
 			o.Selector, err = labels.Parse(selector)
 			if err != nil {
-				log.Fatal(fmt.Errorf("could not parse selector %s", err.Error()))
+				return fmt.Errorf("could not parse selector %s", err.Error())
 			}
 
 			if err := scorecard.RunTests(o); err != nil {
 				log.Fatal(err)
 			}
+			return nil
 		},
 	}
 

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -15,10 +15,12 @@
 package scorecard
 
 import (
+	"fmt"
 	"log"
 
 	scorecard "github.com/operator-framework/operator-sdk/internal/scorecard/alpha"
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 func NewCmd() *cobra.Command {
@@ -34,11 +36,20 @@ func NewCmd() *cobra.Command {
 		Long:   `Has flags to configure dsl, bundle, and selector.`,
 		Hidden: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			options, err := scorecard.GetOptions(config, selector)
+
+			var err error
+			o := scorecard.Options{}
+			o.Config, err = scorecard.LoadConfig(config)
 			if err != nil {
-				log.Fatal(err)
+				log.Fatal(fmt.Errorf("could not find config file %s", err.Error()))
 			}
-			if err := scorecard.RunTests(options); err != nil {
+
+			o.Selector, err = labels.Parse(selector)
+			if err != nil {
+				log.Fatal(fmt.Errorf("could not parse selector %s", err.Error()))
+			}
+
+			if err := scorecard.RunTests(o); err != nil {
 				log.Fatal(err)
 			}
 		},

--- a/internal/scorecard/alpha/config.go
+++ b/internal/scorecard/alpha/config.go
@@ -1,0 +1,29 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alpha
+
+type ScorecardTest struct {
+	Name        string            `yaml:"name"`                 // The container test name
+	Image       string            `yaml:"image"`                // The container image name
+	Entrypoint  string            `yaml:"entrypoint,omitempty"` // An optional entrypoint passed to the test image
+	Labels      map[string]string `yaml:"labels"`               // User defined labels used to filter tests
+	Description string            `yaml:"description"`          // User readable test description
+}
+
+// ScorecardConfig represents the set of test configurations which scorecard
+// would run based on user input
+type ScorecardConfig struct {
+	Tests []ScorecardTest `yaml:"tests"`
+}

--- a/internal/scorecard/alpha/config.go
+++ b/internal/scorecard/alpha/config.go
@@ -22,8 +22,8 @@ type ScorecardTest struct {
 	Description string            `yaml:"description"`          // User readable test description
 }
 
-// ScorecardConfig represents the set of test configurations which scorecard
+// Config represents the set of test configurations which scorecard
 // would run based on user input
-type ScorecardConfig struct {
+type Config struct {
 	Tests []ScorecardTest `yaml:"tests"`
 }

--- a/internal/scorecard/alpha/config_test.go
+++ b/internal/scorecard/alpha/config_test.go
@@ -1,0 +1,44 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alpha
+
+import (
+	"testing"
+)
+
+func TestInvalidConfigPath(t *testing.T) {
+
+	cases := []struct {
+		configPathValue string
+		wantError       bool
+	}{
+		{"", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.configPathValue, func(t *testing.T) {
+			_, err := LoadConfig(c.configPathValue)
+			if err != nil && c.wantError {
+				t.Logf("Wanted error and got error : %v", err)
+				return
+			} else if err != nil && !c.wantError {
+				t.Errorf("Wanted result but got error: %v", err)
+				return
+			}
+
+		})
+
+	}
+}

--- a/internal/scorecard/alpha/labels_test.go
+++ b/internal/scorecard/alpha/labels_test.go
@@ -17,7 +17,7 @@ package alpha
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
+	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -37,7 +37,7 @@ func TestEmptySelector(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.selectorValue, func(t *testing.T) {
-			var scConfig ScorecardConfig
+			var scConfig Config
 
 			err := yaml.Unmarshal([]byte(testConfig), &scConfig)
 			if err != nil {

--- a/internal/scorecard/alpha/labels_test.go
+++ b/internal/scorecard/alpha/labels_test.go
@@ -1,0 +1,113 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alpha
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestEmptySelector(t *testing.T) {
+
+	cases := []struct {
+		selectorValue string
+		testsSelected int
+		wantError     bool
+	}{
+		{"", 7, false},
+		{"suite in (kuttl)", 1, false},
+		{"test=basic-check-spec-test", 1, false},
+		{"testXwriteintocr", 0, false},
+		{"test X writeintocr", 0, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.selectorValue, func(t *testing.T) {
+			var scConfig ScorecardConfig
+
+			err := yaml.Unmarshal([]byte(testConfig), &scConfig)
+			if err != nil {
+				t.Log(err)
+				return
+			}
+
+			selector, err := labels.Parse(c.selectorValue)
+			if err != nil && c.wantError {
+				t.Logf("Wanted error and got error : %v", err)
+				return
+			} else if err != nil && !c.wantError {
+				t.Errorf("Wanted result but got error: %v", err)
+				return
+			}
+
+			tests := selectTests(selector, scConfig.Tests)
+			testsSelected := len(tests)
+			if testsSelected != c.testsSelected {
+				t.Errorf("Wanted testsSelected %d, got: %d", c.testsSelected, testsSelected)
+			}
+		})
+
+	}
+}
+
+const testConfig = `tests:
+- name: "customtest1"
+  image: quay.io/someuser/customtest1:v0.0.1
+  labels:
+    suite: custom
+    test: customtest1
+  description: an ISV custom test that does...
+- name: "customtest2"
+  image: quay.io/someuser/customtest2:v0.0.1
+  labels:
+    suite: custom
+    test: customtest2
+  description: an ISV custom test that does...
+- name: "basic-check-spec"
+  image: quay.io/redhat/basictests:v0.0.1
+  entrypoint: basic-check-spec
+  labels:
+    suite: basic
+    test: basic-check-spec-test
+  description: check the spec test
+- name: "basic-check-status"
+  image: quay.io/redhat/basictests:v0.0.1
+  entrypoint: basic-check-status
+  labels:
+    suite: basic
+    test: basic-check-status-test
+  description: check the status test
+- name: "olm-bundle-validation"
+  image: quay.io/redhat/olmtests:v0.0.1
+  entrypoint: olm-bundle-validation
+  labels:
+    suite: olm
+    test: olm-bundle-validation-test
+  description: validate the bundle test
+- name: "olm-crds-have-validation"
+  image: quay.io/redhat/olmtests:v0.0.1
+  entrypoint: olm-crds-have-validation
+  labels:
+    suite: olm
+    test: olm-crds-have-validation-test
+  description: CRDs have validation
+- name: "kuttl-tests"
+  image: quay.io/redhat/kuttltests:v0.0.1
+  labels:
+    suite: kuttl
+  description: Kuttl tests
+`

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -55,7 +55,9 @@ func RunTests(flags ScorecardFlags) error {
 	tests := selectTests(selector, scConfig.Tests)
 
 	for i := 0; i < len(tests); i++ {
-		runTest(tests[i])
+		if err := runTest(tests[i]); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -67,11 +69,9 @@ func RunTests(flags ScorecardFlags) error {
 func lookupConfig(flags ScorecardFlags) (ScorecardConfig, error) {
 	sc := ScorecardConfig{}
 
+	// TODO handle getting config from bundle (ondisk or image)
 	_, err := os.Stat(flags.Config)
-	if os.IsNotExist(err) {
-		// TODO get config from bundle (ondisk or image)
-		return sc, err
-	} else {
+	if !os.IsNotExist(err) {
 		yamlFile, err := ioutil.ReadFile(flags.Config)
 		if err != nil {
 			return sc, err
@@ -101,9 +101,9 @@ func selectTests(selector labels.Selector, tests []ScorecardTest) []ScorecardTes
 
 // runTest executes a single test
 // TODO handle the test output
-func runTest(test ScorecardTest) error {
+func runTest(test ScorecardTest) (err error) {
 	log.Printf("running test %s labels %v", test.Name, test.Labels)
-	return nil
+	return err
 }
 
 func ConfigDocLink() string {

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -52,7 +52,7 @@ func RunTests(o Options) error {
 // LoadConfig will find and return the scorecard config, the config file
 // can be passed in via command line flag or from a bundle location or
 // bundle image
-func LoadConfig(configFlag string) (Config, error) {
+func LoadConfig(configFilePath string) (Config, error) {
 	c := Config{}
 
 	// TODO handle getting config from bundle (ondisk or image)

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -23,14 +23,9 @@ import (
 	"strings"
 
 	"github.com/operator-framework/operator-sdk/version"
-	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
-)
-
-var (
-	Log = logrus.New()
 )
 
 type Options struct {

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"strings"
 
 	"github.com/operator-framework/operator-sdk/version"
@@ -56,11 +55,7 @@ func LoadConfig(configFilePath string) (Config, error) {
 	c := Config{}
 
 	// TODO handle getting config from bundle (ondisk or image)
-	_, err := os.Stat(configFlag)
-	if os.IsNotExist(err) {
-		return c, err
-	}
-	yamlFile, err := ioutil.ReadFile(configFlag)
+	yamlFile, err := ioutil.ReadFile(configFilePath)
 	if err != nil {
 		return c, err
 	}
@@ -103,18 +98,4 @@ func ConfigDocLink() string {
 	return fmt.Sprintf(
 		"https://github.com/operator-framework/operator-sdk/blob/%s/doc/test-framework/scorecard.md",
 		version.Version)
-}
-
-// GetOptions validates the command line options
-func GetOptions(configFlag, selectorFlag string) (o Options, err error) {
-	o.Config, err = LoadConfig(configFlag)
-	if err != nil {
-		return o, fmt.Errorf("could not find config file %s", err.Error())
-	}
-
-	o.Selector, err = labels.Parse(selectorFlag)
-	if err != nil {
-		return o, fmt.Errorf("could not parse selector %s", err.Error())
-	}
-	return o, nil
 }

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -15,6 +15,7 @@
 package alpha
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -92,9 +93,12 @@ func selectTests(selector labels.Selector, tests []ScorecardTest) []ScorecardTes
 
 // runTest executes a single test
 // TODO once tests exists, handle the test output
-func runTest(test ScorecardTest) (err error) {
+func runTest(test ScorecardTest) error {
+	if test.Name == "" {
+		return errors.New("todo - remove later, only for linter")
+	}
 	log.Printf("running test %s labels %v", test.Name, test.Labels)
-	return err
+	return nil
 }
 
 func ConfigDocLink() string {

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -93,6 +93,7 @@ func selectTests(selector labels.Selector, tests []ScorecardTest) []ScorecardTes
 	selected := make([]ScorecardTest, 0)
 	for i := 0; i < len(tests); i++ {
 		if selector.String() == "" || selector.Matches(labels.Set(tests[i].Labels)) {
+			// TODO olm manifests check
 			selected = append(selected, tests[i])
 		}
 	}
@@ -100,7 +101,7 @@ func selectTests(selector labels.Selector, tests []ScorecardTest) []ScorecardTes
 }
 
 // runTest executes a single test
-// TODO handle the test output
+// TODO once tests exists, handle the test output
 func runTest(test ScorecardTest) (err error) {
 	log.Printf("running test %s labels %v", test.Name, test.Labels)
 	return err

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -1,0 +1,116 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alpha
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/operator-framework/operator-sdk/version"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var (
+	Log = logrus.New()
+)
+
+type ScorecardFlags struct {
+	Config       string
+	Bundle       string
+	Selector     string
+	ListAll      bool
+	OutputFormat string
+	Kubeconfig   string
+}
+
+// RunTests executes the scorecard tests as configured
+func RunTests(flags ScorecardFlags) error {
+	scConfig, err := lookupConfig(flags)
+	if err != nil {
+		return err
+	}
+
+	selector, err := labels.Parse(flags.Selector)
+	if err != nil {
+		return err
+	}
+
+	tests := selectTests(selector, scConfig.Tests)
+
+	for i := 0; i < len(tests); i++ {
+		runTest(tests[i])
+	}
+
+	return nil
+}
+
+// lookupConfig will find and return the scorecard config, the config file
+// can be passed in via command line flag or from a bundle location or
+// bundle image
+func lookupConfig(flags ScorecardFlags) (ScorecardConfig, error) {
+	sc := ScorecardConfig{}
+
+	_, err := os.Stat(flags.Config)
+	if os.IsNotExist(err) {
+		// TODO get config from bundle (ondisk or image)
+		return sc, err
+	} else {
+		yamlFile, err := ioutil.ReadFile(flags.Config)
+		if err != nil {
+			return sc, err
+		}
+
+		if err := yaml.Unmarshal(yamlFile, &sc); err != nil {
+			return sc, err
+		}
+		return sc, nil
+	}
+
+	return sc, nil
+}
+
+// selectTests applies an optionally passed selector expression
+// against the configured set of tests, returning the selected tests
+func selectTests(selector labels.Selector, tests []ScorecardTest) []ScorecardTest {
+
+	selected := make([]ScorecardTest, 0)
+	for i := 0; i < len(tests); i++ {
+		if selector.String() == "" || selector.Matches(labels.Set(tests[i].Labels)) {
+			selected = append(selected, tests[i])
+		}
+	}
+	return selected
+}
+
+// runTest executes a single test
+// TODO handle the test output
+func runTest(test ScorecardTest) error {
+	log.Printf("running test %s labels %v", test.Name, test.Labels)
+	return nil
+}
+
+func ConfigDocLink() string {
+	if strings.HasSuffix(version.Version, "+git") {
+		return "https://github.com/operator-framework/operator-sdk/blob/master/doc/test-framework/scorecard.md"
+	}
+	return fmt.Sprintf(
+		"https://github.com/operator-framework/operator-sdk/blob/%s/doc/test-framework/scorecard.md",
+		version.Version)
+}


### PR DESCRIPTION
 

**Description of the change:**

this is the initial label processing of the alpha scorecard, it selects the tests to be run
by the selector flag value passed in.  At this point since the tests are not written, the 
test name and test labels are printed only instead of the actual test being run.

**Motivation for the change:**

part of the larger alpha scorecard  implementation, this PR is focused on adding the
selector logic only.

