### PR TITLE
Look for more than just roles when detecting project type for Ansible-based Operators

### DIFF
--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -34,13 +34,15 @@ const (
 	GoModEnv   = "GO111MODULE"
 	SrcDir     = "src"
 
-	fsep            = string(filepath.Separator)
-	mainFile        = "main.go"
-	managerMainFile = "cmd" + fsep + "manager" + fsep + mainFile
-	buildDockerfile = "build" + fsep + "Dockerfile"
-	rolesDir        = "roles"
-	helmChartsDir   = "helm-charts"
-	goModFile       = "go.mod"
+	fsep             = string(filepath.Separator)
+	mainFile         = "main.go"
+	managerMainFile  = "cmd" + fsep + "manager" + fsep + mainFile
+	buildDockerfile  = "build" + fsep + "Dockerfile"
+	rolesDir         = "roles"
+	requirementsFile = "requirements.yml"
+	moleculeDir      = "molecule"
+	helmChartsDir    = "helm-charts"
+	goModFile        = "go.mod"
 
 	noticeColor = "\033[1;36m%s\033[0m"
 )
@@ -208,7 +210,15 @@ func IsOperatorGo() bool {
 
 func IsOperatorAnsible() bool {
 	stat, err := os.Stat(rolesDir)
-	return (err == nil && stat.IsDir()) || os.IsExist(err)
+	if (err == nil && stat.IsDir()) || os.IsExist(err) {
+		return true
+	}
+	stat, err = os.Stat(moleculeDir)
+	if (err == nil && stat.IsDir()) || os.IsExist(err) {
+		return true
+	}
+	_, err = os.Stat(requirementsFile)
+	return err == nil || os.IsExist(err)
 }
 
 func IsOperatorHelm() bool {


### PR DESCRIPTION

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Project type detection will now detect Ansible if one of `roles/`, `molecule/` or `requirements.yml` are present at the project root.

**Motivation for the change:**
closes #2726
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
