### PR TITLE
Scorecard2 pod exec3

### DIFF
--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -37,6 +37,7 @@ func NewCmd() *cobra.Command {
 		serviceAccount string
 		list           bool
 		skipCleanup    bool
+		parallel       bool
 		waitTime       time.Duration
 	)
 	scorecardCmd := &cobra.Command{
@@ -52,6 +53,7 @@ func NewCmd() *cobra.Command {
 				Namespace:      namespace,
 				BundlePath:     bundle,
 				SkipCleanup:    skipCleanup,
+				Parallel:       parallel,
 				WaitTime:       waitTime,
 			}
 
@@ -103,6 +105,7 @@ func NewCmd() *cobra.Command {
 	scorecardCmd.Flags().StringVarP(&serviceAccount, "service-account", "s", "default", "Service account to use for tests")
 	scorecardCmd.Flags().BoolVarP(&list, "list", "L", false, "Option to enable listing which tests are run")
 	scorecardCmd.Flags().BoolVarP(&skipCleanup, "skip-cleanup", "x", false, "Disable resource cleanup after tests are run")
+	scorecardCmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run tests in parallel")
 	scorecardCmd.Flags().DurationVarP(&waitTime, "wait-time", "w", time.Duration(30*time.Second),
 		"seconds to wait for tests to complete. Example: 35s")
 

--- a/internal/scorecard/alpha/config.go
+++ b/internal/scorecard/alpha/config.go
@@ -17,7 +17,6 @@ package alpha
 import (
 	"io/ioutil"
 
-	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -28,7 +27,6 @@ type Test struct {
 	Entrypoint  []string          `yaml:"entrypoint,omitempty"`
 	Labels      map[string]string `yaml:"labels"`      // User defined labels used to filter tests
 	Description string            `yaml:"description"` // User readable test description
-	TestPod     *v1.Pod           `yaml:"-"`           // Pod that ran the test
 }
 
 // Config represents the set of test configurations which scorecard

--- a/internal/scorecard/alpha/formatting.go
+++ b/internal/scorecard/alpha/formatting.go
@@ -34,16 +34,15 @@ func getTestResult(client kubernetes.Interface, p *v1.Pod, test Test) (output v1
 		r.Description = test.Description
 		r.Errors = []string{fmt.Sprintf("Error getting pod log %s", err.Error())}
 		return r
-	} else {
-		// marshal pod log into ScorecardTestResult
-		err := json.Unmarshal(logBytes, &output)
-		if err != nil {
-			r := v1alpha2.ScorecardTestResult{}
-			r.Name = test.Name
-			r.Description = test.Description
-			r.Errors = []string{fmt.Sprintf("Error unmarshalling test result %s", err.Error())}
-			return r
-		}
+	}
+	// marshal pod log into ScorecardTestResult
+	err = json.Unmarshal(logBytes, &output)
+	if err != nil {
+		r := v1alpha2.ScorecardTestResult{}
+		r.Name = test.Name
+		r.Description = test.Description
+		r.Errors = []string{fmt.Sprintf("Error unmarshalling test result %s", err.Error())}
+		return r
 	}
 	return output
 }

--- a/internal/scorecard/alpha/formatting.go
+++ b/internal/scorecard/alpha/formatting.go
@@ -19,36 +19,30 @@ import (
 	"fmt"
 
 	"github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
-// getTestResults fetches the test pod logs and converts it into
+// getTestResult fetches the test pod log and converts it into
 // ScorecardOutput format
-func getTestResults(client kubernetes.Interface, tests []Test) (output v1alpha2.ScorecardOutput) {
-	output.Results = make([]v1alpha2.ScorecardTestResult, 0)
+func getTestResult(client kubernetes.Interface, p *v1.Pod, test Test) (output v1alpha2.ScorecardTestResult) {
 
-	for _, test := range tests {
-		p := test.TestPod
-		logBytes, err := getPodLog(client, p)
+	logBytes, err := getPodLog(client, p)
+	if err != nil {
+		r := v1alpha2.ScorecardTestResult{}
+		r.Name = test.Name
+		r.Description = test.Description
+		r.Errors = []string{fmt.Sprintf("Error getting pod log %s", err.Error())}
+		return r
+	} else {
+		// marshal pod log into ScorecardTestResult
+		err := json.Unmarshal(logBytes, &output)
 		if err != nil {
 			r := v1alpha2.ScorecardTestResult{}
 			r.Name = test.Name
 			r.Description = test.Description
-			r.Errors = []string{fmt.Sprintf("Error getting pod log %s", err.Error())}
-			output.Results = append(output.Results, r)
-		} else {
-			// marshal pod log into ScorecardTestResult
-			var sc v1alpha2.ScorecardTestResult
-			err := json.Unmarshal(logBytes, &sc)
-			if err != nil {
-				r := v1alpha2.ScorecardTestResult{}
-				r.Name = test.Name
-				r.Description = test.Description
-				r.Errors = []string{fmt.Sprintf("Error unmarshalling test result %s", err.Error())}
-				output.Results = append(output.Results, r)
-			} else {
-				output.Results = append(output.Results, sc)
-			}
+			r.Errors = []string{fmt.Sprintf("Error unmarshalling test result %s", err.Error())}
+			return r
 		}
 	}
 	return output
@@ -57,7 +51,7 @@ func getTestResults(client kubernetes.Interface, tests []Test) (output v1alpha2.
 // ListTests lists the scorecard tests as configured that would be
 // run based on user selection
 func (o Scorecard) ListTests() (output v1alpha2.ScorecardOutput, err error) {
-	tests := selectTests(o.Selector, o.Config.Tests)
+	tests := o.selectTests()
 	if len(tests) == 0 {
 		fmt.Println("no tests selected")
 		return output, err

--- a/internal/scorecard/alpha/labels_test.go
+++ b/internal/scorecard/alpha/labels_test.go
@@ -37,15 +37,15 @@ func TestEmptySelector(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.selectorValue, func(t *testing.T) {
-			var scConfig Config
+			o := Scorecard{}
 
-			err := yaml.Unmarshal([]byte(testConfig), &scConfig)
+			err := yaml.Unmarshal([]byte(testConfig), &o.Config)
 			if err != nil {
 				t.Log(err)
 				return
 			}
 
-			selector, err := labels.Parse(c.selectorValue)
+			o.Selector, err = labels.Parse(c.selectorValue)
 			if err == nil && c.wantError {
 				t.Fatalf("Wanted error but got no error")
 			} else if err != nil {
@@ -55,7 +55,7 @@ func TestEmptySelector(t *testing.T) {
 				return
 			}
 
-			tests := selectTests(selector, scConfig.Tests)
+			tests := o.selectTests()
 			testsSelected := len(tests)
 			if testsSelected != c.testsSelected {
 				t.Errorf("Wanted testsSelected %d, got: %d", c.testsSelected, testsSelected)

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -64,7 +64,7 @@ func (o Scorecard) RunTests() (testOutput v1alpha2.ScorecardOutput, err error) {
 		if err != nil {
 			return testOutput, fmt.Errorf("test %s failed %w", test.Name, err)
 		}
-		err = o.waitForTestToComplete(pod, test)
+		err = o.waitForTestToComplete(pod)
 		if err != nil {
 			return testOutput, err
 		}
@@ -114,7 +114,7 @@ func ConfigDocLink() string {
 
 // waitForTestToComplete waits for a fixed amount of time while
 // checking for a test pod to complete
-func (o Scorecard) waitForTestToComplete(p *v1.Pod, test Test) (err error) {
+func (o Scorecard) waitForTestToComplete(p *v1.Pod) (err error) {
 	waitTimeInSeconds := int(o.WaitTime.Seconds())
 	for elapsedSeconds := 0; elapsedSeconds < waitTimeInSeconds; elapsedSeconds++ {
 		var tmp *v1.Pod

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -28,21 +28,21 @@ import (
 )
 
 type Scorecard struct {
-	Config          Config
-	Selector        labels.Selector
-	BundlePath      string
-	WaitTime        time.Duration
-	Kubeconfig      string
-	Namespace       string
-	bundleConfigMap *v1.ConfigMap
-	ServiceAccount  string
-	Client          kubernetes.Interface
-	SkipCleanup     bool
+	Config              Config
+	Selector            labels.Selector
+	BundlePath          string
+	WaitTime            time.Duration
+	Kubeconfig          string
+	Namespace           string
+	ServiceAccount      string
+	BundleConfigMapName string
+	Client              kubernetes.Interface
+	SkipCleanup         bool
 }
 
 // RunTests executes the scorecard tests as configured
 func (o Scorecard) RunTests() (testOutput v1alpha2.ScorecardOutput, err error) {
-	tests := selectTests(o.Selector, o.Config.Tests)
+	tests := o.selectTests()
 	if len(tests) == 0 {
 		fmt.Println("no tests selected")
 		return testOutput, err
@@ -54,42 +54,39 @@ func (o Scorecard) RunTests() (testOutput v1alpha2.ScorecardOutput, err error) {
 	}
 
 	// create a ConfigMap holding the bundle contents
-	o.bundleConfigMap, err = createConfigMap(o, bundleData)
+	o.BundleConfigMapName, err = createConfigMap(o, bundleData)
 	if err != nil {
 		return testOutput, fmt.Errorf("error creating ConfigMap %w", err)
 	}
 
-	for i, test := range tests {
-		var err error
-		tests[i].TestPod, err = o.runTest(test)
+	for _, test := range tests {
+		pod, err := o.runTest(test)
 		if err != nil {
 			return testOutput, fmt.Errorf("test %s failed %w", test.Name, err)
 		}
+		err = o.waitForTestToComplete(pod, test)
+		if err != nil {
+			return testOutput, err
+		}
+		testOutput.Results = append(testOutput.Results, getTestResult(o.Client, pod, test))
 	}
 
 	if !o.SkipCleanup {
-		defer deletePods(o.Client, tests)
-		defer deleteConfigMap(o.Client, o.bundleConfigMap)
+		defer deletePods(o)
+		defer deleteConfigMap(o)
 	}
-
-	err = o.waitForTestsToComplete(tests)
-	if err != nil {
-		return testOutput, err
-	}
-
-	testOutput = getTestResults(o.Client, tests)
 
 	return testOutput, err
 }
 
 // selectTests applies an optionally passed selector expression
 // against the configured set of tests, returning the selected tests
-func selectTests(selector labels.Selector, tests []Test) []Test {
+func (o Scorecard) selectTests() []Test {
 
 	selected := make([]Test, 0)
 
-	for _, test := range tests {
-		if selector.String() == "" || selector.Matches(labels.Set(test.Labels)) {
+	for _, test := range o.Config.Tests {
+		if o.Selector.String() == "" || o.Selector.Matches(labels.Set(test.Labels)) {
 			// TODO olm manifests check
 			selected = append(selected, test)
 		}
@@ -115,27 +112,20 @@ func ConfigDocLink() string {
 		version.Version)
 }
 
-// waitForTestsToComplete waits for a fixed amount of time while
-// checking for test pods to complete
-func (o Scorecard) waitForTestsToComplete(tests []Test) (err error) {
+// waitForTestToComplete waits for a fixed amount of time while
+// checking for a test pod to complete
+func (o Scorecard) waitForTestToComplete(p *v1.Pod, test Test) (err error) {
 	waitTimeInSeconds := int(o.WaitTime.Seconds())
 	for elapsedSeconds := 0; elapsedSeconds < waitTimeInSeconds; elapsedSeconds++ {
-		allPodsCompleted := true
-		for _, test := range tests {
-			p := test.TestPod
-			var tmp *v1.Pod
-			tmp, err = o.Client.CoreV1().Pods(p.Namespace).Get(p.Name, metav1.GetOptions{})
-			if err != nil {
-				return fmt.Errorf("error getting pod %s %w", p.Name, err)
-			}
-			if tmp.Status.Phase != v1.PodSucceeded {
-				allPodsCompleted = false
-			}
-
+		var tmp *v1.Pod
+		tmp, err = o.Client.CoreV1().Pods(p.Namespace).Get(p.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("error getting pod %s %w", p.Name, err)
 		}
-		if allPodsCompleted {
+		if tmp.Status.Phase == v1.PodSucceeded {
 			return nil
 		}
+
 		time.Sleep(1 * time.Second)
 	}
 	return fmt.Errorf("error - wait time of %d seconds has been exceeded", o.WaitTime)

--- a/internal/scorecard/alpha/testconfigmap.go
+++ b/internal/scorecard/alpha/testconfigmap.go
@@ -21,15 +21,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/client-go/kubernetes"
 )
 
 // createConfigMap creates a ConfigMap that will hold the bundle
 // contents to be mounted into the test Pods
-func createConfigMap(o Scorecard, bundleData []byte) (configMap *v1.ConfigMap, err error) {
+func createConfigMap(o Scorecard, bundleData []byte) (configMapName string, err error) {
 	cfg := getConfigMapDefinition(o.Namespace, bundleData)
-	configMap, err = o.Client.CoreV1().ConfigMaps(o.Namespace).Create(cfg)
-	return configMap, err
+	configMap, err := o.Client.CoreV1().ConfigMaps(o.Namespace).Create(cfg)
+	return configMap.Name, err
 }
 
 // getConfigMapDefinition returns a ConfigMap definition that
@@ -53,9 +52,9 @@ func getConfigMapDefinition(namespace string, bundleData []byte) *v1.ConfigMap {
 
 // deleteConfigMap deletes the test bundle ConfigMap and is called
 // as part of the test run cleanup
-func deleteConfigMap(client kubernetes.Interface, configMap *v1.ConfigMap) {
-	err := client.CoreV1().ConfigMaps(configMap.Namespace).Delete(configMap.Name, &metav1.DeleteOptions{})
+func deleteConfigMap(o Scorecard) {
+	err := o.Client.CoreV1().ConfigMaps(o.Namespace).Delete(o.BundleConfigMapName, &metav1.DeleteOptions{})
 	if err != nil {
-		log.Errorf("Error deleting configMap %s %s", configMap.Name, err.Error())
+		log.Errorf("Error deleting configMap %s %w", o.BundleConfigMapName, err)
 	}
 }

--- a/internal/scorecard/alpha/testpod.go
+++ b/internal/scorecard/alpha/testpod.go
@@ -34,7 +34,8 @@ func getPodDefinition(test Test, o Scorecard) *v1.Pod {
 			Name:      fmt.Sprintf("scorecard-test-%s", rand.String(4)),
 			Namespace: o.Namespace,
 			Labels: map[string]string{
-				"app": "scorecard-test",
+				"app":     "scorecard-test",
+				"testrun": o.BundleConfigMapName,
 			},
 		},
 		Spec: v1.PodSpec{
@@ -61,7 +62,7 @@ func getPodDefinition(test Test, o Scorecard) *v1.Pod {
 					VolumeSource: v1.VolumeSource{
 						ConfigMap: &v1.ConfigMapVolumeSource{
 							LocalObjectReference: v1.LocalObjectReference{
-								Name: o.bundleConfigMap.Name,
+								Name: o.BundleConfigMapName,
 							},
 						},
 					},
@@ -88,13 +89,13 @@ func getPodLog(client kubernetes.Interface, pod *v1.Pod) (logOutput []byte, err 
 	return buf.Bytes(), err
 }
 
-func deletePods(client kubernetes.Interface, tests []Test) {
-	for _, test := range tests {
-		p := test.TestPod
-		err := client.CoreV1().Pods(p.Namespace).Delete(p.Name, &metav1.DeleteOptions{})
-		if err != nil {
-			log.Errorf("Error deleting pod %s %s\n", p.Name, err.Error())
-		}
-
+func deletePods(o Scorecard) {
+	do := metav1.DeleteOptions{}
+	selector := fmt.Sprintf("testrun=%s", o.BundleConfigMapName)
+	lo := metav1.ListOptions{LabelSelector: selector}
+	err := o.Client.CoreV1().Pods(o.Namespace).DeleteCollection(&do, lo)
+	if err != nil {
+		log.Errorf("Error deleting pods selector %s %w\n", selector, err)
 	}
+
 }


### PR DESCRIPTION


**Description of the change:**

this PR is focused on adding the ability to run tests in parallel as well as the default which is sequentially, this PR adds a --parallel command flag that uses can set, also it cleans up a lot of the pod execution logic in scorecard.go

**Motivation for the change:**

general cleanup of the code plus adding the parallel feature which might be useful for end-users if their tests can indeed run in parallel, the scorecard doesn't enforce which tests can run in parallel and this is left to end users to determine if this is possible and that tests do not collide with each other.