### PR TITLE
.travis.yml: use before_script as to not override test.before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,8 +135,8 @@ jobs:
     # Build and test go
     - <<: *test
       name: Go on Kubernetes
-      before_install:
-        - (cd / && go get github.com/mattn/goveralls)
+      before_script:
+      - (cd / && go get github.com/mattn/goveralls)
       script:
       - make test-unit
       - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=coverage.out -repotoken=$COVERALLS_TOKEN


### PR DESCRIPTION
**Description of the change:** use before_script as to not override test.before_install in .travis.yml


**Motivation for the change:** Go tests no longer respect docs-only check

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
