### PR TITLE
internal/scaffold/helm/chart.go: change default API version

### DIFF
--- a/changelog/fragments/helm-rm-default-api-version.yaml
+++ b/changelog/fragments/helm-rm-default-api-version.yaml
@@ -1,0 +1,31 @@
+entries:
+  - description: >
+      Changed default API version for new Helm-based operators
+      to `helm.operator-sdk/v1alpha1`. The `k8s.io` domain is
+      reserved, so CRDs should not use it without explicit appproval.
+      See the [API Review Process](https://github.com/kubernetes/community/blob/81ec4af0ed02b4c5c0917a16563250b2f45250c2/sig-architecture/api-review-process.md#mandatory) for details.
+     
+    kind: change
+
+    # Is this a breaking change?
+    breaking: false
+
+    migration:
+      header: Helm-based operators should not use `k8s.io` API version suffix
+      body: |-
+        Newly created Helm-based operators no longer use the `k8s.io` domain
+        suffix as a default API version because it is reserved. APIs and CRDs
+        using this domain [require API review][api-review] and approval.
+        Existing projects that do not have this approval should migrate to use
+        a new CRD API version suffix.
+
+        Make the following changes to migrate to a new group name:
+  
+          - `watches.yaml` - Update the `group` field.
+          - `deploy/role.yaml` - Update the `apiGroups` field in the policy rule giving access to the CRD.
+          - `deploy/crds/`
+            - Update the `metadata.name` and `spec.group` fields in the CRD files.
+            - Update the `apiVersion` field in the CR files.
+            - Rename the CRD and CR files to reflect the new group name.
+
+        [api-review]: https://github.com/kubernetes/community/blob/81ec4af0ed02b4c5c0917a16563250b2f45250c2/sig-architecture/api-review-process.md#mandatory

--- a/internal/scaffold/helm/chart.go
+++ b/internal/scaffold/helm/chart.go
@@ -21,8 +21,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/operator-framework/operator-sdk/internal/scaffold"
-
 	"github.com/iancoleman/strcase"
 	log "github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/chart"
@@ -32,6 +30,8 @@ import (
 	"helm.sh/helm/v3/pkg/downloader"
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/repo"
+
+	"github.com/operator-framework/operator-sdk/internal/scaffold"
 )
 
 const (
@@ -42,7 +42,7 @@ const (
 
 	// DefaultAPIVersion is the Kubernetes CRD API Version used for fetched
 	// charts when the --api-version flag is not specified
-	DefaultAPIVersion string = "charts.helm.k8s.io/v1alpha1"
+	DefaultAPIVersion string = "helm.operator-sdk/v1alpha1"
 )
 
 // CreateChartOptions is used to configure how a Helm chart is scaffolded


### PR DESCRIPTION
**Description of the change:**
Changed default API version for new Helm-based operators to `helm.operator-sdk/v1alpha1`. 

**Motivation for the change:**
The `k8s.io` domain is reserved, so CRDs should not use it without explicit appproval.
