### PR TITLE
user_setup scripts: add double quotes

### DIFF
--- a/images/scorecard-proxy/bin/user_setup
+++ b/images/scorecard-proxy/bin/user_setup
@@ -2,12 +2,12 @@
 set -x
 
 # ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
-mkdir -p ${HOME}
-chown ${USER_UID}:0 ${HOME}
-chmod ug+rwx ${HOME}
+mkdir -p "${HOME}"
+chown "${USER_UID}:0" "${HOME}"
+chmod ug+rwx "${HOME}"
 
 # runtime user will need to be able to self-insert in /etc/passwd
 chmod g+rw /etc/passwd
 
 # no need for this script to remain in the image after running
-rm $0
+rm "$0"

--- a/internal/scaffold/ansible/usersetup.go
+++ b/internal/scaffold/ansible/usersetup.go
@@ -39,10 +39,10 @@ set -x
 
 # ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
 echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
-mkdir -p ${HOME}/.ansible/tmp
-chown -R ${USER_UID}:0 ${HOME}
-chmod -R ug+rwx ${HOME}
+mkdir -p "${HOME}/.ansible/tmp"
+chown -R "${USER_UID}:0" "${HOME}"
+chmod -R ug+rwx "${HOME}"
 
 # no need for this script to remain in the image after running
-rm $0
+rm "$0"
 `

--- a/internal/scaffold/helm/usersetup.go
+++ b/internal/scaffold/helm/usersetup.go
@@ -39,10 +39,10 @@ set -x
 
 # ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
 echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
-mkdir -p ${HOME}
-chown ${USER_UID}:0 ${HOME}
-chmod ug+rwx ${HOME}
+mkdir -p "${HOME}"
+chown "${USER_UID}:0" "${HOME}"
+chmod ug+rwx "${HOME}"
 
 # no need for this script to remain in the image after running
-rm $0
+rm "$0"
 `

--- a/internal/scaffold/usersetup.go
+++ b/internal/scaffold/usersetup.go
@@ -41,10 +41,10 @@ set -x
 
 # ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
 echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
-mkdir -p ${HOME}
-chown ${USER_UID}:0 ${HOME}
-chmod ug+rwx ${HOME}
+mkdir -p "${HOME}"
+chown "${USER_UID}:0" "${HOME}"
+chmod ug+rwx "${HOME}"
 
 # no need for this script to remain in the image after running
-rm $0
+rm "$0"
 `

--- a/internal/scaffold/usersetup_test.go
+++ b/internal/scaffold/usersetup_test.go
@@ -38,10 +38,10 @@ set -x
 
 # ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
 echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
-mkdir -p ${HOME}
-chown ${USER_UID}:0 ${HOME}
-chmod ug+rwx ${HOME}
+mkdir -p "${HOME}"
+chown "${USER_UID}:0" "${HOME}"
+chmod ug+rwx "${HOME}"
 
 # no need for this script to remain in the image after running
-rm $0
+rm "$0"
 `

--- a/test/test-framework/build/bin/user_setup
+++ b/test/test-framework/build/bin/user_setup
@@ -2,12 +2,12 @@
 set -x
 
 # ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
-mkdir -p ${HOME}
-chown ${USER_UID}:0 ${HOME}
-chmod ug+rwx ${HOME}
+mkdir -p "${HOME}"
+chown "${USER_UID}:0" "${HOME}"
+chmod ug+rwx "${HOME}"
 
 # runtime user will need to be able to self-insert in /etc/passwd
 chmod g+rw /etc/passwd
 
 # no need for this script to remain in the image after running
-rm $0
+rm "$0"


### PR DESCRIPTION
sh/bash best practice is to always use double quotes when interpolating
strings from variables.  This commit updates the user_setup scripts to
do this.  They now pass shellcheck linting

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Add double quotes around interpolated arguments in user_setup shell scripts 

**Motivation for the change:**

- Follow shell best practices
- Get a feel for this community and whether it's worth investing time helping out with things big and small in the future
- Something to do on a Saturday during a worldwide pandemic, while learning how to write operators
- Satisfy my OCD

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
