### PR TITLE
Scorecard2 pod execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ tags
 test/ansible-operator/ansible-operator
 test/helm-operator/helm-operator
 images/scorecard-proxy/scorecard-proxy
+images/scorecard-test/scorecard-test
 
 # Test artifacts
 pkg/ansible/runner/testdata/valid.yaml

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -16,7 +16,6 @@ package scorecard
 
 import (
 	"fmt"
-	"log"
 
 	scorecard "github.com/operator-framework/operator-sdk/internal/scorecard/alpha"
 	"github.com/spf13/cobra"
@@ -72,16 +71,10 @@ func NewCmd() *cobra.Command {
 			}
 
 			if list {
-				if err := scorecard.ListTests(o); err != nil {
-					log.Fatal(err)
-				}
-				return nil
+				return scorecard.ListTests(o)
 			}
 
-			if err := scorecard.RunTests(o); err != nil {
-				log.Fatal(err)
-			}
-			return nil
+			return scorecard.RunTests(o)
 		},
 	}
 

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -96,7 +96,7 @@ func NewCmd() *cobra.Command {
 	scorecardCmd.Flags().StringVarP(&serviceAccount, "service-account", "s", "default", "service account to run the test images")
 	scorecardCmd.Flags().BoolVarP(&list, "list", "L", false, "option to enable listing which tests are run")
 	scorecardCmd.Flags().BoolVarP(&cleanup, "cleanup", "x", true, "option to disable resource cleanup after tests are run")
-	scorecardCmd.Flags().IntVarP(&waitTime, "waittime", "w", 30, "time in seconds to wait for tests to complete")
+	scorecardCmd.Flags().IntVarP(&waitTime, "wait-time", "w", 30, "time in seconds to wait for tests to complete")
 
 	return scorecardCmd
 }

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -96,7 +96,8 @@ func NewCmd() *cobra.Command {
 	scorecardCmd.Flags().StringVar(&bundle, "bundle", "", "path to the operator bundle contents on disk")
 	scorecardCmd.Flags().StringVarP(&selector, "selector", "l", "", "label selector to determine which tests are run")
 	scorecardCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "namespace to run the test images in")
-	scorecardCmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Output format for results.  Valid values: text, json")
+	scorecardCmd.Flags().StringVarP(&outputFormat, "output", "o", "text",
+		"Output format for results.  Valid values: text, json")
 	scorecardCmd.Flags().StringVarP(&serviceAccount, "service-account", "s", "default", "Service account to use for tests")
 	scorecardCmd.Flags().BoolVarP(&list, "list", "L", false, "Option to enable listing which tests are run")
 	scorecardCmd.Flags().BoolVarP(&skipCleanup, "skip-cleanup", "x", true, "Disable resource cleanup after tests are run")

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -54,6 +54,11 @@ func NewCmd() *cobra.Command {
 				SkipCleanup:    skipCleanup,
 				WaitTime:       waitTime,
 			}
+
+			if bundle == "" {
+				return fmt.Errorf("bundle flag required")
+			}
+
 			o.Client, err = scorecard.GetKubeClient(kubeconfig)
 			if err != nil {
 				return fmt.Errorf("could not get kubernetes client: %w", err)
@@ -61,10 +66,6 @@ func NewCmd() *cobra.Command {
 			o.Config, err = scorecard.LoadConfig(config)
 			if err != nil {
 				return fmt.Errorf("could not find config file %s", err.Error())
-			}
-
-			if bundle == "" {
-				return fmt.Errorf("bundle flag required")
 			}
 
 			o.Selector, err = labels.Parse(selector)

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -33,6 +33,7 @@ func NewCmd() *cobra.Command {
 		namespace      string
 		serviceAccount string
 		list           bool
+		cleanup        bool
 	)
 	scorecardCmd := &cobra.Command{
 		Use:    "scorecard",
@@ -42,7 +43,14 @@ func NewCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			var err error
-			o := scorecard.Options{}
+			o := scorecard.Options{
+				ServiceAccount: serviceAccount,
+				Namespace:      namespace,
+				List:           list,
+				BundlePath:     bundle,
+				OutputFormat:   output,
+				Cleanup:        cleanup,
+			}
 			o.Client, err = scorecard.GetKubeClient(kubeconfig)
 			if err != nil {
 				return fmt.Errorf("could not get Kube connection %s", err.Error())
@@ -55,12 +63,6 @@ func NewCmd() *cobra.Command {
 			if bundle == "" {
 				return fmt.Errorf("bundle flag required")
 			}
-
-			o.ServiceAccount = serviceAccount
-			o.Namespace = namespace
-			o.List = list
-			o.BundlePath = bundle
-			o.OutputFormat = output
 
 			o.Selector, err = labels.Parse(selector)
 			if err != nil {
@@ -91,6 +93,7 @@ func NewCmd() *cobra.Command {
 	scorecardCmd.Flags().StringVarP(&output, "output", "o", "text", "Output format for results.  Valid values: text, json")
 	scorecardCmd.Flags().StringVarP(&serviceAccount, "service-account", "s", "default", "service account to run the test images")
 	scorecardCmd.Flags().BoolVarP(&list, "list", "L", false, "option to enable listing which tests are run")
+	scorecardCmd.Flags().BoolVarP(&cleanup, "cleanup", "x", true, "option to disable resource cleanup after tests are run")
 
 	return scorecardCmd
 }

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -56,7 +56,7 @@ func NewCmd() *cobra.Command {
 			}
 			o.Client, err = scorecard.GetKubeClient(kubeconfig)
 			if err != nil {
-				return fmt.Errorf("could not get Kube connection %s", err.Error())
+				return fmt.Errorf("could not get kubernetes client: %w", err)
 			}
 			o.Config, err = scorecard.LoadConfig(config)
 			if err != nil {

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -34,6 +34,7 @@ func NewCmd() *cobra.Command {
 		serviceAccount string
 		list           bool
 		cleanup        bool
+		waitTime       int
 	)
 	scorecardCmd := &cobra.Command{
 		Use:    "scorecard",
@@ -50,6 +51,7 @@ func NewCmd() *cobra.Command {
 				BundlePath:     bundle,
 				OutputFormat:   output,
 				Cleanup:        cleanup,
+				WaitTime:       waitTime,
 			}
 			o.Client, err = scorecard.GetKubeClient(kubeconfig)
 			if err != nil {
@@ -94,6 +96,7 @@ func NewCmd() *cobra.Command {
 	scorecardCmd.Flags().StringVarP(&serviceAccount, "service-account", "s", "default", "service account to run the test images")
 	scorecardCmd.Flags().BoolVarP(&list, "list", "L", false, "option to enable listing which tests are run")
 	scorecardCmd.Flags().BoolVarP(&cleanup, "cleanup", "x", true, "option to disable resource cleanup after tests are run")
+	scorecardCmd.Flags().IntVarP(&waitTime, "waittime", "w", 30, "time in seconds to wait for tests to complete")
 
 	return scorecardCmd
 }

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -27,7 +27,8 @@ func NewCmd() *cobra.Command {
 	var (
 		config string
 		//bundle   string // TODO - to be implemented
-		selector string
+		selector   string
+		kubeconfig string
 		//list     bool // TODO - to be implemented
 	)
 	scorecardCmd := &cobra.Command{
@@ -39,6 +40,10 @@ func NewCmd() *cobra.Command {
 
 			var err error
 			o := scorecard.Options{}
+			o.Client, err = scorecard.GetKubeClient(kubeconfig)
+			if err != nil {
+				return fmt.Errorf("could not get Kube connection %s", err.Error())
+			}
 			o.Config, err = scorecard.LoadConfig(config)
 			if err != nil {
 				return fmt.Errorf("could not find config file %s", err.Error())
@@ -60,6 +65,8 @@ func NewCmd() *cobra.Command {
 
 	scorecardCmd.Flags().StringVarP(&config, "config", "c", "",
 		"path to a new to be defined DSL yaml formatted file that configures what tests get executed")
+	scorecardCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "kubeconfig path")
+
 	//	scorecardCmd.Flags().StringVar(&bundle, "bundle", "", "path to the operator bundle contents on disk")
 	scorecardCmd.Flags().StringVarP(&selector, "selector", "l", "", "label selector to determine which tests are run")
 	//	scorecardCmd.Flags().BoolVarP(&list, "list", "L", false, "option to enable listing which tests are run")

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -32,7 +32,7 @@ func NewCmd() *cobra.Command {
 		namespace      string
 		serviceAccount string
 		list           bool
-		cleanup        bool
+		skipCleanup        bool
 		waitTime       int
 	)
 	scorecardCmd := &cobra.Command{

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -93,7 +93,7 @@ func NewCmd() *cobra.Command {
 	scorecardCmd.Flags().StringVarP(&selector, "selector", "l", "", "label selector to determine which tests are run")
 	scorecardCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "namespace to run the test images in")
 	scorecardCmd.Flags().StringVarP(&output, "output", "o", "text", "Output format for results.  Valid values: text, json")
-	scorecardCmd.Flags().StringVarP(&serviceAccount, "service-account", "s", "default", "service account to run the test images")
+	scorecardCmd.Flags().StringVarP(&serviceAccount, "service-account", "s", "default", "service account to use for tests")
 	scorecardCmd.Flags().BoolVarP(&list, "list", "L", false, "option to enable listing which tests are run")
 	scorecardCmd.Flags().BoolVarP(&cleanup, "cleanup", "x", true, "option to disable resource cleanup after tests are run")
 	scorecardCmd.Flags().IntVarP(&waitTime, "wait-time", "w", 30, "time in seconds to wait for tests to complete")

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -25,9 +25,9 @@ import (
 
 func NewCmd() *cobra.Command {
 	var (
-		config string
-		output string
-		//bundle   string // TODO - to be implemented
+		config         string
+		output         string
+		bundle         string
 		selector       string
 		kubeconfig     string
 		namespace      string
@@ -52,17 +52,20 @@ func NewCmd() *cobra.Command {
 				return fmt.Errorf("could not find config file %s", err.Error())
 			}
 
+			if bundle == "" {
+				return fmt.Errorf("bundle flag required")
+			}
+
 			o.ServiceAccount = serviceAccount
 			o.Namespace = namespace
 			o.List = list
+			o.BundlePath = bundle
 			o.OutputFormat = output
 
 			o.Selector, err = labels.Parse(selector)
 			if err != nil {
 				return fmt.Errorf("could not parse selector %s", err.Error())
 			}
-
-			// TODO - process list and output formatting here?
 
 			if list {
 				if err := scorecard.ListTests(o); err != nil {
@@ -82,7 +85,7 @@ func NewCmd() *cobra.Command {
 		"path to a new to be defined DSL yaml formatted file that configures what tests get executed")
 	scorecardCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "kubeconfig path")
 
-	//	scorecardCmd.Flags().StringVar(&bundle, "bundle", "", "path to the operator bundle contents on disk")
+	scorecardCmd.Flags().StringVar(&bundle, "bundle", "", "path to the operator bundle contents on disk")
 	scorecardCmd.Flags().StringVarP(&selector, "selector", "l", "", "label selector to determine which tests are run")
 	scorecardCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "namespace to run the test images in")
 	scorecardCmd.Flags().StringVarP(&output, "output", "o", "text", "Output format for results.  Valid values: text, json")

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -63,26 +63,27 @@ func NewCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("could not get kubernetes client: %w", err)
 			}
+
 			o.Config, err = scorecard.LoadConfig(config)
 			if err != nil {
-				return fmt.Errorf("could not find config file %s", err.Error())
+				return fmt.Errorf("could not find config file %w", err)
 			}
 
 			o.Selector, err = labels.Parse(selector)
 			if err != nil {
-				return fmt.Errorf("could not parse selector %s", err.Error())
+				return fmt.Errorf("could not parse selector %w", err)
 			}
 
 			var scorecardOutput v1alpha2.ScorecardOutput
 			if list {
 				scorecardOutput, err = scorecard.ListTests(o)
 				if err != nil {
-					return fmt.Errorf("error listing tests %s", err.Error())
+					return fmt.Errorf("error listing tests %w", err)
 				}
 			} else {
 				scorecardOutput, err = scorecard.RunTests(o)
 				if err != nil {
-					return fmt.Errorf("error running tests %s", err.Error())
+					return fmt.Errorf("error running tests %w", err)
 				}
 			}
 

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -17,6 +17,8 @@ package scorecard
 import (
 	"fmt"
 
+	"time"
+
 	scorecard "github.com/operator-framework/operator-sdk/internal/scorecard/alpha"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/labels"
@@ -32,7 +34,7 @@ func NewCmd() *cobra.Command {
 		namespace      string
 		serviceAccount string
 		list           bool
-		skipCleanup        bool
+		skipCleanup    bool
 		waitTime       time.Duration
 	)
 	scorecardCmd := &cobra.Command{
@@ -46,10 +48,9 @@ func NewCmd() *cobra.Command {
 			o := scorecard.Options{
 				ServiceAccount: serviceAccount,
 				Namespace:      namespace,
-				List:           list,
 				BundlePath:     bundle,
 				OutputFormat:   output,
-				Cleanup:        cleanup,
+				Cleanup:        skipCleanup,
 				WaitTime:       waitTime,
 			}
 			o.Client, err = scorecard.GetKubeClient(kubeconfig)
@@ -88,8 +89,8 @@ func NewCmd() *cobra.Command {
 	scorecardCmd.Flags().StringVarP(&output, "output", "o", "text", "Output format for results.  Valid values: text, json")
 	scorecardCmd.Flags().StringVarP(&serviceAccount, "service-account", "s", "default", "service account to use for tests")
 	scorecardCmd.Flags().BoolVarP(&list, "list", "L", false, "option to enable listing which tests are run")
-	scorecardCmd.Flags().BoolVarP(&cleanup, "cleanup", "x", true, "option to disable resource cleanup after tests are run")
-	scorecardCmd.Flags().IntVarP(&waitTime, "wait-time", "w", 30, "time in seconds to wait for tests to complete")
+	scorecardCmd.Flags().BoolVarP(&skipCleanup, "skip-cleanup", "x", true, "option to disable resource cleanup after tests are run")
+	scorecardCmd.Flags().DurationVarP(&waitTime, "wait-time", "w", time.Duration(30*time.Second), "time in seconds to wait for tests to complete")
 
 	return scorecardCmd
 }

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -100,7 +100,7 @@ func NewCmd() *cobra.Command {
 		"Output format for results.  Valid values: text, json")
 	scorecardCmd.Flags().StringVarP(&serviceAccount, "service-account", "s", "default", "Service account to use for tests")
 	scorecardCmd.Flags().BoolVarP(&list, "list", "L", false, "Option to enable listing which tests are run")
-	scorecardCmd.Flags().BoolVarP(&skipCleanup, "skip-cleanup", "x", true, "Disable resource cleanup after tests are run")
+	scorecardCmd.Flags().BoolVarP(&skipCleanup, "skip-cleanup", "x", false, "Disable resource cleanup after tests are run")
 	scorecardCmd.Flags().DurationVarP(&waitTime, "wait-time", "w", time.Duration(30*time.Second),
 		"seconds to wait for tests to complete. Example: 35s")
 

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -47,7 +47,7 @@ func NewCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			var err error
-			o := scorecard.Options{
+			o := scorecard.Scorecard{
 				ServiceAccount: serviceAccount,
 				Namespace:      namespace,
 				BundlePath:     bundle,
@@ -76,12 +76,12 @@ func NewCmd() *cobra.Command {
 
 			var scorecardOutput v1alpha2.ScorecardOutput
 			if list {
-				scorecardOutput, err = scorecard.ListTests(o)
+				scorecardOutput, err = o.ListTests()
 				if err != nil {
 					return fmt.Errorf("error listing tests %w", err)
 				}
 			} else {
-				scorecardOutput, err = scorecard.RunTests(o)
+				scorecardOutput, err = o.RunTests()
 				if err != nil {
 					return fmt.Errorf("error running tests %w", err)
 				}

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -51,7 +51,7 @@ func NewCmd() *cobra.Command {
 				ServiceAccount: serviceAccount,
 				Namespace:      namespace,
 				BundlePath:     bundle,
-				Cleanup:        skipCleanup,
+				SkipCleanup:    skipCleanup,
 				WaitTime:       waitTime,
 			}
 			o.Client, err = scorecard.GetKubeClient(kubeconfig)

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -33,7 +33,7 @@ func NewCmd() *cobra.Command {
 		serviceAccount string
 		list           bool
 		skipCleanup        bool
-		waitTime       int
+		waitTime       time.Duration
 	)
 	scorecardCmd := &cobra.Command{
 		Use:    "scorecard",

--- a/hack/image/build-scorecard-test-image.sh
+++ b/hack/image/build-scorecard-test-image.sh
@@ -4,14 +4,14 @@ set -eux
 
 source hack/lib/image_lib.sh
 
-# TODO build test image
-#WD="$(dirname "$(pwd)")"
-#GOOS=linux CGO_ENABLED=0 \
-#  go build \
-#  -gcflags "all=-trimpath=${WD}" \
-#  -asmflags "all=-trimpath=${WD}" \
-#  -o images/scorecard-test/scorecard-test \
-#  images/scorecard-test/cmd/test/main.go
+# build scorecard test image
+WD="$(dirname "$(pwd)")"
+GOOS=linux CGO_ENABLED=0 \
+  go build \
+  -gcflags "all=-trimpath=${WD}" \
+  -asmflags "all=-trimpath=${WD}" \
+  -o images/scorecard-test/scorecard-test \
+  images/scorecard-test/cmd/test/main.go
 
 # Build base image
 pushd images/scorecard-test

--- a/images/scorecard-test/Dockerfile
+++ b/images/scorecard-test/Dockerfile
@@ -5,12 +5,11 @@ ENV TEST=/usr/local/bin/scorecard-test \
     USER_UID=1001 \
     USER_NAME=test
 
-# TODO install test binary 
-# COPY scorecard-test ${TEST}
+# install test binary 
+COPY scorecard-test ${TEST}
 
 COPY bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
-
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 

--- a/images/scorecard-test/cmd/test/main.go
+++ b/images/scorecard-test/cmd/test/main.go
@@ -77,8 +77,6 @@ func main() {
 		result = tests.SpecDescriptorsTest(cfg)
 	case tests.OLMStatusDescriptorsTest:
 		result = tests.StatusDescriptorsTest(cfg)
-	case tests.BasicCheckStatusTest:
-		result = tests.CheckStatusTest(cfg)
 	case tests.BasicCheckSpecTest:
 		result = tests.CheckSpecTest(cfg)
 	default:
@@ -104,7 +102,6 @@ func printValidTests() (result v1alpha2.ScorecardTestResult) {
 		tests.OLMCRDsHaveResourcesTest,
 		tests.OLMSpecDescriptorsTest,
 		tests.OLMStatusDescriptorsTest,
-		tests.BasicCheckStatusTest,
 		tests.BasicCheckSpecTest)
 	result.Suggestions = append(result.Suggestions, str)
 	return result

--- a/images/scorecard-test/cmd/test/main.go
+++ b/images/scorecard-test/cmd/test/main.go
@@ -50,7 +50,7 @@ func main() {
 		log.Fatal("test name argument is required")
 	}
 
-	// Create tmp directory for the unzipped bundle
+	// Create tmp directory for the untar'd bundle
 	tmpDir, err := ioutil.TempDir("/tmp", "scorecard-bundle")
 	if err != nil {
 		log.Fatal(err)

--- a/images/scorecard-test/cmd/test/main.go
+++ b/images/scorecard-test/cmd/test/main.go
@@ -96,7 +96,7 @@ func printValidTests() (result v1alpha2.ScorecardTestResult) {
 	result.Errors = make([]string, 0)
 	result.Suggestions = make([]string, 0)
 
-	str := fmt.Sprintf("Valid tests for this image include: %s, %s, %s, %s, %s, %s, %s",
+	str := fmt.Sprintf("Valid tests for this image include: %s, %s, %s, %s, %s, %s",
 		tests.OLMBundleValidationTest,
 		tests.OLMCRDsHaveValidationTest,
 		tests.OLMCRDsHaveResourcesTest,

--- a/images/scorecard-test/cmd/test/main.go
+++ b/images/scorecard-test/cmd/test/main.go
@@ -69,17 +69,17 @@ func main() {
 
 	switch entrypoint[0] {
 	case tests.OLMBundleValidationTest:
-		result = tests.BundleValidationTest(cfg)
+		result = tests.BundleValidationTest(*cfg)
 	case tests.OLMCRDsHaveValidationTest:
-		result = tests.CRDsHaveValidationTest(cfg)
+		result = tests.CRDsHaveValidationTest(*cfg)
 	case tests.OLMCRDsHaveResourcesTest:
-		result = tests.CRDsHaveResourcesTest(cfg)
+		result = tests.CRDsHaveResourcesTest(*cfg)
 	case tests.OLMSpecDescriptorsTest:
-		result = tests.SpecDescriptorsTest(cfg)
+		result = tests.SpecDescriptorsTest(*cfg)
 	case tests.OLMStatusDescriptorsTest:
-		result = tests.StatusDescriptorsTest(cfg)
+		result = tests.StatusDescriptorsTest(*cfg)
 	case tests.BasicCheckSpecTest:
-		result = tests.CheckSpecTest(cfg)
+		result = tests.CheckSpecTest(*cfg)
 	default:
 		result = printValidTests()
 	}

--- a/images/scorecard-test/cmd/test/main.go
+++ b/images/scorecard-test/cmd/test/main.go
@@ -55,7 +55,7 @@ func main() {
 	}
 	defer os.Remove(tmpDir)
 
-	err = alpha.Untartar(bundleTar, tmpDir)
+	err = alpha.UntarFile(bundleTar, tmpDir)
 	if err != nil {
 		log.Fatalf("error untarring bundle %s", err.Error())
 	}

--- a/images/scorecard-test/cmd/test/main.go
+++ b/images/scorecard-test/cmd/test/main.go
@@ -105,6 +105,6 @@ func printValidTests() (result v1alpha2.ScorecardTestResult) {
 		tests.OLMSpecDescriptorsTest,
 		tests.OLMStatusDescriptorsTest,
 		tests.BasicCheckSpecTest)
-	result.Suggestions = append(result.Suggestions, str)
+	result.Errors = append(result.Errors, str)
 	return result
 }

--- a/images/scorecard-test/cmd/test/main.go
+++ b/images/scorecard-test/cmd/test/main.go
@@ -15,15 +15,11 @@
 package main
 
 import (
-	"archive/zip"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
 	scapiv1alpha2 "github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
@@ -58,13 +54,6 @@ func main() {
 	}
 	defer os.Remove(tmpDir)
 
-	// Unzip the bundle
-	/**
-	_, err = Unzip(bundleZip, tmpDir)
-	if err != nil {
-		log.Fatalf("error unzipping bundle %s", err.Error())
-	}
-	*/
 	err = alpha.Untartar(bundleZip, tmpDir)
 	if err != nil {
 		log.Fatalf("error untarring bundle %s", err.Error())
@@ -102,64 +91,6 @@ func main() {
 	}
 	fmt.Printf("%s\n", string(prettyJSON))
 
-}
-
-// Unzip will decompress a zip archive, moving all files and folders
-// within the zip file (parameter 1) to an output directory (parameter 2).
-func Unzip(src string, dest string) ([]string, error) {
-
-	var filenames []string
-
-	r, err := zip.OpenReader(src)
-	if err != nil {
-		return filenames, err
-	}
-	defer r.Close()
-
-	for _, f := range r.File {
-
-		// Store filename/path for returning and using later on
-		fpath := filepath.Join(dest, f.Name)
-
-		// Check for ZipSlip. More Info: http://bit.ly/2MsjAWE
-		if !strings.HasPrefix(fpath, filepath.Clean(dest)+string(os.PathSeparator)) {
-			return filenames, fmt.Errorf("%s: illegal file path", fpath)
-		}
-
-		filenames = append(filenames, fpath)
-
-		if f.FileInfo().IsDir() {
-			// Make Folder
-			os.MkdirAll(fpath, os.ModePerm)
-			continue
-		}
-
-		// Make File
-		if err = os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
-			return filenames, err
-		}
-
-		outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-		if err != nil {
-			return filenames, err
-		}
-
-		rc, err := f.Open()
-		if err != nil {
-			return filenames, err
-		}
-
-		_, err = io.Copy(outFile, rc)
-
-		// Close the file without defer to close before next iteration of loop
-		outFile.Close()
-		rc.Close()
-
-		if err != nil {
-			return filenames, err
-		}
-	}
-	return filenames, nil
 }
 
 func printValidTests() (result v1alpha2.ScorecardTestResult) {

--- a/images/scorecard-test/cmd/test/main.go
+++ b/images/scorecard-test/cmd/test/main.go
@@ -15,10 +15,15 @@
 package main
 
 import (
+	"archive/zip"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
+	"strings"
 
 	scapiv1alpha2 "github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
 
@@ -35,7 +40,7 @@ import (
 // test image.
 
 const (
-	bundlePath = "/scorecard"
+	bundleZip = "/scorecard/bundle.zip"
 )
 
 func main() {
@@ -44,7 +49,23 @@ func main() {
 		log.Fatal("test name argument is required")
 	}
 
-	cfg, err := tests.GetBundle(bundlePath)
+	// Create tmp directory for the unzipped bundle
+	tmpDir, err := ioutil.TempDir("/tmp", "scorecard-bundle")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpDir)
+
+	// TODO remove this log
+	log.Printf("directory %s\n", tmpDir)
+
+	// Unzip the bundle
+	_, err = Unzip(bundleZip, tmpDir)
+	if err != nil {
+		log.Fatalf("error unzipping bundle %s", err.Error())
+	}
+
+	cfg, err := tests.GetBundle(tmpDir)
 	if err != nil {
 		log.Fatal(err.Error())
 	}
@@ -78,4 +99,62 @@ func main() {
 	}
 	fmt.Printf("%s\n", string(prettyJSON))
 
+}
+
+// Unzip will decompress a zip archive, moving all files and folders
+// within the zip file (parameter 1) to an output directory (parameter 2).
+func Unzip(src string, dest string) ([]string, error) {
+
+	var filenames []string
+
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return filenames, err
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+
+		// Store filename/path for returning and using later on
+		fpath := filepath.Join(dest, f.Name)
+
+		// Check for ZipSlip. More Info: http://bit.ly/2MsjAWE
+		if !strings.HasPrefix(fpath, filepath.Clean(dest)+string(os.PathSeparator)) {
+			return filenames, fmt.Errorf("%s: illegal file path", fpath)
+		}
+
+		filenames = append(filenames, fpath)
+
+		if f.FileInfo().IsDir() {
+			// Make Folder
+			os.MkdirAll(fpath, os.ModePerm)
+			continue
+		}
+
+		// Make File
+		if err = os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
+			return filenames, err
+		}
+
+		outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+		if err != nil {
+			return filenames, err
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			return filenames, err
+		}
+
+		_, err = io.Copy(outFile, rc)
+
+		// Close the file without defer to close before next iteration of loop
+		outFile.Close()
+		rc.Close()
+
+		if err != nil {
+			return filenames, err
+		}
+	}
+	return filenames, nil
 }

--- a/images/scorecard-test/cmd/test/main.go
+++ b/images/scorecard-test/cmd/test/main.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
 	scapiv1alpha2 "github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
 
 	"github.com/operator-framework/operator-sdk/internal/scorecard/alpha/tests"
@@ -85,9 +86,7 @@ func main() {
 	case tests.BasicCheckSpecTest:
 		result = tests.CheckSpecTest(cfg)
 	default:
-		log.Fatal("invalid test name argument passed")
-		// TODO print out full list of test names to give a hint
-		// to the end user on what the valid tests are
+		result = printValidTests()
 	}
 
 	prettyJSON, err := json.MarshalIndent(result, "", "    ")
@@ -154,4 +153,21 @@ func Unzip(src string, dest string) ([]string, error) {
 		}
 	}
 	return filenames, nil
+}
+
+func printValidTests() (result v1alpha2.ScorecardTestResult) {
+	result.State = scapiv1alpha2.FailState
+	result.Errors = make([]string, 0)
+	result.Suggestions = make([]string, 0)
+
+	str := fmt.Sprintf("Valid tests for this image include: %s, %s, %s, %s, %s, %s, %s",
+		tests.OLMBundleValidationTest,
+		tests.OLMCRDsHaveValidationTest,
+		tests.OLMCRDsHaveResourcesTest,
+		tests.OLMSpecDescriptorsTest,
+		tests.OLMStatusDescriptorsTest,
+		tests.BasicCheckStatusTest,
+		tests.BasicCheckSpecTest)
+	result.Suggestions = append(result.Suggestions, str)
+	return result
 }

--- a/images/scorecard-test/cmd/test/main.go
+++ b/images/scorecard-test/cmd/test/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
 	scapiv1alpha2 "github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
 
+	"github.com/operator-framework/operator-sdk/internal/scorecard/alpha"
 	"github.com/operator-framework/operator-sdk/internal/scorecard/alpha/tests"
 )
 
@@ -58,9 +59,15 @@ func main() {
 	defer os.Remove(tmpDir)
 
 	// Unzip the bundle
+	/**
 	_, err = Unzip(bundleZip, tmpDir)
 	if err != nil {
 		log.Fatalf("error unzipping bundle %s", err.Error())
+	}
+	*/
+	err = alpha.Untartar(bundleZip, tmpDir)
+	if err != nil {
+		log.Fatalf("error untarring bundle %s", err.Error())
 	}
 
 	cfg, err := tests.GetBundle(tmpDir)

--- a/images/scorecard-test/cmd/test/main.go
+++ b/images/scorecard-test/cmd/test/main.go
@@ -38,7 +38,8 @@ import (
 // test image.
 
 const (
-	bundleZip = "/scorecard/bundle.zip"
+	// bundleTar is the tar file containing the bundle contents
+	bundleTar = "/scorecard/bundle.tar"
 )
 
 func main() {
@@ -54,7 +55,7 @@ func main() {
 	}
 	defer os.Remove(tmpDir)
 
-	err = alpha.Untartar(bundleZip, tmpDir)
+	err = alpha.Untartar(bundleTar, tmpDir)
 	if err != nil {
 		log.Fatalf("error untarring bundle %s", err.Error())
 	}
@@ -91,6 +92,7 @@ func main() {
 
 }
 
+// printValidTests will print out full list of test names to give a hint to the end user on what the valid tests are
 func printValidTests() (result v1alpha2.ScorecardTestResult) {
 	result.State = scapiv1alpha2.FailState
 	result.Errors = make([]string, 0)

--- a/images/scorecard-test/cmd/test/main.go
+++ b/images/scorecard-test/cmd/test/main.go
@@ -56,9 +56,6 @@ func main() {
 	}
 	defer os.Remove(tmpDir)
 
-	// TODO remove this log
-	log.Printf("directory %s\n", tmpDir)
-
 	// Unzip the bundle
 	_, err = Unzip(bundleZip, tmpDir)
 	if err != nil {

--- a/internal/scorecard/alpha/bundle.go
+++ b/internal/scorecard/alpha/bundle.go
@@ -1,0 +1,164 @@
+package alpha
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func getBundleData(bundlePath string) (bundleData []byte, err error) {
+
+	// make sure the bundle exists on disk
+	_, err = os.Stat(bundlePath)
+	if os.IsNotExist(err) {
+		return bundleData, fmt.Errorf("bundle path is not valid %s", err.Error())
+	}
+
+	// tar up the bundle contents into a file
+	src := bundlePath
+	var buf bytes.Buffer
+	err = Tar(src, &buf)
+	if err != nil {
+		return bundleData, fmt.Errorf("error creating tar of bundle %s", err.Error())
+	}
+	//fmt.Printf("len %d\n", len(buf.Bytes()))
+
+	return buf.Bytes(), err
+}
+
+// Tar takes a source and variable writers and walks 'source' writing each file
+// found to the tar writer; the purpose for accepting multiple writers is to allow
+// for multiple outputs (for example a file, or md5 hash)
+func Tar(src string, writers ...io.Writer) error {
+
+	// ensure the src actually exists before trying to tar it
+	if _, err := os.Stat(src); err != nil {
+		return fmt.Errorf("Unable to tar files - %v", err.Error())
+	}
+
+	mw := io.MultiWriter(writers...)
+
+	gzw := gzip.NewWriter(mw)
+	defer gzw.Close()
+
+	tw := tar.NewWriter(gzw)
+	defer tw.Close()
+
+	// walk path
+	return filepath.Walk(src, func(file string, fi os.FileInfo, err error) error {
+
+		// return on any error
+		if err != nil {
+			return err
+		}
+
+		// return on non-regular files (thanks to [kumo](https://medium.com/@komuw/just-like-you-did-fbdd7df829d3) for this suggested update)
+		if !fi.Mode().IsRegular() {
+			return nil
+		}
+
+		// create a new dir/file header
+		header, err := tar.FileInfoHeader(fi, fi.Name())
+		if err != nil {
+			return err
+		}
+
+		// update the name to correctly reflect the desired destination when untaring
+		header.Name = strings.TrimPrefix(strings.Replace(file, src, "", -1), string(filepath.Separator))
+
+		// write the header
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+
+		// open files for taring
+		f, err := os.Open(file)
+		if err != nil {
+			return err
+		}
+
+		// copy file data into tar writer
+		if _, err := io.Copy(tw, f); err != nil {
+			return err
+		}
+
+		// manually close here after each file operation; defering would cause each file close
+		// to wait until all operations have completed.
+		f.Close()
+
+		return nil
+	})
+
+}
+
+// Untar takes a destination path and a reader; a tar reader loops over the tarfile
+// creating the file structure at 'dst' along the way, and writing any files
+func Untar(dst string, r io.Reader) error {
+
+	gzr, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+
+	for {
+		header, err := tr.Next()
+
+		switch {
+
+		// if no more files are found return
+		case err == io.EOF:
+			return nil
+
+			// return any other error
+		case err != nil:
+			return err
+
+			// if the header is nil, just skip it (not sure how this happens)
+		case header == nil:
+			continue
+		}
+
+		// the target location where the dir/file should be created
+		target := filepath.Join(dst, header.Name)
+
+		// the following switch could also be done using fi.Mode(), not sure if there
+		// a benefit of using one vs. the other.
+		// fi := header.FileInfo()
+
+		// check the file type
+		switch header.Typeflag {
+
+		// if its a dir and it doesn't exist create it
+		case tar.TypeDir:
+			if _, err := os.Stat(target); err != nil {
+				if err := os.MkdirAll(target, 0755); err != nil {
+					return err
+				}
+			}
+
+			// if it's a file create it
+		case tar.TypeReg:
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+
+			// copy over contents
+			if _, err := io.Copy(f, tr); err != nil {
+				return err
+			}
+
+			// manually close here after each file operation; defering would cause each file close
+			// to wait until all operations have completed.
+			f.Close()
+		}
+	}
+}

--- a/internal/scorecard/alpha/bundle.go
+++ b/internal/scorecard/alpha/bundle.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 // getBundleData tars up the contents of a bundle from a path, and returns that tar file in []byte
@@ -29,7 +31,7 @@ func getBundleData(bundlePath string) (bundleData []byte, err error) {
 		return bundleData, fmt.Errorf("bundle path is not valid %s", err.Error())
 	}
 
-	tempTarFileName := fmt.Sprintf("%s%ctempBundle-%s.tar", os.TempDir(), os.PathSeparator, randomString())
+	tempTarFileName := fmt.Sprintf("%s%ctempBundle-%s.tar", os.TempDir(), os.PathSeparator, rand.String(4))
 
 	paths := []string{bundlePath}
 	err = CreateTarFile(tempTarFileName, paths)

--- a/internal/scorecard/alpha/bundle.go
+++ b/internal/scorecard/alpha/bundle.go
@@ -20,6 +20,7 @@ import (
 	"os"
 )
 
+// getBundleData tars up the contents of a bundle from a path, and returns that tar file in []byte
 func getBundleData(bundlePath string) (bundleData []byte, err error) {
 
 	// make sure the bundle exists on disk
@@ -28,14 +29,18 @@ func getBundleData(bundlePath string) (bundleData []byte, err error) {
 		return bundleData, fmt.Errorf("bundle path is not valid %s", err.Error())
 	}
 
+	tempTarFileName := fmt.Sprintf("%s%ctempBundle-%s.tar", os.TempDir(), os.PathSeparator, randomString())
+
 	paths := []string{bundlePath}
-	err = Tartar("/tmp/my.tar", paths)
+	err = Tartar(tempTarFileName, paths)
 	if err != nil {
 		return bundleData, fmt.Errorf("error creating tar of bundle %s", err.Error())
 	}
 
+	defer os.Remove(tempTarFileName)
+
 	var buf []byte
-	buf, err = ioutil.ReadFile("/tmp/my.tar")
+	buf, err = ioutil.ReadFile(tempTarFileName)
 	if err != nil {
 		return bundleData, fmt.Errorf("error reading tar of bundle %s", err.Error())
 	}

--- a/internal/scorecard/alpha/bundle.go
+++ b/internal/scorecard/alpha/bundle.go
@@ -1,14 +1,9 @@
 package alpha
 
 import (
-	"archive/tar"
-	"bytes"
-	"compress/gzip"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"os"
-	"path/filepath"
-	"strings"
 )
 
 func getBundleData(bundlePath string) (bundleData []byte, err error) {
@@ -19,146 +14,19 @@ func getBundleData(bundlePath string) (bundleData []byte, err error) {
 		return bundleData, fmt.Errorf("bundle path is not valid %s", err.Error())
 	}
 
-	// tar up the bundle contents into a file
-	src := bundlePath
-	var buf bytes.Buffer
-	err = Tar(src, &buf)
+	paths := []string{bundlePath}
+	err = Tartar("/tmp/my.tar", paths)
 	if err != nil {
 		return bundleData, fmt.Errorf("error creating tar of bundle %s", err.Error())
 	}
-	//fmt.Printf("len %d\n", len(buf.Bytes()))
 
-	return buf.Bytes(), err
-}
-
-// Tar takes a source and variable writers and walks 'source' writing each file
-// found to the tar writer; the purpose for accepting multiple writers is to allow
-// for multiple outputs (for example a file, or md5 hash)
-func Tar(src string, writers ...io.Writer) error {
-
-	// ensure the src actually exists before trying to tar it
-	if _, err := os.Stat(src); err != nil {
-		return fmt.Errorf("Unable to tar files - %v", err.Error())
-	}
-
-	mw := io.MultiWriter(writers...)
-
-	gzw := gzip.NewWriter(mw)
-	defer gzw.Close()
-
-	tw := tar.NewWriter(gzw)
-	defer tw.Close()
-
-	// walk path
-	return filepath.Walk(src, func(file string, fi os.FileInfo, err error) error {
-
-		// return on any error
-		if err != nil {
-			return err
-		}
-
-		// return on non-regular files (thanks to [kumo](https://medium.com/@komuw/just-like-you-did-fbdd7df829d3) for this suggested update)
-		if !fi.Mode().IsRegular() {
-			return nil
-		}
-
-		// create a new dir/file header
-		header, err := tar.FileInfoHeader(fi, fi.Name())
-		if err != nil {
-			return err
-		}
-
-		// update the name to correctly reflect the desired destination when untaring
-		header.Name = strings.TrimPrefix(strings.Replace(file, src, "", -1), string(filepath.Separator))
-
-		// write the header
-		if err := tw.WriteHeader(header); err != nil {
-			return err
-		}
-
-		// open files for taring
-		f, err := os.Open(file)
-		if err != nil {
-			return err
-		}
-
-		// copy file data into tar writer
-		if _, err := io.Copy(tw, f); err != nil {
-			return err
-		}
-
-		// manually close here after each file operation; defering would cause each file close
-		// to wait until all operations have completed.
-		f.Close()
-
-		return nil
-	})
-
-}
-
-// Untar takes a destination path and a reader; a tar reader loops over the tarfile
-// creating the file structure at 'dst' along the way, and writing any files
-func Untar(dst string, r io.Reader) error {
-
-	gzr, err := gzip.NewReader(r)
+	var buf []byte
+	buf, err = ioutil.ReadFile("/tmp/my.tar")
 	if err != nil {
-		return err
+		return bundleData, fmt.Errorf("error reading tar of bundle %s", err.Error())
 	}
-	defer gzr.Close()
 
-	tr := tar.NewReader(gzr)
+	fmt.Printf("bundle bytes len %d\n", len(buf))
 
-	for {
-		header, err := tr.Next()
-
-		switch {
-
-		// if no more files are found return
-		case err == io.EOF:
-			return nil
-
-			// return any other error
-		case err != nil:
-			return err
-
-			// if the header is nil, just skip it (not sure how this happens)
-		case header == nil:
-			continue
-		}
-
-		// the target location where the dir/file should be created
-		target := filepath.Join(dst, header.Name)
-
-		// the following switch could also be done using fi.Mode(), not sure if there
-		// a benefit of using one vs. the other.
-		// fi := header.FileInfo()
-
-		// check the file type
-		switch header.Typeflag {
-
-		// if its a dir and it doesn't exist create it
-		case tar.TypeDir:
-			if _, err := os.Stat(target); err != nil {
-				if err := os.MkdirAll(target, 0755); err != nil {
-					return err
-				}
-			}
-
-			// if it's a file create it
-		case tar.TypeReg:
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
-			if err != nil {
-				return err
-			}
-
-			// copy over contents
-			if _, err := io.Copy(f, tr); err != nil {
-				return err
-			}
-
-			// manually close here after each file operation; defering would cause each file close
-			// to wait until all operations have completed.
-			f.Close()
-		}
-	}
+	return buf, err
 }

--- a/internal/scorecard/alpha/bundle.go
+++ b/internal/scorecard/alpha/bundle.go
@@ -28,7 +28,7 @@ func getBundleData(bundlePath string) (bundleData []byte, err error) {
 	// make sure the bundle exists on disk
 	_, err = os.Stat(bundlePath)
 	if os.IsNotExist(err) {
-		return bundleData, fmt.Errorf("bundle path is not valid %s", err.Error())
+		return bundleData, fmt.Errorf("bundle path is not valid %w", err)
 	}
 
 	tempTarFileName := fmt.Sprintf("%s%ctempBundle-%s.tar", os.TempDir(), os.PathSeparator, rand.String(4))
@@ -36,7 +36,7 @@ func getBundleData(bundlePath string) (bundleData []byte, err error) {
 	paths := []string{bundlePath}
 	err = CreateTarFile(tempTarFileName, paths)
 	if err != nil {
-		return bundleData, fmt.Errorf("error creating tar of bundle %s", err.Error())
+		return bundleData, fmt.Errorf("error creating tar of bundle %w", err)
 	}
 
 	defer os.Remove(tempTarFileName)
@@ -44,7 +44,7 @@ func getBundleData(bundlePath string) (bundleData []byte, err error) {
 	var buf []byte
 	buf, err = ioutil.ReadFile(tempTarFileName)
 	if err != nil {
-		return bundleData, fmt.Errorf("error reading tar of bundle %s", err.Error())
+		return bundleData, fmt.Errorf("error reading tar of bundle %w", err)
 	}
 
 	return buf, err

--- a/internal/scorecard/alpha/bundle.go
+++ b/internal/scorecard/alpha/bundle.go
@@ -1,3 +1,17 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package alpha
 
 import (
@@ -25,8 +39,6 @@ func getBundleData(bundlePath string) (bundleData []byte, err error) {
 	if err != nil {
 		return bundleData, fmt.Errorf("error reading tar of bundle %s", err.Error())
 	}
-
-	fmt.Printf("bundle bytes len %d\n", len(buf))
 
 	return buf, err
 }

--- a/internal/scorecard/alpha/bundle.go
+++ b/internal/scorecard/alpha/bundle.go
@@ -32,7 +32,7 @@ func getBundleData(bundlePath string) (bundleData []byte, err error) {
 	tempTarFileName := fmt.Sprintf("%s%ctempBundle-%s.tar", os.TempDir(), os.PathSeparator, randomString())
 
 	paths := []string{bundlePath}
-	err = Tartar(tempTarFileName, paths)
+	err = CreateTarFile(tempTarFileName, paths)
 	if err != nil {
 		return bundleData, fmt.Errorf("error creating tar of bundle %s", err.Error())
 	}

--- a/internal/scorecard/alpha/config.go
+++ b/internal/scorecard/alpha/config.go
@@ -17,7 +17,7 @@ package alpha
 import (
 	"io/ioutil"
 
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 	v1 "k8s.io/api/core/v1"
 )
 

--- a/internal/scorecard/alpha/config.go
+++ b/internal/scorecard/alpha/config.go
@@ -17,11 +17,11 @@ package alpha
 import (
 	"io/ioutil"
 
-	"sigs.k8s.io/yaml"
 	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
 )
 
-type ScorecardTest struct {
+type Test struct {
 	Name        string            `yaml:"name"`                 // The container test name
 	Image       string            `yaml:"image"`                // The container image name
 	Entrypoint  string            `yaml:"entrypoint,omitempty"` // An optional entrypoint passed to the test image
@@ -33,7 +33,7 @@ type ScorecardTest struct {
 // Config represents the set of test configurations which scorecard
 // would run based on user input
 type Config struct {
-	Tests []ScorecardTest `yaml:"tests"`
+	Tests []Test `yaml:"tests"`
 }
 
 // LoadConfig will find and return the scorecard config, the config file

--- a/internal/scorecard/alpha/config.go
+++ b/internal/scorecard/alpha/config.go
@@ -22,12 +22,13 @@ import (
 )
 
 type Test struct {
-	Name        string            `yaml:"name"`                 // The container test name
-	Image       string            `yaml:"image"`                // The container image name
-	Entrypoint  string            `yaml:"entrypoint,omitempty"` // An optional entrypoint passed to the test image
-	Labels      map[string]string `yaml:"labels"`               // User defined labels used to filter tests
-	Description string            `yaml:"description"`          // User readable test description
-	TestPod     *v1.Pod           `yaml:"-"`                    // Pod that ran the test
+	Name  string `yaml:"name"`  // The container test name
+	Image string `yaml:"image"` // The container image name
+	// An list of commands and arguments passed to the test image
+	Entrypoint  []string          `yaml:"entrypoint,omitempty"`
+	Labels      map[string]string `yaml:"labels"`      // User defined labels used to filter tests
+	Description string            `yaml:"description"` // User readable test description
+	TestPod     *v1.Pod           `yaml:"-"`           // Pod that ran the test
 }
 
 // Config represents the set of test configurations which scorecard

--- a/internal/scorecard/alpha/config.go
+++ b/internal/scorecard/alpha/config.go
@@ -14,16 +14,43 @@
 
 package alpha
 
+import (
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+	v1 "k8s.io/api/core/v1"
+)
+
 type ScorecardTest struct {
 	Name        string            `yaml:"name"`                 // The container test name
 	Image       string            `yaml:"image"`                // The container image name
 	Entrypoint  string            `yaml:"entrypoint,omitempty"` // An optional entrypoint passed to the test image
 	Labels      map[string]string `yaml:"labels"`               // User defined labels used to filter tests
 	Description string            `yaml:"description"`          // User readable test description
+	TestPod     *v1.Pod           `yaml:"-"`                    // Pod that ran the test
 }
 
 // Config represents the set of test configurations which scorecard
 // would run based on user input
 type Config struct {
 	Tests []ScorecardTest `yaml:"tests"`
+}
+
+// LoadConfig will find and return the scorecard config, the config file
+// can be passed in via command line flag or from a bundle location or
+// bundle image
+func LoadConfig(configFilePath string) (Config, error) {
+	c := Config{}
+
+	// TODO handle getting config from bundle (ondisk or image)
+	yamlFile, err := ioutil.ReadFile(configFilePath)
+	if err != nil {
+		return c, err
+	}
+
+	if err := yaml.Unmarshal(yamlFile, &c); err != nil {
+		return c, err
+	}
+
+	return c, nil
 }

--- a/internal/scorecard/alpha/config_test.go
+++ b/internal/scorecard/alpha/config_test.go
@@ -30,11 +30,12 @@ func TestInvalidConfigPath(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.configPathValue, func(t *testing.T) {
 			_, err := LoadConfig(c.configPathValue)
-			if err != nil && c.wantError {
-				t.Logf("Wanted error and got error : %v", err)
-				return
-			} else if err != nil && !c.wantError {
-				t.Errorf("Wanted result but got error: %v", err)
+			if err == nil && c.wantError {
+				t.Fatalf("Wanted error but got no error")
+			} else if err != nil {
+				if !c.wantError {
+					t.Fatalf("Wanted result but got error: %v", err)
+				}
 				return
 			}
 

--- a/internal/scorecard/alpha/formatting.go
+++ b/internal/scorecard/alpha/formatting.go
@@ -74,7 +74,7 @@ func printOutput(outputFormat string, output v1alpha2.ScorecardOutput) {
 	if outputFormat == "text" {
 		o, err := output.MarshalText()
 		if err != nil {
-			fmt.Printf(err.Error())
+			fmt.Println(err.Error())
 			return
 		}
 		fmt.Printf("%s\n", o)
@@ -83,13 +83,13 @@ func printOutput(outputFormat string, output v1alpha2.ScorecardOutput) {
 	if outputFormat == "json" {
 		bytes, err := json.MarshalIndent(output, "", "  ")
 		if err != nil {
-			fmt.Printf(err.Error())
+			fmt.Println(err.Error())
 			return
 		}
 		fmt.Printf("%s\n", string(bytes))
 		return
 	}
 
-	fmt.Printf("error, invalid output format selected")
+	fmt.Println("error, invalid output format selected")
 
 }

--- a/internal/scorecard/alpha/formatting.go
+++ b/internal/scorecard/alpha/formatting.go
@@ -56,7 +56,7 @@ func getTestResults(client kubernetes.Interface, tests []Test) (output v1alpha2.
 
 // ListTests lists the scorecard tests as configured that would be
 // run based on user selection
-func ListTests(o Options) (output v1alpha2.ScorecardOutput, err error) {
+func (o Scorecard) ListTests() (output v1alpha2.ScorecardOutput, err error) {
 	tests := selectTests(o.Selector, o.Config.Tests)
 	if len(tests) == 0 {
 		fmt.Println("no tests selected")

--- a/internal/scorecard/alpha/formatting.go
+++ b/internal/scorecard/alpha/formatting.go
@@ -47,14 +47,13 @@ func getTestResults(client kubernetes.Interface, tests []ScorecardTest) (output 
 
 // ListTests lists the scorecard tests as configured that would be
 // run based on user selection
-func ListTests(o Options) error {
+func ListTests(o Options) (output v1alpha2.ScorecardOutput, err error) {
 	tests := selectTests(o.Selector, o.Config.Tests)
 	if len(tests) == 0 {
 		fmt.Println("no tests selected")
-		return nil
+		return output, err
 	}
 
-	output := v1alpha2.ScorecardOutput{}
 	output.Results = make([]v1alpha2.ScorecardTestResult, 0)
 
 	for i := 0; i < len(tests); i++ {
@@ -65,30 +64,5 @@ func ListTests(o Options) error {
 		output.Results = append(output.Results, testResult)
 	}
 
-	err := printOutput(o.OutputFormat, output)
-
-	return err
-}
-
-func printOutput(outputFormat string, output v1alpha2.ScorecardOutput) error {
-	switch outputFormat {
-	case "text":
-		o, err := output.MarshalText()
-		if err != nil {
-			fmt.Println(err.Error())
-			return err
-		}
-		fmt.Printf("%s\n", o)
-	case "json":
-		bytes, err := json.MarshalIndent(output, "", "  ")
-		if err != nil {
-			fmt.Println(err.Error())
-			return err
-		}
-		fmt.Printf("%s\n", string(bytes))
-	default:
-		return fmt.Errorf("invalid output format selected")
-	}
-	return nil
-
+	return output, err
 }

--- a/internal/scorecard/alpha/formatting.go
+++ b/internal/scorecard/alpha/formatting.go
@@ -65,31 +65,30 @@ func ListTests(o Options) error {
 		output.Results = append(output.Results, testResult)
 	}
 
-	printOutput(o.OutputFormat, output)
+	err := printOutput(o.OutputFormat, output)
 
-	return nil
+	return err
 }
 
-func printOutput(outputFormat string, output v1alpha2.ScorecardOutput) {
-	if outputFormat == "text" {
+func printOutput(outputFormat string, output v1alpha2.ScorecardOutput) error {
+	switch outputFormat {
+	case "text":
 		o, err := output.MarshalText()
 		if err != nil {
 			fmt.Println(err.Error())
-			return
+			return err
 		}
 		fmt.Printf("%s\n", o)
-		return
-	}
-	if outputFormat == "json" {
+	case "json":
 		bytes, err := json.MarshalIndent(output, "", "  ")
 		if err != nil {
 			fmt.Println(err.Error())
-			return
+			return err
 		}
 		fmt.Printf("%s\n", string(bytes))
-		return
+	default:
+		return fmt.Errorf("invalid output format selected")
 	}
-
-	fmt.Println("error, invalid output format selected")
+	return nil
 
 }

--- a/internal/scorecard/alpha/formatting.go
+++ b/internal/scorecard/alpha/formatting.go
@@ -24,7 +24,7 @@ import (
 
 // getTestResults fetches the test pod logs and converts it into
 // ScorecardOutput format
-func getTestResults(client kubernetes.Interface, tests []ScorecardTest) (output v1alpha2.ScorecardOutput) {
+func getTestResults(client kubernetes.Interface, tests []Test) (output v1alpha2.ScorecardOutput) {
 	output.Results = make([]v1alpha2.ScorecardTestResult, 0)
 	for i := 0; i < len(tests); i++ {
 		t := tests[i]

--- a/internal/scorecard/alpha/formatting.go
+++ b/internal/scorecard/alpha/formatting.go
@@ -26,14 +26,14 @@ import (
 // ScorecardOutput format
 func getTestResults(client kubernetes.Interface, tests []Test) (output v1alpha2.ScorecardOutput) {
 	output.Results = make([]v1alpha2.ScorecardTestResult, 0)
-	for i := 0; i < len(tests); i++ {
-		t := tests[i]
-		p := t.TestPod
+
+	for _, test := range tests {
+		p := test.TestPod
 		logBytes, err := getPodLog(client, p)
 		if err != nil {
 			r := v1alpha2.ScorecardTestResult{}
-			r.Name = t.Name
-			r.Description = t.Description
+			r.Name = test.Name
+			r.Description = test.Description
 			r.Errors = []string{fmt.Sprintf("Error getting pod log %s", err.Error())}
 			output.Results = append(output.Results, r)
 		} else {
@@ -42,8 +42,8 @@ func getTestResults(client kubernetes.Interface, tests []Test) (output v1alpha2.
 			err := json.Unmarshal(logBytes, &sc)
 			if err != nil {
 				r := v1alpha2.ScorecardTestResult{}
-				r.Name = t.Name
-				r.Description = t.Description
+				r.Name = test.Name
+				r.Description = test.Description
 				r.Errors = []string{fmt.Sprintf("Error unmarshalling test result %s", err.Error())}
 				output.Results = append(output.Results, r)
 			} else {
@@ -65,11 +65,11 @@ func ListTests(o Options) (output v1alpha2.ScorecardOutput, err error) {
 
 	output.Results = make([]v1alpha2.ScorecardTestResult, 0)
 
-	for i := 0; i < len(tests); i++ {
+	for _, test := range tests {
 		testResult := v1alpha2.ScorecardTestResult{}
-		testResult.Name = tests[i].Name
-		testResult.Labels = tests[i].Labels
-		testResult.Description = tests[i].Description
+		testResult.Name = test.Name
+		testResult.Labels = test.Labels
+		testResult.Description = test.Description
 		output.Results = append(output.Results, testResult)
 	}
 

--- a/internal/scorecard/alpha/formatting.go
+++ b/internal/scorecard/alpha/formatting.go
@@ -1,0 +1,95 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alpha
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
+	"k8s.io/client-go/kubernetes"
+)
+
+// getTestResults fetches the test pod logs and converts it into
+// ScorecardOutput format
+func getTestResults(client kubernetes.Interface, tests []ScorecardTest) (output v1alpha2.ScorecardOutput) {
+	output.Results = make([]v1alpha2.ScorecardTestResult, 0)
+	for i := 0; i < len(tests); i++ {
+		p := tests[i].TestPod
+		logBytes, err := getPodLog(client, p)
+		if err != nil {
+			fmt.Printf("error getting pod log %s\n", err.Error())
+		} else {
+			// marshal pod log into ScorecardTestResult
+			var sc v1alpha2.ScorecardTestResult
+			err := json.Unmarshal(logBytes, &sc)
+			if err != nil {
+				fmt.Printf("error unmarshalling test result %s\n", err.Error())
+			} else {
+				output.Results = append(output.Results, sc)
+			}
+		}
+	}
+	return output
+}
+
+// ListTests lists the scorecard tests as configured that would be
+// run based on user selection
+func ListTests(o Options) error {
+	tests := selectTests(o.Selector, o.Config.Tests)
+	if len(tests) == 0 {
+		fmt.Println("no tests selected")
+		return nil
+	}
+
+	output := v1alpha2.ScorecardOutput{}
+	output.Results = make([]v1alpha2.ScorecardTestResult, 0)
+
+	for i := 0; i < len(tests); i++ {
+		testResult := v1alpha2.ScorecardTestResult{}
+		testResult.Name = tests[i].Name
+		testResult.Labels = tests[i].Labels
+		testResult.Description = tests[i].Description
+		output.Results = append(output.Results, testResult)
+	}
+
+	printOutput(o.OutputFormat, output)
+
+	return nil
+}
+
+func printOutput(outputFormat string, output v1alpha2.ScorecardOutput) {
+	if outputFormat == "text" {
+		o, err := output.MarshalText()
+		if err != nil {
+			fmt.Printf(err.Error())
+			return
+		}
+		fmt.Printf("%s\n", o)
+		return
+	}
+	if outputFormat == "json" {
+		bytes, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			fmt.Printf(err.Error())
+			return
+		}
+		fmt.Printf("%s\n", string(bytes))
+		return
+	}
+
+	fmt.Printf("error, invalid output format selected")
+
+}

--- a/internal/scorecard/alpha/formatting.go
+++ b/internal/scorecard/alpha/formatting.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -30,13 +31,13 @@ func getTestResults(client kubernetes.Interface, tests []ScorecardTest) (output 
 		p := tests[i].TestPod
 		logBytes, err := getPodLog(client, p)
 		if err != nil {
-			fmt.Printf("error getting pod log %s\n", err.Error())
+			log.Errorf("Error getting pod log %s\n", err.Error())
 		} else {
 			// marshal pod log into ScorecardTestResult
 			var sc v1alpha2.ScorecardTestResult
 			err := json.Unmarshal(logBytes, &sc)
 			if err != nil {
-				fmt.Printf("error unmarshalling test result %s\n", err.Error())
+				log.Errorf("Error unmarshalling test result %s\n", err.Error())
 			} else {
 				output.Results = append(output.Results, sc)
 			}

--- a/internal/scorecard/alpha/kubeclient.go
+++ b/internal/scorecard/alpha/kubeclient.go
@@ -33,9 +33,7 @@ func GetKubeClient(kubeconfig string) (client kubernetes.Interface, err error) {
 
 	var inCluster bool
 
-	if kubeconfig != "" {
-		// use the command line flag
-	} else {
+	if kubeconfig == "" {
 		envVar := os.Getenv("KUBECONFIG")
 		if envVar != "" {
 			// use the KUBECONFIG env variable

--- a/internal/scorecard/alpha/kubeclient.go
+++ b/internal/scorecard/alpha/kubeclient.go
@@ -1,0 +1,47 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alpha
+
+import (
+	"os"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// GetKubeClient will get a kubernetes client from the ...
+func GetKubeClient(kubeconfig string) (client kubernetes.Interface, err error) {
+
+	// use the current context in kubeconfig
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return client, err
+	}
+
+	// create the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return client, err
+	}
+
+	return clientset, err
+}
+
+func homeDir() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE") // windows
+}

--- a/internal/scorecard/alpha/labels_test.go
+++ b/internal/scorecard/alpha/labels_test.go
@@ -68,40 +68,52 @@ func TestEmptySelector(t *testing.T) {
 const testConfig = `tests:
 - name: "customtest1"
   image: quay.io/someuser/customtest1:v0.0.1
+  entrypoint: 
+  - custom-test
   labels:
     suite: custom
     test: customtest1
   description: an ISV custom test that does...
 - name: "customtest2"
   image: quay.io/someuser/customtest2:v0.0.1
+  entrypoint: 
+  - custom-test
   labels:
     suite: custom
     test: customtest2
   description: an ISV custom test that does...
 - name: "basic-check-spec"
   image: quay.io/redhat/basictests:v0.0.1
-  entrypoint: basic-check-spec
+  entrypoint: 
+  - scorecard-test
+  - basic-check-spec
   labels:
     suite: basic
     test: basic-check-spec-test
   description: check the spec test
 - name: "basic-check-status"
   image: quay.io/redhat/basictests:v0.0.1
-  entrypoint: basic-check-status
+  entrypoint: 
+  - scorecard-test
+  - basic-check-status
   labels:
     suite: basic
     test: basic-check-status-test
   description: check the status test
 - name: "olm-bundle-validation"
   image: quay.io/redhat/olmtests:v0.0.1
-  entrypoint: olm-bundle-validation
+  entrypoint: 
+  - scorecard-test
+  - olm-bundle-validation
   labels:
     suite: olm
     test: olm-bundle-validation-test
   description: validate the bundle test
 - name: "olm-crds-have-validation"
   image: quay.io/redhat/olmtests:v0.0.1
-  entrypoint: olm-crds-have-validation
+  entrypoint: 
+  - scorecard-test
+  - olm-crds-have-validation
   labels:
     suite: olm
     test: olm-crds-have-validation-test
@@ -110,5 +122,8 @@ const testConfig = `tests:
   image: quay.io/redhat/kuttltests:v0.0.1
   labels:
     suite: kuttl
+  entrypoint:
+  - kuttl-test
+  - olm-status-descriptors
   description: Kuttl tests
 `

--- a/internal/scorecard/alpha/labels_test.go
+++ b/internal/scorecard/alpha/labels_test.go
@@ -46,11 +46,12 @@ func TestEmptySelector(t *testing.T) {
 			}
 
 			selector, err := labels.Parse(c.selectorValue)
-			if err != nil && c.wantError {
-				t.Logf("Wanted error and got error : %v", err)
-				return
-			} else if err != nil && !c.wantError {
-				t.Errorf("Wanted result but got error: %v", err)
+			if err == nil && c.wantError {
+				t.Fatalf("Wanted error but got no error")
+			} else if err != nil {
+				if !c.wantError {
+					t.Fatalf("Wanted result but got error: %v", err)
+				}
 				return
 			}
 

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -60,6 +60,7 @@ func RunTests(o Options) error {
 
 	// TODO replace sleep with a watch on the list of pods
 	time.Sleep(7 * time.Second)
+	defer deletePods(o.Client, createdPods)
 
 	testOutput := getTestResults(o.Client, createdPods)
 	printOutput(o.OutputFormat, testOutput)

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -38,7 +38,7 @@ type Options struct {
 	BundleConfigMap *v1.ConfigMap
 	ServiceAccount  string
 	Client          kubernetes.Interface
-	Cleanup         bool
+	SkipCleanup     bool
 }
 
 // RunTests executes the scorecard tests as configured
@@ -68,7 +68,7 @@ func RunTests(o Options) (testOutput v1alpha2.ScorecardOutput, err error) {
 		}
 	}
 
-	if o.Cleanup {
+	if !o.SkipCleanup {
 		defer deletePods(o.Client, tests)
 		defer deleteConfigMap(o.Client, o.BundleConfigMap)
 	}

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -30,8 +30,6 @@ import (
 type Options struct {
 	Config          Config
 	Selector        labels.Selector
-	List            bool
-	Cleanup         bool
 	BundlePath      string
 	WaitTime        int
 	OutputFormat    string
@@ -40,6 +38,8 @@ type Options struct {
 	BundleConfigMap *v1.ConfigMap
 	ServiceAccount  string
 	Client          kubernetes.Interface
+	List            bool
+	Cleanup         bool
 }
 
 // RunTests executes the scorecard tests as configured
@@ -82,9 +82,9 @@ func RunTests(o Options) error {
 	}
 
 	testOutput := getTestResults(o.Client, tests)
-	printOutput(o.OutputFormat, testOutput)
+	err = printOutput(o.OutputFormat, testOutput)
 
-	return nil
+	return err
 }
 
 // selectTests applies an optionally passed selector expression

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -84,9 +84,9 @@ func RunTests(o Options) (testOutput v1alpha2.ScorecardOutput, err error) {
 
 // selectTests applies an optionally passed selector expression
 // against the configured set of tests, returning the selected tests
-func selectTests(selector labels.Selector, tests []ScorecardTest) []ScorecardTest {
+func selectTests(selector labels.Selector, tests []Test) []Test {
 
-	selected := make([]ScorecardTest, 0)
+	selected := make([]Test, 0)
 	for i := 0; i < len(tests); i++ {
 		if selector.String() == "" || selector.Matches(labels.Set(tests[i].Labels)) {
 			// TODO olm manifests check
@@ -97,8 +97,7 @@ func selectTests(selector labels.Selector, tests []ScorecardTest) []ScorecardTes
 }
 
 // runTest executes a single test
-// TODO once tests exists, handle the test output
-func runTest(o Options, test ScorecardTest) (result *v1.Pod, err error) {
+func runTest(o Options, test Test) (result *v1.Pod, err error) {
 
 	// Create a Pod to run the test
 	podDef := getPodDefinition(test, o)
@@ -117,7 +116,7 @@ func ConfigDocLink() string {
 
 // waitForTestsToComplete waits for a fixed amount of time while
 // checking for test pods to complete
-func waitForTestsToComplete(o Options, tests []ScorecardTest) (err error) {
+func waitForTestsToComplete(o Options, tests []Test) (err error) {
 	waitTimeInSeconds := int(o.WaitTime.Seconds())
 	for elapsedSeconds := 0; elapsedSeconds < waitTimeInSeconds; elapsedSeconds++ {
 		allPodsCompleted := true

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -15,7 +15,6 @@
 package alpha
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -100,9 +99,6 @@ func selectTests(selector labels.Selector, tests []ScorecardTest) []ScorecardTes
 // runTest executes a single test
 // TODO once tests exists, handle the test output
 func runTest(o Options, test ScorecardTest) (result *v1.Pod, err error) {
-	if test.Name == "" {
-		return result, errors.New("todo - remove later, only for linter")
-	}
 
 	// Create a Pod to run the test
 	podDef := getPodDefinition(test, o)

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -50,20 +50,20 @@ func RunTests(o Options) (testOutput v1alpha2.ScorecardOutput, err error) {
 
 	bundleData, err := getBundleData(o.BundlePath)
 	if err != nil {
-		return testOutput, fmt.Errorf("error getting bundle data %s", err.Error())
+		return testOutput, fmt.Errorf("error getting bundle data %w", err)
 	}
 
 	// create a ConfigMap holding the bundle contents
 	o.bundleConfigMap, err = createConfigMap(o, bundleData)
 	if err != nil {
-		return testOutput, fmt.Errorf("error creating ConfigMap %s", err.Error())
+		return testOutput, fmt.Errorf("error creating ConfigMap %w", err)
 	}
 
 	for i, test := range tests {
 		var err error
 		tests[i].TestPod, err = runTest(o, test)
 		if err != nil {
-			return testOutput, fmt.Errorf("test %s failed %s", test.Name, err.Error())
+			return testOutput, fmt.Errorf("test %s failed %w", test.Name, err)
 		}
 	}
 
@@ -126,7 +126,7 @@ func waitForTestsToComplete(o Options, tests []Test) (err error) {
 			var tmp *v1.Pod
 			tmp, err = o.Client.CoreV1().Pods(p.Namespace).Get(p.Name, metav1.GetOptions{})
 			if err != nil {
-				return fmt.Errorf("error getting pod %s %s", p.Name, err.Error())
+				return fmt.Errorf("error getting pod %s %w", p.Name, err)
 			}
 			if tmp.Status.Phase != v1.PodSucceeded {
 				allPodsCompleted = false

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -75,7 +75,7 @@ func RunTests(o Options) error {
 
 	// TODO replace sleep with a watch on the list of pods
 	time.Sleep(7 * time.Second)
-	defer deletePods(o.Client, createdPods)
+	//defer deletePods(o.Client, createdPods)
 	//defer deleteConfigMap(o.Client, o.BundleConfigMap.Name)
 
 	testOutput := getTestResults(o.Client, createdPods)

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -34,6 +34,7 @@ type Options struct {
 	Config          Config
 	Selector        labels.Selector
 	List            bool
+	Cleanup         bool
 	BundlePath      string
 	OutputFormat    string
 	Kubeconfig      string
@@ -75,8 +76,11 @@ func RunTests(o Options) error {
 
 	// TODO replace sleep with a watch on the list of pods
 	time.Sleep(7 * time.Second)
-	//defer deletePods(o.Client, createdPods)
-	//defer deleteConfigMap(o.Client, o.BundleConfigMap.Name)
+
+	if o.Cleanup {
+		defer deletePods(o.Client, createdPods)
+		defer deleteConfigMap(o.Client, o.BundleConfigMap)
+	}
 
 	testOutput := getTestResults(o.Client, createdPods)
 	printOutput(o.OutputFormat, testOutput)

--- a/internal/scorecard/alpha/tar.go
+++ b/internal/scorecard/alpha/tar.go
@@ -1,3 +1,17 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package alpha
 
 import (
@@ -38,24 +52,15 @@ func Tartar(tarName string, paths []string) (err error) {
 	for _, path := range paths {
 		// validate path
 		path = filepath.Clean(path)
-		base := filepath.Base(path)
-		rel, err := filepath.Rel(base, path)
 		absPath, err := filepath.Abs(path)
 		if err != nil {
 			fmt.Println(err)
 			continue
 		}
-		fmt.Sprintf("rel %s\n", rel)
-		//fmt.Printf("rel %s\n", rel)
-		//fmt.Printf("base %s\n", base)
-		//fmt.Printf("path %s \n", path)
-		//fmt.Printf("absPath %s\n", absPath)
 		if absPath == absTar {
-			//fmt.Printf("tar file %s cannot be the source\n", tarName)
 			continue
 		}
 		if absPath == filepath.Dir(absTar) {
-			//fmt.Printf("tar file %s cannot be in source %s\n", tarName, absPath)
 			continue
 		}
 
@@ -69,7 +74,6 @@ func Tartar(tarName string, paths []string) (err error) {
 			if err != nil {
 				return err
 			}
-			//fmt.Printf("header is %v\n", hdr)
 
 			relFilePath := file
 			if filepath.IsAbs(path) {
@@ -81,8 +85,6 @@ func Tartar(tarName string, paths []string) (err error) {
 			// ensure header has relative file path
 			hdr.Name = relFilePath
 
-			//fmt.Printf("relFilePath [%s]\n", relFilePath)
-			//fmt.Printf("trimmed [%s]\n", strings.TrimPrefix(relFilePath, path))
 			hdr.Name = strings.TrimPrefix(relFilePath, path)
 			if err := tw.WriteHeader(hdr); err != nil {
 				return err
@@ -106,10 +108,9 @@ func Tartar(tarName string, paths []string) (err error) {
 		}
 
 		// build tar
-		if err := filepath.Walk(path, walker); err != nil {
-			//fmt.Printf("failed to add %s to tar: %s\n", path, err)
-		} else {
-			//fmt.Printf("add %s to tar\n", path)
+		err = filepath.Walk(path, walker)
+		if err != nil {
+			return fmt.Errorf("failed to add %s to tar: %s", path, err)
 		}
 	}
 	return nil
@@ -154,7 +155,6 @@ func Untartar(tarName, xpath string) (err error) {
 		finfo := hdr.FileInfo()
 		fileName := hdr.Name
 		if filepath.IsAbs(fileName) {
-			//fmt.Printf("removing / prefix from %s\n", fileName)
 			fileName, err = filepath.Rel("/", fileName)
 			if err != nil {
 				return err
@@ -174,7 +174,6 @@ func Untartar(tarName, xpath string) (err error) {
 		if err != nil {
 			return err
 		}
-		//fmt.Printf("x %s\n", absFileName)
 		n, cpErr := io.Copy(file, tr)
 		if closeErr := file.Close(); closeErr != nil { // close file immediately
 			return err

--- a/internal/scorecard/alpha/tar.go
+++ b/internal/scorecard/alpha/tar.go
@@ -1,0 +1,191 @@
+package alpha
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// tarrer walks paths to create tar file tarName
+func Tartar(tarName string, paths []string) (err error) {
+	tarFile, err := os.Create(tarName)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = tarFile.Close()
+	}()
+
+	absTar, err := filepath.Abs(tarName)
+	if err != nil {
+		return err
+	}
+
+	// enable compression if file ends in .gz
+	tw := tar.NewWriter(tarFile)
+	if strings.HasSuffix(tarName, ".gz") || strings.HasSuffix(tarName, ".gzip") {
+		gz := gzip.NewWriter(tarFile)
+		defer gz.Close()
+		tw = tar.NewWriter(gz)
+	}
+	defer tw.Close()
+
+	// walk each specified path and add encountered file to tar
+	for _, path := range paths {
+		// validate path
+		path = filepath.Clean(path)
+		base := filepath.Base(path)
+		rel, err := filepath.Rel(base, path)
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+		fmt.Sprintf("rel %s\n", rel)
+		//fmt.Printf("rel %s\n", rel)
+		//fmt.Printf("base %s\n", base)
+		//fmt.Printf("path %s \n", path)
+		//fmt.Printf("absPath %s\n", absPath)
+		if absPath == absTar {
+			//fmt.Printf("tar file %s cannot be the source\n", tarName)
+			continue
+		}
+		if absPath == filepath.Dir(absTar) {
+			//fmt.Printf("tar file %s cannot be in source %s\n", tarName, absPath)
+			continue
+		}
+
+		walker := func(file string, finfo os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			// fill in header info using func FileInfoHeader
+			hdr, err := tar.FileInfoHeader(finfo, finfo.Name())
+			if err != nil {
+				return err
+			}
+			//fmt.Printf("header is %v\n", hdr)
+
+			relFilePath := file
+			if filepath.IsAbs(path) {
+				relFilePath, err = filepath.Rel(path, file)
+				if err != nil {
+					return err
+				}
+			}
+			// ensure header has relative file path
+			hdr.Name = relFilePath
+
+			//fmt.Printf("relFilePath [%s]\n", relFilePath)
+			//fmt.Printf("trimmed [%s]\n", strings.TrimPrefix(relFilePath, path))
+			hdr.Name = strings.TrimPrefix(relFilePath, path)
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+			// if path is a dir, dont continue
+			if finfo.Mode().IsDir() {
+				return nil
+			}
+
+			// add file to tar
+			srcFile, err := os.Open(file)
+			if err != nil {
+				return err
+			}
+			defer srcFile.Close()
+			_, err = io.Copy(tw, srcFile)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+
+		// build tar
+		if err := filepath.Walk(path, walker); err != nil {
+			//fmt.Printf("failed to add %s to tar: %s\n", path, err)
+		} else {
+			//fmt.Printf("add %s to tar\n", path)
+		}
+	}
+	return nil
+}
+
+// untarrer extract contant of file tarName into location xpath
+func Untartar(tarName, xpath string) (err error) {
+	tarFile, err := os.Open(tarName)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = tarFile.Close()
+	}()
+
+	absPath, err := filepath.Abs(xpath)
+	if err != nil {
+		return err
+	}
+
+	tr := tar.NewReader(tarFile)
+	if strings.HasSuffix(tarName, ".gz") || strings.HasSuffix(tarName, ".gzip") {
+		gz, err := gzip.NewReader(tarFile)
+		if err != nil {
+			return err
+		}
+		defer gz.Close()
+		tr = tar.NewReader(gz)
+	}
+
+	// untar each segment
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		// determine proper file path info
+		finfo := hdr.FileInfo()
+		fileName := hdr.Name
+		if filepath.IsAbs(fileName) {
+			//fmt.Printf("removing / prefix from %s\n", fileName)
+			fileName, err = filepath.Rel("/", fileName)
+			if err != nil {
+				return err
+			}
+		}
+		absFileName := filepath.Join(absPath, fileName)
+
+		if finfo.Mode().IsDir() {
+			if err := os.MkdirAll(absFileName, 0755); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// create new file with original file mode
+		file, err := os.OpenFile(absFileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, finfo.Mode().Perm())
+		if err != nil {
+			return err
+		}
+		//fmt.Printf("x %s\n", absFileName)
+		n, cpErr := io.Copy(file, tr)
+		if closeErr := file.Close(); closeErr != nil { // close file immediately
+			return err
+		}
+		if cpErr != nil {
+			return cpErr
+		}
+		if n != finfo.Size() {
+			return fmt.Errorf("unexpected bytes written: wrote %d, want %d", n, finfo.Size())
+		}
+	}
+	return nil
+
+}

--- a/internal/scorecard/alpha/tar.go
+++ b/internal/scorecard/alpha/tar.go
@@ -116,8 +116,8 @@ func Tartar(tarName string, paths []string) (err error) {
 	return nil
 }
 
-// untarrer extract contant of file tarName into location xpath
-func Untartar(tarName, xpath string) (err error) {
+// untar a file into a location
+func UntarFile(tarName, target string) (err error) {
 	tarFile, err := os.Open(tarName)
 	if err != nil {
 		return err
@@ -126,7 +126,7 @@ func Untartar(tarName, xpath string) (err error) {
 		err = tarFile.Close()
 	}()
 
-	absPath, err := filepath.Abs(xpath)
+	absPath, err := filepath.Abs(target)
 	if err != nil {
 		return err
 	}

--- a/internal/scorecard/alpha/tar.go
+++ b/internal/scorecard/alpha/tar.go
@@ -110,7 +110,7 @@ func CreateTarFile(tarName string, paths []string) (err error) {
 		// build tar
 		err = filepath.Walk(path, walker)
 		if err != nil {
-			return fmt.Errorf("failed to add %s to tar: %s", path, err)
+			return fmt.Errorf("failed to add %s to tar: %w", path, err)
 		}
 	}
 	return nil

--- a/internal/scorecard/alpha/tar.go
+++ b/internal/scorecard/alpha/tar.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 )
 
-// tarrer walks paths to create tar file tarName
-func Tartar(tarName string, paths []string) (err error) {
+// CreateTarFile walks paths to create tar file tarName
+func CreateTarFile(tarName string, paths []string) (err error) {
 	tarFile, err := os.Create(tarName)
 	if err != nil {
 		return err

--- a/internal/scorecard/alpha/testconfigmap.go
+++ b/internal/scorecard/alpha/testconfigmap.go
@@ -20,6 +20,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -35,7 +36,7 @@ func createConfigMap(o Options, bundleData []byte) (configMap *v1.ConfigMap, err
 // will hold the bundle contents and eventually will be mounted
 // into each test Pod
 func getConfigMapDefinition(namespace string, bundleData []byte) *v1.ConfigMap {
-	configMapName := fmt.Sprintf("scorecard-test-%s", randomString())
+	configMapName := fmt.Sprintf("scorecard-test-%s", rand.String(4))
 	data := make(map[string][]byte)
 	data["bundle.tar"] = bundleData
 	return &v1.ConfigMap{

--- a/internal/scorecard/alpha/testconfigmap.go
+++ b/internal/scorecard/alpha/testconfigmap.go
@@ -17,6 +17,7 @@ package alpha
 import (
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -54,6 +55,6 @@ func getConfigMapDefinition(namespace string, bundleData []byte) *v1.ConfigMap {
 func deleteConfigMap(client kubernetes.Interface, configMap *v1.ConfigMap) {
 	err := client.CoreV1().ConfigMaps(configMap.Namespace).Delete(configMap.Name, &metav1.DeleteOptions{})
 	if err != nil {
-		fmt.Printf("error deleting configMap %s %s", configMap.Name, err.Error())
+		log.Errorf("Error deleting configMap %s %s", configMap.Name, err.Error())
 	}
 }

--- a/internal/scorecard/alpha/testconfigmap.go
+++ b/internal/scorecard/alpha/testconfigmap.go
@@ -26,7 +26,7 @@ import (
 
 // createConfigMap creates a ConfigMap that will hold the bundle
 // contents to be mounted into the test Pods
-func createConfigMap(o Options, bundleData []byte) (configMap *v1.ConfigMap, err error) {
+func createConfigMap(o Scorecard, bundleData []byte) (configMap *v1.ConfigMap, err error) {
 	cfg := getConfigMapDefinition(o.Namespace, bundleData)
 	configMap, err = o.Client.CoreV1().ConfigMaps(o.Namespace).Create(cfg)
 	return configMap, err

--- a/internal/scorecard/alpha/testconfigmap.go
+++ b/internal/scorecard/alpha/testconfigmap.go
@@ -1,0 +1,60 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alpha
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// createConfigMap creates a ConfigMap that will hold the bundle
+// contents to be mounted into the test Pods
+func createConfigMap(o Options, bundleData []byte) (configMap *v1.ConfigMap, err error) {
+	cfg := getConfigMapDefinition(o.Namespace, bundleData)
+	configMap, err = o.Client.CoreV1().ConfigMaps(o.Namespace).Create(cfg)
+	return configMap, err
+}
+
+// getConfigMapDefinition returns a ConfigMap definition that
+// will hold the bundle contents and eventually will be mounted
+// into each test Pod
+func getConfigMapDefinition(namespace string, bundleData []byte) *v1.ConfigMap {
+	configMapName := fmt.Sprintf("scorecard-test-%s", randomString())
+	data := make(map[string][]byte)
+	data["bundle.zip"] = bundleData
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": "scorecard-test",
+			},
+		},
+		BinaryData: data,
+	}
+}
+
+// deleteConfigMap deletes the test bundle ConfigMap and is called
+// as part of the test run cleanup
+func deleteConfigMap(client kubernetes.Interface, configMap *v1.ConfigMap) error {
+	err := client.CoreV1().ConfigMaps(configMap.Namespace).Delete(configMap.Name, &metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("error deleting configMap %s %s\n", configMap.Name, err.Error())
+	}
+	return nil
+}

--- a/internal/scorecard/alpha/testconfigmap.go
+++ b/internal/scorecard/alpha/testconfigmap.go
@@ -51,10 +51,9 @@ func getConfigMapDefinition(namespace string, bundleData []byte) *v1.ConfigMap {
 
 // deleteConfigMap deletes the test bundle ConfigMap and is called
 // as part of the test run cleanup
-func deleteConfigMap(client kubernetes.Interface, configMap *v1.ConfigMap) error {
+func deleteConfigMap(client kubernetes.Interface, configMap *v1.ConfigMap) {
 	err := client.CoreV1().ConfigMaps(configMap.Namespace).Delete(configMap.Name, &metav1.DeleteOptions{})
 	if err != nil {
-		return fmt.Errorf("error deleting configMap %s %s\n", configMap.Name, err.Error())
+		fmt.Printf("error deleting configMap %s %s", configMap.Name, err.Error())
 	}
-	return nil
 }

--- a/internal/scorecard/alpha/testconfigmap.go
+++ b/internal/scorecard/alpha/testconfigmap.go
@@ -36,7 +36,7 @@ func createConfigMap(o Options, bundleData []byte) (configMap *v1.ConfigMap, err
 func getConfigMapDefinition(namespace string, bundleData []byte) *v1.ConfigMap {
 	configMapName := fmt.Sprintf("scorecard-test-%s", randomString())
 	data := make(map[string][]byte)
-	data["bundle.zip"] = bundleData
+	data["bundle.tar"] = bundleData
 	return &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      configMapName,

--- a/internal/scorecard/alpha/testdata/config.yaml
+++ b/internal/scorecard/alpha/testdata/config.yaml
@@ -25,13 +25,6 @@ tests:
     suite: basic
     test: basic-check-status-test
   description: check the status test
-- name: "foo-check-status"
-  image: quay.io/operator-framework/scorecard-test:dev
-  entrypoint: foo-check-status
-  labels:
-    suite: basic
-    test: foo
-  description: check the status test
 - name: "olm-bundle-validation"
   image: quay.io/operator-framework/scorecard-test:dev
   entrypoint: olm-bundle-validation

--- a/internal/scorecard/alpha/testdata/config.yaml
+++ b/internal/scorecard/alpha/testdata/config.yaml
@@ -25,6 +25,13 @@ tests:
     suite: basic
     test: basic-check-status-test
   description: check the status test
+- name: "foo-check-status"
+  image: quay.io/operator-framework/scorecard-test:dev
+  entrypoint: foo-check-status
+  labels:
+    suite: basic
+    test: foo
+  description: check the status test
 - name: "olm-bundle-validation"
   image: quay.io/operator-framework/scorecard-test:dev
   entrypoint: olm-bundle-validation

--- a/internal/scorecard/alpha/testdata/config.yaml
+++ b/internal/scorecard/alpha/testdata/config.yaml
@@ -1,11 +1,15 @@
 tests:
 - name: "customtest1"
   image: quay.io/jemccorm/customtest1:v0.0.1
+  entrypoint: 
+  - custom-test
   labels:
     suite: custom
     test: customtest1
   description: an ISV custom test that does...
 - name: "customtest2"
+  entrypoint: 
+  - custom-test
   image: quay.io/jemccorm/customtest2:v0.0.1
   labels:
     suite: custom
@@ -13,42 +17,54 @@ tests:
   description: an ISV custom test that does...
 - name: "basic-check-spec"
   image: quay.io/operator-framework/scorecard-test:dev
-  entrypoint: basic-check-spec
+  entrypoint: 
+  - scorecard-test
+  - basic-check-spec
   labels:
     suite: basic
     test: basic-check-spec-test
   description: check the spec test
 - name: "olm-bundle-validation"
   image: quay.io/operator-framework/scorecard-test:dev
-  entrypoint: olm-bundle-validation
+  entrypoint: 
+  - scorecard-test
+  - olm-bundle-validation
   labels:
     suite: olm
     test: olm-bundle-validation-test
   description: validate the bundle test
 - name: "olm-crds-have-validation"
   image: quay.io/operator-framework/scorecard-test:dev
-  entrypoint: olm-crds-have-validation
+  entrypoint: 
+  - scorecard-test
+  - olm-crds-have-validation
   labels:
     suite: olm
     test: olm-crds-have-validation-test
   description: CRDs have validation
 - name: "olm-crds-have-resources"
   image: quay.io/operator-framework/scorecard-test:dev
-  entrypoint: olm-crds-have-resources
+  entrypoint: 
+  - scorecard-test
+  - olm-crds-have-resources
   labels:
     suite: olm
     test: olm-crds-have-resources-test
   description: CRDs have resources
 - name: "olm-spec-descriptors"
   image: quay.io/operator-framework/scorecard-test:dev
-  entrypoint: olm-spec-descriptors
+  entrypoint: 
+  - scorecard-test
+  - olm-spec-descriptors
   labels:
     suite: olm
     test: olm-spec-descriptors-test
   description: OLM Spec Descriptors
 - name: "olm-status-descriptors"
   image: quay.io/operator-framework/scorecard-test:dev
-  entrypoint: olm-status-descriptors
+  entrypoint: 
+  - scorecard-test
+  - olm-status-descriptors
   labels:
     suite: olm
     test: olm-status-descriptors-test
@@ -58,4 +74,6 @@ tests:
   labels:
     suite: kuttl
   description: Kuttl tests
-
+  entrypoint: 
+  - kuttl-test
+  - olm-status-descriptors

--- a/internal/scorecard/alpha/testdata/config.yaml
+++ b/internal/scorecard/alpha/testdata/config.yaml
@@ -1,0 +1,68 @@
+tests:
+- name: "customtest1"
+  image: quay.io/jemccorm/customtest1:v0.0.1
+  labels:
+    suite: custom
+    test: customtest1
+  description: an ISV custom test that does...
+- name: "customtest2"
+  image: quay.io/jemccorm/customtest2:v0.0.1
+  labels:
+    suite: custom
+    test: customtest2
+  description: an ISV custom test that does...
+- name: "basic-check-spec"
+  image: quay.io/operator-framework/scorecard-test:dev
+  entrypoint: basic-check-spec
+  labels:
+    suite: basic
+    test: basic-check-spec-test
+  description: check the spec test
+- name: "basic-check-status"
+  image: quay.io/operator-framework/scorecard-test:dev
+  entrypoint: basic-check-status
+  labels:
+    suite: basic
+    test: basic-check-status-test
+  description: check the status test
+- name: "olm-bundle-validation"
+  image: quay.io/operator-framework/scorecard-test:dev
+  entrypoint: olm-bundle-validation
+  labels:
+    suite: olm
+    test: olm-bundle-validation-test
+  description: validate the bundle test
+- name: "olm-crds-have-validation"
+  image: quay.io/operator-framework/scorecard-test:dev
+  entrypoint: olm-crds-have-validation
+  labels:
+    suite: olm
+    test: olm-crds-have-validation-test
+  description: CRDs have validation
+- name: "olm-crds-have-resources"
+  image: quay.io/operator-framework/scorecard-test:dev
+  entrypoint: olm-crds-have-resources
+  labels:
+    suite: olm
+    test: olm-crds-have-resources-test
+  description: CRDs have resources
+- name: "olm-spec-descriptors"
+  image: quay.io/operator-framework/scorecard-test:dev
+  entrypoint: olm-spec-descriptors
+  labels:
+    suite: olm
+    test: olm-spec-descriptors-test
+  description: OLM Spec Descriptors
+- name: "olm-status-descriptors"
+  image: quay.io/operator-framework/scorecard-test:dev
+  entrypoint: olm-status-descriptors
+  labels:
+    suite: olm
+    test: olm-status-descriptors-test
+  description: OLM Status Descriptors
+- name: "kuttl-tests"
+  image: quay.io/operator-framework/scorecard-kuttl:dev
+  labels:
+    suite: kuttl
+  description: Kuttl tests
+

--- a/internal/scorecard/alpha/testdata/config.yaml
+++ b/internal/scorecard/alpha/testdata/config.yaml
@@ -18,13 +18,6 @@ tests:
     suite: basic
     test: basic-check-spec-test
   description: check the spec test
-- name: "basic-check-status"
-  image: quay.io/operator-framework/scorecard-test:dev
-  entrypoint: basic-check-status
-  labels:
-    suite: basic
-    test: basic-check-status-test
-  description: check the status test
 - name: "olm-bundle-validation"
   image: quay.io/operator-framework/scorecard-test:dev
   entrypoint: olm-bundle-validation

--- a/internal/scorecard/alpha/testdata/pod.yaml
+++ b/internal/scorecard/alpha/testdata/pod.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: scorecard-test
+  namespace: default
+spec:
+  containers:
+  - env:
+    - name: NAMESPACE
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.namespace
+    image: quay.io/operator-framework/scorecard-test:dev 
+    imagePullPolicy: IfNotPresent
+    name: scorecard-test
+    command: ["/usr/local/bin/scorecard-test"]
+    args: ["basic-check-spec"]
+    resources: {}
+    volumeMounts:
+    - mountPath: /scorecard
+      name: scorecard-bundle
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  volumes:
+  - name: scorecard-bundle
+    configMap:
+      name: scorecard-bundle

--- a/internal/scorecard/alpha/testpod.go
+++ b/internal/scorecard/alpha/testpod.go
@@ -1,0 +1,70 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alpha
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// getPodDefinition fills out a Pod definition based on
+// information from the test
+func getPodDefinition(test ScorecardTest, namespace, serviceAccount string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "scorecard-test",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"name": "scorecard-test",
+			},
+		},
+		Spec: v1.PodSpec{
+			ServiceAccountName: serviceAccount,
+			RestartPolicy:      v1.RestartPolicyNever,
+			Containers: []v1.Container{
+				{
+					Name:            "scorecard-test",
+					Image:           "quay.io/operator-framework/scorecard-test:dev",
+					ImagePullPolicy: v1.PullIfNotPresent,
+					Command: []string{
+						"/usr/local/bin/scorecard-test",
+					},
+					Args: []string{
+						test.Entrypoint,
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							MountPath: "/scorecard",
+							Name:      "scorecard-bundle",
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "scorecard-bundle",
+					VolumeSource: v1.VolumeSource{
+						ConfigMap: &v1.ConfigMapVolumeSource{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "scorecard-bundle",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/scorecard/alpha/testpod.go
+++ b/internal/scorecard/alpha/testpod.go
@@ -45,12 +45,7 @@ func getPodDefinition(test Test, o Scorecard) *v1.Pod {
 					Name:            "scorecard-test",
 					Image:           "quay.io/operator-framework/scorecard-test:dev",
 					ImagePullPolicy: v1.PullIfNotPresent,
-					Command: []string{
-						"/usr/local/bin/scorecard-test",
-					},
-					Args: []string{
-						test.Entrypoint,
-					},
+					Command:         test.Entrypoint,
 					VolumeMounts: []v1.VolumeMount{
 						{
 							MountPath: "/scorecard",

--- a/internal/scorecard/alpha/testpod.go
+++ b/internal/scorecard/alpha/testpod.go
@@ -28,7 +28,7 @@ import (
 
 // getPodDefinition fills out a Pod definition based on
 // information from the test
-func getPodDefinition(test Test, o Options) *v1.Pod {
+func getPodDefinition(test Test, o Scorecard) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("scorecard-test-%s", rand.String(4)),

--- a/internal/scorecard/alpha/testpod.go
+++ b/internal/scorecard/alpha/testpod.go
@@ -95,7 +95,7 @@ func stringWithCharset(length int, charset string) string {
 	return string(b)
 }
 
-func getPodLog(client kubernetes.Interface, pod v1.Pod) (logOutput []byte, err error) {
+func getPodLog(client kubernetes.Interface, pod *v1.Pod) (logOutput []byte, err error) {
 
 	req := client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &v1.PodLogOptions{})
 	podLogs, err := req.Stream()
@@ -113,9 +113,9 @@ func getPodLog(client kubernetes.Interface, pod v1.Pod) (logOutput []byte, err e
 	return buf.Bytes(), err
 }
 
-func deletePods(client kubernetes.Interface, pods []*v1.Pod) {
-	for i := 0; i < len(pods); i++ {
-		p := pods[i]
+func deletePods(client kubernetes.Interface, tests []ScorecardTest) {
+	for i := 0; i < len(tests); i++ {
+		p := tests[i].TestPod
 		err := client.CoreV1().Pods(p.Namespace).Delete(p.Name, &metav1.DeleteOptions{})
 		if err != nil {
 			fmt.Printf("error deleting pod %s %s\n", p.Name, err.Error())

--- a/internal/scorecard/alpha/testpod.go
+++ b/internal/scorecard/alpha/testpod.go
@@ -15,19 +15,31 @@
 package alpha
 
 import (
+	"fmt"
+	"math/rand"
+	"time"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	charset = "abcdefghijklmnopqrstuvwxyz"
+)
+
+var seededRand *rand.Rand = rand.New(
+	rand.NewSource(time.Now().UnixNano()))
+
 // getPodDefinition fills out a Pod definition based on
 // information from the test
 func getPodDefinition(test ScorecardTest, namespace, serviceAccount string) *v1.Pod {
+	podName := fmt.Sprintf("scorecard-test-%s", randomString())
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "scorecard-test",
+			Name:      podName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"name": "scorecard-test",
+				"app": "scorecard-test",
 			},
 		},
 		Spec: v1.PodSpec{
@@ -67,4 +79,16 @@ func getPodDefinition(test ScorecardTest, namespace, serviceAccount string) *v1.
 			},
 		},
 	}
+}
+
+func randomString() string {
+	return stringWithCharset(4, charset)
+}
+
+func stringWithCharset(length int, charset string) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
 }

--- a/internal/scorecard/alpha/testpod.go
+++ b/internal/scorecard/alpha/testpod.go
@@ -113,3 +113,16 @@ func getPodLog(client kubernetes.Interface, pod v1.Pod) (logOutput []byte, err e
 	//logOutput = buf.String()
 	return buf.Bytes(), err
 }
+
+func deletePods(client kubernetes.Interface, pods []*v1.Pod) {
+	for i := 0; i < len(pods); i++ {
+		p := pods[i]
+		err := client.CoreV1().Pods(p.Namespace).Delete(p.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			fmt.Printf("error deleting pod %s %s\n", p.Name, err.Error())
+		} else {
+			fmt.Printf("deleted pod %s\n", p.Name)
+		}
+
+	}
+}

--- a/internal/scorecard/alpha/testpod.go
+++ b/internal/scorecard/alpha/testpod.go
@@ -96,7 +96,7 @@ func stringWithCharset(length int, charset string) string {
 	return string(b)
 }
 
-func getPodLog(client kubernetes.Interface, pod v1.Pod) (logOutput string, err error) {
+func getPodLog(client kubernetes.Interface, pod v1.Pod) (logOutput []byte, err error) {
 
 	req := client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &v1.PodLogOptions{})
 	podLogs, err := req.Stream()
@@ -110,6 +110,6 @@ func getPodLog(client kubernetes.Interface, pod v1.Pod) (logOutput string, err e
 	if err != nil {
 		return logOutput, err
 	}
-	logOutput = buf.String()
-	return logOutput, err
+	//logOutput = buf.String()
+	return buf.Bytes(), err
 }

--- a/internal/scorecard/alpha/testpod.go
+++ b/internal/scorecard/alpha/testpod.go
@@ -36,7 +36,7 @@ var seededRand *rand.Rand = rand.New(
 
 // getPodDefinition fills out a Pod definition based on
 // information from the test
-func getPodDefinition(test ScorecardTest, o Options) *v1.Pod {
+func getPodDefinition(test Test, o Options) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("scorecard-test-%s", randomString()),
@@ -114,7 +114,7 @@ func getPodLog(client kubernetes.Interface, pod *v1.Pod) (logOutput []byte, err 
 	return buf.Bytes(), err
 }
 
-func deletePods(client kubernetes.Interface, tests []ScorecardTest) {
+func deletePods(client kubernetes.Interface, tests []Test) {
 	for i := 0; i < len(tests); i++ {
 		p := tests[i].TestPod
 		err := client.CoreV1().Pods(p.Namespace).Delete(p.Name, &metav1.DeleteOptions{})

--- a/internal/scorecard/alpha/testpod.go
+++ b/internal/scorecard/alpha/testpod.go
@@ -21,6 +21,7 @@ import (
 	"math/rand"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -118,7 +119,7 @@ func deletePods(client kubernetes.Interface, tests []ScorecardTest) {
 		p := tests[i].TestPod
 		err := client.CoreV1().Pods(p.Namespace).Delete(p.Name, &metav1.DeleteOptions{})
 		if err != nil {
-			fmt.Printf("error deleting pod %s %s\n", p.Name, err.Error())
+			log.Errorf("Error deleting pod %s %s\n", p.Name, err.Error())
 		}
 
 	}

--- a/internal/scorecard/alpha/testpod.go
+++ b/internal/scorecard/alpha/testpod.go
@@ -119,8 +119,6 @@ func deletePods(client kubernetes.Interface, tests []ScorecardTest) {
 		err := client.CoreV1().Pods(p.Namespace).Delete(p.Name, &metav1.DeleteOptions{})
 		if err != nil {
 			fmt.Printf("error deleting pod %s %s\n", p.Name, err.Error())
-		} else {
-			fmt.Printf("deleted pod %s\n", p.Name)
 		}
 
 	}

--- a/internal/scorecard/alpha/testpod.go
+++ b/internal/scorecard/alpha/testpod.go
@@ -35,18 +35,17 @@ var seededRand *rand.Rand = rand.New(
 
 // getPodDefinition fills out a Pod definition based on
 // information from the test
-func getPodDefinition(test ScorecardTest, namespace, serviceAccount string) *v1.Pod {
-	podName := fmt.Sprintf("scorecard-test-%s", randomString())
+func getPodDefinition(test ScorecardTest, o Options) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: namespace,
+			Name:      fmt.Sprintf("scorecard-test-%s", randomString()),
+			Namespace: o.Namespace,
 			Labels: map[string]string{
 				"app": "scorecard-test",
 			},
 		},
 		Spec: v1.PodSpec{
-			ServiceAccountName: serviceAccount,
+			ServiceAccountName: o.ServiceAccount,
 			RestartPolicy:      v1.RestartPolicyNever,
 			Containers: []v1.Container{
 				{
@@ -74,7 +73,7 @@ func getPodDefinition(test ScorecardTest, namespace, serviceAccount string) *v1.
 					VolumeSource: v1.VolumeSource{
 						ConfigMap: &v1.ConfigMapVolumeSource{
 							LocalObjectReference: v1.LocalObjectReference{
-								Name: "scorecard-bundle",
+								Name: o.BundleConfigMap.Name,
 							},
 						},
 					},

--- a/internal/scorecard/alpha/tests/basic.go
+++ b/internal/scorecard/alpha/tests/basic.go
@@ -15,6 +15,7 @@
 package tests
 
 import (
+	"github.com/operator-framework/operator-registry/pkg/registry"
 	scapiv1alpha2 "github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
 )
 
@@ -24,7 +25,7 @@ const (
 )
 
 // CheckStatusTest verifies that CRs have a status block
-func CheckStatusTest(conf TestBundle) scapiv1alpha2.ScorecardTestResult {
+func CheckStatusTest(bundle registry.Bundle) scapiv1alpha2.ScorecardTestResult {
 	r := scapiv1alpha2.ScorecardTestResult{}
 	r.Name = BasicCheckStatusTest
 	r.Description = "Custom Resource has a Status Block"
@@ -35,7 +36,7 @@ func CheckStatusTest(conf TestBundle) scapiv1alpha2.ScorecardTestResult {
 }
 
 // CheckSpecTest verifies that CRs have a spec block
-func CheckSpecTest(conf TestBundle) scapiv1alpha2.ScorecardTestResult {
+func CheckSpecTest(bundle registry.Bundle) scapiv1alpha2.ScorecardTestResult {
 	r := scapiv1alpha2.ScorecardTestResult{}
 	r.Name = BasicCheckSpecTest
 	r.Description = "Custom Resource has a Spec Block"

--- a/internal/scorecard/alpha/tests/basic.go
+++ b/internal/scorecard/alpha/tests/basic.go
@@ -20,20 +20,8 @@ import (
 )
 
 const (
-	BasicCheckStatusTest = "basic-check-status"
-	BasicCheckSpecTest   = "basic-check-spec"
+	BasicCheckSpecTest = "basic-check-spec"
 )
-
-// CheckStatusTest verifies that CRs have a status block
-func CheckStatusTest(bundle registry.Bundle) scapiv1alpha2.ScorecardTestResult {
-	r := scapiv1alpha2.ScorecardTestResult{}
-	r.Name = BasicCheckStatusTest
-	r.Description = "Custom Resource has a Status Block"
-	r.State = scapiv1alpha2.PassState
-	r.Errors = make([]string, 0)
-	r.Suggestions = make([]string, 0)
-	return r
-}
 
 // CheckSpecTest verifies that CRs have a spec block
 func CheckSpecTest(bundle registry.Bundle) scapiv1alpha2.ScorecardTestResult {

--- a/internal/scorecard/alpha/tests/bundle_test.go
+++ b/internal/scorecard/alpha/tests/bundle_test.go
@@ -68,7 +68,7 @@ func TestBundleCRs(t *testing.T) {
 				return
 			}
 			var crList []unstructured.Unstructured
-			crList, err = GetCRs(bundle)
+			crList, err = GetCRs(*bundle)
 			if err != nil {
 				t.Error(err)
 				return
@@ -107,7 +107,7 @@ func TestBasicAndOLM(t *testing.T) {
 				t.Errorf("Error getting bundle %s", err.Error())
 			}
 
-			result := c.function(bundle)
+			result := c.function(*bundle)
 			if result.State != scapiv1alpha2.PassState {
 				t.Errorf("%s result State %v expected", result.Name, scapiv1alpha2.PassState)
 				return

--- a/internal/scorecard/alpha/tests/bundle_test.go
+++ b/internal/scorecard/alpha/tests/bundle_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/operator-framework/operator-registry/pkg/registry"
 	scapiv1alpha2 "github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -68,8 +69,8 @@ func TestBundleCRs(t *testing.T) {
 			if err != nil {
 				t.Errorf("Invalid filepath")
 			}
-			var cfg TestBundle
-			cfg, err = GetBundle(abs)
+			var bundle registry.Bundle
+			bundle, err = GetBundle(abs)
 			if err != nil && c.wantError {
 				t.Logf("Wanted error and got error : %v", err)
 				return
@@ -78,7 +79,7 @@ func TestBundleCRs(t *testing.T) {
 				return
 			}
 			var crList []unstructured.Unstructured
-			crList, err = cfg.GetCRs()
+			crList, err = GetCRs(bundle)
 			if err != nil {
 				t.Error(err)
 				return
@@ -98,7 +99,7 @@ func TestBasicAndOLM(t *testing.T) {
 	cases := []struct {
 		bundlePath string
 		state      scapiv1alpha2.State
-		function   func(TestBundle) scapiv1alpha2.ScorecardTestResult
+		function   func(registry.Bundle) scapiv1alpha2.ScorecardTestResult
 	}{
 		{"../testdata", scapiv1alpha2.PassState, CheckStatusTest},
 		{"../testdata", scapiv1alpha2.PassState, CheckSpecTest},
@@ -117,13 +118,13 @@ func TestBasicAndOLM(t *testing.T) {
 			if err != nil {
 				t.Errorf("Invalid filepath")
 			}
-			var cfg TestBundle
-			cfg, err = GetBundle(abs)
+			var bundle registry.Bundle
+			bundle, err = GetBundle(abs)
 			if err != nil {
 				t.Errorf("Error getting bundle %s", err.Error())
 			}
 
-			result := c.function(cfg)
+			result := c.function(bundle)
 			if result.State != scapiv1alpha2.PassState {
 				t.Errorf("%s result State %v expected", result.Name, scapiv1alpha2.PassState)
 				return

--- a/internal/scorecard/alpha/tests/bundle_test.go
+++ b/internal/scorecard/alpha/tests/bundle_test.go
@@ -79,6 +79,10 @@ func TestBundleCRs(t *testing.T) {
 			}
 			var crList []unstructured.Unstructured
 			crList, err = cfg.GetCRs()
+			if err != nil {
+				t.Error(err)
+				return
+			}
 			if len(crList) != c.crCount {
 				t.Errorf("Wanted %d CRs but got: %d", c.crCount, len(crList))
 				return

--- a/internal/scorecard/alpha/tests/bundle_test.go
+++ b/internal/scorecard/alpha/tests/bundle_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	scapiv1alpha2 "github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestBundlePath(t *testing.T) {
@@ -76,8 +77,10 @@ func TestBundleCRs(t *testing.T) {
 				t.Errorf("Wanted result but got error: %v", err)
 				return
 			}
-			if len(cfg.Bundles) != c.crCount {
-				t.Errorf("Wanted %d CRs but got: %d", c.crCount, len(cfg.Bundles))
+			var crList []unstructured.Unstructured
+			crList, err = cfg.GetCRs()
+			if len(crList) != c.crCount {
+				t.Errorf("Wanted %d CRs but got: %d", c.crCount, len(crList))
 				return
 			}
 

--- a/internal/scorecard/alpha/tests/bundle_test.go
+++ b/internal/scorecard/alpha/tests/bundle_test.go
@@ -15,8 +15,6 @@
 package tests
 
 import (
-	"log"
-	"path/filepath"
 	"testing"
 
 	"github.com/operator-framework/operator-registry/pkg/registry"
@@ -36,11 +34,7 @@ func TestBundlePath(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.bundlePath, func(t *testing.T) {
 
-			abs, err := filepath.Abs(c.bundlePath)
-			if err != nil {
-				log.Println(err)
-			}
-			_, err = GetBundle(abs)
+			_, err := GetBundle(c.bundlePath)
 			if err != nil && c.wantError {
 				t.Logf("Wanted error and got error : %v", err)
 				return
@@ -65,12 +59,7 @@ func TestBundleCRs(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.bundlePath, func(t *testing.T) {
 
-			abs, err := filepath.Abs(c.bundlePath)
-			if err != nil {
-				t.Errorf("Invalid filepath")
-			}
-			var bundle registry.Bundle
-			bundle, err = GetBundle(abs)
+			bundle, err := GetBundle(c.bundlePath)
 			if err != nil && c.wantError {
 				t.Logf("Wanted error and got error : %v", err)
 				return
@@ -113,12 +102,7 @@ func TestBasicAndOLM(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.bundlePath, func(t *testing.T) {
 
-			abs, err := filepath.Abs(c.bundlePath)
-			if err != nil {
-				t.Errorf("Invalid filepath")
-			}
-			var bundle registry.Bundle
-			bundle, err = GetBundle(abs)
+			bundle, err := GetBundle(c.bundlePath)
 			if err != nil {
 				t.Errorf("Error getting bundle %s", err.Error())
 			}

--- a/internal/scorecard/alpha/tests/bundle_test.go
+++ b/internal/scorecard/alpha/tests/bundle_test.go
@@ -101,7 +101,6 @@ func TestBasicAndOLM(t *testing.T) {
 		state      scapiv1alpha2.State
 		function   func(registry.Bundle) scapiv1alpha2.ScorecardTestResult
 	}{
-		{"../testdata", scapiv1alpha2.PassState, CheckStatusTest},
 		{"../testdata", scapiv1alpha2.PassState, CheckSpecTest},
 		{"../testdata", scapiv1alpha2.PassState, BundleValidationTest},
 		{"../testdata", scapiv1alpha2.PassState, CRDsHaveValidationTest},

--- a/internal/scorecard/alpha/tests/crhelper.go
+++ b/internal/scorecard/alpha/tests/crhelper.go
@@ -15,7 +15,6 @@
 package tests
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -43,24 +42,9 @@ func GetCRs(bundle registry.Bundle) (crList []unstructured.Unstructured, err err
 		return crList, nil
 	}
 
-	var crInterfaces []map[string]interface{}
-	err = json.Unmarshal([]byte(almExamples), &crInterfaces)
+	err = json.Unmarshal([]byte(almExamples), &crList)
 	if err != nil {
 		return crList, err
 	}
-	for i := 0; i < len(crInterfaces); i++ {
-		buff := new(bytes.Buffer)
-		enc := json.NewEncoder(buff)
-		err := enc.Encode(crInterfaces[i])
-		if err != nil {
-			return crList, err
-		}
-		obj := &unstructured.Unstructured{}
-		if err := obj.UnmarshalJSON(buff.Bytes()); err != nil {
-			return crList, err
-		}
-		crList = append(crList, *obj)
-	}
-
 	return crList, err
 }

--- a/internal/scorecard/alpha/tests/crhelper.go
+++ b/internal/scorecard/alpha/tests/crhelper.go
@@ -19,15 +19,16 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/operator-framework/operator-registry/pkg/registry"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // GetCRs parses a Bundle's CSV for CRs
-func (c TestBundle) GetCRs() (crList []unstructured.Unstructured, err error) {
+func GetCRs(bundle registry.Bundle) (crList []unstructured.Unstructured, err error) {
 
 	// get CRs from CSV's alm-examples annotation, assume single bundle
 
-	csv, err := c.Bundle.ClusterServiceVersion()
+	csv, err := bundle.ClusterServiceVersion()
 	if err != nil {
 		return crList, fmt.Errorf("error in csv retrieval %s", err.Error())
 	}

--- a/internal/scorecard/alpha/tests/crhelper.go
+++ b/internal/scorecard/alpha/tests/crhelper.go
@@ -44,7 +44,7 @@ func GetCRs(bundle registry.Bundle) (crList []unstructured.Unstructured, err err
 
 	err = json.Unmarshal([]byte(almExamples), &crList)
 	if err != nil {
-		return crList, err
+		return nil, fmt.Errorf("failed to parse alm-examples annotation: %v", err)
 	}
 	return crList, err
 }

--- a/internal/scorecard/alpha/tests/crhelper.go
+++ b/internal/scorecard/alpha/tests/crhelper.go
@@ -46,5 +46,5 @@ func GetCRs(bundle registry.Bundle) (crList []unstructured.Unstructured, err err
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse alm-examples annotation: %v", err)
 	}
-	return crList, err
+	return crList, nil
 }

--- a/internal/scorecard/alpha/tests/crhelper.go
+++ b/internal/scorecard/alpha/tests/crhelper.go
@@ -1,0 +1,67 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// GetCRs parses a Bundle's CSV for CRs
+func (c TestBundle) GetCRs() (crList []unstructured.Unstructured, err error) {
+
+	// get CRs from CSV's alm-examples annotation, assume single bundle
+
+	csv, err := c.Bundles[0].ClusterServiceVersion()
+	if err != nil {
+		return crList, fmt.Errorf("error in csv retrieval %s", err.Error())
+	}
+
+	if csv.GetAnnotations() == nil {
+		return crList, nil
+	}
+
+	almExamples := csv.ObjectMeta.Annotations["alm-examples"]
+
+	if almExamples == "" {
+		return crList, nil
+	}
+
+	if len(c.Bundles) > 0 {
+		var crInterfaces []map[string]interface{}
+		err = json.Unmarshal([]byte(almExamples), &crInterfaces)
+		if err != nil {
+			return crList, err
+		}
+		for i := 0; i < len(crInterfaces); i++ {
+			buff := new(bytes.Buffer)
+			enc := json.NewEncoder(buff)
+			err := enc.Encode(crInterfaces[i])
+			if err != nil {
+				return crList, err
+			}
+			obj := &unstructured.Unstructured{}
+			if err := obj.UnmarshalJSON(buff.Bytes()); err != nil {
+				return crList, err
+			}
+			crList = append(crList, *obj)
+		}
+	}
+
+	return crList, err
+}

--- a/internal/scorecard/alpha/tests/olm.go
+++ b/internal/scorecard/alpha/tests/olm.go
@@ -15,6 +15,7 @@
 package tests
 
 import (
+	"github.com/operator-framework/operator-registry/pkg/registry"
 	scapiv1alpha2 "github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
 )
 
@@ -27,7 +28,7 @@ const (
 )
 
 // BundleValidationTest validates an on-disk bundle
-func BundleValidationTest(conf TestBundle) scapiv1alpha2.ScorecardTestResult {
+func BundleValidationTest(bundle registry.Bundle) scapiv1alpha2.ScorecardTestResult {
 	r := scapiv1alpha2.ScorecardTestResult{}
 	r.Name = OLMBundleValidationTest
 	r.Description = "Validates bundle contents"
@@ -39,7 +40,7 @@ func BundleValidationTest(conf TestBundle) scapiv1alpha2.ScorecardTestResult {
 }
 
 // CRDsHaveValidationTest verifies all CRDs have a validation section
-func CRDsHaveValidationTest(conf TestBundle) scapiv1alpha2.ScorecardTestResult {
+func CRDsHaveValidationTest(bundle registry.Bundle) scapiv1alpha2.ScorecardTestResult {
 	r := scapiv1alpha2.ScorecardTestResult{}
 	r.Name = OLMCRDsHaveValidationTest
 	r.Description = "All CRDs have an OpenAPI validation subsection"
@@ -50,7 +51,7 @@ func CRDsHaveValidationTest(conf TestBundle) scapiv1alpha2.ScorecardTestResult {
 }
 
 // CRDsHaveResourcesTest verifies CRDs have resources listed in its owned CRDs section
-func CRDsHaveResourcesTest(conf TestBundle) scapiv1alpha2.ScorecardTestResult {
+func CRDsHaveResourcesTest(bundle registry.Bundle) scapiv1alpha2.ScorecardTestResult {
 	r := scapiv1alpha2.ScorecardTestResult{}
 	r.Name = OLMCRDsHaveResourcesTest
 	r.Description = "All Owned CRDs contain a resources subsection"
@@ -62,7 +63,7 @@ func CRDsHaveResourcesTest(conf TestBundle) scapiv1alpha2.ScorecardTestResult {
 }
 
 // SpecDescriptorsTest verifies all spec fields have descriptors
-func SpecDescriptorsTest(conf TestBundle) scapiv1alpha2.ScorecardTestResult {
+func SpecDescriptorsTest(bundle registry.Bundle) scapiv1alpha2.ScorecardTestResult {
 	r := scapiv1alpha2.ScorecardTestResult{}
 	r.Name = OLMSpecDescriptorsTest
 	r.Description = "All spec fields have matching descriptors in the CSV"
@@ -73,7 +74,7 @@ func SpecDescriptorsTest(conf TestBundle) scapiv1alpha2.ScorecardTestResult {
 }
 
 // StatusDescriptorsTest verifies all CRDs have status descriptors
-func StatusDescriptorsTest(conf TestBundle) scapiv1alpha2.ScorecardTestResult {
+func StatusDescriptorsTest(bundle registry.Bundle) scapiv1alpha2.ScorecardTestResult {
 	r := scapiv1alpha2.ScorecardTestResult{}
 	r.Name = OLMStatusDescriptorsTest
 	r.Description = "All status fields have matching descriptors in the CSV"

--- a/internal/scorecard/alpha/tests/test_bundle.go
+++ b/internal/scorecard/alpha/tests/test_bundle.go
@@ -49,7 +49,7 @@ func GetBundle(bundlePath string) (bundle *registry.Bundle, err error) {
 	if bundles[0] == nil {
 		return nil, fmt.Errorf("bundle is invalid nil value")
 	}
-	bundle = *bundles[0]
+	bundle = bundles[0]
 	_, err = bundle.ClusterServiceVersion()
 	if err != nil {
 		return nil, fmt.Errorf("error in csv retrieval %s", err.Error())

--- a/internal/scorecard/alpha/tests/test_bundle.go
+++ b/internal/scorecard/alpha/tests/test_bundle.go
@@ -20,23 +20,16 @@ import (
 	"os"
 
 	"github.com/operator-framework/api/pkg/manifests"
-	"github.com/operator-framework/api/pkg/validation/errors"
 	"github.com/operator-framework/operator-registry/pkg/registry"
 	"github.com/sirupsen/logrus"
 )
 
-// TestBundle holds the bundle contents to be tested
-type TestBundle struct {
-	BundleErrors []errors.ManifestResult
-	Bundle       registry.Bundle
-}
-
-// GetBundle parses a Bundle from a given on-disk path returning a TestBundle
-func GetBundle(bundlePath string) (cfg TestBundle, err error) {
+// GetBundle parses a Bundle from a given on-disk path returning a bundle
+func GetBundle(bundlePath string) (bundle registry.Bundle, err error) {
 
 	// validate the path
 	if _, err := os.Stat(bundlePath); os.IsNotExist(err) {
-		return cfg, err
+		return bundle, err
 	}
 
 	validationLogOutput := new(bytes.Buffer)
@@ -47,13 +40,14 @@ func GetBundle(bundlePath string) (cfg TestBundle, err error) {
 	// TODO evaluate another API call that would support the new
 	// bundle format
 	var bundles []*registry.Bundle
-	_, bundles, cfg.BundleErrors = manifests.GetManifestsDir(bundlePath)
+	//var bundleErrors []errors.ManifestResult
+	_, bundles, _ = manifests.GetManifestsDir(bundlePath)
 
-	cfg.Bundle = *bundles[0]
-	_, err = cfg.Bundle.ClusterServiceVersion()
+	bundle = *bundles[0]
+	_, err = bundle.ClusterServiceVersion()
 	if err != nil {
-		return cfg, fmt.Errorf("error in csv retrieval %s", err.Error())
+		return bundle, fmt.Errorf("error in csv retrieval %s", err.Error())
 	}
 
-	return cfg, err
+	return bundle, err
 }

--- a/internal/scorecard/alpha/tests/test_bundle.go
+++ b/internal/scorecard/alpha/tests/test_bundle.go
@@ -46,7 +46,7 @@ func GetBundle(bundlePath string) (cfg TestBundle, err error) {
 		return cfg, fmt.Errorf("no bundle found")
 	}
 
-	csv, err := cfg.Bundles[0].ClusterServiceVersion()
+	_, err = cfg.Bundles[0].ClusterServiceVersion()
 	if err != nil {
 		return cfg, fmt.Errorf("error in csv retrieval %s", err.Error())
 	}

--- a/internal/scorecard/alpha/tests/test_bundle.go
+++ b/internal/scorecard/alpha/tests/test_bundle.go
@@ -25,7 +25,7 @@ import (
 )
 
 // GetBundle parses a Bundle from a given on-disk path returning a bundle
-func GetBundle(bundlePath string) (bundle registry.Bundle, err error) {
+func GetBundle(bundlePath string) (bundle *registry.Bundle, err error) {
 
 	// validate the path
 	if _, err := os.Stat(bundlePath); os.IsNotExist(err) {

--- a/internal/scorecard/alpha/tests/test_bundle.go
+++ b/internal/scorecard/alpha/tests/test_bundle.go
@@ -49,5 +49,5 @@ func GetBundle(bundlePath string) (bundle registry.Bundle, err error) {
 		return bundle, fmt.Errorf("error in csv retrieval %s", err.Error())
 	}
 
-	return bundle, err
+	return bundle, nil
 }

--- a/internal/scorecard/alpha/tests/test_bundle.go
+++ b/internal/scorecard/alpha/tests/test_bundle.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"bytes"
 	"fmt"
+	"os"
 
 	"github.com/operator-framework/api/pkg/manifests"
 	"github.com/operator-framework/api/pkg/validation/errors"
@@ -32,6 +33,11 @@ type TestBundle struct {
 
 // GetBundle parses a Bundle from a given on-disk path returning a TestBundle
 func GetBundle(bundlePath string) (cfg TestBundle, err error) {
+
+	// validate the path
+	if _, err := os.Stat(bundlePath); os.IsNotExist(err) {
+		return cfg, err
+	}
 
 	validationLogOutput := new(bytes.Buffer)
 	origOutput := logrus.StandardLogger().Out

--- a/internal/scorecard/alpha/tests/test_bundle.go
+++ b/internal/scorecard/alpha/tests/test_bundle.go
@@ -25,11 +25,11 @@ import (
 )
 
 // GetBundle parses a Bundle from a given on-disk path returning a bundle
-func GetBundle(bundlePath string) (bundle registry.Bundle, err error) {
+func GetBundle(bundlePath string) (bundle *registry.Bundle, err error) {
 
 	// validate the path
 	if _, err := os.Stat(bundlePath); os.IsNotExist(err) {
-		return bundle, err
+		return nil, err
 	}
 
 	validationLogOutput := new(bytes.Buffer)
@@ -44,15 +44,15 @@ func GetBundle(bundlePath string) (bundle registry.Bundle, err error) {
 	_, bundles, _ = manifests.GetManifestsDir(bundlePath)
 
 	if len(bundles) == 0 {
-		return bundle, fmt.Errorf("bundle was not found")
+		return nil, fmt.Errorf("bundle was not found")
 	}
 	if bundles[0] == nil {
-		return bundle, fmt.Errorf("bundle is invalid nil value")
+		return nil, fmt.Errorf("bundle is invalid nil value")
 	}
 	bundle = *bundles[0]
 	_, err = bundle.ClusterServiceVersion()
 	if err != nil {
-		return bundle, fmt.Errorf("error in csv retrieval %s", err.Error())
+		return nil, fmt.Errorf("error in csv retrieval %s", err.Error())
 	}
 
 	return bundle, nil

--- a/internal/scorecard/alpha/tests/test_bundle.go
+++ b/internal/scorecard/alpha/tests/test_bundle.go
@@ -27,7 +27,7 @@ import (
 // TestBundle holds the bundle contents to be tested
 type TestBundle struct {
 	BundleErrors []errors.ManifestResult
-	Bundles      []*registry.Bundle
+	Bundle       registry.Bundle
 }
 
 // GetBundle parses a Bundle from a given on-disk path returning a TestBundle
@@ -40,13 +40,11 @@ func GetBundle(bundlePath string) (cfg TestBundle, err error) {
 
 	// TODO evaluate another API call that would support the new
 	// bundle format
-	_, cfg.Bundles, cfg.BundleErrors = manifests.GetManifestsDir(bundlePath)
+	var bundles []*registry.Bundle
+	_, bundles, cfg.BundleErrors = manifests.GetManifestsDir(bundlePath)
 
-	if len(cfg.Bundles) == 0 {
-		return cfg, fmt.Errorf("no bundle found")
-	}
-
-	_, err = cfg.Bundles[0].ClusterServiceVersion()
+	cfg.Bundle = *bundles[0]
+	_, err = cfg.Bundle.ClusterServiceVersion()
 	if err != nil {
 		return cfg, fmt.Errorf("error in csv retrieval %s", err.Error())
 	}

--- a/internal/scorecard/alpha/tests/test_bundle.go
+++ b/internal/scorecard/alpha/tests/test_bundle.go
@@ -25,7 +25,7 @@ import (
 )
 
 // GetBundle parses a Bundle from a given on-disk path returning a bundle
-func GetBundle(bundlePath string) (bundle *registry.Bundle, err error) {
+func GetBundle(bundlePath string) (bundle registry.Bundle, err error) {
 
 	// validate the path
 	if _, err := os.Stat(bundlePath); os.IsNotExist(err) {
@@ -43,6 +43,12 @@ func GetBundle(bundlePath string) (bundle *registry.Bundle, err error) {
 	//var bundleErrors []errors.ManifestResult
 	_, bundles, _ = manifests.GetManifestsDir(bundlePath)
 
+	if len(bundles) == 0 {
+		return bundle, fmt.Errorf("bundle was not found")
+	}
+	if bundles[0] == nil {
+		return bundle, fmt.Errorf("bundle is invalid nil value")
+	}
 	bundle = *bundles[0]
 	_, err = bundle.ClusterServiceVersion()
 	if err != nil {


### PR DESCRIPTION


**Description of the change:**
this PR adds functionality to the alpha scorecard implementation, you can test
this PR out by running the following command as an example:
```
operator-sdk alpha scorecard \
--config=internal/scorecard/alpha/testdata/config.yaml \
--selector=suite=basic \
-o json \
--bundle=internal/scorecard/alpha/testdata/bundle/ \
--cleanup=true
```
this PR includes the following:
 
 * creates a ConfigMap that holds the on-disk bundle contents, this ConfigMap is passed to test pods
 * test pods are created by the scorecard for selected tests
 * test pod logs are fetched and converted into Scorecard test output for viewing results
 * output is formatted into json or text as the case with the current scorecard
 * a cleanup flag is optional if you want to have access to the test pods for debugging

**Motivation for the change:**

this is part of a larger set of work to implement the alpha scorecard, but this PR is mostly focused on wiring up the scorecard command to have test pods created, and test pod log transformed into scorecard output format for user reporting.
