### PR TITLE
[wip] Interactive subcommand while generating CSV

### DIFF
--- a/internal/generate/olm-catalog/InteractiveCSVcmd.go
+++ b/internal/generate/olm-catalog/InteractiveCSVcmd.go
@@ -1,0 +1,38 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package olmcatalog
+
+// InteractiveCSVCmd includes the list of CSV fields which would be asked from
+// the user while CSV generation.
+type InteractiveCSVcmd struct {
+	// DisplayName is the name of the crd.
+	DisplayName string
+	// Keywords is a list of keywords describing the Operator.
+	Keywords []string
+	// Maintainers is a list of human or organizational entities maintaining the
+	// Operator, with a name and email.
+	Maintainers map[string]string
+	// Provider is the name of the operator provider with a name.
+	Provider map[string]string
+	// List of key, value pairs which can be added and are used by Operator internals.
+	Labels map[string]string
+	// A minimum version of Kubernetes that server is supposed to have so operator(s)
+	// can be deployed. The Kubernetes version must be in "Major.Minor.Patch"
+	// format (e.g: 1.11.0).
+	MinKubeVersion string
+	// A list of relevant links for the Operator. Common links include documentation,
+	// how-to guides, blog posts, and the company homepage
+	Links map[string]string
+}

--- a/internal/generate/olm-catalog/csv_go_test.go
+++ b/internal/generate/olm-catalog/csv_go_test.go
@@ -162,6 +162,7 @@ func TestUpgradeFromExistingCSVWithInputsToOutput(t *testing.T) {
 	}
 
 	// Upgrade new CSV from old
+	// TODO: Modify tests based on modified function signature
 	g := NewCSV(cfg, csvVersion, fromVersion)
 	if err := g.Generate(); err != nil {
 		t.Fatalf("Failed to execute CSV generator: %v", err)


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR introduces the interactive sub-command feature while generating CSV.
The following fields in the CSV can be filled using the input provided by the users:
- DisplayName (a name to display for the Operator in Operator Hub)
- Keywords : a list of keywords describing the Operator
- Maintainers : a list of human or organizational entities maintaining the Operator, with a name and email.
- provider: the Operator provider, with a name; usually an organization
- labels: a list of key:value pairs to be used by Operator internals
- version: semantic version of the Operator, ex. 0.1.1
- MinKubeVersion: A minimum version of Kubernetes that server is supposed to have so operator(s) can be deployed. The Kubernetes version must be in "Major.Minor.Patch" format (e.g: 1.11.0).
- replaces: the name of the CSV being replaced by this CSV
- links: a list of URL's to websites, documentation, etc. pertaining to the Operator or application being managed, each with a name and url
- maturity: the Operator's maturity, ex. alpha

Additionally, the subcommand is to be made optional, wherein the user can chose to disable it with a flag.


**Motivation for the change:**
To enable operator developers to have an interactive dialogue with the SDK to create the CSV.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
