### PR TITLE
operator-migrate: migrate an existing SDK project to a kubebuilder-style one

### DIFF
--- a/cmd/operator-migrate/cmd.go
+++ b/cmd/operator-migrate/cmd.go
@@ -1,0 +1,131 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/operator-sdk/internal/flags"
+	"github.com/operator-framework/operator-sdk/internal/util/projutil"
+)
+
+const (
+	migrationDocLinkGo = "https://sdk.operatorframework.io/docs/golang/project_migration_guide"
+	// TODO: add ansible and helm migration doc links when ready.
+)
+
+type migrateCmd struct {
+	pluginType string
+	fromDir    string
+	toDir      string
+	license    string
+	owner      string
+	repo       string
+
+	verbose bool
+}
+
+func rootCmd() *cobra.Command {
+	c := &migrateCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "operator-migrate",
+		Short: "migrates a legacy Operator SDK project to a Kubebuilder-style project",
+		Long: `Migrate a legacy Operator SDK project to a Kubebuilder-style project
+by scaffolding a new project using 'operator-sdk init' and adding APIs using
+'operator-sdk create api', both with current project data.
+`,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if c.verbose {
+				if err := projutil.SetGoVerbose(); err != nil {
+					log.Fatalf("Could not set GOFLAGS: (%v)", err)
+				}
+				log.SetLevel(log.DebugLevel)
+				log.Debug("Debug logging is set")
+			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			projectConfig := filepath.Join(c.fromDir, "PROJECT")
+			if _, err = os.Stat(projectConfig); err == nil || os.IsExist(err) {
+				log.Fatalf("Project %s is already migrated", c.fromDir)
+			}
+
+			var layout pluginKey
+			if c.pluginType != "" {
+				if layout, err = toPluginKey(c.pluginType); err != nil {
+					return err
+				}
+			}
+
+			if projutil.CheckProjectRoot() != nil {
+				if c.fromDir == "" {
+					return fmt.Errorf("--from must be set if not running in a project")
+				}
+				if c.pluginType == "" {
+					return fmt.Errorf("--type must be set if not running in a project")
+				}
+			} else {
+				if c.fromDir == "" {
+					c.fromDir = "."
+				}
+				if c.pluginType == "" {
+					switch t := projutil.GetOperatorType(); t {
+					case projutil.OperatorTypeGo:
+						layout = pluginKeyGo
+					default:
+						log.Fatalf(`Migration is not supported for project type %s, possible values: ["go"]`, t)
+					}
+				}
+			}
+
+			if err = c.runWithPlugin(layout); err != nil && !errors.As(err, &needsHelpErr{}) {
+				log.Fatal(err)
+			}
+			return err
+		},
+	}
+
+	cmd.PersistentFlags().BoolVar(&c.verbose, flags.VerboseOpt, false, "enable verbose logging")
+
+	cmd.Flags().StringVar(&c.pluginType, "type", "", `type of project being migrated, possible values: ["go"]`)
+	cmd.Flags().StringVar(&c.license, "license", "", "license type to use")
+	cmd.Flags().StringVar(&c.repo, "repo", "",
+		"project repository path or name. If the project is a Go operator, the path "+
+			"must be a module path (default is the legacy project's go.mod module). "+
+			"Otherwise the repo is the project's name (default is the legacy project's directory name)")
+	cmd.Flags().StringVar(&c.owner, "owner", "", "owner of the project, this information goes into the license")
+	cmd.Flags().StringVar(&c.fromDir, "from-dir", "", "directory of project to migrate")
+	cmd.Flags().StringVar(&c.toDir, "to-dir", "", "directory to place migrated project")
+
+	return cmd
+}
+
+type needsHelpErr struct {
+	err error
+}
+
+func (e needsHelpErr) Error() string {
+	return e.err.Error()
+}
+
+func (e needsHelpErr) Unwrap() error {
+	return e.err
+}

--- a/cmd/operator-migrate/golang.go
+++ b/cmd/operator-migrate/golang.go
@@ -1,0 +1,146 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"golang.org/x/mod/modfile"
+	"golang.org/x/tools/imports"
+)
+
+func isPathTypeGo(path string) (bool, error) {
+	return filepath.Ext(path) == ".go", nil
+}
+
+func (p project) fixPathGo(filePath string) string {
+
+	pathSplit := strings.Split(filepath.Clean(filePath), sep)
+	if len(pathSplit) < 2 || filePath == "go.mod" || filePath == "go.sum" {
+		return filePath
+	}
+
+	switch {
+	case pathSplit[0] == "deploy":
+		filePath = filepath.Join("config", filepath.Join(pathSplit[1:]...))
+	case pathSplit[0] == "pkg" && pathSplit[1] == "apis":
+		if p.multiGroup {
+			filePath = filepath.Join(pathSplit[1:]...)
+		} else {
+			// Subdirectory of pkg/apis
+			if len(pathSplit) > 3 {
+				pathSplit = pathSplit[1:]
+			}
+			filePath = filepath.Join("api", filepath.Join(pathSplit[2:]...))
+		}
+	case pathSplit[0] == "pkg" && pathSplit[1] == "controller":
+		// Subdirectory of pkg/controller
+		if !p.multiGroup && len(pathSplit) > 3 {
+			pathSplit = pathSplit[1:]
+		}
+		filePath = filepath.Join("controllers", filepath.Join(pathSplit[2:]...))
+	case pathSplit[0] == "cmd" && pathSplit[1] == "manager":
+		filePath = filepath.Join(pathSplit[2:]...)
+	case pathSplit[0] == "build" && pathSplit[1] == "Dockerfile":
+		filePath = pathSplit[1]
+	case pathSplit[0] == "build" && pathSplit[1] == "bin":
+		filePath = filepath.Join(pathSplit[1:]...)
+	}
+
+	return addOldExt(filePath)
+}
+
+func (p project) importsWalkFuncGo(pathChanges map[string]string) filepath.WalkFunc {
+	return func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		b, err := afero.ReadFile(p.fs, path)
+		if err != nil {
+			return err
+		}
+		if filepath.Ext(path) == ".go" {
+			for newPath, oldPath := range pathChanges {
+				b = fixImportsGo(b, p.repo, newPath, oldPath)
+			}
+			if b, err = imports.Process("", b, nil); err != nil {
+				return fmt.Errorf("error processing %s: %v", path, err)
+			}
+		}
+		return afero.WriteFile(p.fs, path, b, info.Mode())
+	}
+}
+
+func fixImportsGo(b []byte, repo, newPath, oldPath string) []byte {
+	if oldPath == "." || oldPath == "" {
+		return b
+	}
+	if newPath == "." {
+		newPath = ""
+	}
+	newPkg := path.Join(repo, filepath.ToSlash(newPath))
+	oldPkg := path.Join(repo, filepath.ToSlash(oldPath))
+	if newPkg == oldPkg || newPkg == repo {
+		return b
+	}
+	log.Debugf("Replacing strings in file %s:\n\tfrom: %q\n\tto:   %q", oldPath, oldPkg, newPkg)
+	b = bytes.ReplaceAll(b, []byte(`"`+oldPkg+`"`), []byte(`"`+newPkg+`"`))
+	// Also replace package name.
+	b = bytes.ReplaceAll(b, []byte(" "+path.Base(oldPkg)+"."), []byte(" "+path.Base(newPkg)+"."))
+	return b
+}
+
+var (
+	modFileGoRegexp     = regexp.MustCompile(`\bgo [1-2]\.[1-9]([1-9])?\b`)
+	modFileModuleRegexp = regexp.MustCompile(`\bmodule [^\n]+\b`)
+)
+
+func parseModFile(dir string) (*modfile.File, error) {
+	path := filepath.Join(dir, "go.mod")
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return modfile.ParseLax(path, b, nil)
+}
+
+// mergeModFiles merges modA and modB into modA.
+func mergeModFiles(modA, modB *modfile.File) error {
+	ab, err := modA.Format()
+	if err != nil {
+		return err
+	}
+	bb, err := modB.Format()
+	if err != nil {
+		return err
+	}
+	bb = modFileGoRegexp.ReplaceAll(bb, []byte{})
+	bb = modFileModuleRegexp.ReplaceAll(bb, []byte{})
+	newMod, err := modfile.ParseLax("", append(ab, bb...), nil)
+	if err != nil {
+		return err
+	}
+	*modA = *newMod
+	return nil
+}

--- a/cmd/operator-migrate/main.go
+++ b/cmd/operator-migrate/main.go
@@ -1,0 +1,23 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "os"
+
+func main() {
+	if err := rootCmd().Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/operator-migrate/migrate.go
+++ b/cmd/operator-migrate/migrate.go
@@ -1,0 +1,140 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/plugin"
+	kbgov2 "sigs.k8s.io/kubebuilder/pkg/plugin/v2"
+)
+
+type pluginKey string
+
+// These plugin keys use the latest imported plugin version.
+// NB(estroz): these should probably be versioned since the CLI (flags) used to migrate the project may change,
+// or freeze this version and have users upgrade from that version using version migration guides.
+var (
+	pluginKeyGo = pluginKey(plugin.KeyFor(kbgov2.Plugin{}))
+)
+
+func toPluginKey(opt string) (pluginKey, error) {
+	switch opt {
+	case "go":
+		return pluginKeyGo, nil
+	}
+	return "", fmt.Errorf(`plugin type %s not supported, possible values: ["go"]`, opt)
+}
+
+func (c *migrateCmd) runWithPlugin(layout pluginKey) (err error) {
+	sdkProject := &project{
+		layout:  layout,
+		repo:    c.repo,
+		license: c.license,
+		owner:   c.owner,
+	}
+	if sdkProject.layout == pluginKeyGo {
+		if sdkProject.modFile, err = parseModFile(c.fromDir); err != nil {
+			return err
+		}
+		if sdkProject.repo == "" {
+			sdkProject.repo = sdkProject.modFile.Module.Mod.Path
+		} else if err = sdkProject.modFile.AddModuleStmt(sdkProject.repo); err != nil {
+			return err
+		}
+	}
+	if sdkProject.repo == "" {
+		return needsHelpErr{errors.New("--repo must be set")}
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	if c.toDir == "" {
+		c.toDir, err = ioutil.TempDir(wd, path.Base(sdkProject.repo)+"-migrated-")
+		if err != nil {
+			return err
+		}
+		if c.toDir, err = filepath.Rel(wd, c.toDir); err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("Beginning partial migration of project %s in directory %s\n\n", c.fromDir, c.toDir)
+
+	c.fromDir, c.toDir = filepath.Clean(c.fromDir), filepath.Clean(c.toDir)
+	if err = sdkProject.parseFromDir(c.fromDir); err != nil {
+		return err
+	}
+	if err = sdkProject.migrateToDir(c.toDir); err != nil {
+		return err
+	}
+
+	// Print the correct link to a migration guide for an operator type.
+	migrationDocLink := ""
+	switch layout {
+	case pluginKeyGo:
+		migrationDocLink = migrationDocLinkGo
+	}
+	fmt.Printf("\nPartial migration complete. Please read the migration doc for further instructions:\n%s\n",
+		migrationDocLink)
+
+	return nil
+}
+
+type operatorSDK struct {
+	cmd
+}
+
+func (c operatorSDK) run(args ...string) (string, error) { //nolint:unparam
+	cmd := exec.Command("operator-sdk", args...)
+	if c.dir != "" {
+		cmd.Dir = c.dir
+	}
+	cmd.Env = append(c.env, os.Environ()...)
+	fmt.Println(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, string(out))
+	}
+	return string(out), nil
+}
+
+type cmd struct {
+	dir string
+	env []string
+}
+
+func (c cmd) run(cmdStr string, args ...string) (string, error) { //nolint:unparam
+	cmd := exec.Command(cmdStr, args...)
+	if c.dir != "" {
+		cmd.Dir = c.dir
+	}
+	cmd.Env = append(c.env, os.Environ()...)
+	fmt.Println(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%v: %s", err, string(out))
+	}
+	return string(out), nil
+}

--- a/cmd/operator-migrate/project.go
+++ b/cmd/operator-migrate/project.go
@@ -1,0 +1,292 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"golang.org/x/mod/modfile"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
+	"sigs.k8s.io/yaml"
+)
+
+// File path separator.
+const sep = string(filepath.Separator)
+
+// project contains all information required to define an operator project.
+type project struct {
+	layout     pluginKey
+	license    string
+	owner      string
+	repo       string
+	domain     string
+	gvks       gvks
+	multiGroup bool
+
+	// fs holds parsed project information.
+	fs afero.Fs
+	// modFile is only used for Go projects.
+	modFile *modfile.File
+}
+
+// gvk wraps a config resource and adds other useful fields.
+type gvk struct {
+	config.GVK
+	shortGroup string
+	crdVersion string
+}
+
+type gvks []gvk
+
+// isMultiGroup returns true if more than one group name exists in gvks.
+func (gs gvks) isMultiGroup() bool {
+	if len(gs) == 0 {
+		return false
+	}
+
+	firstGroup := gs[0].Group
+	for _, gvk := range gs[1:] {
+		if firstGroup != gvk.Group {
+			return true
+		}
+	}
+	return false
+}
+
+// pathChecker is a function that returns true if a file should be modified somehow
+// before being copied to the new project.
+type pathChecker func(string) (bool, error)
+
+// pathFixer returns some modified string that is based on the input file path.
+// That modified string will be used as the new path for the input file path.
+type pathFixer func(string) string
+
+// parseFromDir parses a full project from dir.
+func (p *project) parseFromDir(dir string) error {
+	p.fs = afero.NewMemMapFs()
+
+	seenGVKs := make(map[config.GVK]struct{})
+	err := filepath.Walk(filepath.Join(dir, "deploy"), p.getGVKsFromCRDs(seenGVKs))
+	if err != nil {
+		return err
+	}
+
+	p.multiGroup = p.gvks.isMultiGroup()
+	if len(p.gvks) != 0 {
+		gvk := p.gvks[0]
+		p.domain = strings.TrimPrefix(gvk.Group, gvk.shortGroup+".")
+	}
+
+	var isPathOfType pathChecker
+	var fixPath pathFixer
+	switch p.layout {
+	case pluginKeyGo:
+		isPathOfType = isPathTypeGo
+		fixPath = p.fixPathGo
+	}
+
+	pathChanges := make(map[string]string)
+	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || isFileIgnore(filepath.Base(path)) {
+			return err
+		}
+
+		oldPath := strings.TrimPrefix(path, dir+sep)
+		newPath := fixPath(oldPath)
+		log.Debugf("Fix path:\n\tfrom: %s\n\tto:   %s", oldPath, newPath)
+
+		if pathOfType, err := isPathOfType(path); err != nil {
+			return err
+		} else if pathOfType {
+			pathChanges[filepath.Dir(newPath)] = filepath.Dir(oldPath)
+		}
+
+		if err = p.fs.MkdirAll(filepath.Dir(newPath), 0777); err != nil {
+			return err
+		}
+		b, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return afero.WriteFile(p.fs, newPath, b, info.Mode())
+	})
+	if err != nil {
+		return err
+	}
+
+	var walkFunc filepath.WalkFunc
+	switch p.layout {
+	case pluginKeyGo:
+		walkFunc = p.importsWalkFuncGo(pathChanges)
+	}
+
+	return afero.Walk(p.fs, ".", walkFunc)
+}
+
+func (p *project) getGVKsFromCRDs(seenGVKs map[config.GVK]struct{}) filepath.WalkFunc {
+	return func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || filepath.Ext(path) != ".yaml" {
+			return err
+		}
+
+		b, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		typeMeta, err := k8sutil.GetTypeMetaFromBytes(b)
+		if err == nil && typeMeta.Kind == "CustomResourceDefinition" {
+			gvks, err := getCRGVKs(b, seenGVKs)
+			if err != nil {
+				return err
+			}
+			p.gvks = append(p.gvks, gvks...)
+		}
+		return nil
+	}
+}
+
+func isFileIgnore(path string) bool {
+	return path == "go.mod" || path == "go.sum" || strings.HasPrefix(path, "zz_generated")
+}
+
+func addOldExt(filePath string) string {
+	ext := filepath.Ext(filePath)
+	return strings.TrimSuffix(filePath, ext) + ".old" + ext
+}
+
+func getCRGVKs(crdBytes []byte, seenGVKs map[config.GVK]struct{}) (gvks []gvk, err error) {
+	crd := v1beta1.CustomResourceDefinition{}
+	if err := yaml.Unmarshal(crdBytes, &crd); err != nil {
+		return nil, err
+	}
+
+	for _, version := range crd.Spec.Versions {
+		groupSplit := strings.SplitN(crd.Spec.Group, ".", 2)
+
+		gvk := gvk{}
+		gvk.crdVersion = crd.GetObjectKind().GroupVersionKind().Version
+		gvk.shortGroup = groupSplit[0]
+		gvk.Group = crd.Spec.Group
+		gvk.Version = version.Name
+		gvk.Kind = crd.Spec.Names.Kind
+
+		if _, seenGVK := seenGVKs[gvk.GVK]; !seenGVK {
+			gvks = append(gvks, gvk)
+			seenGVKs[gvk.GVK] = struct{}{}
+		}
+	}
+	return
+}
+
+// migrateToDir rewrites a parsed project from the prior format to the new format in dir.
+func (p *project) migrateToDir(dir string) error {
+	if err := os.MkdirAll(dir, 0777); err != nil {
+		return err
+	}
+	sdk := operatorSDK{}
+	sdk.dir = dir
+
+	args := []string{
+		"init",
+		"--plugins", string(p.layout),
+		"--project-version", "3-alpha",
+		"--repo", p.repo,
+	}
+	if p.domain != "" {
+		args = append(args, "--domain", p.domain)
+	}
+	switch p.layout {
+	case pluginKeyGo:
+		sdk.env = append(sdk.env, "GO111MODULE=on")
+		args = append(args, "--fetch-deps=false")
+		if p.license != "" {
+			args = append(args, "--license", p.license)
+		}
+		if p.owner != "" {
+			args = append(args, "--owner", p.owner)
+		}
+	}
+	if _, err := sdk.run(args...); err != nil {
+		return err
+	}
+
+	if p.multiGroup {
+		args = []string{"edit", "--multigroup"}
+		if _, err := sdk.cmd.run("kubebuilder", args...); err != nil {
+			return err
+		}
+	}
+
+	for _, gvk := range p.gvks {
+		args = []string{
+			"create", "api",
+			"--group", gvk.shortGroup,
+			"--version", gvk.Version,
+			"--kind", gvk.Kind,
+		}
+		switch p.layout {
+		case pluginKeyGo:
+			args = append(args, "--resource", "--controller")
+		}
+		if _, err := sdk.run(args...); err != nil {
+			return err
+		}
+	}
+
+	// Merge mod files.
+	if p.layout == pluginKeyGo {
+		newModFile, err := parseModFile(dir)
+		if err != nil {
+			return err
+		}
+		if err = mergeModFiles(newModFile, p.modFile); err != nil {
+			return err
+		}
+		newModFile.Cleanup()
+		b, err := newModFile.Format()
+		if err != nil {
+			return fmt.Errorf("error merging modules: %v", err)
+		}
+		if err := ioutil.WriteFile(filepath.Join(dir, "go.mod"), b, 0755); err != nil {
+			return fmt.Errorf("error writing go.mod: %v", err)
+		}
+	}
+
+	return afero.Walk(p.fs, ".", func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		b, err := afero.ReadFile(p.fs, path)
+		if err != nil {
+			return fmt.Errorf("error reading morphed file: %v", err)
+		}
+		if err = os.MkdirAll(filepath.Join(dir, filepath.Dir(path)), 0777); err != nil {
+			return err
+		}
+		if err = ioutil.WriteFile(filepath.Join(dir, path), b, info.Mode()); err != nil {
+			return fmt.Errorf("error writing migrated file: %v", err)
+		}
+		return nil
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.14.1
+	golang.org/x/mod v0.2.0
 	golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b
 	gomodules.xyz/jsonpatch/v3 v3.0.1
 	gopkg.in/yaml.v2 v2.2.8


### PR DESCRIPTION
**Description of the change:** `operator-migrate` migrates an operator-sdk-style project to a kubebuilder-style project.

**Motivation for the change:** eases the migration process to a kubebuilder-style project:
```sh
$ go install ./cmd/operator-migrate/...
$ operator-migrate --from-dir your/sdk/operator --type go
```
This will run `operator-sdk init` then `operator-sdk create api` for each API type found in `deploy/crds`.

TODO's:
- [ ] more configuration options
- [ ] improve automated migration process
- [ ] test data
