### PR TITLE
fix type-o in olm run command example

### DIFF
--- a/doc/user/olm-catalog/olm-cli.md
+++ b/doc/user/olm-catalog/olm-cli.md
@@ -365,9 +365,9 @@ requires the typical setup described above.
 [pkg-manifest]:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/how-to-update-operators.md
 [operator-bundle]:https://github.com/operator-framework/operator-registry/tree/v1.5.3#manifest-format
 [sdk-olm-design]:https://github.com/operator-framework/operator-sdk/blob/master/doc/proposals/sdk-integration-with-olm.md
-[cli-olm-install]:https://github.com/operator-framework/operator-sdk/blob/master/doc/cli/operator-sdk_olm_install.md
-[cli-olm-status]:https://github.com/operator-framework/operator-sdk/blob/master/doc/cli/operator-sdk_olm_status.md
-[cli-generate-csv]:https://github.com/operator-framework/operator-sdk/blob/master/doc/cli/operator-sdk_generate_csv.md
+[cli-olm-install]:../../../website/content/en/docs/cli/operator-sdk_olm_install.md
+[cli-olm-status]:../../../website/content/en/docs/cli/operator-sdk_olm_status.md
+[cli-generate-csv]:../../../website/content/en/docs/cli/operator-sdk_generate_csv.md
 [sdk-release-v0.15.0]:https://github.com/operator-framework/operator-sdk/releases/tag/v0.15.0
 [sdk-user-guide-go]:https://github.com/operator-framework/operator-sdk/blob/master/doc/user-guide.md
 [sdk-user-guide-ansible]:https://github.com/operator-framework/operator-sdk/blob/master/doc/ansible/user-guide.md

--- a/doc/user/olm-catalog/olm-cli.md
+++ b/doc/user/olm-catalog/olm-cli.md
@@ -242,7 +242,7 @@ in your bundle directory (no `Secret`'s, etc.), you can deploy your Operator
 using the following command invocation:
 
 ```console
-$ operator-sdk run --olm --manifests deploy/olm-catalog-memcached-operator --operator-version 0.1.0
+$ operator-sdk run --olm --manifests deploy/olm-catalog/memcached-operator --operator-version 0.1.0
 INFO[0000] loading Bundles                               dir=deploy/olm-catalog/memcached-operator
 INFO[0000] directory                                     dir=deploy/olm-catalog/memcached-operator file=memcached-operator load=bundles
 INFO[0000] directory                                     dir=deploy/olm-catalog/memcached-operator file=0.1.0 load=bundles

--- a/website/content/en/docs/golang/olm-integration/olm-cli.md
+++ b/website/content/en/docs/golang/olm-integration/olm-cli.md
@@ -246,7 +246,7 @@ in your bundle directory (no `Secret`'s, etc.), you can deploy your Operator
 using the following command invocation:
 
 ```console
-$ operator-sdk run --olm --manifests deploy/olm-catalog-memcached-operator --operator-version 0.1.0
+$ operator-sdk run --olm --manifests deploy/olm-catalog/memcached-operator --operator-version 0.1.0
 INFO[0000] loading Bundles                               dir=deploy/olm-catalog/memcached-operator
 INFO[0000] directory                                     dir=deploy/olm-catalog/memcached-operator file=memcached-operator load=bundles
 INFO[0000] directory                                     dir=deploy/olm-catalog/memcached-operator file=0.1.0 load=bundles


### PR DESCRIPTION


**Description of the change:**
fixes a small type-o in an sdk olm run example.

**Motivation for the change:**

small doc fix only.
