### PR TITLE
Implement Scorecard 2 Base Image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,12 @@ SOURCES = $(shell find . -name '*.go' -not -path "*/vendor/*")
 ANSIBLE_BASE_IMAGE = quay.io/operator-framework/ansible-operator
 HELM_BASE_IMAGE = quay.io/operator-framework/helm-operator
 SCORECARD_PROXY_BASE_IMAGE = quay.io/operator-framework/scorecard-proxy
+SCORECARD_TEST_BASE_IMAGE = quay.io/operator-framework/scorecard-test
 
 ANSIBLE_IMAGE ?= $(ANSIBLE_BASE_IMAGE)
 HELM_IMAGE ?= $(HELM_BASE_IMAGE)
 SCORECARD_PROXY_IMAGE ?= $(SCORECARD_PROXY_BASE_IMAGE)
+SCORECARD_TEST_IMAGE ?= $(SCORECARD_TEST_BASE_IMAGE)
 
 ANSIBLE_ARCHES:="amd64" "ppc64le" "s390x" "arm64"
 HELM_ARCHES:="amd64" "ppc64le" "s390x" "arm64"
@@ -171,6 +173,9 @@ image-build-helm: build/operator-sdk-dev-linux-gnu
 image-build-scorecard-proxy:
 	./hack/image/build-scorecard-proxy-image.sh $(SCORECARD_PROXY_BASE_IMAGE):dev
 
+image-build-scorecard-test:
+	./hack/image/build-scorecard-test-image.sh $(SCORECARD_TEST_BASE_IMAGE):dev
+
 image-push: image-push-ansible image-push-helm image-push-scorecard-proxy ## Push all images
 
 image-push-ansible:
@@ -190,6 +195,9 @@ image-push-scorecard-proxy:
 
 image-push-scorecard-proxy-multiarch:
 	./hack/image/push-manifest-list.sh $(SCORECARD_PROXY_IMAGE) ${SCORECARD_PROXY_ARCHES}
+
+image-push-scorecard-test:
+	./hack/image/push-image-tags.sh $(SCORECARD_TEST_BASE_IMAGE):dev $(SCORECARD_TEST_IMAGE)-$(shell go env GOARCH)
 
 ##############################
 # Tests                      #

--- a/hack/image/build-scorecard-test-image.sh
+++ b/hack/image/build-scorecard-test-image.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eux
+
+source hack/lib/image_lib.sh
+
+# TODO build test image
+#WD="$(dirname "$(pwd)")"
+#GOOS=linux CGO_ENABLED=0 \
+#  go build \
+#  -gcflags "all=-trimpath=${WD}" \
+#  -asmflags "all=-trimpath=${WD}" \
+#  -o images/scorecard-test/scorecard-test \
+#  images/scorecard-test/cmd/test/main.go
+
+# Build base image
+pushd images/scorecard-test
+docker build -t "$1" .
+# If using a kind cluster, load the image into all nodes.
+load_image_if_kind "$1"
+popd

--- a/images/scorecard-test/Dockerfile
+++ b/images/scorecard-test/Dockerfile
@@ -1,0 +1,17 @@
+# Base image
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ENV TEST=/usr/local/bin/scorecard-test \
+    USER_UID=1001 \
+    USER_NAME=test
+
+# TODO install test binary 
+# COPY scorecard-test ${TEST}
+
+COPY bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}

--- a/images/scorecard-test/bin/entrypoint
+++ b/images/scorecard-test/bin/entrypoint
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+
+# This is documented here:
+# https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
+
+if ! whoami &>/dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-proxy}:x:$(id -u):$(id -g):${USER_NAME:-proxy} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+
+exec ${PROXY} $@

--- a/images/scorecard-test/bin/entrypoint
+++ b/images/scorecard-test/bin/entrypoint
@@ -3,10 +3,4 @@
 # This is documented here:
 # https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
 
-if ! whoami &>/dev/null; then
-  if [ -w /etc/passwd ]; then
-    echo "${USER_NAME:-test}:x:$(id -u):$(id -g):${USER_NAME:-test} user:${HOME}:/sbin/nologin" >> /etc/passwd
-  fi
-fi
-
 exec ${TEST} $@

--- a/images/scorecard-test/bin/entrypoint
+++ b/images/scorecard-test/bin/entrypoint
@@ -5,8 +5,8 @@
 
 if ! whoami &>/dev/null; then
   if [ -w /etc/passwd ]; then
-    echo "${USER_NAME:-proxy}:x:$(id -u):$(id -g):${USER_NAME:-proxy} user:${HOME}:/sbin/nologin" >> /etc/passwd
+    echo "${USER_NAME:-test}:x:$(id -u):$(id -g):${USER_NAME:-test} user:${HOME}:/sbin/nologin" >> /etc/passwd
   fi
 fi
 
-exec ${PROXY} $@
+exec ${TEST} $@

--- a/images/scorecard-test/bin/user_setup
+++ b/images/scorecard-test/bin/user_setup
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -x
+
+# ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+mkdir -p "${HOME}"
+chown "${USER_UID}:0" "${HOME}"
+chmod ug+rwx "${HOME}"
+
+# runtime user will need to be able to self-insert in /etc/passwd
+chmod g+rw /etc/passwd
+
+# no need for this script to remain in the image after running
+rm "$0"

--- a/images/scorecard-test/bin/user_setup
+++ b/images/scorecard-test/bin/user_setup
@@ -6,8 +6,5 @@ mkdir -p "${HOME}"
 chown "${USER_UID}:0" "${HOME}"
 chmod ug+rwx "${HOME}"
 
-# runtime user will need to be able to self-insert in /etc/passwd
-chmod g+rw /etc/passwd
-
 # no need for this script to remain in the image after running
 rm "$0"

--- a/images/scorecard-test/bin/user_setup
+++ b/images/scorecard-test/bin/user_setup
@@ -2,6 +2,8 @@
 set -x
 
 # ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
+
 mkdir -p "${HOME}"
 chown "${USER_UID}:0" "${HOME}"
 chmod ug+rwx "${HOME}"


### PR DESCRIPTION
Create base image to support new scorecard system. Adds image build/push to Makefile (not enabled by default), a script to generate images and the base image dockerfile. Future additions will include building and executing the test binary as well as passing along test selection data to the test binary.