### PR TITLE
Bundle creation docs are missing code format

### DIFF
--- a/cmd/operator-sdk/bundle/create.go
+++ b/cmd/operator-sdk/bundle/create.go
@@ -55,20 +55,20 @@ image, set '--generate-only=true'. A bundle Dockerfile, bundle metadata, and
 a 'manifests/' directory containing your bundle manifests will be written if
 '--generate-only=true':
 
-$ operator-sdk bundle create --generate-only --directory ./deploy/olm-catalog/test-operator/0.1.0
-$ ls .
-...
-bundle.Dockerfile
-...
-$ tree ./deploy/olm-catalog/test-operator/
-└── 0.1.0
-	└── example.com_tests_crd.yaml
-	└── test-operator.v0.1.0.clusterserviceversion.yaml
-└── manifests
-	└── example.com_tests_crd.yaml
-	└── test-operator.v0.1.0.clusterserviceversion.yaml
-└── metadata
-	└── annotations.yaml
+	$ operator-sdk bundle create --generate-only --directory ./deploy/olm-catalog/test-operator/0.1.0
+	$ ls .
+	...
+	bundle.Dockerfile
+	...
+	$ tree ./deploy/olm-catalog/test-operator/
+	└── 0.1.0
+		└── example.com_tests_crd.yaml
+		└── test-operator.v0.1.0.clusterserviceversion.yaml
+	└── manifests
+		└── example.com_tests_crd.yaml
+		└── test-operator.v0.1.0.clusterserviceversion.yaml
+	└── metadata
+		└── annotations.yaml
 
 '--generate-only' is useful if you want to build an operator's bundle image
 manually, modify metadata before building an image, or want to generate a

--- a/doc/cli/operator-sdk_bundle_create.md
+++ b/doc/cli/operator-sdk_bundle_create.md
@@ -13,20 +13,20 @@ image, set '--generate-only=true'. A bundle Dockerfile, bundle metadata, and
 a 'manifests/' directory containing your bundle manifests will be written if
 '--generate-only=true':
 
-$ operator-sdk bundle create --generate-only --directory ./deploy/olm-catalog/test-operator/0.1.0
-$ ls .
-...
-bundle.Dockerfile
-...
-$ tree ./deploy/olm-catalog/test-operator/
-└── 0.1.0
-	└── example.com_tests_crd.yaml
-	└── test-operator.v0.1.0.clusterserviceversion.yaml
-└── manifests
-	└── example.com_tests_crd.yaml
-	└── test-operator.v0.1.0.clusterserviceversion.yaml
-└── metadata
-	└── annotations.yaml
+	$ operator-sdk bundle create --generate-only --directory ./deploy/olm-catalog/test-operator/0.1.0
+	$ ls .
+	...
+	bundle.Dockerfile
+	...
+	$ tree ./deploy/olm-catalog/test-operator/
+	└── 0.1.0
+		└── example.com_tests_crd.yaml
+		└── test-operator.v0.1.0.clusterserviceversion.yaml
+	└── manifests
+		└── example.com_tests_crd.yaml
+		└── test-operator.v0.1.0.clusterserviceversion.yaml
+	└── metadata
+		└── annotations.yaml
 
 '--generate-only' is useful if you want to build an operator's bundle image
 manually, modify metadata before building an image, or want to generate a

--- a/website/content/en/docs/cli/operator-sdk_bundle_create.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle_create.md
@@ -13,20 +13,20 @@ image, set '--generate-only=true'. A bundle Dockerfile, bundle metadata, and
 a 'manifests/' directory containing your bundle manifests will be written if
 '--generate-only=true':
 
-$ operator-sdk bundle create --generate-only --directory ./deploy/olm-catalog/test-operator/0.1.0
-$ ls .
-...
-bundle.Dockerfile
-...
-$ tree ./deploy/olm-catalog/test-operator/
-└── 0.1.0
-	└── example.com_tests_crd.yaml
-	└── test-operator.v0.1.0.clusterserviceversion.yaml
-└── manifests
-	└── example.com_tests_crd.yaml
-	└── test-operator.v0.1.0.clusterserviceversion.yaml
-└── metadata
-	└── annotations.yaml
+	$ operator-sdk bundle create --generate-only --directory ./deploy/olm-catalog/test-operator/0.1.0
+	$ ls .
+	...
+	bundle.Dockerfile
+	...
+	$ tree ./deploy/olm-catalog/test-operator/
+	└── 0.1.0
+		└── example.com_tests_crd.yaml
+		└── test-operator.v0.1.0.clusterserviceversion.yaml
+	└── manifests
+		└── example.com_tests_crd.yaml
+		└── test-operator.v0.1.0.clusterserviceversion.yaml
+	└── metadata
+		└── annotations.yaml
 
 '--generate-only' is useful if you want to build an operator's bundle image
 manually, modify metadata before building an image, or want to generate a


### PR DESCRIPTION
Signed-off-by: dmesser <dmesser@redhat.com>

Bundle creation CLI docs are missing code format. Addresses #2772 