### PR TITLE
internal/generate/crd: change default CRD to v1

### DIFF
--- a/changelog/fragments/crd-default-v1.yaml
+++ b/changelog/fragments/crd-default-v1.yaml
@@ -1,0 +1,26 @@
+entries:
+  - description: >
+      Changed the default CRD version from `apiextensions.k8s.io/v1beta1`
+      to `apiextensions.k8s.io/v1` for commands that create or generate
+      CRDs.
+
+    kind: change
+
+    breaking: true
+
+    migration:
+      header: Default CRD version
+      body: |-
+        The default CRD version was changed from `apiextensions.k8s.io/v1beta1`
+        to `apiextensions.k8s.io/v1` for commands that create or generate
+        CRDs. To migrate CRDs from `v1beta1` to `v1`, simply re-run
+        `operator-sdk generate crds`. To continue generating CRDs with
+        `apiextensions.k8s.io/v1beta1`, use `--crd-version=v1beta1`.
+
+        The following CRD versions are (or will be) compatible with the
+        following Kubernetes versions:
+
+          - Kubernetes <= v1.15 - Only `apiextensions.k8s.io/v1beta1` supported
+          - Kubernetes v1.16 through v1.18 - Both `apiextensions.k8s.io/v1beta1`
+            and `apiextensions.k8s.io/v1` supported
+          - Kubernetes >= v1.19 - Only `apiextensions.k8s.io/v1` supported

--- a/internal/generate/crd/crd.go
+++ b/internal/generate/crd/crd.go
@@ -23,11 +23,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/operator-framework/operator-sdk/internal/generate/gen"
-	"github.com/operator-framework/operator-sdk/internal/scaffold"
-	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
-	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -36,9 +31,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
+
+	"github.com/operator-framework/operator-sdk/internal/generate/gen"
+	"github.com/operator-framework/operator-sdk/internal/scaffold"
+	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
+	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
 )
 
-const DefaultCRDVersion = "v1beta1"
+const DefaultCRDVersion = "v1"
 
 // Generator configures the CustomResourceDefintion manifest generator
 // for Go and non-Go projects.

--- a/test/test-framework/deploy/crds/cache.example.com_memcachedrs_crd.yaml
+++ b/test/test-framework/deploy/crds/cache.example.com_memcachedrs_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: memcachedrs.cache.example.com
@@ -10,49 +10,48 @@ spec:
     plural: memcachedrs
     singular: memcachedrs
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: MemcachedRS is the Schema for the memcachedrs API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MemcachedRSSpec defines the desired state of MemcachedRS
-          properties:
-            numNodes:
-              format: int32
-              type: integer
-          required:
-          - numNodes
-          type: object
-        status:
-          description: MemcachedRSStatus defines the observed state of MemcachedRS
-          properties:
-            nodeList:
-              items:
-                type: string
-              type: array
-            test:
-              type: boolean
-          required:
-          - nodeList
-          - test
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MemcachedRS is the Schema for the memcachedrs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MemcachedRSSpec defines the desired state of MemcachedRS
+            properties:
+              numNodes:
+                format: int32
+                type: integer
+            required:
+            - numNodes
+            type: object
+          status:
+            description: MemcachedRSStatus defines the observed state of MemcachedRS
+            properties:
+              nodeList:
+                items:
+                  type: string
+                type: array
+              test:
+                type: boolean
+            required:
+            - nodeList
+            - test
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/test/test-framework/deploy/crds/cache.example.com_memcacheds_crd.yaml
+++ b/test/test-framework/deploy/crds/cache.example.com_memcacheds_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: memcacheds.cache.example.com
@@ -10,48 +10,47 @@ spec:
     plural: memcacheds
     singular: memcached
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Memcached is the Schema for the memcacheds API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MemcachedSpec defines the desired state of Memcached
-          properties:
-            size:
-              description: Size is the size of the memcached deployment
-              format: int32
-              type: integer
-          required:
-          - size
-          type: object
-        status:
-          description: MemcachedStatus defines the observed state of Memcached
-          properties:
-            nodes:
-              description: Nodes are the names of the memcached pods
-              items:
-                type: string
-              type: array
-          required:
-          - nodes
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Memcached is the Schema for the memcacheds API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MemcachedSpec defines the desired state of Memcached
+            properties:
+              size:
+                description: Size is the size of the memcached deployment
+                format: int32
+                type: integer
+            required:
+            - size
+            type: object
+          status:
+            description: MemcachedStatus defines the observed state of Memcached
+            properties:
+              nodes:
+                description: Nodes are the names of the memcached pods
+                items:
+                  type: string
+                type: array
+            required:
+            - nodes
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/website/content/en/docs/cli/operator-sdk_add_api.md
+++ b/website/content/en/docs/cli/operator-sdk_add_api.md
@@ -88,7 +88,7 @@ operator-sdk add api [flags]
 
 ```
       --api-version string          Kubernetes apiVersion and has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)
-      --crd-version string          CRD version to generate (default "v1beta1")
+      --crd-version string          CRD version to generate (default "v1")
       --helm-chart string           Initialize helm operator with existing helm chart (<URL>, <repo>/<name>, or local path). Valid only for --type helm
       --helm-chart-repo string      Chart repository URL for the requested helm chart, Valid only for --type helm
       --helm-chart-version string   Specific version of the helm chart (default is latest version). Valid only for --type helm

--- a/website/content/en/docs/cli/operator-sdk_add_crd.md
+++ b/website/content/en/docs/cli/operator-sdk_add_crd.md
@@ -24,7 +24,7 @@ operator-sdk add crd [flags]
 
 ```
       --api-version string   Kubernetes apiVersion and has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)
-      --crd-version string   CRD version to generate (default "v1beta1")
+      --crd-version string   CRD version to generate (default "v1")
   -h, --help                 help for crd
       --kind string          Kubernetes CustomResourceDefintion kind. (e.g AppService)
 ```

--- a/website/content/en/docs/cli/operator-sdk_generate_crds.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_crds.md
@@ -26,7 +26,7 @@ operator-sdk generate crds [flags]
 ### Options
 
 ```
-      --crd-version string   CRD version to generate (default "v1beta1")
+      --crd-version string   CRD version to generate (default "v1")
   -h, --help                 help for crds
 ```
 

--- a/website/content/en/docs/cli/operator-sdk_new.md
+++ b/website/content/en/docs/cli/operator-sdk_new.md
@@ -70,7 +70,7 @@ operator-sdk new <project-name> [flags]
 
 ```
       --api-version string          Kubernetes apiVersion and has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)
-      --crd-version string          CRD version to generate (default "v1beta1")
+      --crd-version string          CRD version to generate (default "v1")
       --generate-playbook           Generate a playbook skeleton. (Only used for --type ansible)
       --git-init                    Initialize the project directory as a git repository (default false)
       --header-file string          Path to file containing headers for generated Go files. Copied to hack/boilerplate.go.txt


### PR DESCRIPTION
**Description of the change:**
Changed the default CRD version from `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1` for commands that create or generate CRDs.

**Motivation for the change:**
`v1beta1` CRDs will be removed in Kubernetes v1.19, which is the next release. We need to help users start migrating from `v1beta1` to `v1` CRDs.
