### PR TITLE
generate csv: de-deprecate package manifests format

### DIFF
--- a/changelog/fragments/2944-change.yaml
+++ b/changelog/fragments/2944-change.yaml
@@ -2,8 +2,8 @@ entries:
   - description: >
       Revert deprecation of the package manifests format. See
       [#2755](https://github.com/operator-framework/operator-sdk/pull/2755) for
-      deprecation details. The package manifests format will be supported
-      indefinitely.
+      deprecation details. The package manifests format is still officially supported
+      by the Operator Framework
 
     kind: change
 

--- a/changelog/fragments/2944-change.yaml
+++ b/changelog/fragments/2944-change.yaml
@@ -1,0 +1,10 @@
+entries:
+  - description: >
+      Revert deprecation of the package manifests format. See
+      [#2755](https://github.com/operator-framework/operator-sdk/pull/2755) for
+      deprecation details. The package manifests format will be supported
+      indefinitely.
+
+    kind: change
+
+    breaking: false

--- a/cmd/operator-sdk/bundle/cmd.go
+++ b/cmd/operator-sdk/bundle/cmd.go
@@ -32,12 +32,17 @@ type bundleCmd struct {
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bundle",
-		Short: "Work with operator bundle metadata and bundle images",
-		Long: `Generate operator bundle metadata and build operator bundle images, which
-are used to manage operators in the Operator Lifecycle Manager.
+		Short: "Manage operator bundle metadata",
+		Long: `Manage bundle builds, bundle metadata generation, and bundle validation.
+An operator bundle is a portable operator packaging format understood by Kubernetes
+native software, like the Operator Lifecycle Manager.
 
-More information on operator bundle images and metadata:
-https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md#docker`,
+More information about operator bundles and metadata:
+https://github.com/operator-framework/operator-registry#manifest-format
+
+Operator Lifecycle Manager:
+https://github.com/operator-framework/operator-lifecycle-manager
+`,
 	}
 
 	cmd.AddCommand(

--- a/cmd/operator-sdk/bundle/cmd.go
+++ b/cmd/operator-sdk/bundle/cmd.go
@@ -38,7 +38,7 @@ An operator bundle is a portable operator packaging format understood by Kuberne
 native software, like the Operator Lifecycle Manager.
 
 More information about operator bundles and metadata:
-https://github.com/operator-framework/operator-registry#manifest-format
+https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md
 
 Operator Lifecycle Manager:
 https://github.com/operator-framework/operator-lifecycle-manager

--- a/cmd/operator-sdk/bundle/create.go
+++ b/cmd/operator-sdk/bundle/create.go
@@ -73,7 +73,7 @@ will be written if '--generate-only=true':
 manually or modify metadata before building an image.
 
 More information on operator bundle images and the manifests/metadata format:
-https://github.com/operator-framework/operator-registry#manifest-format
+https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md
 
 NOTE: bundle images are not runnable.
 `,

--- a/cmd/operator-sdk/bundle/create.go
+++ b/cmd/operator-sdk/bundle/create.go
@@ -15,16 +15,15 @@
 package bundle
 
 import (
-	"crypto/sha256"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	catalog "github.com/operator-framework/operator-sdk/internal/generate/olm-catalog"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 
+	"github.com/blang/semver"
 	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -40,6 +39,7 @@ type bundleCreateCmd struct {
 
 // newCreateCmd returns a command that will build operator bundle image or
 // generate metadata for them.
+//nolint:lll
 func newCreateCmd() *cobra.Command {
 	c := &bundleCreateCmd{}
 
@@ -51,32 +51,29 @@ bundle image containing operator metadata and manifests, tagged with the
 provided image tag.
 
 To write all files required to build a bundle image without building the
-image, set '--generate-only=true'. A bundle Dockerfile, bundle metadata, and
-a 'manifests/' directory containing your bundle manifests will be written if
-'--generate-only=true':
+image, set '--generate-only=true'. A bundle.Dockerfile and bundle metadata
+will be written if '--generate-only=true':
 
-	$ operator-sdk bundle create --generate-only --directory ./deploy/olm-catalog/test-operator/0.1.0
-	$ ls .
-	...
-	bundle.Dockerfile
-	...
-	$ tree ./deploy/olm-catalog/test-operator/
-	└── 0.1.0
-		└── example.com_tests_crd.yaml
-		└── test-operator.v0.1.0.clusterserviceversion.yaml
-	└── manifests
-		└── example.com_tests_crd.yaml
-		└── test-operator.v0.1.0.clusterserviceversion.yaml
-	└── metadata
-		└── annotations.yaml
+` + "```" + `
+  $ operator-sdk bundle create --generate-only --directory ./deploy/olm-catalog/test-operator/manifests
+  $ ls .
+  ...
+  bundle.Dockerfile
+  ...
+  $ tree ./deploy/olm-catalog/test-operator/
+  ./deploy/olm-catalog/test-operator/
+  ├── manifests
+  │   ├── example.com_tests_crd.yaml
+  │   └── test-operator.clusterserviceversion.yaml
+  └── metadata
+      └── annotations.yaml
+` + "```" + `
 
 '--generate-only' is useful if you want to build an operator's bundle image
-manually, modify metadata before building an image, or want to generate a
-'manifests/' directory containing your operator manifests for compatibility
-with other operator tooling.
+manually or modify metadata before building an image.
 
-More information on operator bundle images and metadata:
-https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md#docker
+More information on operator bundle images and the manifests/metadata format:
+https://github.com/operator-framework/operator-registry#manifest-format
 
 NOTE: bundle images are not runnable.
 `,
@@ -84,7 +81,7 @@ NOTE: bundle images are not runnable.
 This image will contain manifests for package channels 'stable' and 'beta':
 
   $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
-      --directory ./deploy/olm-catalog/test-operator/0.1.0 \
+      --directory ./deploy/olm-catalog/test-operator/manifests \
       --package test-operator \
       --channels stable,beta \
       --default-channel stable
@@ -92,16 +89,13 @@ This image will contain manifests for package channels 'stable' and 'beta':
 Assuming your operator has the same name as your repo directory and the only
 channel is 'stable', the above command can be abbreviated to:
 
-  $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
-      --directory ./deploy/olm-catalog/test-operator/0.1.0
+  $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0
 
-The following invocation will generate test-operator bundle metadata, a
-'manifests/' dir, and Dockerfile for your latest operator version without
-building the image:
+The following invocation will generate test-operator bundle metadata and a
+bundle.Dockerfile for your latest operator version without building the image:
 
   $ operator-sdk bundle create \
       --generate-only \
-      --directory ./deploy/olm-catalog/test-operator/0.1.0 \
       --package test-operator \
       --channels beta \
       --default-channel beta
@@ -113,24 +107,6 @@ building the image:
 
 			if err = c.validate(args); err != nil {
 				return fmt.Errorf("error validating args: %v", err)
-			}
-
-			rootDir := filepath.Dir(c.directory)
-			manifestsDir := filepath.Join(rootDir, bundle.ManifestsDir)
-
-			// To ensure users don't accidentally overwrite their manifests dir
-			// created previously, make sure they have set --overwrite or no
-			// contents of the directory differ in the source directory.
-			if !c.overwrite && isExist(manifestsDir) && c.outputDir == filepath.Dir(c.directory) {
-				dirsDiffer, err := areDirsDiff(c.directory, manifestsDir)
-				if err != nil {
-					log.Fatal(err)
-				}
-				if dirsDiffer {
-					log.Fatalf("'manifests' dir already exists at %s. Set --overwrite=true "+
-						"to overwrite its contents with contents in %s",
-						manifestsDir, c.directory)
-				}
 			}
 
 			if c.generateOnly {
@@ -154,7 +130,7 @@ building the image:
 
 func (c *bundleCreateCmd) addToFlagSet(fs *pflag.FlagSet) {
 	fs.StringVarP(&c.directory, "directory", "d", "",
-		"The directory where bundle manifests are located, ex. <project-root>/deploy/olm-catalog/test-operator/0.1.0")
+		"The directory where bundle manifests are located, ex. <project-root>/deploy/olm-catalog/test-operator/manifests")
 	fs.StringVarP(&c.outputDir, "output-dir", "o", "",
 		"Optional output directory for operator manifests")
 	fs.StringVarP(&c.imageTag, "tag", "t", "",
@@ -179,27 +155,25 @@ func (c *bundleCreateCmd) setDefaults() (err error) {
 	if c.packageName == "" {
 		c.packageName = filepath.Base(projutil.MustGetwd())
 	}
+	defaultManifestsDir := filepath.Join(catalog.OLMCatalogDir, c.packageName, bundle.ManifestsDir)
 	if c.directory == "" {
-		c.directory = filepath.Join(catalog.OLMCatalogDir, c.packageName, bundle.ManifestsDir)
+		if isNotExist(defaultManifestsDir) {
+			return fmt.Errorf("default manifests directory %s does not exist; "+
+				"set --directory to a valid bundle manifests directory", defaultManifestsDir)
+		}
+		c.directory = defaultManifestsDir
 	}
 
-	// Clean and make paths relative for less verbose error messages.
-	if c.directory, err = relDir(c.directory); err != nil {
-		return err
-	}
-	// Set outputDir in any case so we make the operator-registry file generator
-	// write 'manifests/' every time, and handle cleanup logic in runBuild().
-	if c.outputDir == "" {
-		c.outputDir = filepath.Dir(c.directory)
-	}
-	if c.outputDir, err = relDir(c.outputDir); err != nil {
-		return err
+	// Clean and make paths relative for less verbose error messages. Don't return
+	// an error if we cannot.
+	if dir, err := relWd(c.directory); err == nil {
+		c.directory = dir
 	}
 
 	return nil
 }
 
-func relDir(dir string) (out string, err error) {
+func relWd(dir string) (out string, err error) {
 	if out, err = filepath.Abs(dir); err != nil {
 		return "", err
 	}
@@ -216,6 +190,11 @@ func (c bundleCreateCmd) validate(args []string) error {
 	}
 	if c.packageName == "" {
 		return fmt.Errorf("--package must be set")
+	}
+	// Bundle commands only work with bundle directory formats, not package
+	// manifests formats.
+	if isPackageManifestsDir(c.directory, c.packageName) {
+		return fmt.Errorf("bundle commands can only be used on bundle directory formats")
 	}
 	if c.generateOnly {
 		if len(args) != 0 {
@@ -244,17 +223,13 @@ func (c bundleCreateCmd) runGenerate() error {
 func (c bundleCreateCmd) runBuild() error {
 	rootDir := filepath.Dir(c.directory)
 	metadataDir := filepath.Join(rootDir, bundle.MetadataDir)
-	manifestsDir := filepath.Join(rootDir, bundle.ManifestsDir)
 
 	// Clean up transient files once the image is built, as they are no longer
 	// needed.
-	if !isExist(manifestsDir) {
-		defer remove(manifestsDir)
-	}
-	if !isExist(metadataDir) {
+	if isNotExist(metadataDir) {
 		defer remove(metadataDir)
 	}
-	if !isExist(bundle.DockerFile) {
+	if isNotExist(bundle.DockerFile) {
 		defer remove(bundle.DockerFile)
 	}
 
@@ -280,55 +255,16 @@ func isExist(path string) bool {
 	return err == nil || os.IsExist(err)
 }
 
-// areDirsDiff returns true if either file names or file contents differ
-// between dirA and dirB.
-func areDirsDiff(dirA, dirB string) (bool, error) {
-	if filepath.Clean(dirA) == filepath.Clean(dirB) {
-		return false, nil
-	}
-	fileMapA, err := getDirFileMap(dirA)
-	if err != nil {
-		return false, err
-	}
-	fileMapB, err := getDirFileMap(dirB)
-	if err != nil {
-		return false, err
-	}
-	if len(fileMapB) != len(fileMapA) {
-		return true, nil
-	}
-	for pathA, contentsA := range fileMapA {
-		contentsB, hasPathA := fileMapB[pathA]
-		if !hasPathA || contentsA != contentsB {
-			return true, nil
-		}
-	}
-	return false, nil
+// isNotExist returns true if path does not exist.
+func isNotExist(path string) bool {
+	_, err := os.Stat(path)
+	return err != nil && os.IsNotExist(err)
 }
 
-// getDirFileMap returns a map of file names to contents as strings for all
-// normal files in dir (recursive).
-func getDirFileMap(dir string) (map[string]string, error) {
-	fileMap := make(map[string]string)
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			b, err := ioutil.ReadFile(path)
-			if err != nil {
-				return err
-			}
-			fileMap[filepath.Base(path)] = hashContents(b)
-		}
-		return nil
-	})
-	return fileMap, err
-}
-
-// hashContents returns the hexadecimal representation of hashed b.
-func hashContents(b []byte) string {
-	h := sha256.New()
-	_, _ = h.Write(b)
-	return fmt.Sprintf("%x", h.Sum(nil))
+// isPackageManifestsDir checks if dir is a package manifests format directory
+// by checking for the existence of a package manifest and a semver-named directory.
+func isPackageManifestsDir(dir, operatorName string) bool {
+	packageManifestPath := filepath.Join(filepath.Dir(dir), operatorName+".package.yaml")
+	_, err := semver.ParseTolerant(filepath.Clean(filepath.Base(dir)))
+	return isExist(packageManifestPath) && err == nil
 }

--- a/cmd/operator-sdk/bundle/validate.go
+++ b/cmd/operator-sdk/bundle/validate.go
@@ -45,17 +45,18 @@ format of an operator bundle image or an operator bundles directory on-disk
 containing operator metadata and manifests. This command will exit with a non-zero
 exit code if any validation tests fail.
 
-Note: if validating an image, the image must exist in a remote registry, not
+More information on operator bundle images and the manifests/metadata format:
+https://github.com/operator-framework/operator-registry#manifest-format
+
+NOTE: if validating an image, the image must exist in a remote registry, not
 just locally.
 `,
 		Example: `The following command flow will generate test-operator bundle image manifests
 and validate them, assuming a bundle for 'test-operator' version v0.1.0 exists at
-<project-root>/deploy/olm-catalog/test-operator/0.1.0:
+<project-root>/deploy/olm-catalog/test-operator/manifests:
 
   # Generate manifests locally.
-  $ operator-sdk bundle create \
-      --generate-only \
-      --directory ./deploy/olm-catalog/test-operator/0.1.0
+  $ operator-sdk bundle create --generate-only
 
   # Validate the directory containing manifests and metadata.
   $ operator-sdk bundle validate ./deploy/olm-catalog/test-operator
@@ -63,8 +64,7 @@ and validate them, assuming a bundle for 'test-operator' version v0.1.0 exists a
 To build and validate an image:
 
   # Build and push the image using the docker CLI.
-	$ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
-      --directory ./deploy/olm-catalog/test-operator/0.1.0
+  $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0
   $ docker push quay.io/example/test-operator:v0.1.0
 
   # Ensure the image with modified metadata and Dockerfile is valid.
@@ -77,7 +77,7 @@ To build and validate an image:
 			}
 			// If the argument isn't a directory, assume it's an image.
 			if isExist(args[0]) {
-				if c.directory, err = relDir(args[0]); err != nil {
+				if c.directory, err = relWd(args[0]); err != nil {
 					log.Fatal(err)
 				}
 			} else {

--- a/cmd/operator-sdk/bundle/validate.go
+++ b/cmd/operator-sdk/bundle/validate.go
@@ -46,7 +46,7 @@ containing operator metadata and manifests. This command will exit with a non-ze
 exit code if any validation tests fail.
 
 More information on operator bundle images and the manifests/metadata format:
-https://github.com/operator-framework/operator-registry#manifest-format
+https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md
 
 NOTE: if validating an image, the image must exist in a remote registry, not
 just locally.

--- a/cmd/operator-sdk/generate/csv.go
+++ b/cmd/operator-sdk/generate/csv.go
@@ -53,10 +53,10 @@ A CSV semantic version is supplied via the --csv-version flag. If your operator
 has already generated a CSV manifest you want to use as a base, supply its
 version to --from-version. Otherwise the SDK will scaffold a new CSV manifest.
 
-The --make-manifests flag directs the generator to create a 'manifests' directory
+The --make-manifests flag directs the generator to create a bundle manifests directory
 intended to hold your latest operator manifests. This flag is true by default.
 
-More information on manifests:
+More information on bundles:
 https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md#operator-bundle-overview
 
 Flags that change project default paths:
@@ -74,71 +74,83 @@ Flags that change project default paths:
     --update-crds=true (the default). Additionally the CR manifests will be used to populate
     the CSV example CRs.
 `,
-		Example: `
-		##### Generate CSV from default input paths #####
-		$ tree pkg/apis/ deploy/
-		pkg/apis/
-		├── ...
-		└── cache
-			├── group.go
-			└── v1alpha1
-				├── ...
-				└── memcached_types.go
-		deploy/
-		├── crds
-		│   ├── cache.example.com_memcacheds_crd.yaml
-		│   └── cache.example.com_v1alpha1_memcached_cr.yaml
-		├── operator.yaml
-		├── role.yaml
-		├── role_binding.yaml
-		└── service_account.yaml
+		Example: `    ##### Generate a CSV in bundle format from default input paths #####
+    $ tree pkg/apis/ deploy/
+    pkg/apis/
+    ├── ...
+    └── cache
+        ├── group.go
+        ├── v1alpha1
+        ├── ...
+        └── memcached_types.go
+    deploy/
+    ├── crds
+    │   ├── cache.example.com_memcacheds_crd.yaml
+    │   └── cache.example.com_v1alpha1_memcached_cr.yaml
+    ├── operator.yaml
+    ├── role.yaml
+    ├── role_binding.yaml
+    └── service_account.yaml
 
-		$ operator-sdk generate csv --csv-version=0.0.1 --update-crds
-		INFO[0000] Generating CSV manifest version 0.0.1
-		...
+    $ operator-sdk generate csv --csv-version=0.0.1
+    INFO[0000] Generating CSV manifest version 0.0.1
+    ...
 
-		$ tree deploy/
-		deploy/
-		...
-		├── olm-catalog
-		│   └── memcached-operator
-		│       ├── 0.0.1
-		│       │   ├── cache.example.com_memcacheds_crd.yaml
-		│       │   └── memcached-operator.v0.0.1.clusterserviceversion.yaml
-		│       └── memcached-operator.package.yaml
-		...
+    $ tree deploy/
+    deploy/
+    ...
+    └── olm-catalog
+        └── memcached-operator
+            └── manifests
+                ├── cache.example.com_memcacheds_crd.yaml
+                └── memcached-operator.clusterserviceversion.yaml
+    ...
 
+    ##### Generate a CSV in package manifests format from default input paths #####
 
+		$ operator-sdk generate csv --csv-version=0.0.1 --make-manifests=false --update-crds
+    INFO[0000] Generating CSV manifest version 0.0.1
+    ...
+    $ tree deploy/
+    deploy/
+    ...
+    └── olm-catalog
+        └── memcached-operator
+            ├── 0.0.1
+            │   ├── cache.example.com_memcacheds_crd.yaml
+            │   └── memcached-operator.v0.0.1.clusterserviceversion.yaml
+            └── memcached-operator.package.yaml
+    ...
 
-		##### Generate CSV from custom input paths #####
-		$ operator-sdk generate csv --csv-version=0.0.1 --update-crds \
-		--deploy-dir=config --apis-dir=api --output-dir=production
-		INFO[0000] Generating CSV manifest version 0.0.1
-		...
+    ##### Generate CSV from custom input paths #####
+    $ operator-sdk generate csv --csv-version=0.0.1 --update-crds \
+    --deploy-dir=config --apis-dir=api --output-dir=production
+    INFO[0000] Generating CSV manifest version 0.0.1
+    ...
 
-		$ tree config/ api/ production/
-		config/
-		├── crds
-		│   ├── cache.example.com_memcacheds_crd.yaml
-		│   └── cache.example.com_v1alpha1_memcached_cr.yaml
-		├── operator.yaml
-		├── role.yaml
-		├── role_binding.yaml
-		└── service_account.yaml
-		api/
-		├── ...
-		└── cache
-			├── group.go
-			└── v1alpha1
-				├── ...
-				└── memcached_types.go
-		production/
-		└── olm-catalog
-			└── memcached-operator
-				├── 0.0.1
-				│   ├── cache.example.com_memcacheds_crd.yaml
-				│   └── memcached-operator.v0.0.1.clusterserviceversion.yaml
-				└── memcached-operator.package.yaml
+    $ tree config/ api/ production/
+    config/
+    ├── crds
+    │   ├── cache.example.com_memcacheds_crd.yaml
+    │   └── cache.example.com_v1alpha1_memcached_cr.yaml
+    ├── operator.yaml
+    ├── role.yaml
+    ├── role_binding.yaml
+    └── service_account.yaml
+    api/
+    ├── ...
+    └── cache
+    |   ├── group.go
+    |   └── v1alpha1
+    |       ├── ...
+    |       └── memcached_types.go
+    production/
+    └── olm-catalog
+        └── memcached-operator
+            ├── 0.0.1
+            │   ├── cache.example.com_memcacheds_crd.yaml
+            │   └── memcached-operator.v0.0.1.clusterserviceversion.yaml
+            └── memcached-operator.package.yaml
 `,
 
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/hack/lib/test_lib.sh
+++ b/hack/lib/test_lib.sh
@@ -107,3 +107,8 @@ function check_file() {
     fi
   fi
 }
+
+function echo_run() {
+	echo "$@"
+	$@
+}

--- a/hack/tests/subcommand-bundle.sh
+++ b/hack/tests/subcommand-bundle.sh
@@ -11,17 +11,19 @@ OPERATOR_NAME="memcached-operator"
 OPERATOR_VERSION_1="0.0.2"
 OPERATOR_VERSION_2="0.0.3"
 OPERATOR_BUNDLE_IMAGE_2="quay.io/example/${OPERATOR_NAME}:${OPERATOR_VERSION_2}"
-OPERATOR_BUNDLE_ROOT_DIR="deploy/olm-catalog/${OPERATOR_NAME}"
-OPERATOR_BUNDLE_DIR_1="${OPERATOR_BUNDLE_ROOT_DIR}/${OPERATOR_VERSION_1}"
-OPERATOR_BUNDLE_DIR_2="${OPERATOR_BUNDLE_ROOT_DIR}/${OPERATOR_VERSION_2}"
+OPERATOR_ROOT_DIR="deploy/olm-catalog/${OPERATOR_NAME}"
+OPERATOR_PACKAGE_MANIFEST_DIR_1="${OPERATOR_ROOT_DIR}/${OPERATOR_VERSION_1}"
+OPERATOR_PACKAGE_MANIFEST_DIR_2="${OPERATOR_ROOT_DIR}/${OPERATOR_VERSION_2}"
+OPERATOR_BUNDLE_MANIFESTS_DIR="${OPERATOR_ROOT_DIR}/manifests"
+OPERATOR_BUNDLE_METADATA_DIR="${OPERATOR_ROOT_DIR}/metadata"
 OUTPUT_DIR="foo"
 
 function create() {
-  operator-sdk bundle create $1 --directory $2 --package $OPERATOR_NAME ${@:3}
+  echo_run operator-sdk bundle create $1 --directory $2 --package $OPERATOR_NAME ${@:3}
 }
 
 function generate() {
-  operator-sdk bundle create --generate-only --directory $1 --package $OPERATOR_NAME ${@:2}
+  echo_run operator-sdk bundle create --generate-only --directory $1 --package $OPERATOR_NAME ${@:2}
 }
 
 function check_validate_pass() {
@@ -48,111 +50,103 @@ header_text "Running 'operator-sdk bundle' subcommand tests."
 
 TEST_NAME="create with version ${OPERATOR_VERSION_2}"
 header_text "$TEST_NAME"
-create $OPERATOR_BUNDLE_IMAGE_2 "$OPERATOR_BUNDLE_DIR_2"
-check_dir "$TEST_NAME" "${OUTPUT_DIR}/manifests" 0
-check_dir "$TEST_NAME" "${OUTPUT_DIR}/metadata" 0
-check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/metadata" 0
-check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/manifests" 0
+cp -r "$OPERATOR_PACKAGE_MANIFEST_DIR_2" "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+create $OPERATOR_BUNDLE_IMAGE_2 "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_MANIFESTS_DIR" 1
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_METADATA_DIR" 0
 check_file "$TEST_NAME" "bundle.Dockerfile" 0
 cleanup_case
 
 TEST_NAME="create with version ${OPERATOR_VERSION_2} and output-dir"
 header_text "$TEST_NAME"
-create $OPERATOR_BUNDLE_IMAGE_2 "$OPERATOR_BUNDLE_DIR_2" --output-dir "$OUTPUT_DIR"
+cp -r "$OPERATOR_PACKAGE_MANIFEST_DIR_2" "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+create $OPERATOR_BUNDLE_IMAGE_2 "$OPERATOR_BUNDLE_MANIFESTS_DIR" --output-dir "$OUTPUT_DIR"
 check_dir "$TEST_NAME" "${OUTPUT_DIR}/manifests" 1
 check_dir "$TEST_NAME" "${OUTPUT_DIR}/metadata" 1
-check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/metadata" 0
-check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/manifests" 0
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_MANIFESTS_DIR" 1
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_METADATA_DIR" 0
 check_file "$TEST_NAME" "bundle.Dockerfile" 0
 check_validate_pass "$TEST_NAME" "$OUTPUT_DIR"
 cleanup_case
 
 TEST_NAME="generate with version ${OPERATOR_VERSION_2}"
 header_text "$TEST_NAME"
-generate "$OPERATOR_BUNDLE_DIR_2"
-check_dir "$TEST_NAME" "${OUTPUT_DIR}/manifests" 0
-check_dir "$TEST_NAME" "${OUTPUT_DIR}/metadata" 0
-check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/metadata" 1
-check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/manifests" 1
+cp -r "$OPERATOR_PACKAGE_MANIFEST_DIR_2" "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+generate "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_MANIFESTS_DIR" 1
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_METADATA_DIR" 1
 check_file "$TEST_NAME" "bundle.Dockerfile" 1
-check_validate_pass "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR"
+check_validate_pass "$TEST_NAME" "$OPERATOR_ROOT_DIR"
 cleanup_case
 
 TEST_NAME="generate with version ${OPERATOR_VERSION_2} and output-dir"
 header_text "$TEST_NAME"
-generate "$OPERATOR_BUNDLE_DIR_2" --output-dir "$OUTPUT_DIR"
+cp -r "$OPERATOR_PACKAGE_MANIFEST_DIR_2" "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+generate "$OPERATOR_BUNDLE_MANIFESTS_DIR" --output-dir "$OUTPUT_DIR"
 check_dir "$TEST_NAME" "${OUTPUT_DIR}/manifests" 1
 check_dir "$TEST_NAME" "${OUTPUT_DIR}/metadata" 1
-check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/metadata" 0
-check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/manifests" 0
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_MANIFESTS_DIR" 1
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_METADATA_DIR" 0
 check_file "$TEST_NAME" "bundle.Dockerfile" 1
 check_validate_pass "$TEST_NAME" "$OUTPUT_DIR"
 cleanup_case
 
 TEST_NAME="create with version ${OPERATOR_VERSION_2} with existing metadata"
 header_text "$TEST_NAME"
-generate "$OPERATOR_BUNDLE_DIR_2"
-create $OPERATOR_BUNDLE_IMAGE_2 "$OPERATOR_BUNDLE_DIR_2"
-check_dir "$TEST_NAME" "${OUTPUT_DIR}/manifests" 0
-check_dir "$TEST_NAME" "${OUTPUT_DIR}/metadata" 0
-check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/metadata" 1
-check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/manifests" 1
+cp -r "$OPERATOR_PACKAGE_MANIFEST_DIR_2" "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+generate "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+create $OPERATOR_BUNDLE_IMAGE_2 "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_MANIFESTS_DIR" 1
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_METADATA_DIR" 1
 check_file "$TEST_NAME" "bundle.Dockerfile" 1
-check_validate_pass "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR"
+check_validate_pass "$TEST_NAME" "$OPERATOR_ROOT_DIR"
 cleanup_case
 
 TEST_NAME="create with version ${OPERATOR_VERSION_2} with existing metadata and output-dir"
 header_text "$TEST_NAME"
-generate "$OPERATOR_BUNDLE_DIR_2"
-create $OPERATOR_BUNDLE_IMAGE_2 "$OPERATOR_BUNDLE_DIR_2" --output-dir "$OUTPUT_DIR"
+cp -r "$OPERATOR_PACKAGE_MANIFEST_DIR_2" "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+generate "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+create $OPERATOR_BUNDLE_IMAGE_2 "$OPERATOR_BUNDLE_MANIFESTS_DIR" --output-dir "$OUTPUT_DIR"
 check_dir "$TEST_NAME" "${OUTPUT_DIR}/manifests" 1
 check_dir "$TEST_NAME" "${OUTPUT_DIR}/metadata" 1
-check_dir "$TEST_NAME" "${OPERATOR_BUNDLE_ROOT_DIR}/manifests" 1
-check_dir "$TEST_NAME" "${OPERATOR_BUNDLE_ROOT_DIR}/metadata" 1
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_MANIFESTS_DIR" 1
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_METADATA_DIR" 1
 check_file "$TEST_NAME" "bundle.Dockerfile" 1
 check_validate_pass "$TEST_NAME" "$OUTPUT_DIR"
-check_validate_pass "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR"
-cleanup_case
-
-TEST_NAME="error on create with version ${OPERATOR_VERSION_2} with existing manifests version ${OPERATOR_VERSION_1}"
-header_text "$TEST_NAME"
-generate "$OPERATOR_BUNDLE_DIR_1"
-if create $OPERATOR_BUNDLE_IMAGE_2 "$OPERATOR_BUNDLE_DIR_2"; then
-  error_text "$TEST_NAME: expected error"
-  exit 1
-fi
+check_validate_pass "$TEST_NAME" "$OPERATOR_ROOT_DIR"
 cleanup_case
 
 TEST_NAME="create with version ${OPERATOR_VERSION_2} with existing manifests/metadata version ${OPERATOR_VERSION_1} and overwrite"
 header_text "$TEST_NAME"
-generate "$OPERATOR_BUNDLE_DIR_2"
-create $OPERATOR_BUNDLE_IMAGE_2 "$OPERATOR_BUNDLE_DIR_2" --overwrite
-check_dir "$TEST_NAME" "${OUTPUT_DIR}/manifests" 0
-check_dir "$TEST_NAME" "${OUTPUT_DIR}/metadata" 0
-check_dir "$TEST_NAME" "${OPERATOR_BUNDLE_ROOT_DIR}/manifests" 1
-check_dir "$TEST_NAME" "${OPERATOR_BUNDLE_ROOT_DIR}/metadata" 1
+cp -r "$OPERATOR_PACKAGE_MANIFEST_DIR_2" "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+generate "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+create $OPERATOR_BUNDLE_IMAGE_2 "$OPERATOR_BUNDLE_MANIFESTS_DIR" --overwrite
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_MANIFESTS_DIR" 1
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_METADATA_DIR" 1
 check_file "$TEST_NAME" "bundle.Dockerfile" 1
-check_validate_pass "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR"
+check_validate_pass "$TEST_NAME" "$OPERATOR_ROOT_DIR"
 cleanup_case
 
 TEST_NAME="error on validate invalid generated bundle content with version ${OPERATOR_VERSION_2}"
 header_text "$TEST_NAME"
-generate "$OPERATOR_BUNDLE_DIR_2"
-check_dir "$TEST_NAME" "${OPERATOR_BUNDLE_ROOT_DIR}/manifests" 1
-check_dir "$TEST_NAME" "${OPERATOR_BUNDLE_ROOT_DIR}/metadata" 1
+cp -r "$OPERATOR_PACKAGE_MANIFEST_DIR_2" "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+generate "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_MANIFESTS_DIR" 1
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_METADATA_DIR" 1
 # Change version to an invalid value.
-sed -i 's/version: '$OPERATOR_VERSION_2'/version: a.b.c/g' "${OPERATOR_BUNDLE_ROOT_DIR}"/manifests/*.clusterserviceversion.yaml
-check_validate_fail "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR"
+sed -i 's/version: '$OPERATOR_VERSION_2'/version: a.b.c/g' "${OPERATOR_BUNDLE_MANIFESTS_DIR}"/*.clusterserviceversion.yaml
+check_validate_fail "$TEST_NAME" "$OPERATOR_ROOT_DIR"
 cleanup_case
 
 TEST_NAME="error on validate invalid generated bundle format with version ${OPERATOR_VERSION_2}"
 header_text "$TEST_NAME"
-generate "$OPERATOR_BUNDLE_DIR_2"
-check_dir "$TEST_NAME" "${OPERATOR_BUNDLE_ROOT_DIR}/manifests" 1
-check_dir "$TEST_NAME" "${OPERATOR_BUNDLE_ROOT_DIR}/metadata" 1
+cp -r "$OPERATOR_PACKAGE_MANIFEST_DIR_2" "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+generate "$OPERATOR_BUNDLE_MANIFESTS_DIR"
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_MANIFESTS_DIR" 1
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_METADATA_DIR" 1
 # Change annotations mediatype to the incorrect type.
-sed -i 's/mediatype.v1: registry+v1/mediatype.v1: plain/g' "${OPERATOR_BUNDLE_ROOT_DIR}"/metadata/annotations.yaml
-check_validate_fail "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR"
+sed -i 's/mediatype.v1: registry+v1/mediatype.v1: plain/g' "${OPERATOR_BUNDLE_METADATA_DIR}/annotations.yaml"
+check_validate_fail "$TEST_NAME" "$OPERATOR_ROOT_DIR"
 cleanup_case
 
 header_text "All 'operator-sdk bundle' subcommand tests passed."

--- a/internal/generate/olm-catalog/package_manifest.go
+++ b/internal/generate/olm-catalog/package_manifest.go
@@ -27,14 +27,10 @@ import (
 	"github.com/operator-framework/operator-registry/pkg/registry"
 	"github.com/operator-framework/operator-sdk/internal/scaffold"
 	"github.com/operator-framework/operator-sdk/internal/util/fileutil"
-	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 )
-
-// Deprecated: The package manifest generator will no longer create new package
-// manifests, only update existing ones. This generator will be removed in v0.19.0.
 
 const (
 	packageManifestFileExt = ".package.yaml"
@@ -87,7 +83,7 @@ func (g PkgGenerator) Generate() error {
 		return err
 	}
 	if len(fileMap) == 0 {
-		return nil
+		return errors.New("error generating package manifest: no generated file found")
 	}
 	pkgManifestOutputDir := filepath.Join(g.OutputDir, OLMCatalogChildDir, g.OperatorName)
 	if err = os.MkdirAll(pkgManifestOutputDir, fileutil.DefaultDirFileMode); err != nil {
@@ -106,30 +102,9 @@ func (g PkgGenerator) Generate() error {
 // generate either reads an existing package manifest or creates a new
 // manifest and modifies it based on values set in s.
 func (g PkgGenerator) generate() (map[string][]byte, error) {
-	pkgManifestOutputDir := filepath.Join(g.OutputDir, OLMCatalogChildDir, g.OperatorName)
-	path := filepath.Join(pkgManifestOutputDir, g.fileName)
-	pkg := registry.PackageManifest{}
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return nil, nil
-	} else if err == nil || os.IsExist(err) {
-		projutil.PrintDeprecationWarning("Package manifests are deprecated. " +
-			"Run `operator-sdk bundle create --generate-only` to create operator metadata")
-
-		// NewBundle can now be called without a csvVersion, but existing package
-		// manifests still require a csvVersion for updates.
-		if g.CSVVersion == "" {
-			return nil, fmt.Errorf("a CSV version is required to updating existing package manifests")
-		}
-
-		b, err := ioutil.ReadFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read package manifest %s: %v", path, err)
-		}
-		if err = yaml.Unmarshal(b, &pkg); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal package manifest %s: %v", path, err)
-		}
-	} else {
-		return nil, fmt.Errorf("error reading package manifest %s: %v", path, err)
+	pkg, err := g.buildPackageManifest()
+	if err != nil {
+		return nil, err
 	}
 
 	g.setChannels(&pkg)
@@ -152,7 +127,6 @@ func (g PkgGenerator) generate() (map[string][]byte, error) {
 
 // buildPackageManifest will create a registry.PackageManifest from scratch, or reads
 // an existing one if found at the expected path.
-// Deprecated: only used for testing other methods on g.
 func (g PkgGenerator) buildPackageManifest() (registry.PackageManifest, error) {
 	pkgManifestOutputDir := filepath.Join(g.OutputDir, OLMCatalogChildDir, g.OperatorName)
 	path := filepath.Join(pkgManifestOutputDir, g.fileName)
@@ -202,7 +176,6 @@ func validatePackageManifest(pkg *registry.PackageManifest) error {
 }
 
 // newPackageManifest will return the registry.PackageManifest populated.
-// Deprecated: only used for testing other methods on g.
 func newPackageManifest(operatorName, channelName, version string) registry.PackageManifest {
 	// Take the current CSV version to be the "alpha" channel, as an operator
 	// should only be designated anything more stable than "alpha" by a human.

--- a/internal/generate/olm-catalog/package_manifest_test.go
+++ b/internal/generate/olm-catalog/package_manifest_test.go
@@ -15,6 +15,10 @@
 package olmcatalog
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/operator-framework/operator-registry/pkg/registry"
@@ -22,49 +26,69 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGeneratePkgManifestToOutput(t *testing.T) {
-	cleanupFunc := chDirWithCleanup(t, testNonStandardLayoutDataDir)
-	defer cleanupFunc()
+func TestGeneratePackageManifestToOutput(t *testing.T) {
+	chdirCleanup := chDirWithCleanup(t, testNonStandardLayoutDataDir)
+	defer chdirCleanup()
+
+	// Temporary output dir for generating package manifest.
+	outputDir, mktempCleanup := mkTempDirWithCleanup(t, "-output-catalog")
+	defer mktempCleanup()
 
 	g := PkgGenerator{
 		OperatorName:     testProjectName,
-		OutputDir:        "expected-catalog",
+		OutputDir:        outputDir,
 		CSVVersion:       csvVersion,
-		Channel:          "beta",
-		ChannelIsDefault: false,
+		Channel:          "stable",
+		ChannelIsDefault: true,
 	}
-	g.setDefaults()
-	fileMap, err := g.generate()
-	if err != nil {
+	if err := g.Generate(); err != nil {
 		t.Fatalf("Failed to execute package manifest generator: %v", err)
 	}
 
-	if b, ok := fileMap[g.fileName]; !ok {
-		t.Error("Failed to generate package manifest")
-	} else {
-		assert.Equal(t, packageManifestNonStandardExp, string(b))
+	pkgManFileName := getPkgFileName(testProjectName)
+
+	// Read expected Package Manifest
+	expCatalogDir := filepath.Join("expected-catalog", OLMCatalogChildDir)
+	pkgManExpBytes, err := ioutil.ReadFile(filepath.Join(expCatalogDir, testProjectName, pkgManFileName))
+	if err != nil {
+		t.Fatalf("Failed to read expected package manifest file: %v", err)
 	}
+	pkgManExp := string(pkgManExpBytes)
+
+	// Read generated Package Manifest from OutputDir/olm-catalog
+	outputCatalogDir := filepath.Join(g.OutputDir, OLMCatalogChildDir)
+	pkgManOutputBytes, err := ioutil.ReadFile(filepath.Join(outputCatalogDir, testProjectName, pkgManFileName))
+	if err != nil {
+		t.Fatalf("Failed to read output package manifest file: %v", err)
+	}
+	pkgManOutput := string(pkgManOutputBytes)
+
+	assert.Equal(t, pkgManExp, pkgManOutput)
+
 }
 
-const packageManifestNonStandardExp = `channels:
-- currentCSV: memcached-operator.v0.0.1
-  name: alpha
-- currentCSV: memcached-operator.v0.0.3
-  name: beta
-- currentCSV: memcached-operator.v0.0.4
-  name: stable
-defaultChannel: stable
-packageName: memcached-operator
-`
-
 func TestGeneratePackageManifest(t *testing.T) {
-	cleanupFunc := chDirWithCleanup(t, testGoDataDir)
-	defer cleanupFunc()
+	chdirCleanup := chDirWithCleanup(t, testNonStandardLayoutDataDir)
+	defer chdirCleanup()
+
+	// Temporary output dir for generating package manifest.
+	outputDir, mktempCleanup := mkTempDirWithCleanup(t, "-output-catalog")
+	defer mktempCleanup()
+
+	manifestsRootDir := filepath.Join(outputDir, OLMCatalogChildDir, testProjectName)
+	if err := os.MkdirAll(manifestsRootDir, os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	outputPath := filepath.Join(manifestsRootDir, getPkgFileName(testProjectName))
+	err := ioutil.WriteFile(outputPath, []byte(packageManifestInput), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	g := PkgGenerator{
 		OperatorName:     testProjectName,
-		OutputDir:        "deploy",
 		CSVVersion:       csvVersion,
+		OutputDir:        outputDir,
 		Channel:          "stable",
 		ChannelIsDefault: true,
 	}
@@ -81,19 +105,33 @@ func TestGeneratePackageManifest(t *testing.T) {
 	}
 }
 
+const packageManifestInput = `channels:
+- currentCSV: memcached-operator.v0.0.2
+  name: alpha
+defaultChannel: alpha
+packageName: memcached-operator
+`
+
+const packageManifestExp = `channels:
+- currentCSV: memcached-operator.v0.0.2
+  name: alpha
+- currentCSV: memcached-operator.v0.0.3
+  name: stable
+defaultChannel: stable
+packageName: memcached-operator
+`
+
 func TestValidatePackageManifest(t *testing.T) {
 	cleanupFunc := chDirWithCleanup(t, testGoDataDir)
 	defer cleanupFunc()
 
 	g := PkgGenerator{
 		OperatorName:     testProjectName,
-		OutputDir:        "deploy",
 		CSVVersion:       csvVersion,
 		Channel:          "stable",
 		ChannelIsDefault: true,
 	}
 
-	g.setDefaults()
 	// pkg is a basic, valid package manifest.
 	pkg, err := g.buildPackageManifest()
 	if err != nil {
@@ -143,11 +181,59 @@ func TestValidatePackageManifest(t *testing.T) {
 	}
 }
 
-const packageManifestExp = `channels:
-- currentCSV: memcached-operator.v0.0.2
-  name: alpha
-- currentCSV: memcached-operator.v0.0.3
-  name: stable
-defaultChannel: stable
-packageName: memcached-operator
-`
+func TestNewPackageManifest(t *testing.T) {
+	type args struct {
+		operatorName string
+		channelName  string
+		version      string
+	}
+	tests := []struct {
+		name string
+		args args
+		want registry.PackageManifest
+	}{
+		{
+			name: "Should return a valid registry.PackageManifest",
+			want: registry.PackageManifest{
+				PackageName: "memcached-operator",
+				Channels: []registry.PackageChannel{
+					registry.PackageChannel{
+						Name:           "stable",
+						CurrentCSVName: "memcached-operator.v0.0.3",
+					},
+				},
+				DefaultChannelName: "stable",
+			},
+			args: args{
+				operatorName: testProjectName,
+				channelName:  "stable",
+				version:      csvVersion,
+			},
+		},
+		{
+			name: "Should return a valid registry.PackageManifest with channel == alpha when it is not informed",
+			want: registry.PackageManifest{
+				PackageName: "memcached-operator",
+				Channels: []registry.PackageChannel{
+					registry.PackageChannel{
+						Name:           "alpha",
+						CurrentCSVName: "memcached-operator.v0.0.3",
+					},
+				},
+				DefaultChannelName: "alpha",
+			},
+			args: args{
+				operatorName: testProjectName,
+				version:      csvVersion,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newPackageManifest(tt.args.operatorName, tt.args.channelName, tt.args.version)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewPackageManifest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/generate/testdata/non-standard-layout/expected-catalog/olm-catalog/memcached-operator/memcached-operator.package.yaml
+++ b/internal/generate/testdata/non-standard-layout/expected-catalog/olm-catalog/memcached-operator/memcached-operator.package.yaml
@@ -1,7 +1,5 @@
 channels:
-- currentCSV: memcached-operator.v0.0.1
-  name: alpha
-- currentCSV: memcached-operator.v0.0.4
+- currentCSV: memcached-operator.v0.0.3
   name: stable
 defaultChannel: stable
 packageName: memcached-operator

--- a/website/content/en/docs/cli/operator-sdk.md
+++ b/website/content/en/docs/cli/operator-sdk.md
@@ -19,7 +19,7 @@ An SDK for building operators with ease
 
 * [operator-sdk add](../operator-sdk_add)	 - Adds a controller or resource to the project
 * [operator-sdk build](../operator-sdk_build)	 - Compiles code and builds artifacts
-* [operator-sdk bundle](../operator-sdk_bundle)	 - Work with operator bundle metadata and bundle images
+* [operator-sdk bundle](../operator-sdk_bundle)	 - Manage operator bundle metadata
 * [operator-sdk cleanup](../operator-sdk_cleanup)	 - Delete and clean up after a running Operator
 * [operator-sdk completion](../operator-sdk_completion)	 - Generators for shell completions
 * [operator-sdk generate](../operator-sdk_generate)	 - Invokes a specific generator

--- a/website/content/en/docs/cli/operator-sdk_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle.md
@@ -12,7 +12,7 @@ An operator bundle is a portable operator packaging format understood by Kuberne
 native software, like the Operator Lifecycle Manager.
 
 More information about operator bundles and metadata:
-https://github.com/operator-framework/operator-registry#manifest-format
+https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md
 
 Operator Lifecycle Manager:
 https://github.com/operator-framework/operator-lifecycle-manager

--- a/website/content/en/docs/cli/operator-sdk_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle.md
@@ -3,15 +3,20 @@ title: "operator-sdk bundle"
 ---
 ## operator-sdk bundle
 
-Work with operator bundle metadata and bundle images
+Manage operator bundle metadata
 
 ### Synopsis
 
-Generate operator bundle metadata and build operator bundle images, which
-are used to manage operators in the Operator Lifecycle Manager.
+Manage bundle builds, bundle metadata generation, and bundle validation.
+An operator bundle is a portable operator packaging format understood by Kubernetes
+native software, like the Operator Lifecycle Manager.
 
-More information on operator bundle images and metadata:
-https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md#docker
+More information about operator bundles and metadata:
+https://github.com/operator-framework/operator-registry#manifest-format
+
+Operator Lifecycle Manager:
+https://github.com/operator-framework/operator-lifecycle-manager
+
 
 ### Options
 

--- a/website/content/en/docs/cli/operator-sdk_bundle_create.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle_create.md
@@ -34,7 +34,7 @@ will be written if '--generate-only=true':
 manually or modify metadata before building an image.
 
 More information on operator bundle images and the manifests/metadata format:
-https://github.com/operator-framework/operator-registry#manifest-format
+https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md
 
 NOTE: bundle images are not runnable.
 

--- a/website/content/en/docs/cli/operator-sdk_bundle_create.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle_create.md
@@ -12,32 +12,29 @@ bundle image containing operator metadata and manifests, tagged with the
 provided image tag.
 
 To write all files required to build a bundle image without building the
-image, set '--generate-only=true'. A bundle Dockerfile, bundle metadata, and
-a 'manifests/' directory containing your bundle manifests will be written if
-'--generate-only=true':
+image, set '--generate-only=true'. A bundle.Dockerfile and bundle metadata
+will be written if '--generate-only=true':
 
-	$ operator-sdk bundle create --generate-only --directory ./deploy/olm-catalog/test-operator/0.1.0
-	$ ls .
-	...
-	bundle.Dockerfile
-	...
-	$ tree ./deploy/olm-catalog/test-operator/
-	└── 0.1.0
-		└── example.com_tests_crd.yaml
-		└── test-operator.v0.1.0.clusterserviceversion.yaml
-	└── manifests
-		└── example.com_tests_crd.yaml
-		└── test-operator.v0.1.0.clusterserviceversion.yaml
-	└── metadata
-		└── annotations.yaml
+```
+  $ operator-sdk bundle create --generate-only --directory ./deploy/olm-catalog/test-operator/manifests
+  $ ls .
+  ...
+  bundle.Dockerfile
+  ...
+  $ tree ./deploy/olm-catalog/test-operator/
+  ./deploy/olm-catalog/test-operator/
+  ├── manifests
+  │   ├── example.com_tests_crd.yaml
+  │   └── test-operator.clusterserviceversion.yaml
+  └── metadata
+      └── annotations.yaml
+```
 
 '--generate-only' is useful if you want to build an operator's bundle image
-manually, modify metadata before building an image, or want to generate a
-'manifests/' directory containing your operator manifests for compatibility
-with other operator tooling.
+manually or modify metadata before building an image.
 
-More information on operator bundle images and metadata:
-https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md#docker
+More information on operator bundle images and the manifests/metadata format:
+https://github.com/operator-framework/operator-registry#manifest-format
 
 NOTE: bundle images are not runnable.
 
@@ -53,7 +50,7 @@ The following invocation will build a test-operator 0.1.0 bundle image using Doc
 This image will contain manifests for package channels 'stable' and 'beta':
 
   $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
-      --directory ./deploy/olm-catalog/test-operator/0.1.0 \
+      --directory ./deploy/olm-catalog/test-operator/manifests \
       --package test-operator \
       --channels stable,beta \
       --default-channel stable
@@ -61,16 +58,13 @@ This image will contain manifests for package channels 'stable' and 'beta':
 Assuming your operator has the same name as your repo directory and the only
 channel is 'stable', the above command can be abbreviated to:
 
-  $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
-      --directory ./deploy/olm-catalog/test-operator/0.1.0
+  $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0
 
-The following invocation will generate test-operator bundle metadata, a
-'manifests/' dir, and Dockerfile for your latest operator version without
-building the image:
+The following invocation will generate test-operator bundle metadata and a
+bundle.Dockerfile for your latest operator version without building the image:
 
   $ operator-sdk bundle create \
       --generate-only \
-      --directory ./deploy/olm-catalog/test-operator/0.1.0 \
       --package test-operator \
       --channels beta \
       --default-channel beta
@@ -82,7 +76,7 @@ building the image:
 ```
   -c, --channels string          The comma-separated list of channels that bundle image belongs to (default "stable")
   -e, --default-channel string   The default channel for the bundle image
-  -d, --directory string         The directory where bundle manifests are located, ex. <project-root>/deploy/olm-catalog/test-operator/0.1.0
+  -d, --directory string         The directory where bundle manifests are located, ex. <project-root>/deploy/olm-catalog/test-operator/manifests
   -g, --generate-only            Generate metadata/, manifests/ and a Dockerfile on disk without building the bundle image
   -h, --help                     help for create
   -b, --image-builder string     Tool to build container images. One of: [docker, podman, buildah] (default "docker")
@@ -94,5 +88,5 @@ building the image:
 
 ### SEE ALSO
 
-* [operator-sdk bundle](../operator-sdk_bundle)	 - Work with operator bundle metadata and bundle images
+* [operator-sdk bundle](../operator-sdk_bundle)	 - Manage operator bundle metadata
 

--- a/website/content/en/docs/cli/operator-sdk_bundle_validate.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle_validate.md
@@ -12,7 +12,10 @@ format of an operator bundle image or an operator bundles directory on-disk
 containing operator metadata and manifests. This command will exit with a non-zero
 exit code if any validation tests fail.
 
-Note: if validating an image, the image must exist in a remote registry, not
+More information on operator bundle images and the manifests/metadata format:
+https://github.com/operator-framework/operator-registry#manifest-format
+
+NOTE: if validating an image, the image must exist in a remote registry, not
 just locally.
 
 
@@ -25,12 +28,10 @@ operator-sdk bundle validate [flags]
 ```
 The following command flow will generate test-operator bundle image manifests
 and validate them, assuming a bundle for 'test-operator' version v0.1.0 exists at
-<project-root>/deploy/olm-catalog/test-operator/0.1.0:
+<project-root>/deploy/olm-catalog/test-operator/manifests:
 
   # Generate manifests locally.
-  $ operator-sdk bundle create \
-      --generate-only \
-      --directory ./deploy/olm-catalog/test-operator/0.1.0
+  $ operator-sdk bundle create --generate-only
 
   # Validate the directory containing manifests and metadata.
   $ operator-sdk bundle validate ./deploy/olm-catalog/test-operator
@@ -38,8 +39,7 @@ and validate them, assuming a bundle for 'test-operator' version v0.1.0 exists a
 To build and validate an image:
 
   # Build and push the image using the docker CLI.
-	$ operator-sdk bundle create quay.io/example/test-operator:v0.1.0 \
-      --directory ./deploy/olm-catalog/test-operator/0.1.0
+  $ operator-sdk bundle create quay.io/example/test-operator:v0.1.0
   $ docker push quay.io/example/test-operator:v0.1.0
 
   # Ensure the image with modified metadata and Dockerfile is valid.
@@ -57,5 +57,5 @@ To build and validate an image:
 
 ### SEE ALSO
 
-* [operator-sdk bundle](../operator-sdk_bundle)	 - Work with operator bundle metadata and bundle images
+* [operator-sdk bundle](../operator-sdk_bundle)	 - Manage operator bundle metadata
 

--- a/website/content/en/docs/cli/operator-sdk_bundle_validate.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle_validate.md
@@ -13,7 +13,7 @@ containing operator metadata and manifests. This command will exit with a non-ze
 exit code if any validation tests fail.
 
 More information on operator bundle images and the manifests/metadata format:
-https://github.com/operator-framework/operator-registry#manifest-format
+https://github.com/openshift/enhancements/blob/master/enhancements/olm/operator-bundle.md
 
 NOTE: if validating an image, the image must exist in a remote registry, not
 just locally.

--- a/website/content/en/docs/cli/operator-sdk_generate_csv.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_csv.md
@@ -14,10 +14,10 @@ A CSV semantic version is supplied via the --csv-version flag. If your operator
 has already generated a CSV manifest you want to use as a base, supply its
 version to --from-version. Otherwise the SDK will scaffold a new CSV manifest.
 
-The --make-manifests flag directs the generator to create a 'manifests' directory
+The --make-manifests flag directs the generator to create a bundle manifests directory
 intended to hold your latest operator manifests. This flag is true by default.
 
-More information on manifests:
+More information on bundles:
 https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md#operator-bundle-overview
 
 Flags that change project default paths:
@@ -43,71 +43,83 @@ operator-sdk generate csv [flags]
 ### Examples
 
 ```
+    ##### Generate a CSV in bundle format from default input paths #####
+    $ tree pkg/apis/ deploy/
+    pkg/apis/
+    ├── ...
+    └── cache
+        ├── group.go
+        ├── v1alpha1
+        ├── ...
+        └── memcached_types.go
+    deploy/
+    ├── crds
+    │   ├── cache.example.com_memcacheds_crd.yaml
+    │   └── cache.example.com_v1alpha1_memcached_cr.yaml
+    ├── operator.yaml
+    ├── role.yaml
+    ├── role_binding.yaml
+    └── service_account.yaml
 
-		##### Generate CSV from default input paths #####
-		$ tree pkg/apis/ deploy/
-		pkg/apis/
-		├── ...
-		└── cache
-			├── group.go
-			└── v1alpha1
-				├── ...
-				└── memcached_types.go
-		deploy/
-		├── crds
-		│   ├── cache.example.com_memcacheds_crd.yaml
-		│   └── cache.example.com_v1alpha1_memcached_cr.yaml
-		├── operator.yaml
-		├── role.yaml
-		├── role_binding.yaml
-		└── service_account.yaml
+    $ operator-sdk generate csv --csv-version=0.0.1
+    INFO[0000] Generating CSV manifest version 0.0.1
+    ...
 
-		$ operator-sdk generate csv --csv-version=0.0.1 --update-crds
-		INFO[0000] Generating CSV manifest version 0.0.1
-		...
+    $ tree deploy/
+    deploy/
+    ...
+    └── olm-catalog
+        └── memcached-operator
+            └── manifests
+                ├── cache.example.com_memcacheds_crd.yaml
+                └── memcached-operator.clusterserviceversion.yaml
+    ...
 
-		$ tree deploy/
-		deploy/
-		...
-		├── olm-catalog
-		│   └── memcached-operator
-		│       ├── 0.0.1
-		│       │   ├── cache.example.com_memcacheds_crd.yaml
-		│       │   └── memcached-operator.v0.0.1.clusterserviceversion.yaml
-		│       └── memcached-operator.package.yaml
-		...
+    ##### Generate a CSV in package manifests format from default input paths #####
 
+		$ operator-sdk generate csv --csv-version=0.0.1 --make-manifests=false --update-crds
+    INFO[0000] Generating CSV manifest version 0.0.1
+    ...
+    $ tree deploy/
+    deploy/
+    ...
+    └── olm-catalog
+        └── memcached-operator
+            ├── 0.0.1
+            │   ├── cache.example.com_memcacheds_crd.yaml
+            │   └── memcached-operator.v0.0.1.clusterserviceversion.yaml
+            └── memcached-operator.package.yaml
+    ...
 
+    ##### Generate CSV from custom input paths #####
+    $ operator-sdk generate csv --csv-version=0.0.1 --update-crds \
+    --deploy-dir=config --apis-dir=api --output-dir=production
+    INFO[0000] Generating CSV manifest version 0.0.1
+    ...
 
-		##### Generate CSV from custom input paths #####
-		$ operator-sdk generate csv --csv-version=0.0.1 --update-crds \
-		--deploy-dir=config --apis-dir=api --output-dir=production
-		INFO[0000] Generating CSV manifest version 0.0.1
-		...
-
-		$ tree config/ api/ production/
-		config/
-		├── crds
-		│   ├── cache.example.com_memcacheds_crd.yaml
-		│   └── cache.example.com_v1alpha1_memcached_cr.yaml
-		├── operator.yaml
-		├── role.yaml
-		├── role_binding.yaml
-		└── service_account.yaml
-		api/
-		├── ...
-		└── cache
-			├── group.go
-			└── v1alpha1
-				├── ...
-				└── memcached_types.go
-		production/
-		└── olm-catalog
-			└── memcached-operator
-				├── 0.0.1
-				│   ├── cache.example.com_memcacheds_crd.yaml
-				│   └── memcached-operator.v0.0.1.clusterserviceversion.yaml
-				└── memcached-operator.package.yaml
+    $ tree config/ api/ production/
+    config/
+    ├── crds
+    │   ├── cache.example.com_memcacheds_crd.yaml
+    │   └── cache.example.com_v1alpha1_memcached_cr.yaml
+    ├── operator.yaml
+    ├── role.yaml
+    ├── role_binding.yaml
+    └── service_account.yaml
+    api/
+    ├── ...
+    └── cache
+    |   ├── group.go
+    |   └── v1alpha1
+    |       ├── ...
+    |       └── memcached_types.go
+    production/
+    └── olm-catalog
+        └── memcached-operator
+            ├── 0.0.1
+            │   ├── cache.example.com_memcacheds_crd.yaml
+            │   └── memcached-operator.v0.0.1.clusterserviceversion.yaml
+            └── memcached-operator.package.yaml
 
 ```
 

--- a/website/content/en/docs/olm-integration/generating-a-csv.md
+++ b/website/content/en/docs/olm-integration/generating-a-csv.md
@@ -41,14 +41,40 @@ of the following layouts for the API types directory.
 
 ### Output
 
-By default `generate csv` will create a [*bundle*][doc-bundle] directory
-`deploy/olm-catalog/<operator-name>/manifests` containing your CSV and CRDs.
-To change where the CSV bundle directory is generated use the `--ouput-dir` flag.
+By default `generate csv` will create a CSV and copy CRDs in the [*bundle*][doc-bundle]
+manifests format:
 
-## Creating a new CSV
+```
+deploy/
+└── olm-catalog
+    └── <operator-name>
+        └── manifests
+            ├── cache.example.com_memcacheds_crd.yaml
+            └── <operator-name>.clusterserviceversion.yaml
+```
+
+Setting `--make-manifests=false` will create a CSV and package manifest in the
+[package manifests format](#package-manifests-format):
+
+```
+deploy/
+└── olm-catalog
+    └── <operator-name>
+        ├── 0.0.1
+        │   └── <operator-name>.v0.0.1.clusterserviceversion.yaml
+        └── <operator-name>.package.yaml
+```
+
+Set the `--ouput-dir` flag to change where the CSV is generated.
+
+**Note:** `generate csv` will populate many but not all fields in your CSV
+automatically. Subsequent calls to `generate csv` will warn you of missing
+required fields. See the list of fields [below](#csv-fields) for more information.
+
+#### Bundle format (default)
 
 CSV's are versioned by their `metadata.name` and `spec.version` fields and stored
-in bundle directories. To create a CSV for version `0.0.1`, run:
+in a bundle manifests directory. To create a CSV for version `0.0.1`, run:
 
 ```console
 $ operator-sdk generate csv --csv-version 0.0.1
@@ -59,47 +85,55 @@ with `<operator-name>.v0.0.1` and version `0.0.1`. This command will also copy a
 manifests from `deploy/crds` or the value passed to `--crd-dir` to that CSV's directory.
 Note that a valid semantic version is required.
 
-**Note:** `generate csv` will populate many but not all fields in your CSV
-automatically. Subsequent calls to `generate csv` will warn you of missing
-required fields. See the list of fields [below](#csv-fields) for more information.
-
-#### Deprecated behavior
-
-_This behavior is deprecated. If you have versioned bundle directories, consider
-removing them and using default behavior_
+#### Package manifests format
 
 Setting `--make-manifests=false` will create a CSV in a versioned directory
-`deploy/olm-catalog/<operator-name>/0.0.1/<operator-name>.v0.0.1.clusterserviceversion.yaml`,
-If a versioned bundle directory exists on disk, `generate csv` allows you to
-upgrade your CSV from that version using the `--from-version` flag. Example: if you
-have an existing CSV with version `0.0.1` and want to write a new version `0.0.2`, you can run:
+`deploy/olm-catalog/<operator-name>/0.0.1/<operator-name>.v0.0.1.clusterserviceversion.yaml`:
 
 ```console
-$ operator-sdk generate csv --csv-version 0.0.2 --from-version 0.0.1
+$ operator-sdk generate csv --make-manifests=false --csv-version 0.0.1
 ```
 
-This will write a new CSV manifest to `deploy/olm-catalog/<operator-name>/0.0.2/<operator-name>.v0.0.2.clusterserviceversion.yaml`
-containing user-defined data from `0.0.1` and any modifications you've made to
-the configured inputs.
-
-Setting `--update-crds=false` prevents the generator from updating bundled CRD manifests.
+Setting `--update-crds=true` directs the generator to update bundled CRD manifests.
 
 ## Updating your CSV
 
 Let's say you added a new CRD `deploy/crds/group.domain.com_resource_crd.yaml`
 to your Operator project, and added a port to your Deployment manifest `operator.yaml`.
-Assuming you're using the same version as above, updating your CSV is as simple
-as running `operator-sdk generate csv`. Doing so will append your new CRD to
-`spec.customresourcedefinitions.owned`, replace the old data at `spec.install.spec.deployments`
-with your updated Deployment, and update your existing CSV manifest.
+If using a bundle format, the current version of your CSV can be updated by running:
 
-The SDK will not overwrite [user-defined](#csv-fields) fields like `spec.maintainers`.
+```console
+$ operator-sdk generate csv
+```
+
+If using a package manifests format, run:
+
+```console
+$ operator-sdk generate csv --make-manifests=false --csv-version <existing-version>
+```
+
+Running the command for either format will append your new CRD to `spec.customresourcedefinitions.owned`,
+replace the old data at `spec.install.spec.deployments` with your updated Deployment,
+and update your existing CSV manifest. The SDK will not overwrite [user-defined](#csv-fields)
+fields like `spec.maintainers`.
 
 ## Upgrading your CSV
 
-New versions of your CSV are created by running `operator-sdk generate csv --csv-version <new-version>`.
-Doing will persist user-defined fields, updates `spec.version`,
-and populates `spec.replaces` with the old CSV versions' name.
+Lets say you're upgrading your Operator version. If using a bundle format,
+a new version of your CSV can be created by running:
+
+```console
+$ operator-sdk generate csv --csv-version <new-version>
+```
+
+If using a package manifests format, run:
+
+```console
+$ operator-sdk generate csv --make-manifests=false --csv-version <new-version> --from-version <old-version>
+```
+
+Running the command for either format will persist user-defined fields,
+updates `spec.version`, and populates `spec.replaces` with the old CSV versions' name.
 
 ## CSV fields
 

--- a/website/content/en/docs/olm-integration/user-guide.md
+++ b/website/content/en/docs/olm-integration/user-guide.md
@@ -76,13 +76,13 @@ and metadata for an Operator [bundle][operator-bundle]. From the bundle docs:
 > container registry. Ultimately, an operator bundle will be used by Operator
 > Registry and OLM to install an operator in OLM-enabled clusters.
 
-A bundle is built using on-disk manifests and metadata that define an Operator
+A bundle consists of on-disk manifests and metadata that define an Operator
 at a particular version. At this stage in memcached-operator's development,
-we only need to worry about generating these files; the bundle becomes important
+we only need to worry about generating bundle files; bundle images becomes important
 once we're ready to [publish](#publishing-an-operator) our Operator. For a condensed
 overview of all bundle operations supported by the SDK, read [this doc][doc-bundle-cli].
 
-We will now create manifests by running [`operator-sdk generate csv`][cli-generate-csv]
+We will now create bundle manifests by running [`operator-sdk generate csv`][cli-generate-csv]
 in the root of the memcached-operator project:
 
 **Note:** while `generate csv` only officially supports Go Operators, it will
@@ -97,8 +97,8 @@ INFO[0004] Required csv fields not filled in file deploy/olm-catalog/memcached-o
 INFO[0004] Created deploy/olm-catalog/memcached-operator/manifests/memcached-operator.clusterserviceversion.yaml
 ```
 
-A bundle directory containing a CSV and all CRDs in `deploy/crds` has been created
-at `deploy/olm-catalog/memcached-operator/manifests`:
+A bundle manifests directory containing a CSV and all CRDs in `deploy/crds` has
+been created at `deploy/olm-catalog/memcached-operator/manifests`:
 
 ```console
 $ tree deploy/olm-catalog/memcached-operator


### PR DESCRIPTION
**Description of the change:** remove deprecation notices and comments for package manifests format generation

**Motivation for the change:** operator authors should be able to manage the operator-registry manifests format using the SDK, since it is still supported by operator-registry servers.


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
