### PR TITLE
update config to fix broken Github links in doc footer

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -81,7 +81,7 @@ version_menu = "Releases"
   url = "https://github.com/operator-framework/operator-sdk/tree/v0.16.x/doc"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-# github_repo = "https://github.com/operator-framework/operator-sdk"
+github_repo = "https://github.com/operator-framework/operator-sdk"
 
 # Specify a value here if your content directory is not in your repo's root directory
 github_subdir = "website"
@@ -91,7 +91,6 @@ gcs_engine_id = "011737558837375720776:fsdu1nryfng"
 
 # Enable Algolia DocSearch
 algolia_docsearch = false
-
 
 
 # User interface configuration


### PR DESCRIPTION
fixes the link to the repo from docs in the website