### PR TITLE
website: ignore kubebuilder docs

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -10,6 +10,9 @@ enableRobotsTXT = true
 # Will give values to .Lastmod etc.
 enableGitInfo = true
 
+# Ignore drafts
+ignoreFiles = ["docs/kubebuilder"]
+
 # Language settings
 contentDir = "content/en"
 defaultContentLanguage = "en"


### PR DESCRIPTION
**Description of the change:**
Configure Hugo to ignore WIP kubebuilder docs

**Motivation for the change:**
Keep Kubebuilder docs out of site until KB integration is ready.

