### PR TITLE
doc: fix and improve bundle command info

### DIFF
--- a/cmd/operator-sdk/bundle/cmd.go
+++ b/cmd/operator-sdk/bundle/cmd.go
@@ -33,15 +33,20 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bundle",
 		Short: "Manage operator bundle metadata",
-		Long: `Manage bundle builds, bundle metadata generation, and bundle validation.
+		Long: `
+Manage bundle builds, bundle metadata generation, and bundle validation.
 An operator bundle is a portable operator packaging format understood by Kubernetes
 native software, like the Operator Lifecycle Manager.
 
-More information about operator bundles and metadata:
-https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md
+The bundle generate and in this command follow the Operator Registry Manifests format.
+Note that, the bundle metadata and bundle images will be validated following the Operator Registry rules.
 
-Operator Lifecycle Manager:
-https://github.com/operator-framework/operator-lifecycle-manager
+And then, for further information over the integration with OLM via SDK see its docs:
+https://sdk.operatorframework.io/docs/olm-integration/
+
+Notes:
+* More info about OLM: https://github.com/operator-framework/operator-lifecycle-manager.
+* More info about the bundle format see: https://github.com/operator-framework/operator-registry#manifest-format.
 `,
 	}
 

--- a/cmd/operator-sdk/bundle/create.go
+++ b/cmd/operator-sdk/bundle/create.go
@@ -63,7 +63,7 @@ metadata associated with the operator.
 		
 Notes:
 * The image is not runnable.
-* For more information on operator bundle images and metadata format see: 
+* More info on Operator Bundle images and metadata format see: 
   https://github.com/operator-framework/operator-registry#manifest-format 
 `,
 		Example: `

--- a/cmd/operator-sdk/bundle/create.go
+++ b/cmd/operator-sdk/bundle/create.go
@@ -46,59 +46,76 @@ func newCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create an operator bundle image",
-		Long: `The 'operator-sdk bundle create' command will build an operator
-bundle image containing operator metadata and manifests, tagged with the
-provided image tag.
+		Long: `
+The 'operator-sdk bundle create' command will build an operator bundle image containing operator metadata and 
+manifests, tagged with the provided image tag. 
+		
+To write all files required to build a bundle image without building the image, set '--generate-only=true'. 
+		
+A bundle Dockerfile, bundle metadata, and a 'manifests/' directory containing your bundle manifests will 
+be written if '--generate-only=true'. Note that, if the 'manifests/' do not exist, this command will 
+create the directory which is expected with the CRD's resources from the '/deploy/crds/' directory and generate 
+a CSV file that can be applied to the cluster using standard tooling like kubectl and defines its 
+integration with OLM. 
 
-To write all files required to build a bundle image without building the
-image, set '--generate-only=true'. A bundle.Dockerfile and bundle metadata
-will be written if '--generate-only=true':
+Also, the /metadata directory will be created with resources that are used to store supporting 
+metadata associated with the operator.
+		
+Notes:
+* The image is not runnable.
+* For more information on operator bundle images and metadata format see: 
+  https://github.com/operator-framework/operator-registry#manifest-format 
+`,
+		Example: `
+The following invocation will build a memcached-operator bundle metadata locally which is useful 
+if you want to build an operator's bundle image manually, modify metadata before building an image, 
+or want to generate a 'manifests/' directory containing your operator manifests for compatibility
+with other operator tooling.
 
-` + "```" + `
-  $ operator-sdk bundle create --generate-only --directory ./deploy/olm-catalog/test-operator/manifests
+  $ operator-sdk bundle create --generate-only
+		
+  # The following is the directory of an operator registry bundle which will be generated.
+
   $ ls .
   ...
   bundle.Dockerfile
   ...
-  $ tree ./deploy/olm-catalog/test-operator/
-  ./deploy/olm-catalog/test-operator/
-  ├── manifests
-  │   ├── example.com_tests_crd.yaml
-  │   └── test-operator.clusterserviceversion.yaml
+  $ tree ./deploy/olm-catalog/memcached-operator/
+  └── manifests
+  	└── cache.example.com_memcacheds_crd.yaml
+  	└── memcached-operator.clusterserviceversion.yaml
   └── metadata
-      └── annotations.yaml
-` + "```" + `
+  	└── annotations.yaml
+		
+  # Now, you can, for example, validate the bundle generate locally with:
+  $ operator-sdk bundle validate \
+	--directory ./deploy/olm-catalog/memcached-operator/	
+		
+The following invocation will build a test-operator 0.1.0 bundle image using Docker. 
 
-'--generate-only' is useful if you want to build an operator's bundle image
-manually or modify metadata before building an image.
-
-More information on operator bundle images and the manifests/metadata format:
-https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md
-
-NOTE: bundle images are not runnable.
-`,
-		Example: `The following invocation will build a test-operator 0.1.0 bundle image using Docker.
-This image will contain manifests for package channels 'stable' and 'beta':
+  # This image will contain manifests for package channels 'stable' and 'beta':
 
   $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
-      --directory ./deploy/olm-catalog/test-operator/manifests \
-      --package test-operator \
-      --channels stable,beta \
-      --default-channel stable
+    --directory ./deploy/olm-catalog/test-operator/ \
+    --package test-operator \
+    --channels stable,beta \
+    --default-channel stable
 
-Assuming your operator has the same name as your repo directory and the only
-channel is 'stable', the above command can be abbreviated to:
+  # Assuming your operator has the same name as your repo directory and the only channel is 'stable',
+  the above command can be abbreviated to:
 
-  $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0
+  $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
+    --directory ./deploy/olm-catalog/test-operator/
 
-The following invocation will generate test-operator bundle metadata and a
-bundle.Dockerfile for your latest operator version without building the image:
+  # The following invocation will generate test-operator bundle metadata, a 'manifests/' dir, and Dockerfile 
+  for your latest operator version without building the image:
 
   $ operator-sdk bundle create \
-      --generate-only \
-      --package test-operator \
-      --channels beta \
-      --default-channel beta
+    --generate-only \
+    --directory ./deploy/olm-catalog/test-operator/ \
+    --package test-operator \
+    --channels beta \
+    --default-channel beta
 `,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if err = c.setDefaults(); err != nil {

--- a/cmd/operator-sdk/bundle/validate.go
+++ b/cmd/operator-sdk/bundle/validate.go
@@ -43,21 +43,17 @@ func newValidateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Validate an operator bundle image",
-		Long: `The 'operator-sdk bundle validate' command can validate both content and
+		Long: `
+The 'operator-sdk bundle validate' command can validate both content and
 format of an operator bundle image or an operator bundles directory on-disk
 containing operator metadata and manifests. This command will exit with an
 exit code of 1 if any validation errors arise, and 0 if only warnings arise or
 all validators pass.
 
-More information on operator bundle images and the manifests/metadata format:
-https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md
-
-NOTE: if validating an image, the image must exist in a remote registry, not
-just locally.
-`,
-		Example: `The following command flow will generate test-operator bundle image manifests
-and validate them, assuming a bundle for 'test-operator' version v0.1.0 exists at
-<project-root>/deploy/olm-catalog/test-operator/manifests:
+NOTE: If validating an image, the image must exist in a remote registry, not just locally.`,
+		Example: `
+The following command flow will generate test-operator bundle image manifests and validate them, assuming 
+a bundle for 'test-operator' version v0.1.0 exists at <project-root>/deploy/olm-catalog/test-operator/:
 
   # Generate manifests locally.
   $ operator-sdk bundle create --generate-only
@@ -68,12 +64,12 @@ and validate them, assuming a bundle for 'test-operator' version v0.1.0 exists a
 To build and validate an image:
 
   # Build and push the image using the docker CLI.
-  $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0
+	$ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
+      --directory ./deploy/olm-catalog/test-operator/
   $ docker push quay.io/example/test-operator:v0.1.0
 
   # Ensure the image with modified metadata and Dockerfile is valid.
   $ operator-sdk bundle validate quay.io/example/test-operator:v0.1.0
-
 `,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if viper.GetBool(flags.VerboseOpt) {

--- a/cmd/operator-sdk/bundle/validate.go
+++ b/cmd/operator-sdk/bundle/validate.go
@@ -63,11 +63,14 @@ a bundle for 'test-operator' version v0.1.0 exists at <project-root>/deploy/olm-
 
 To build and validate an image:
 
-  # Build and push the image using the docker CLI.
-	$ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
-      --directory ./deploy/olm-catalog/test-operator/
-  $ docker push quay.io/example/test-operator:v0.1.0
+  # Create a registry namespace or use an existing one.
+  $ export QUAY_NAMESPACE=<your-namespace>
 
+  # Build and push the image using the docker CLI.
+  $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
+      --directory ./deploy/olm-catalog/test-operator/
+  $ docker push quay.io/$QUAY_NAMESPACE/test-operator:v0.1.0
+		
   # Ensure the image with modified metadata and Dockerfile is valid.
   $ operator-sdk bundle validate quay.io/example/test-operator:v0.1.0
 `,

--- a/website/content/en/docs/cli/operator-sdk_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle.md
@@ -7,15 +7,20 @@ Manage operator bundle metadata
 
 ### Synopsis
 
+
 Manage bundle builds, bundle metadata generation, and bundle validation.
 An operator bundle is a portable operator packaging format understood by Kubernetes
 native software, like the Operator Lifecycle Manager.
 
-More information about operator bundles and metadata:
-https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md
+The bundle generate and in this command follow the Operator Registry Manifests format.
+Note that, the bundle metadata and bundle images will be validated following the Operator Registry rules.
 
-Operator Lifecycle Manager:
-https://github.com/operator-framework/operator-lifecycle-manager
+And then, for further information over the integration with OLM via SDK see its docs:
+https://sdk.operatorframework.io/docs/olm-integration/
+
+Notes:
+* More info about OLM: https://github.com/operator-framework/operator-lifecycle-manager.
+* More info about the bundle format see: https://github.com/operator-framework/operator-registry#manifest-format.
 
 
 ### Options

--- a/website/content/en/docs/cli/operator-sdk_bundle_create.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle_create.md
@@ -24,7 +24,7 @@ metadata associated with the operator.
 		
 Notes:
 * The image is not runnable.
-* For more information on operator bundle images and metadata format see: 
+* More info on Operator Bundle images and metadata format see: 
   https://github.com/operator-framework/operator-registry#manifest-format 
 
 

--- a/website/content/en/docs/cli/operator-sdk_bundle_create.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle_create.md
@@ -7,36 +7,25 @@ Create an operator bundle image
 
 ### Synopsis
 
-The 'operator-sdk bundle create' command will build an operator
-bundle image containing operator metadata and manifests, tagged with the
-provided image tag.
 
-To write all files required to build a bundle image without building the
-image, set '--generate-only=true'. A bundle.Dockerfile and bundle metadata
-will be written if '--generate-only=true':
+The 'operator-sdk bundle create' command will build an operator bundle image containing operator metadata and 
+manifests, tagged with the provided image tag. 
+		
+To write all files required to build a bundle image without building the image, set '--generate-only=true'. 
+		
+A bundle Dockerfile, bundle metadata, and a 'manifests/' directory containing your bundle manifests will 
+be written if '--generate-only=true'. Note that, if the 'manifests/' do not exist, this command will 
+create the directory which is expected with the CRD's resources from the '/deploy/crds/' directory and generate 
+a CSV file that can be applied to the cluster using standard tooling like kubectl and defines its 
+integration with OLM. 
 
-```
-  $ operator-sdk bundle create --generate-only --directory ./deploy/olm-catalog/test-operator/manifests
-  $ ls .
-  ...
-  bundle.Dockerfile
-  ...
-  $ tree ./deploy/olm-catalog/test-operator/
-  ./deploy/olm-catalog/test-operator/
-  ├── manifests
-  │   ├── example.com_tests_crd.yaml
-  │   └── test-operator.clusterserviceversion.yaml
-  └── metadata
-      └── annotations.yaml
-```
-
-'--generate-only' is useful if you want to build an operator's bundle image
-manually or modify metadata before building an image.
-
-More information on operator bundle images and the manifests/metadata format:
-https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md
-
-NOTE: bundle images are not runnable.
+Also, the /metadata directory will be created with resources that are used to store supporting 
+metadata associated with the operator.
+		
+Notes:
+* The image is not runnable.
+* For more information on operator bundle images and metadata format see: 
+  https://github.com/operator-framework/operator-registry#manifest-format 
 
 
 ```
@@ -46,28 +35,56 @@ operator-sdk bundle create [flags]
 ### Examples
 
 ```
-The following invocation will build a test-operator 0.1.0 bundle image using Docker.
-This image will contain manifests for package channels 'stable' and 'beta':
+
+The following invocation will build a memcached-operator bundle metadata locally which is useful 
+if you want to build an operator's bundle image manually, modify metadata before building an image, 
+or want to generate a 'manifests/' directory containing your operator manifests for compatibility
+with other operator tooling.
+
+  $ operator-sdk bundle create --generate-only
+		
+  # The following is the directory of an operator registry bundle which will be generated.
+
+  $ ls .
+  ...
+  bundle.Dockerfile
+  ...
+  $ tree ./deploy/olm-catalog/memcached-operator/
+  └── manifests
+  	└── cache.example.com_memcacheds_crd.yaml
+  	└── memcached-operator.clusterserviceversion.yaml
+  └── metadata
+  	└── annotations.yaml
+		
+  # Now, you can, for example, validate the bundle generate locally with:
+  $ operator-sdk bundle validate \
+	--directory ./deploy/olm-catalog/memcached-operator/	
+		
+The following invocation will build a test-operator 0.1.0 bundle image using Docker. 
+
+  # This image will contain manifests for package channels 'stable' and 'beta':
 
   $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
-      --directory ./deploy/olm-catalog/test-operator/manifests \
-      --package test-operator \
-      --channels stable,beta \
-      --default-channel stable
+    --directory ./deploy/olm-catalog/test-operator/ \
+    --package test-operator \
+    --channels stable,beta \
+    --default-channel stable
 
-Assuming your operator has the same name as your repo directory and the only
-channel is 'stable', the above command can be abbreviated to:
+  # Assuming your operator has the same name as your repo directory and the only channel is 'stable',
+  the above command can be abbreviated to:
 
-  $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0
+  $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
+    --directory ./deploy/olm-catalog/test-operator/
 
-The following invocation will generate test-operator bundle metadata and a
-bundle.Dockerfile for your latest operator version without building the image:
+  # The following invocation will generate test-operator bundle metadata, a 'manifests/' dir, and Dockerfile 
+  for your latest operator version without building the image:
 
   $ operator-sdk bundle create \
-      --generate-only \
-      --package test-operator \
-      --channels beta \
-      --default-channel beta
+    --generate-only \
+    --directory ./deploy/olm-catalog/test-operator/ \
+    --package test-operator \
+    --channels beta \
+    --default-channel beta
 
 ```
 

--- a/website/content/en/docs/cli/operator-sdk_bundle_validate.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle_validate.md
@@ -35,11 +35,14 @@ a bundle for 'test-operator' version v0.1.0 exists at <project-root>/deploy/olm-
 
 To build and validate an image:
 
-  # Build and push the image using the docker CLI.
-	$ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
-      --directory ./deploy/olm-catalog/test-operator/
-  $ docker push quay.io/example/test-operator:v0.1.0
+  # Create a registry namespace or use an existing one.
+  $ export QUAY_NAMESPACE=<your-namespace>
 
+  # Build and push the image using the docker CLI.
+  $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
+      --directory ./deploy/olm-catalog/test-operator/
+  $ docker push quay.io/$QUAY_NAMESPACE/test-operator:v0.1.0
+		
   # Ensure the image with modified metadata and Dockerfile is valid.
   $ operator-sdk bundle validate quay.io/example/test-operator:v0.1.0
 

--- a/website/content/en/docs/cli/operator-sdk_bundle_validate.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle_validate.md
@@ -7,18 +7,14 @@ Validate an operator bundle image
 
 ### Synopsis
 
+
 The 'operator-sdk bundle validate' command can validate both content and
 format of an operator bundle image or an operator bundles directory on-disk
 containing operator metadata and manifests. This command will exit with an
 exit code of 1 if any validation errors arise, and 0 if only warnings arise or
 all validators pass.
 
-More information on operator bundle images and the manifests/metadata format:
-https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md
-
-NOTE: if validating an image, the image must exist in a remote registry, not
-just locally.
-
+NOTE: If validating an image, the image must exist in a remote registry, not just locally.
 
 ```
 operator-sdk bundle validate [flags]
@@ -27,9 +23,9 @@ operator-sdk bundle validate [flags]
 ### Examples
 
 ```
-The following command flow will generate test-operator bundle image manifests
-and validate them, assuming a bundle for 'test-operator' version v0.1.0 exists at
-<project-root>/deploy/olm-catalog/test-operator/manifests:
+
+The following command flow will generate test-operator bundle image manifests and validate them, assuming 
+a bundle for 'test-operator' version v0.1.0 exists at <project-root>/deploy/olm-catalog/test-operator/:
 
   # Generate manifests locally.
   $ operator-sdk bundle create --generate-only
@@ -40,12 +36,12 @@ and validate them, assuming a bundle for 'test-operator' version v0.1.0 exists a
 To build and validate an image:
 
   # Build and push the image using the docker CLI.
-  $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0
+	$ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
+      --directory ./deploy/olm-catalog/test-operator/
   $ docker push quay.io/example/test-operator:v0.1.0
 
   # Ensure the image with modified metadata and Dockerfile is valid.
   $ operator-sdk bundle validate quay.io/example/test-operator:v0.1.0
-
 
 ```
 


### PR DESCRIPTION
**Description of the change:**
- remove the link for the https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md#docker
- add in the command help the relevant info as in the CLI docs
- fix the examples since the layout project has no longer the dir directory
- add the links for the relevant docs and places instead of the OCP enhancements
- fix the layout issues for the command line and docs. 

**Motivation for the change:**
Closes #2880
Related to: #2998
