### PR TITLE
WIP: test-framework: read manifests from stdin for kubebuilder alignment

### DIFF
--- a/pkg/test/framework.go
+++ b/pkg/test/framework.go
@@ -293,6 +293,10 @@ func (f *Framework) setupLocalCommand() (*exec.Cmd, error) {
 	if ok {
 		watchNamespace = ns
 	}
+	// TODO: The default kubebuilder main.go has no support for using WATCH_NAMESPACE
+	// The default manager is cluster-scoped.
+	// Will need to introduce WATCH_NAMESPACE support into the main.go scaffold to control
+	// the test namespace for namespace-scoped operators.
 	localCmd.Env = append(localCmd.Env, fmt.Sprintf("%v=%v", k8sutil.WatchNamespaceEnvVar, watchNamespace))
 	return localCmd, nil
 }

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -47,6 +47,8 @@ func (ctx *Context) GetNamespace() (string, error) {
 func (ctx *Context) GetOperatorNamespace() (string, error) {
 	var err error
 	ctx.operatorNamespace, err = ctx.getNamespace(ctx.operatorNamespace)
+	// Set ctx.namespace so GetNamespace() returns the same namespace on subesequent calls
+	ctx.namespace = ctx.operatorNamespace
 	return ctx.operatorNamespace, err
 }
 
@@ -112,6 +114,10 @@ func (ctx *Context) createFromYAML(yamlFile []byte, skipIfExists bool, cleanupOp
 		if err := obj.UnmarshalJSON(jsonSpec); err != nil {
 			return fmt.Errorf("failed to unmarshal object spec: %w", err)
 		}
+
+		// TODO: Not enough to set the object namespace
+		// For Rolebinding/ClusterRolebinding the subjects.namespace
+		// must be set to the operator-namespace as well.
 		obj.SetNamespace(operatorNamespace)
 		err = ctx.client.Create(goctx.TODO(), obj, cleanupOptions)
 		if skipIfExists && apierrors.IsAlreadyExists(err) {


### PR DESCRIPTION
**Description of the change:**
When running in a kubebuilder style project with a `PROJECT` file the `operator-sdk test local` command now expects the test manifest to be piped into stdin i.e 
```
kustomize build config/default | operator-sdk test local ./test/e2e --namespace=default
```

The command still supports using flags to set the namespaced and global manifest paths as a fallback when there is no stdin pipe to preserve compatibility:
```
operator-sdk test local ./test/e2e --namespaced-manifest=foo.yaml --global-manifest=bar.yaml
``` 

**Motivation for the change:**
Align the test-framework and command `operator-sdk test local` to work on a kubebuilder project layout.

**TODO:**
- Running the test in a different namespace than the one set by kustomize will fail because while the framework overrides the object namespace, it won't change the RoleBinding/ClusterRoleBinding's subject. Most likely can be fixed in this PR.

- The default operator scaffolded by the kubebuilder plugin is cluster-scoped but does not support `WATCH_NAMESPACE` like the current SDK `main.go` scaffold does. So in the event of a namespaced operator, the test-framework has no way to pass the `TEST_WATCH_NAMESPACE` to the test operator. This is out of the scope of this PR and needs a design discussion on how/if we want to modify the base main.go scaffold in the new layout.