### PR TITLE
Scorecard2 pod exec3

### DIFF
--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -37,6 +37,7 @@ func NewCmd() *cobra.Command {
 		serviceAccount string
 		list           bool
 		skipCleanup    bool
+		parallel       bool
 		waitTime       time.Duration
 	)
 	scorecardCmd := &cobra.Command{
@@ -52,6 +53,7 @@ func NewCmd() *cobra.Command {
 				Namespace:      namespace,
 				BundlePath:     bundle,
 				SkipCleanup:    skipCleanup,
+				Parallel:       parallel,
 				WaitTime:       waitTime,
 			}
 
@@ -103,6 +105,7 @@ func NewCmd() *cobra.Command {
 	scorecardCmd.Flags().StringVarP(&serviceAccount, "service-account", "s", "default", "Service account to use for tests")
 	scorecardCmd.Flags().BoolVarP(&list, "list", "L", false, "Option to enable listing which tests are run")
 	scorecardCmd.Flags().BoolVarP(&skipCleanup, "skip-cleanup", "x", false, "Disable resource cleanup after tests are run")
+	scorecardCmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run tests in parallel")
 	scorecardCmd.Flags().DurationVarP(&waitTime, "wait-time", "w", time.Duration(30*time.Second),
 		"seconds to wait for tests to complete. Example: 35s")
 

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -115,6 +115,10 @@ func NewCmd() *cobra.Command {
 func printOutput(outputFormat string, output v1alpha2.ScorecardOutput) error {
 	switch outputFormat {
 	case "text":
+		if len(output.Results) == 0 {
+			fmt.Println("0 tests selected")
+			return nil
+		}
 		o, err := output.MarshalText()
 		if err != nil {
 			fmt.Println(err.Error())

--- a/cmd/operator-sdk/alpha/scorecard/cmd.go
+++ b/cmd/operator-sdk/alpha/scorecard/cmd.go
@@ -37,7 +37,6 @@ func NewCmd() *cobra.Command {
 		serviceAccount string
 		list           bool
 		skipCleanup    bool
-		parallel       bool
 		waitTime       time.Duration
 	)
 	scorecardCmd := &cobra.Command{
@@ -53,7 +52,6 @@ func NewCmd() *cobra.Command {
 				Namespace:      namespace,
 				BundlePath:     bundle,
 				SkipCleanup:    skipCleanup,
-				Parallel:       parallel,
 				WaitTime:       waitTime,
 			}
 
@@ -105,7 +103,6 @@ func NewCmd() *cobra.Command {
 	scorecardCmd.Flags().StringVarP(&serviceAccount, "service-account", "s", "default", "Service account to use for tests")
 	scorecardCmd.Flags().BoolVarP(&list, "list", "L", false, "Option to enable listing which tests are run")
 	scorecardCmd.Flags().BoolVarP(&skipCleanup, "skip-cleanup", "x", false, "Disable resource cleanup after tests are run")
-	scorecardCmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run tests in parallel")
 	scorecardCmd.Flags().DurationVarP(&waitTime, "wait-time", "w", time.Duration(30*time.Second),
 		"seconds to wait for tests to complete. Example: 35s")
 

--- a/internal/scorecard/alpha/bundle.go
+++ b/internal/scorecard/alpha/bundle.go
@@ -22,8 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
-// GetBundleData tars up the contents of a bundle from a path, and returns that tar file in []byte
-func (o Scorecard) GetBundleData() (bundleData []byte, err error) {
+// getBundleData tars up the contents of a bundle from a path, and returns that tar file in []byte
+func (o Scorecard) getBundleData() (bundleData []byte, err error) {
 
 	// make sure the bundle exists on disk
 	_, err = os.Stat(o.BundlePath)

--- a/internal/scorecard/alpha/bundle.go
+++ b/internal/scorecard/alpha/bundle.go
@@ -22,18 +22,18 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
-// getBundleData tars up the contents of a bundle from a path, and returns that tar file in []byte
-func getBundleData(bundlePath string) (bundleData []byte, err error) {
+// GetBundleData tars up the contents of a bundle from a path, and returns that tar file in []byte
+func (o Scorecard) GetBundleData() (bundleData []byte, err error) {
 
 	// make sure the bundle exists on disk
-	_, err = os.Stat(bundlePath)
+	_, err = os.Stat(o.BundlePath)
 	if os.IsNotExist(err) {
 		return bundleData, fmt.Errorf("bundle path is not valid %w", err)
 	}
 
 	tempTarFileName := fmt.Sprintf("%s%ctempBundle-%s.tar", os.TempDir(), os.PathSeparator, rand.String(4))
 
-	paths := []string{bundlePath}
+	paths := []string{o.BundlePath}
 	err = CreateTarFile(tempTarFileName, paths)
 	if err != nil {
 		return bundleData, fmt.Errorf("error creating tar of bundle %w", err)

--- a/internal/scorecard/alpha/config.go
+++ b/internal/scorecard/alpha/config.go
@@ -17,7 +17,6 @@ package alpha
 import (
 	"io/ioutil"
 
-	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -28,7 +27,6 @@ type Test struct {
 	Entrypoint  []string          `yaml:"entrypoint,omitempty"`
 	Labels      map[string]string `yaml:"labels"`      // User defined labels used to filter tests
 	Description string            `yaml:"description"` // User readable test description
-	TestPod     *v1.Pod           `yaml:"-"`           // Pod that ran the test
 }
 
 // Config represents the set of test configurations which scorecard

--- a/internal/scorecard/alpha/formatting.go
+++ b/internal/scorecard/alpha/formatting.go
@@ -34,16 +34,15 @@ func getTestResult(client kubernetes.Interface, p *v1.Pod, test Test) (output v1
 		r.Description = test.Description
 		r.Errors = []string{fmt.Sprintf("Error getting pod log %s", err.Error())}
 		return r
-	} else {
-		// marshal pod log into ScorecardTestResult
-		err := json.Unmarshal(logBytes, &output)
-		if err != nil {
-			r := v1alpha2.ScorecardTestResult{}
-			r.Name = test.Name
-			r.Description = test.Description
-			r.Errors = []string{fmt.Sprintf("Error unmarshalling test result %s", err.Error())}
-			return r
-		}
+	}
+	// marshal pod log into ScorecardTestResult
+	err = json.Unmarshal(logBytes, &output)
+	if err != nil {
+		r := v1alpha2.ScorecardTestResult{}
+		r.Name = test.Name
+		r.Description = test.Description
+		r.Errors = []string{fmt.Sprintf("Error unmarshalling test result %s", err.Error())}
+		return r
 	}
 	return output
 }

--- a/internal/scorecard/alpha/formatting.go
+++ b/internal/scorecard/alpha/formatting.go
@@ -19,36 +19,30 @@ import (
 	"fmt"
 
 	"github.com/operator-framework/operator-sdk/pkg/apis/scorecard/v1alpha2"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
-// getTestResults fetches the test pod logs and converts it into
+// getTestResult fetches the test pod log and converts it into
 // ScorecardOutput format
-func getTestResults(client kubernetes.Interface, tests []Test) (output v1alpha2.ScorecardOutput) {
-	output.Results = make([]v1alpha2.ScorecardTestResult, 0)
+func getTestResult(client kubernetes.Interface, p *v1.Pod, test Test) (output v1alpha2.ScorecardTestResult) {
 
-	for _, test := range tests {
-		p := test.TestPod
-		logBytes, err := getPodLog(client, p)
+	logBytes, err := getPodLog(client, p)
+	if err != nil {
+		r := v1alpha2.ScorecardTestResult{}
+		r.Name = test.Name
+		r.Description = test.Description
+		r.Errors = []string{fmt.Sprintf("Error getting pod log %s", err.Error())}
+		return r
+	} else {
+		// marshal pod log into ScorecardTestResult
+		err := json.Unmarshal(logBytes, &output)
 		if err != nil {
 			r := v1alpha2.ScorecardTestResult{}
 			r.Name = test.Name
 			r.Description = test.Description
-			r.Errors = []string{fmt.Sprintf("Error getting pod log %s", err.Error())}
-			output.Results = append(output.Results, r)
-		} else {
-			// marshal pod log into ScorecardTestResult
-			var sc v1alpha2.ScorecardTestResult
-			err := json.Unmarshal(logBytes, &sc)
-			if err != nil {
-				r := v1alpha2.ScorecardTestResult{}
-				r.Name = test.Name
-				r.Description = test.Description
-				r.Errors = []string{fmt.Sprintf("Error unmarshalling test result %s", err.Error())}
-				output.Results = append(output.Results, r)
-			} else {
-				output.Results = append(output.Results, sc)
-			}
+			r.Errors = []string{fmt.Sprintf("Error unmarshalling test result %s", err.Error())}
+			return r
 		}
 	}
 	return output
@@ -57,7 +51,7 @@ func getTestResults(client kubernetes.Interface, tests []Test) (output v1alpha2.
 // ListTests lists the scorecard tests as configured that would be
 // run based on user selection
 func (o Scorecard) ListTests() (output v1alpha2.ScorecardOutput, err error) {
-	tests := selectTests(o.Selector, o.Config.Tests)
+	tests := o.selectTests()
 	if len(tests) == 0 {
 		fmt.Println("no tests selected")
 		return output, err

--- a/internal/scorecard/alpha/labels_test.go
+++ b/internal/scorecard/alpha/labels_test.go
@@ -37,15 +37,15 @@ func TestEmptySelector(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.selectorValue, func(t *testing.T) {
-			var scConfig Config
+			o := Scorecard{}
 
-			err := yaml.Unmarshal([]byte(testConfig), &scConfig)
+			err := yaml.Unmarshal([]byte(testConfig), &o.Config)
 			if err != nil {
 				t.Log(err)
 				return
 			}
 
-			selector, err := labels.Parse(c.selectorValue)
+			o.Selector, err = labels.Parse(c.selectorValue)
 			if err == nil && c.wantError {
 				t.Fatalf("Wanted error but got no error")
 			} else if err != nil {
@@ -55,7 +55,7 @@ func TestEmptySelector(t *testing.T) {
 				return
 			}
 
-			tests := selectTests(selector, scConfig.Tests)
+			tests := o.selectTests()
 			testsSelected := len(tests)
 			if testsSelected != c.testsSelected {
 				t.Errorf("Wanted testsSelected %d, got: %d", c.testsSelected, testsSelected)

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -66,7 +66,7 @@ func (o Scorecard) RunTests() (testOutput v1alpha2.ScorecardOutput, err error) {
 		if err != nil {
 			return testOutput, fmt.Errorf("test %s failed %w", test.Name, err)
 		}
-		err = o.waitForTestToComplete(pod, test)
+		err = o.waitForTestToComplete(pod)
 		if err != nil {
 			return testOutput, err
 		}
@@ -116,7 +116,7 @@ func ConfigDocLink() string {
 
 // waitForTestToComplete waits for a fixed amount of time while
 // checking for a test pod to complete
-func (o Scorecard) waitForTestToComplete(p *v1.Pod, test Test) (err error) {
+func (o Scorecard) waitForTestToComplete(p *v1.Pod) (err error) {
 	waitTimeInSeconds := int(o.WaitTime.Seconds())
 	for elapsedSeconds := 0; elapsedSeconds < waitTimeInSeconds; elapsedSeconds++ {
 		var tmp *v1.Pod

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -40,6 +41,7 @@ type Scorecard struct {
 	BundleConfigMapName string
 	Client              kubernetes.Interface
 	SkipCleanup         bool
+	Parallel            bool
 }
 
 // RunTests executes the scorecard tests as configured
@@ -61,16 +63,32 @@ func (o Scorecard) RunTests() (testOutput v1alpha2.ScorecardOutput, err error) {
 		return testOutput, fmt.Errorf("error creating ConfigMap %w", err)
 	}
 
-	for _, test := range tests {
-		pod, err := o.runTest(test)
-		if err != nil {
-			return testOutput, fmt.Errorf("test %s failed %w", test.Name, err)
+	ctx, cancel := context.WithTimeout(context.Background(), o.WaitTime)
+	defer cancel()
+
+	if o.Parallel {
+		wg := sync.WaitGroup{}
+		wg.Add(len(tests))
+		for idx, test := range tests {
+			go func(i int, t Test) {
+				defer wg.Done()
+				result, err := o.runTest(ctx, test)
+				if err != nil {
+					result = convertErrorToResult(t, err)
+				}
+				testOutput.Results = append(testOutput.Results, result)
+			}(idx, test)
 		}
-		err = o.waitForTestToComplete(pod)
-		if err != nil {
-			return testOutput, err
+		wg.Wait()
+	} else {
+
+		for _, test := range tests {
+			result, err := o.runTest(ctx, test)
+			if err != nil {
+				result = convertErrorToResult(test, err)
+			}
+			testOutput.Results = append(testOutput.Results, result)
 		}
-		testOutput.Results = append(testOutput.Results, getTestResult(o.Client, pod, test))
 	}
 
 	if !o.SkipCleanup {
@@ -97,12 +115,22 @@ func (o Scorecard) selectTests() []Test {
 }
 
 // runTest executes a single test
-func (o Scorecard) runTest(test Test) (result *v1.Pod, err error) {
+func (o Scorecard) runTest(ctx context.Context, test Test) (result v1alpha2.ScorecardTestResult, err error) {
 
 	// Create a Pod to run the test
 	podDef := getPodDefinition(test, o)
-	result, err = o.Client.CoreV1().Pods(o.Namespace).Create(context.TODO(), podDef, metav1.CreateOptions{})
-	return result, err
+	pod, err := o.Client.CoreV1().Pods(o.Namespace).Create(context.TODO(), podDef, metav1.CreateOptions{})
+	if err != nil {
+		return result, err
+	}
+
+	err = o.waitForTestToComplete(pod)
+	if err != nil {
+		return result, err
+	}
+
+	result = getTestResult(o.Client, pod, test)
+	return result, nil
 }
 
 func ConfigDocLink() string {
@@ -132,4 +160,13 @@ func (o Scorecard) waitForTestToComplete(p *v1.Pod) (err error) {
 	}
 	return fmt.Errorf("error - wait time of %d seconds has been exceeded", o.WaitTime)
 
+}
+
+func convertErrorToResult(t Test, err error) (result v1alpha2.ScorecardTestResult) {
+	result.Name = t.Name
+	result.Description = t.Description
+	result.Errors = []string{err.Error()}
+	result.Suggestions = []string{}
+	result.State = v1alpha2.FailState
+	return result
 }

--- a/internal/scorecard/alpha/scorecard.go
+++ b/internal/scorecard/alpha/scorecard.go
@@ -66,28 +66,29 @@ func (o Scorecard) RunTests() (testOutput v1alpha2.ScorecardOutput, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), o.WaitTime)
 	defer cancel()
 
+	testOutput.Results = make([]v1alpha2.ScorecardTestResult, len(tests))
 	if o.Parallel {
 		wg := sync.WaitGroup{}
 		wg.Add(len(tests))
 		for idx, test := range tests {
 			go func(i int, t Test) {
 				defer wg.Done()
-				result, err := o.runTest(ctx, test)
+				result, err := o.runTest(ctx, t)
 				if err != nil {
 					result = convertErrorToResult(t, err)
 				}
-				testOutput.Results = append(testOutput.Results, result)
+				testOutput.Results[i] = result
 			}(idx, test)
 		}
 		wg.Wait()
 	} else {
 
-		for _, test := range tests {
+		for idx, test := range tests {
 			result, err := o.runTest(ctx, test)
 			if err != nil {
 				result = convertErrorToResult(test, err)
 			}
-			testOutput.Results = append(testOutput.Results, result)
+			testOutput.Results[idx] = result
 		}
 	}
 
@@ -115,7 +116,7 @@ func (o Scorecard) selectTests() []Test {
 }
 
 // runTest executes a single test
-func (o Scorecard) runTest(ctx context.Context, test Test) (result v1alpha2.ScorecardTestResult, err error) {
+func (o Scorecard) runTest(_ context.Context, test Test) (result v1alpha2.ScorecardTestResult, err error) {
 
 	// Create a Pod to run the test
 	podDef := getPodDefinition(test, o)

--- a/internal/scorecard/alpha/testconfigmap.go
+++ b/internal/scorecard/alpha/testconfigmap.go
@@ -54,7 +54,7 @@ func getConfigMapDefinition(namespace string, bundleData []byte) *v1.ConfigMap {
 // deleteConfigMap deletes the test bundle ConfigMap and is called
 // as part of the test run cleanup
 func deleteConfigMap(o Scorecard) {
-	err := o.Client.CoreV1().ConfigMaps(o.Namespace).Delete(context.TODO(), o.BundleConfigMapName, &metav1.DeleteOptions{})
+	err := o.Client.CoreV1().ConfigMaps(o.Namespace).Delete(context.TODO(), o.BundleConfigMapName, metav1.DeleteOptions{})
 	if err != nil {
 		log.Errorf("Error deleting configMap %s %w", o.BundleConfigMapName, err)
 	}

--- a/internal/scorecard/alpha/testconfigmap.go
+++ b/internal/scorecard/alpha/testconfigmap.go
@@ -22,15 +22,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/client-go/kubernetes"
 )
 
 // createConfigMap creates a ConfigMap that will hold the bundle
 // contents to be mounted into the test Pods
-func createConfigMap(o Scorecard, bundleData []byte) (configMap *v1.ConfigMap, err error) {
+func createConfigMap(o Scorecard, bundleData []byte) (configMapName string, err error) {
 	cfg := getConfigMapDefinition(o.Namespace, bundleData)
-	configMap, err = o.Client.CoreV1().ConfigMaps(o.Namespace).Create(context.TODO(), cfg, metav1.CreateOptions{})
-	return configMap, err
+	configMap, err := o.Client.CoreV1().ConfigMaps(o.Namespace).Create(context.TODO(), cfg, metav1.CreateOptions{})
+	return configMap.Name, err
 }
 
 // getConfigMapDefinition returns a ConfigMap definition that
@@ -54,9 +53,9 @@ func getConfigMapDefinition(namespace string, bundleData []byte) *v1.ConfigMap {
 
 // deleteConfigMap deletes the test bundle ConfigMap and is called
 // as part of the test run cleanup
-func deleteConfigMap(client kubernetes.Interface, configMap *v1.ConfigMap) {
-	err := client.CoreV1().ConfigMaps(configMap.Namespace).Delete(context.TODO(), configMap.Name, metav1.DeleteOptions{})
+func deleteConfigMap(o Scorecard) {
+	err := o.Client.CoreV1().ConfigMaps(o.Namespace).Delete(context.TODO(), o.BundleConfigMapName, &metav1.DeleteOptions{})
 	if err != nil {
-		log.Errorf("Error deleting configMap %s %s", configMap.Name, err.Error())
+		log.Errorf("Error deleting configMap %s %w", o.BundleConfigMapName, err)
 	}
 }

--- a/internal/scorecard/alpha/testpod.go
+++ b/internal/scorecard/alpha/testpod.go
@@ -94,7 +94,7 @@ func deletePods(o Scorecard) {
 	do := metav1.DeleteOptions{}
 	selector := fmt.Sprintf("testrun=%s", o.BundleConfigMapName)
 	lo := metav1.ListOptions{LabelSelector: selector}
-	err := o.Client.CoreV1().Pods(o.Namespace).DeleteCollection(context.TODO(), &do, lo)
+	err := o.Client.CoreV1().Pods(o.Namespace).DeleteCollection(context.TODO(), do, lo)
 	if err != nil {
 		log.Errorf("Error deleting pods selector %s %w\n", selector, err)
 	}


### PR DESCRIPTION


**Description of the change:**

pod execution refinement, this PR adds a --parallel flag and lets the user run tests in parallel if they choose to, the default is serial and NOT parallel.  This PR also cleans up a lot of the pod
execution code.

**Motivation for the change:**

part of the overall scorecard2 work, this one deals with pod execution mostly.
