### PR TITLE
Remove from run and test commands deprecated namespace flag

### DIFF
--- a/changelog/fragments/remove-run-dep-flags.yaml
+++ b/changelog/fragments/remove-run-dep-flags.yaml
@@ -1,0 +1,27 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      The `ctx.GetNamespace()` from `pkg/test` and the flag  the flag `--namespace` from `operator-sdk run --local`
+      and `operator-sdk test --local` which were deprecated was removed.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "removal"
+
+    # Is this a breaking change?
+    breaking: yes
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: Romoval of deprecated flags and functions
+      body: >
+        The `ctx.GetNamespace()` from `pkg/test` and the flag  the flag `--namespace` from `operator-sdk run --local`
+        and `operator-sdk test --local` which were deprecated was removed. See the migration guide of the version 0.17 to know
+        how to replace its usage.
+

--- a/cmd/operator-sdk/cleanup/cmd.go
+++ b/cmd/operator-sdk/cleanup/cmd.go
@@ -29,9 +29,6 @@ import (
 type cleanupCmd struct {
 	// Common options.
 	kubeconfig string
-	// TODO: remove --namespace and c.namespace
-	//Deprecated: use olmArgs.OperatorNamespace instead
-	namespace string
 
 	// Cleanup type.
 	olm bool
@@ -62,16 +59,6 @@ func NewCmd() *cobra.Command {
 			switch {
 			case c.olm:
 				c.olmArgs.KubeconfigPath = c.kubeconfig
-				//TODO: remove --namespace and c.namespace
-				//use olmArgs.OperatorNamespace directly
-				if cmd.Flags().Changed("namespace") {
-					log.Warn("--namespace is deprecates use --operator-namespace instead")
-					if !cmd.Flags().Changed("operator-namespace") {
-						c.olmArgs.OperatorNamespace = c.namespace
-					} else {
-						log.Warn("--operator-namespace present; ignoring --namespace")
-					}
-				}
 				if c.olmArgs.ManifestsDir == "" {
 					operatorName := filepath.Base(projutil.MustGetwd())
 					c.olmArgs.ManifestsDir = filepath.Join(olmcatalog.OLMCatalogDir, operatorName)
@@ -91,9 +78,6 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().StringVar(&c.kubeconfig, "kubeconfig", "",
 		"The file path to kubernetes configuration file. Defaults to location "+
 			"specified by $KUBECONFIG, or to default file rules if not set")
-	cmd.Flags().StringVar(&c.namespace, "namespace", "",
-		"(Deprecated: use --operator-namespace instead.) The namespace from which operator and namespaces"+
-			"resources are cleaned up")
 
 	// 'cleanup --olm' and related flags. Set as default since this is the only
 	// cleanup type.

--- a/cmd/operator-sdk/run/cmd.go
+++ b/cmd/operator-sdk/run/cmd.go
@@ -33,9 +33,6 @@ import (
 type runCmd struct {
 	// Common options.
 	kubeconfig string
-	//TODO: remove namespace flag before 1.0.0
-	//namespace is deprecated
-	namespace string
 
 	// Run type.
 	olm, local bool
@@ -92,16 +89,6 @@ https://sdk.operatorframework.io/docs/olm-integration/cli-overview
 					log.Fatalf("Failed to run operator using OLM: %v", err)
 				}
 			case c.local:
-				//TODO: remove namespace flag before 1.0.0
-				// set --watch-namespace flag if the --namespace flag is set
-				// (only if --watch-namespace flag is not set)
-				if cmd.Flags().Changed("namespace") {
-					log.Info("--namespace is deprecated; use --watch-namespace instead.")
-					if !cmd.Flags().Changed("watch-namespace") {
-						err := cmd.Flags().Set("watch-namespace", c.namespace)
-						return err
-					}
-				}
 				// Get default namespace to watch if unset.
 				if !cmd.Flags().Changed("watch-namespace") {
 					_, defaultNamespace, err := k8sinternal.GetKubeconfigAndNamespace(c.kubeconfig)
@@ -125,11 +112,6 @@ https://sdk.operatorframework.io/docs/olm-integration/cli-overview
 	cmd.Flags().StringVar(&c.kubeconfig, "kubeconfig", "",
 		"The file path to kubernetes configuration file. Defaults to location "+
 			"specified by $KUBECONFIG, or to default file rules if not set")
-	// Deprecated: namespace exists for historical compatibility. Use watch-namespace instead.
-	//TODO: remove namespace flag before 1.0.0
-	cmd.Flags().StringVar(&c.namespace, "namespace", "",
-		"(Deprecated: use --watch-namespace instead.)"+
-			"The namespace where the operator watches for changes.")
 	// 'run --olm' and related flags.
 	cmd.Flags().BoolVar(&c.olm, "olm", false,
 		"The operator to be run will be managed by OLM in a cluster. "+

--- a/cmd/operator-sdk/test/local.go
+++ b/cmd/operator-sdk/test/local.go
@@ -47,9 +47,6 @@ type testLocalConfig struct {
 	namespacedManPath string
 	goTestFlags       string
 	moleculeTestFlags string
-	// TODO: remove before 1.0.0
-	// Namespace is deprecated
-	namespace          string
 	operatorNamespace  string
 	watchNamespace     string
 	image              string
@@ -77,9 +74,6 @@ func newTestLocalCmd() *cobra.Command {
 		"Additional flags to pass to go test")
 	testCmd.Flags().StringVar(&tlConfig.moleculeTestFlags, "molecule-test-flags", "",
 		"Additional flags to pass to molecule test")
-	// TODO: remove before 1.0.0. Namespace is deprecated
-	testCmd.Flags().StringVar(&tlConfig.namespace, "namespace", "",
-		"(Deprecated: use --operator-namespace instead) If non-empty, single namespace to run tests in")
 	testCmd.Flags().StringVar(&tlConfig.operatorNamespace, "operator-namespace", "",
 		"Namespace where the operator will be deployed, CRs will be created and tests will be executed "+
 			"(By default it will be in the default namespace defined in the kubeconfig)")
@@ -103,16 +97,6 @@ func newTestLocalCmd() *cobra.Command {
 }
 
 func testLocalFunc(cmd *cobra.Command, args []string) error {
-	//TODO: remove before 1.0.0
-	// set --operator-namespace flag if the --namespace flag is set
-	// (only if --operator-namespace flag is not set)
-	if cmd.Flags().Changed("namespace") {
-		log.Info("--namespace is deprecated; use --operator-namespace instead.")
-		if !cmd.Flags().Changed("operator-namespace") {
-			err := cmd.Flags().Set("operator-namespace", tlConfig.namespace)
-			return err
-		}
-	}
 	switch t := projutil.GetOperatorType(); t {
 	case projutil.OperatorTypeGo:
 		return testLocalGoFunc(cmd, args)

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -29,9 +29,6 @@ type Context struct {
 	id         string
 	cleanupFns []cleanupFn
 	// the  namespace is deprecated
-	// todo: remove before 1.0.0
-	// use operatorNamespace or watchNamespace  instead
-	namespace         string
 	operatorNamespace string
 	watchNamespace    string
 	t                 *testing.T
@@ -77,7 +74,6 @@ func (f *Framework) newContext(t *testing.T) *Context {
 	return &Context{
 		id:                 id,
 		t:                  t,
-		namespace:          operatorNamespace,
 		operatorNamespace:  operatorNamespace,
 		watchNamespace:     watchNamespace,
 		namespacedManPath:  *f.NamespacedManPath,

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -32,15 +32,6 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
 )
 
-// TODO: remove before 1.0.0
-// Deprecated: GetNamespace() exists for historical compatibility.
-// Use GetOperatorNamespace() or GetWatchNamespace() instead
-func (ctx *Context) GetNamespace() (string, error) {
-	var err error
-	ctx.namespace, err = ctx.getNamespace(ctx.namespace)
-	return ctx.namespace, err
-}
-
 // GetOperatorNamespace will return an Operator Namespace,
 // if the flag --operator-namespace  not be used (TestOpeatorNamespaceEnv not set)
 // then it will create a new namespace with randon name and return that namespace


### PR DESCRIPTION
**Description of the change:**
      The `ctx.GetNamespace()` from `pkg/test` and the flag  the flag `--namespace` from `operator-sdk run --local`
      and `operator-sdk test --local` which were deprecated was removed.


**Motivation for the change:**

Cleanup and make easier we move forward with the changes. 
