### PR TITLE
Added variadic string param to GetGVKsFromAddToScheme for customkinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - The `--overwrite` flag instructs [`operator-sdk bundle create`](./doc/cli/operator-sdk_bundle_create.md) to overwrite metadata, manifests, and `bundle.Dockerfile`. ([#2715](https://github.com/operator-framework/operator-sdk/pull/2715))
 - [`operator-sdk bundle validate`](./doc/cli/operator-sdk_bundle_validate.md) now accepts either an image tag or a directory arg. If the arg is a directory, its children must contain a `manifests/` and a `metadata/` directory. ([#2737](https://github.com/operator-framework/operator-sdk/pull/2737))
 - Add support to release SDK arm64 binaries and images. ([#2742](https://github.com/operator-framework/operator-sdk/pull/2715))
+- Add variadic string param to GetGVKsFromAddToScheme for customkinds ([2794](https://github.com/operator-framework/operator-sdk/pull/2794))
  
 ### Changed
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -579,7 +579,21 @@ func serveCRMetrics(cfg *rest.Config) error {
 	}
 ```
 
-The `kubemetrics.GenerateAndServeCRMetrics` function requires an RBAC rule to list all GroupVersionKinds in the list of watched namespaces, so you might need to [filter](https://github.com/operator-framework/operator-sdk/blob/v0.15.2/pkg/k8sutil/k8sutil.go#L161) the kinds returned by [`k8sutil.GetGVKsFromAddToScheme`](https://godoc.org/github.com/operator-framework/operator-sdk/pkg/k8sutil#GetGVKsFromAddToScheme) more stringently to avoid authorization errors such as `Failed to list *unstructured.Unstructured`. You may also need to add a rule to LIST your third party API schemas and their dependent schemas not registered with the manager.
+For third part API schemas or CRD which are cluster-scoped:
+
+Example shows a LIST of cluster-scope CRD passed as parameter
+```go
+    ...
+    customMetaKind  := []string{"DeploymentLogOption", "Image"}
+	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme, customMetaKind...)
+	if err != nil {
+		return err
+	}
+
+    ...
+```
+
+The `kubemetrics.GenerateAndServeCRMetrics` function requires an RBAC rule to list all GroupVersionKinds in the list of watched namespaces, so you might need to [filter](https://github.com/operator-framework/operator-sdk/blob/v0.15.2/pkg/k8sutil/k8sutil.go#L161) the kinds returned by [`k8sutil.GetGVKsFromAddToScheme`](https://godoc.org/github.com/operator-framework/operator-sdk/pkg/k8sutil#GetGVKsFromAddToScheme) more stringently to avoid authorization errors such as `Failed to list *unstructured.Unstructured`. You may also need to add a rule to LIST your third party API schemas and their dependent schemas not registered with the manager. Which can be passed as optional parameter to `k8sutil.GetGVKsFromAddToScheme` to handle such scenarios.
 
 ### Handle Cleanup on Deletion
 

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -141,6 +141,7 @@ func GetPod(ctx context.Context, client crclient.Client, ns string) (*corev1.Pod
 }
 
 // GetGVKsFromAddToScheme takes in the runtime scheme and filters out all generic apimachinery meta types.
+// It takes optional param to filter third part API schemas or cluster-scope CRD
 // It returns just the GVK specific to this scheme.
 func GetGVKsFromAddToScheme(addToSchemeFunc func(*runtime.Scheme) error,
 	customMetaKinds ...string) ([]schema.GroupVersionKind, error) {
@@ -155,9 +156,7 @@ func GetGVKsFromAddToScheme(addToSchemeFunc func(*runtime.Scheme) error,
 		if !isKubeMetaKind(gvk.Kind) {
 			ownGVKs = append(ownGVKs, gvk)
 		}
-
 		for _, customKind := range customMetaKinds {
-
 			if customKind == gvk.Kind {
 				ownGVKs = append(ownGVKs, gvk)
 			}

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -142,7 +142,8 @@ func GetPod(ctx context.Context, client crclient.Client, ns string) (*corev1.Pod
 
 // GetGVKsFromAddToScheme takes in the runtime scheme and filters out all generic apimachinery meta types.
 // It returns just the GVK specific to this scheme.
-func GetGVKsFromAddToScheme(addToSchemeFunc func(*runtime.Scheme) error) ([]schema.GroupVersionKind, error) {
+func GetGVKsFromAddToScheme(addToSchemeFunc func(*runtime.Scheme) error,
+	customMetaKinds ...string) ([]schema.GroupVersionKind, error) {
 	s := runtime.NewScheme()
 	err := addToSchemeFunc(s)
 	if err != nil {
@@ -153,6 +154,13 @@ func GetGVKsFromAddToScheme(addToSchemeFunc func(*runtime.Scheme) error) ([]sche
 	for gvk := range schemeAllKnownTypes {
 		if !isKubeMetaKind(gvk.Kind) {
 			ownGVKs = append(ownGVKs, gvk)
+		}
+
+		for _, customKind := range customMetaKinds {
+
+			if customKind == gvk.Kind {
+				ownGVKs = append(ownGVKs, gvk)
+			}
 		}
 	}
 

--- a/website/content/en/docs/golang/quickstart.md
+++ b/website/content/en/docs/golang/quickstart.md
@@ -568,9 +568,23 @@ func serveCRMetrics(cfg *rest.Config) error {
 	}
 ```
 
+For third part API schemas or CRD which are cluster-scoped:
+
+Example shows a LIST of cluster-scope CRD passed as parameter
+```go
+    ...
+    customMetaKind  := []string{"DeploymentLogOption", "Image"}
+	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme, customMetaKind...)
+	if err != nil {
+		return err
+	}
+
+    ...
+```
+
 The `kubemetrics.GenerateAndServeCRMetrics` function requires an RBAC rule to list all GroupVersionKinds in the list of watched namespaces, so you might need to [filter](https://github.com/operator-framework/operator-sdk/blob/v0.15.2/pkg/k8sutil/k8sutil.go#L161) the kinds returned by [`k8sutil.GetGVKsFromAddToScheme`](https://godoc.org/github.com/operator-framework/operator-sdk/pkg/k8sutil#GetGVKsFromAddToScheme) more stringently to avoid authorization errors such as `Failed to list *unstructured.Unstructured`.
 
-In this scenario, this error may occur because your Operator RBAC roles do not include permissions to LIST the third party API schemas or the schemas which are required to them and will be added with. See that the default SDK implementation will just add the Kubernetes schemas and they will be ignored in the metrics It means that you might need to do an similar implementation to filter the third party API schemas and their dependencies added in order to provide a filtered a List of GVK(GroupVersionKind) to the  `GenerateAndServeCRMetrics` method.
+In this scenario, this error may occur because your Operator RBAC roles do not include permissions to LIST the third party API schemas or the schemas which are required to them and will be added with. See that the default SDK implementation will just add the Kubernetes schemas and they will be ignored in the metrics It means that you might need pass an additional parameter `k8sutil.GetGVKsFromAddToScheme` function which contains LIST of the third party API schemas and their dependencies added in order to provide a filtered a List of GVK(GroupVersionKind) to the  `GenerateAndServeCRMetrics` method.
 
 ### Handle Cleanup on Deletion
 


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Added variadic string param to GetGVKsFromAddToScheme for customkinds
it will allow to filter the custom third party or ocp schemas by passing
a list of kinds.

**Motivation for the change:**
The operator which has openshift schemas or custom third party schema will error out:`Failed to list *unstructured.Unstructured `

Eg:
` Failed to list *unstructured.Unstructured: deploymentconfigs.apps.openshift.io "rollback" not found`

This change will allow fixing this type of errors and avoid re-implementation of GetGVKsFromAddToScheme for handling such use-cases
<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
