### PR TITLE
[gen-csv] Add interactive prompts to generate csv

### DIFF
--- a/changelog/fragments/interactive-csv-cmd.yaml
+++ b/changelog/fragments/interactive-csv-cmd.yaml
@@ -1,0 +1,3 @@
+entries:
+    - description: Add flag `--interactive` to the command `operator-sdk generate csv`  in order to enable working with interactive prompts while generating CSV.
+      kind: "addition"

--- a/hack/tests/subcommand-generate-csv.sh
+++ b/hack/tests/subcommand-generate-csv.sh
@@ -41,8 +41,8 @@ function check_crd_files() {
 }
 
 function generate_csv() {
-  echo "operator-sdk generate csv --operator-name $OPERATOR_NAME $@"
-  operator-sdk generate csv --operator-name $OPERATOR_NAME $@
+  echo "operator-sdk generate csv --operator-name $OPERATOR_NAME --interactive=false $@"
+  operator-sdk generate csv --operator-name $OPERATOR_NAME --interactive=false $@
 }
 
 pushd "$TEST_DIR" > /dev/null

--- a/internal/generate/olm-catalog/csv_cmd_prompt.go
+++ b/internal/generate/olm-catalog/csv_cmd_prompt.go
@@ -1,0 +1,91 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package olmcatalog
+
+import (
+	"strings"
+
+	olmapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-sdk/internal/util/projutil"
+)
+
+// InteractiveCSVCmd includes the list of CSV fields which would be asked
+// to the user while generating CSV.
+type interactiveCSVCmd struct {
+	// DisplayName is the name of the crd.
+	DisplayName string
+	// Keyword is a list of keywords describing the operator.
+	Keywords []string
+	// Description of the operator. Can include the features, limitations or
+	// use-cases of the operator.
+	Description string
+	// Name of the publishing entity behind the operator.
+	ProviderName string
+	// URL related to the publishing entity behind the operator.
+	ProviderURL string
+	// Maintainers is the list of organizational entities maintaining the operator.
+	Maintainers []string
+}
+
+// generateInteractivePrompt generates the prompts for user to provide input to the CSV
+// fields.
+func (s *interactiveCSVCmd) generateInteractivePrompt() {
+	s.DisplayName = projutil.GetRequiredInput("Display name for the operator")
+	s.Keywords = projutil.GetStringArray("Comma-separated list of keywords for your operator")
+	s.Description = projutil.GetRequiredInput("Description for the operator")
+	s.ProviderName = projutil.GetRequiredInput("Provider's name for the operator")
+	s.ProviderURL = projutil.GetOptionalInput("Any relevant URL for the provider name")
+	s.Maintainers = projutil.GetStringArray("Comma-separated list of maintainers and their emails" +
+		" (e.g. 'name1:email1, name2:email2')")
+}
+
+// addUImetadata populates the CSV with the data obtained from the interactive
+// prompts which appear while generating CSV.
+func (s *interactiveCSVCmd) addUImetadata(csv *olmapiv1alpha1.ClusterServiceVersion) {
+	if s.DisplayName != "" {
+		csv.Spec.DisplayName = s.DisplayName
+	}
+
+	if len(s.Keywords) != 0 {
+		csv.Spec.Keywords = s.Keywords
+	}
+
+	if s.Description != "" {
+		csv.Spec.Description = s.Description
+	}
+
+	if len(s.Maintainers) != 0 {
+		maintainers := make([]olmapiv1alpha1.Maintainer, 0)
+		for _, entity := range s.Maintainers {
+			entityDetails := strings.Split(entity, ":")
+			if len(entityDetails) == 2 {
+				m := olmapiv1alpha1.Maintainer{}
+				m.Name, m.Email = entityDetails[0], entityDetails[1]
+				maintainers = append(maintainers, m)
+			}
+		}
+		csv.Spec.Maintainers = maintainers
+	}
+
+	if s.ProviderName != "" {
+		provider := olmapiv1alpha1.AppLink{}
+		provider.Name = s.ProviderName
+		if s.ProviderURL != "" {
+			provider.URL = s.ProviderURL
+		}
+		csv.Spec.Provider = provider
+	}
+
+}

--- a/internal/generate/testdata/go/deploy/olm-catalog/memcached-operator/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/internal/generate/testdata/go/deploy/olm-catalog/memcached-operator/manifests/memcached-operator.clusterserviceversion.yaml
@@ -90,7 +90,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: memcached-operator
-                image: quay.io/example/memcached-operator:v0.0.2
+                image: quay.io/example/memcached-operator:v0.0.3
                 imagePullPolicy: Never
                 name: memcached-operator
                 resources: {}

--- a/internal/util/projutil/interactive_promt_util.go
+++ b/internal/util/projutil/interactive_promt_util.go
@@ -1,0 +1,113 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projutil
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+)
+
+// InteractiveLevel captures the user preference on the generation of interactive
+// commands.
+type InteractiveLevel int
+
+const (
+	// User has not turned interactive mode on or off, default to off.
+	InteractiveSoftOff InteractiveLevel = iota
+	// User has explicitly turned interactive mode off.
+	InteractiveHardOff
+	// User only explicitly turned interactive mode on.
+	InteractiveOnAll
+)
+
+func printMessage(msg string, isOptional bool) {
+	fmt.Println()
+	if isOptional {
+		fmt.Print(strings.TrimSpace(msg) + " (optional): " + "\n" + "> ")
+	} else {
+		fmt.Print(strings.TrimSpace(msg) + " (required): " + "\n" + "> ")
+	}
+}
+
+func GetRequiredInput(msg string) string {
+	return getRequiredInput(os.Stdin, msg)
+}
+
+func getRequiredInput(rd io.Reader, msg string) string {
+	reader := bufio.NewReader(rd)
+
+	for {
+		printMessage(msg, false)
+		value := readInput(reader)
+		if value != "" {
+			return value
+		}
+		fmt.Printf("Input is required. ")
+	}
+}
+
+func GetOptionalInput(msg string) string {
+	printMessage(msg, true)
+	value := readInput(bufio.NewReader(os.Stdin))
+	return value
+}
+
+func GetStringArray(msg string) []string {
+	return getStringArray(os.Stdin, msg)
+}
+
+func getStringArray(rd io.Reader, msg string) []string {
+	reader := bufio.NewReader(rd)
+	for {
+		printMessage(msg, false)
+		value := readArray(reader)
+		if len(value) != 0 && len(value[0]) != 0 {
+			return value
+		}
+		fmt.Printf("No list provided. ")
+	}
+}
+
+// readstdin reads a line from stdin and returns the value.
+func readLine(reader *bufio.Reader) string {
+	text, err := reader.ReadString('\n')
+	if err != nil {
+		log.Fatalf("Error when reading input: %v", err)
+	}
+	return strings.TrimSpace(text)
+}
+
+func readInput(reader *bufio.Reader) string {
+	for {
+		text := readLine(reader)
+		return text
+	}
+}
+
+// readArray parses the line from stdin, returns an array
+// of words.
+func readArray(reader *bufio.Reader) []string {
+	arr := make([]string, 0)
+	text := readLine(reader)
+
+	for _, words := range strings.Split(text, ",") {
+		arr = append(arr, strings.TrimSpace(words))
+	}
+	return arr
+}

--- a/internal/util/projutil/interactive_promt_util_test.go
+++ b/internal/util/projutil/interactive_promt_util_test.go
@@ -1,0 +1,95 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projutil
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestUserInput(t *testing.T) {
+	type args struct {
+		msg     string
+		content []byte
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test when user provides input to the command",
+			args: args{
+				msg:     "Enter a word: ",
+				content: []byte("Memcached Operator\n"),
+			},
+			want: "Memcached Operator",
+		},
+		{
+			name: "test when user does not provide input and prompt appears again",
+			args: args{
+				msg:     "Enter a word: ",
+				content: []byte("\nMemcached Operator\n"),
+			},
+			want: "Memcached Operator",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getRequiredInput(bytes.NewBuffer(tt.args.content), tt.args.msg); got != tt.want {
+				t.Errorf("GetRequiredInput() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUserInputStringArray(t *testing.T) {
+	type args struct {
+		msg     string
+		content []byte
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "test when user provides input to the command",
+			args: args{
+				msg:     "Enter list of words",
+				content: []byte("app, memcached-operator \n"),
+			},
+			want: []string{"app", "memcached-operator"},
+		},
+		{
+			name: "test when user does not provide input and prompt appears again",
+			args: args{
+				msg:     "Enter list of words",
+				content: []byte("\noperator, app\n"),
+			},
+			want: []string{"operator", "app"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getStringArray(bytes.NewBuffer(tt.args.content), tt.args.msg); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetRequiredInput() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/website/content/en/docs/cli/operator-sdk_generate_csv.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_csv.md
@@ -131,6 +131,7 @@ operator-sdk generate csv [flags]
       --csv-version string     Semantic version of the CSV. This flag must be set if a package manifest exists
       --deploy-dir string      Project relative path to root directory for operator manifests (Deployment and RBAC) (default "deploy")
   -h, --help                   help for csv
+      --interactive            When set, will enable the interactive command prompt feature to fill the UI metadata fields in CSV
       --make-manifests         When set, the generator will create or update a CSV manifest in a 'manifests' directory. This directory is intended to be used for your latest bundle manifests. The default location is deploy/olm-catalog/<operator-name>/manifests. If --output-dir is set, the directory will be <output-dir>/manifests (default true)
       --operator-name string   Operator name to use while generating CSV
       --output-dir string      Base directory to output generated CSV. If --make-manifests=false the resulting CSV bundle directory will be <output-dir>/olm-catalog/<operator-name>/<csv-version>. If --make-manifests=true, the bundle directory will be <output-dir>/manifests


### PR DESCRIPTION
This PR introduces the feature to provide interactive prompts
to the user to obtain csv metadata.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Add interactive prompts while generating csv.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
