### PR TITLE
bugfix: pass annotation value to strconv.ParseBool

### DIFF
--- a/changelog/fragments/2884-fix.yaml
+++ b/changelog/fragments/2884-fix.yaml
@@ -2,6 +2,6 @@
 # release notes and/or the migration guide
 entries:
   - description: >
-      Fixes issue where the helm.operator-sdk/upgrade-force annotation value for helm-based operators is not parsed. ([#2884](https://github.com/operator-framework/operator-sdk/issues/2884))
+      Fixes issue where the `helm.operator-sdk/upgrade-force` annotation value for Helm based-operators is not parsed. 
     kind: "bugfix"
     breaking: false

--- a/changelog/fragments/2884-fix.yaml
+++ b/changelog/fragments/2884-fix.yaml
@@ -1,0 +1,7 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Fixes issue where the helm.operator-sdk/upgrade-force annotation value for helm-based operators is not parsed. ([#2884](https://github.com/operator-framework/operator-sdk/issues/2884))
+    kind: "bugfix"
+    breaking: false

--- a/pkg/helm/controller/reconcile.go
+++ b/pkg/helm/controller/reconcile.go
@@ -333,7 +333,7 @@ func hasHelmUpgradeForceAnnotation(o *unstructured.Unstructured) bool {
 		return false
 	}
 	value := false
-	if i, err := strconv.ParseBool(helmUpgradeForceAnnotation); err != nil {
+	if i, err := strconv.ParseBool(force); err != nil {
 		log.Info("Could not parse annotation as a boolean",
 			"annotation", helmUpgradeForceAnnotation, "value informed", force)
 	} else {

--- a/pkg/helm/controller/reconcile_test.go
+++ b/pkg/helm/controller/reconcile_test.go
@@ -1,0 +1,88 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestHasHelmUpgradeForceAnnotation(t *testing.T) {
+	tests := []struct {
+		input       map[string]interface{}
+		expectedVal bool
+		expectedOut string
+		name        string
+	}{
+		{
+			input: map[string]interface{}{
+				"helm.operator-sdk/upgrade-force": "True",
+			},
+			expectedVal: true,
+			name:        "base case true",
+		},
+		{
+			input: map[string]interface{}{
+				"helm.operator-sdk/upgrade-force": "False",
+			},
+			expectedVal: false,
+			name:        "base case false",
+		},
+		{
+			input: map[string]interface{}{
+				"helm.operator-sdk/upgrade-force": "1",
+			},
+			expectedVal: true,
+			name:        "true as int",
+		},
+		{
+			input: map[string]interface{}{
+				"helm.operator-sdk/upgrade-force": "0",
+			},
+			expectedVal: false,
+			name:        "false as int",
+		},
+		{
+			input: map[string]interface{}{
+				"helm.operator-sdk/wrong-annotation": "true",
+			},
+			expectedVal: false,
+			name:        "annotation not set",
+		},
+		{
+			input: map[string]interface{}{
+				"helm.operator-sdk/upgrade-force": "invalid",
+			},
+			expectedVal: false,
+			name:        "invalid value",
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expectedVal, hasHelmUpgradeForceAnnotation(annotations(test.input)), test.name)
+	}
+}
+
+func annotations(m map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": m,
+			},
+		},
+	}
+}


### PR DESCRIPTION
**Description of the change:**
helm: pass `force` to strconv.ParseBool() instead of `helmUpgradeForceAnnotation`

**Motivation for the change:**
Fixes issue where helm.operator-sdk/upgrade-force annotation value is not being respected

Closes #2884 
