### PR TITLE
Resources without generation will not skip events

### DIFF
--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -46,7 +46,7 @@ func (GenerationChangedPredicate) Update(e event.UpdateEvent) bool {
 		log.Error(nil, "Update event has no new metadata", "event", e)
 		return false
 	}
-	if e.MetaNew.GetGeneration() == e.MetaOld.GetGeneration() {
+	if e.MetaNew.GetGeneration() == e.MetaOld.GetGeneration() && e.MetaNew.GetGeneration() != 0 {
 		return false
 	}
 	return true

--- a/test/ansible/molecule/cluster/tasks/secrets_test.yml
+++ b/test/ansible/molecule/cluster/tasks/secrets_test.yml
@@ -1,0 +1,56 @@
+---
+- name: Create the v1.Secret
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: test-secret
+        namespace: '{{ namespace }}'
+        labels:
+          reconcile: "yes"
+      data:
+        test: '{{ "test" | b64encode }}'
+
+- name: Wait for the corresponding configmap to be created
+  k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: test-secret
+    namespace: '{{ namespace }}'
+  register: result
+  until: result.resources
+  retries: 10
+
+- name: Assert that the configmap has the proper content
+  assert:
+    that: result.resources.0.data.test == "test"
+
+- name: Update the v1.Secret
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: test-secret
+        namespace: '{{ namespace }}'
+        labels:
+          reconcile: "yes"
+      data:
+        new: '{{ "content" | b64encode }}'
+
+- name: Wait for the corresponding key to be created
+  k8s_facts:
+    api_version: v1
+    kind: ConfigMap
+    name: test-secret
+    namespace: '{{ namespace }}'
+  register: result
+  until: result.resources.0.data.new is defined
+  retries: 10
+
+- name: Assert that the configmap has the proper content
+  assert:
+    that: result.resources.0.data.new == 'content'

--- a/test/ansible/playbooks/secret.yml
+++ b/test/ansible/playbooks/secret.yml
@@ -1,0 +1,23 @@
+---
+- hosts: localhost
+  gather_facts: no
+  collections:
+    - community.kubernetes
+
+  tasks:
+    - meta: end_play
+      when: not (__secret.metadata.get('labels', {}).reconcile|default(false)|bool)
+
+    # This is for testing, but never do this with real secrets
+    - name: Populate configmap with contents of secret
+      k8s:
+        definition: |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: '{{ meta.name }}'
+            namespace: '{{ meta.namespace }}'
+          data:
+            '{{ item.key }}': '{{ item.value | b64decode }}'
+      with_dict: '{{ __secret.data }}'
+

--- a/test/ansible/watches.yaml
+++ b/test/ansible/watches.yaml
@@ -13,3 +13,9 @@
   group: test.example.com
   kind: ExecTest
   playbook: playbooks/exec.yml
+
+- version: v1
+  group: ""
+  kind: Secret
+  playbook: playbooks/secret.yml
+  manageStatus: false


### PR DESCRIPTION
Fixes #2108

If the `metadata.generation` is `0`, the event will now still trigger a
reconciliation.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
