### PR TITLE
kubebuilder/quickstart: add instruction for enabling status subresource

### DIFF
--- a/website/content/en/docs/kubebuilder/quickstart.md
+++ b/website/content/en/docs/kubebuilder/quickstart.md
@@ -109,6 +109,20 @@ type MemcachedStatus struct {
 }
 ```
 
+Add the `+kubebuilder:subresource:status` [marker comment][status_marker] to enable the [status subresource][status_subresource] for the CRD so that the controller can update the CR status without changing the rest of the CR object:
+
+```Go
+// Memcached is the Schema for the memcacheds API
+// +kubebuilder:subresource:status
+type Memcached struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   MemcachedSpec   `json:"spec,omitempty"`
+	Status MemcachedStatus `json:"status,omitempty"`
+}
+```
+
 After modifying the `*_types.go` file always run the following command to update the generated code for that resource type:
 
 ```sh
@@ -455,3 +469,5 @@ See the [advanced topics][advanced_topics] doc for more use cases and under the 
 [legacy_quickstart_doc]: /docs/golang/quickstart/
 [activate_modules]: https://github.com/golang/go/wiki/Modules#how-to-install-and-activate-module-support
 [advanced_topics]: /docs/kubebuilder/advanced-topics/
+[status_marker]: https://book.kubebuilder.io/reference/generating-crd.html#status
+[status_subresource]: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#status-subresource

--- a/website/content/en/docs/kubebuilder/quickstart.md
+++ b/website/content/en/docs/kubebuilder/quickstart.md
@@ -1,8 +1,3 @@
----
-title: Golang Based Operator Quickstart
-linkTitle: Quickstart
-weight: 1
----
 
 **NOTE:** This is a WIP doc for the Kubebuilder integration effort. This new CLI and workflow is currently alpha and there may be breaking changes.
 Please refer to the [quickstart guide][legacy_quickstart_doc] for the default CLI and workflow.
@@ -109,7 +104,7 @@ type MemcachedStatus struct {
 }
 ```
 
-Add the `+kubebuilder:subresource:status` [marker comment][status_marker] to enable the [status subresource][status_subresource] for the CRD so that the controller can update the CR status without changing the rest of the CR object:
+Add the `+kubebuilder:subresource:status` [marker][status_marker] to add a [status subresource][status_subresource] to the CRD manifest so that the controller can update the CR status without changing the rest of the CR object:
 
 ```Go
 // Memcached is the Schema for the memcacheds API


### PR DESCRIPTION
**Description of the change:**
Add docs for enabling status subresource in the kubebuilder quickstart guide.

**Motivation for the change:**
Resolves the error I saw in https://github.com/operator-framework/operator-sdk/pull/2827#issuecomment-613846192 where the controller failed to update the status subresource with the status writer client.
https://github.com/operator-framework/operator-sdk/blob/master/example/kb-memcached-operator/memcached_controller.go.tmpl#L114