### PR TITLE
RFE: Add outputdir info for `bundle create --generate-only`

### DIFF
--- a/changelog/fragments/rfe-bundle-dir.yaml
+++ b/changelog/fragments/rfe-bundle-dir.yaml
@@ -1,0 +1,16 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Now the command `operator-sdk bundle create --generate-only` will output where the files will be generated.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false

--- a/cmd/operator-sdk/bundle/create.go
+++ b/cmd/operator-sdk/bundle/create.go
@@ -232,6 +232,7 @@ func (c bundleCreateCmd) validate(args []string) error {
 // runGenerate generates a bundle.Dockerfile, and manifests/ and metadata/ dirs,
 // always overwriting their contents.
 func (c bundleCreateCmd) runGenerate() error {
+	log.Printf("Generating files in: %s", c.outputDir)
 	err := bundle.GenerateFunc(c.directory, c.outputDir, c.packageName, c.channels, c.defaultChannel, true)
 	if err != nil {
 		return fmt.Errorf("error generating bundle image files: %v", err)


### PR DESCRIPTION
**Description of the change:**
      Now the command `operator-sdk bundle create --generate-only` will output where the files will be generated. See:

> $ operator-sdk bundle create --generate-only 
> INFO[0000] Generating files in: deploy/olm-catalog/memcached-operator 
> INFO[0000] Building annotations.yaml                    
> INFO[0000] Generating output manifests directory        
> INFO[0000] Building Dockerfile                          

**Motivation for the change:**

Closes #2878

