### PR TITLE
run --olm: create one ConfigMap per package

### DIFF
--- a/changelog/fragments/2964-bugfix.yaml
+++ b/changelog/fragments/2964-bugfix.yaml
@@ -1,0 +1,8 @@
+entries:
+  - description: >
+      In 'run --olm', package manifests format must be replicated in a pod's
+      file system for consistent registry initialization.
+
+    kind: "bugfix"
+
+    breaking: false

--- a/hack/tests/integration.sh
+++ b/hack/tests/integration.sh
@@ -4,7 +4,7 @@ set -eu
 
 source hack/lib/image_lib.sh
 
-export OSDK_INTEGRATION_IMAGE="quay.io/example/memcached-operator:v0.0.2"
+export OSDK_INTEGRATION_IMAGE="quay.io/example/memcached-operator:latest"
 
 # Build the operator image.
 pushd test/test-framework

--- a/internal/olm/operator/internal/registry.go
+++ b/internal/olm/operator/internal/registry.go
@@ -17,17 +17,22 @@ package olm
 import (
 	"context"
 	"fmt"
-
-	olmclient "github.com/operator-framework/operator-sdk/internal/olm/client"
+	"path"
 
 	"github.com/operator-framework/operator-registry/pkg/registry"
 	log "github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
+	olmclient "github.com/operator-framework/operator-sdk/internal/olm/client"
+	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
 )
 
 const (
-	// The directory containing all manifests for an operator, with the
-	// package manifest being top-level.
+	// The root directory containing of a package manifests format for an
+	// operator, with the package manifest being top-level.
 	containerManifestsDir = "/registry/manifests"
 )
 
@@ -44,53 +49,143 @@ type RegistryResources struct {
 	Bundles []*registry.Bundle
 }
 
-// FEAT(estroz): allow users to specify labels for registry objects.
-
-// CreateRegistryManifests creates all registry objects required to serve
-// manifests from m.manifests in namespace.
-func (m *RegistryResources) CreateRegistryManifests(ctx context.Context, namespace string) error {
-	pkgName := m.Pkg.PackageName
-	binaryKeyValues, err := createConfigMapBinaryData(m.Pkg, m.Bundles)
-	if err != nil {
-		return fmt.Errorf("error creating registry ConfigMap binary data: %w", err)
+// IsRegistryExist returns true if a registry Deployment exists in namespace.
+func (rr *RegistryResources) IsRegistryExist(ctx context.Context, namespace string) (bool, error) {
+	depKey := types.NamespacedName{
+		Name:      getRegistryServerName(rr.Pkg.PackageName),
+		Namespace: namespace,
 	}
-	cm := newRegistryConfigMap(pkgName, namespace,
-		withBinaryData(binaryKeyValues),
-	)
-	volName := getRegistryVolumeName(pkgName)
-	dep := newRegistryDeployment(pkgName, namespace,
-		withRegistryGRPCContainer(pkgName),
-		withVolumeConfigMap(volName, cm.GetName()),
-		withContainerVolumeMounts(volName, []string{containerManifestsDir}),
-	)
-	service := newRegistryService(pkgName, namespace,
-		withTCPPort("grpc", registryGRPCPort),
-	)
-	if err = m.Client.DoCreate(ctx, cm, dep, service); err != nil {
+	err := rr.Client.KubeClient.Get(ctx, depKey, &appsv1.Deployment{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// IsRegistryDataStale checks if manifest data stored in the on-cluster
+// registry is stale by comparing it to the currently managed data.
+func (rr *RegistryResources) IsRegistryDataStale(ctx context.Context, namespace string) (bool, error) {
+	configMaps, err := rr.getRegistryConfigMaps(ctx, namespace)
+	if err != nil {
+		return false, err
+	}
+	// Simple length comparison for packages + package manifest ConfigMaps.
+	if len(configMaps) != len(rr.Bundles)+1 {
+		return true, nil
+	}
+
+	binaryDataByConfigMap, err := makeConfigMapsForPackageManifests(rr.Pkg, rr.Bundles)
+	if err != nil {
+		return false, err
+	}
+
+	for _, configMap := range configMaps {
+		binaryData, hasName := binaryDataByConfigMap[configMap.GetName()]
+		if !hasName {
+			return true, nil
+		}
+		// If the number of files to be added to the registry don't match the number
+		// of files currently in the registry, we have added or removed a file.
+		if len(binaryData) != len(configMap.BinaryData) {
+			return true, nil
+		}
+		// Check each binary value's key, which contains a base32-encoded md5 digest
+		// component, against the new set of manifest keys.
+		for fileKey := range configMap.BinaryData {
+			if _, match := binaryData[fileKey]; !match {
+				return true, nil
+			}
+			delete(binaryData, fileKey)
+		}
+		// Registry is stale if there are new keys not in the existing ConfigMap.
+		if len(binaryData) != 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// CreatePackageManifestsRegistry creates all registry objects required to serve
+// manifests from rr.manifests in namespace.
+func (rr *RegistryResources) CreatePackageManifestsRegistry(ctx context.Context, namespace string) error {
+	pkgName := rr.Pkg.PackageName
+	labels := makeRegistryLabels(pkgName)
+
+	binaryDataByConfigMap, err := makeConfigMapsForPackageManifests(rr.Pkg, rr.Bundles)
+	if err != nil {
+		return err
+	}
+
+	// Objects to create.
+	objs := make([]runtime.Object, 0, len(binaryDataByConfigMap)+2)
+	// Options for creating a Deployment, since we need to mount all package
+	// ConfigMaps as volumes into pods.
+	opts := make([]func(*appsv1.Deployment), 0, 2*len(binaryDataByConfigMap)+1)
+	opts = append(opts, withRegistryGRPCContainer(pkgName))
+	// Build all package ConfigMaps.
+	for cmName, binaryData := range binaryDataByConfigMap {
+		cm := newConfigMap(cmName, namespace, withBinaryData(binaryData))
+		cm.SetLabels(labels)
+		objs = append(objs, cm)
+
+		volName := k8sutil.TrimDNS1123Label(cmName + "-volume")
+		opts = append(opts,
+			withConfigMapVolume(volName, cmName),
+			withContainerVolumeMounts(volName, path.Join(containerManifestsDir, cmName)),
+		)
+	}
+
+	// Add registry Deployment and Service to objects.
+	dep := newRegistryDeployment(pkgName, namespace, opts...)
+	dep.SetLabels(labels)
+	service := newRegistryService(pkgName, namespace, withTCPPort("grpc", registryGRPCPort))
+	service.SetLabels(labels)
+	objs = append(objs, dep, service)
+
+	if err := rr.Client.DoCreate(ctx, objs...); err != nil {
 		return fmt.Errorf("error creating operator %q registry-server objects: %w", pkgName, err)
 	}
+
+	// Wait for registry Deployment rollout.
 	depKey := types.NamespacedName{
 		Name:      dep.GetName(),
 		Namespace: namespace,
 	}
 	log.Infof("Waiting for Deployment %q rollout to complete", depKey)
-	if err = m.Client.DoRolloutWait(ctx, depKey); err != nil {
+	if err := rr.Client.DoRolloutWait(ctx, depKey); err != nil {
 		return fmt.Errorf("error waiting for Deployment %q to roll out: %w", depKey, err)
 	}
+
 	return nil
 }
 
-// DeleteRegistryManifests deletes all registry objects serving manifests
-// from m.manifests in namespace.
-func (m *RegistryResources) DeleteRegistryManifests(ctx context.Context, namespace string) error {
-	pkgName := m.Pkg.PackageName
-	cm := newRegistryConfigMap(pkgName, namespace)
-	dep := newRegistryDeployment(pkgName, namespace)
-	service := newRegistryService(pkgName, namespace)
-	err := m.Client.DoDelete(ctx, dep, cm, service)
+// DeletePackageManifestsRegistry deletes all registry objects serving manifests
+// for an operator in namespace.
+// TODO: delete by owner reference.
+func (rr *RegistryResources) DeletePackageManifestsRegistry(ctx context.Context, namespace string) error {
+
+	// List all registry ConfigMaps by label.
+	configMaps, err := rr.getRegistryConfigMaps(ctx, namespace)
+	if err != nil {
+		return err
+	}
+
+	// Delete registry Deployment, Service, and ConfigMaps by type.
+	objs := make([]runtime.Object, len(configMaps)+2)
+	for i := range configMaps {
+		objs[i] = &configMaps[i]
+	}
+	pkgName := rr.Pkg.PackageName
+	objs[len(objs)-2] = newRegistryDeployment(pkgName, namespace)
+	objs[len(objs)-1] = newRegistryService(pkgName, namespace)
+	err = rr.Client.DoDelete(ctx, objs...)
 	if err != nil {
 		return fmt.Errorf("error deleting operator %q registry-server objects: %w", pkgName, err)
 	}
+
 	return nil
 }
 
@@ -99,4 +194,15 @@ func (m *RegistryResources) DeleteRegistryManifests(ctx context.Context, namespa
 func GetRegistryServiceAddr(pkgName, namespace string) string {
 	name := getRegistryServerName(pkgName)
 	return fmt.Sprintf("%s.%s.svc.cluster.local:%d", name, namespace, registryGRPCPort)
+}
+
+// makeRegistryLabels creates a set of labels to identify operator-registry objects.
+func makeRegistryLabels(pkgName string) map[string]string {
+	labels := map[string]string{
+		"package-name": k8sutil.TrimDNS1123Label(pkgName),
+	}
+	for k, v := range SDKLabels {
+		labels[k] = v
+	}
+	return labels
 }

--- a/internal/olm/operator/manager.go
+++ b/internal/olm/operator/manager.go
@@ -281,7 +281,7 @@ func (m *operatorManager) run(ctx context.Context) (err error) {
 	if installed, err := status.HasInstalledResources(); !installed {
 		return fmt.Errorf("operator %s did not install successfully\n%s", pkgName, status)
 	} else if err != nil {
-		return fmt.Errorf("operator %qhas resource errors\n%s", pkgName, status)
+		return fmt.Errorf("operator %q has resource errors\n%s", pkgName, status)
 	}
 	log.Infof("Successfully installed %q on OLM version %q", csv.GetName(), olmVer)
 	fmt.Print(status)
@@ -351,27 +351,24 @@ func (m operatorManager) registryUp(ctx context.Context, namespace string) error
 		Bundles: m.bundles,
 	}
 
-	registryStale, err := rr.IsManifestDataStale(ctx, namespace)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
+	if exists, err := rr.IsRegistryExist(ctx, namespace); err != nil {
+		return fmt.Errorf("error checking registry existence: %v", err)
+	} else if exists {
+		if isRegistryStale, err := rr.IsRegistryDataStale(ctx, namespace); err == nil {
+			if !isRegistryStale {
+				log.Infof("%s registry data is current", m.pkg.PackageName)
+				return nil
+			}
+			log.Infof("A stale %s registry exists, deleting", m.pkg.PackageName)
+			if err = rr.DeletePackageManifestsRegistry(ctx, namespace); err != nil {
+				return fmt.Errorf("error deleting registered bundle: %w", err)
+			}
+		} else if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("error checking registry data: %w", err)
 		}
-		// ConfigMap doesn't exist yet, so create it as usual.
-		log.Info("Creating registry")
-		if err = rr.CreateRegistryManifests(ctx, namespace); err != nil {
-			return fmt.Errorf("error registering bundle: %w", err)
-		}
-		return nil
 	}
-	if !registryStale {
-		log.Printf("Registry data is current")
-		return nil
-	}
-	log.Printf("Registry data stale. Recreating registry")
-	if err = rr.DeleteRegistryManifests(ctx, namespace); err != nil {
-		return fmt.Errorf("error deleting registered bundle: %w", err)
-	}
-	if err = rr.CreateRegistryManifests(ctx, namespace); err != nil {
+	log.Infof("Creating %s registry", m.pkg.PackageName)
+	if err := rr.CreatePackageManifestsRegistry(ctx, namespace); err != nil {
 		return fmt.Errorf("error registering bundle: %w", err)
 	}
 
@@ -386,8 +383,8 @@ func (m *operatorManager) registryDown(ctx context.Context, namespace string) er
 	}
 
 	if m.forceRegistry {
-		log.Printf("Deleting registry")
-		if err := rr.DeleteRegistryManifests(ctx, namespace); err != nil {
+		log.Print("Deleting registry")
+		if err := rr.DeletePackageManifestsRegistry(ctx, namespace); err != nil {
 			return fmt.Errorf("error deleting registered bundle: %w", err)
 		}
 	}

--- a/internal/util/k8sutil/k8sutil.go
+++ b/internal/util/k8sutil/k8sutil.go
@@ -128,3 +128,12 @@ func FormatOperatorNameDNS1123(name string) string {
 	}
 	return name
 }
+
+// TrimDNS1123Label trims a label to meet the DNS 1123 label length requirement
+// by removing characters from the beginning of label such that len(label) <= 63.
+func TrimDNS1123Label(label string) string {
+	if len(label) > validation.DNS1123LabelMaxLength {
+		return label[len(label)-validation.DNS1123LabelMaxLength:]
+	}
+	return label
+}

--- a/test/integration/operator_olm_test.go
+++ b/test/integration/operator_olm_test.go
@@ -44,19 +44,20 @@ var (
 
 func TestOLMIntegration(t *testing.T) {
 	if image, ok := os.LookupEnv(imageEnvVar); ok && image != "" {
-		defaultTestImageTag = image
+		testImageTag = image
 	}
-	t.Run("AnnotationsBasic", OperatorAnnotationsBasic)
-	t.Run("AnnotationsAllNamespaces", OperatorAnnotationsAllNamespaces)
-	t.Run("PackageManifestBasic", OperatorPackageManifestBasic)
+	t.Run("BundleBasic", OperatorBundleBasic)
+	t.Run("BundleAllNamespaces", OperatorBundleAllNamespaces)
+	t.Run("PackageManifestsBasic", OperatorPackageManifestsBasic)
+	t.Run("PackageManifestsMultiple", OperatorPackageManifestsMultiplePackages)
 }
 
-func OperatorAnnotationsBasic(t *testing.T) {
+func OperatorBundleBasic(t *testing.T) {
 
 	csvConfig := CSVTemplateConfig{
 		OperatorName:    defaultOperatorName,
 		OperatorVersion: defaultOperatorVersion,
-		TestImageTag:    defaultTestImageTag,
+		TestImageTag:    testImageTag,
 		ReplacesCSVName: "",
 		CRDKeys: []DefinitionKey{
 			{
@@ -74,9 +75,9 @@ func OperatorAnnotationsBasic(t *testing.T) {
 			{Type: operatorsv1alpha1.InstallModeTypeMultiNamespace, Supported: false},
 			{Type: operatorsv1alpha1.InstallModeTypeAllNamespaces, Supported: false},
 		},
-		IsManifests: true,
+		IsBundle: true,
 	}
-	tmp, cleanup := mkTempDirWithCleanup(t, "sdk-integration.")
+	tmp, cleanup := mkTempDirWithCleanup(t, "")
 	defer cleanup()
 
 	channels := []string{"alpha"}
@@ -119,12 +120,12 @@ func OperatorAnnotationsBasic(t *testing.T) {
 	assert.NoError(t, opcmd.Cleanup())
 }
 
-func OperatorAnnotationsAllNamespaces(t *testing.T) {
+func OperatorBundleAllNamespaces(t *testing.T) {
 
 	csvConfig := CSVTemplateConfig{
 		OperatorName:    defaultOperatorName,
 		OperatorVersion: defaultOperatorVersion,
-		TestImageTag:    defaultTestImageTag,
+		TestImageTag:    testImageTag,
 		ReplacesCSVName: "",
 		CRDKeys: []DefinitionKey{
 			{
@@ -142,9 +143,9 @@ func OperatorAnnotationsAllNamespaces(t *testing.T) {
 			{Type: operatorsv1alpha1.InstallModeTypeMultiNamespace, Supported: false},
 			{Type: operatorsv1alpha1.InstallModeTypeAllNamespaces, Supported: true},
 		},
-		IsManifests: true,
+		IsBundle: true,
 	}
-	tmp, cleanup := mkTempDirWithCleanup(t, "sdk-integration.")
+	tmp, cleanup := mkTempDirWithCleanup(t, "")
 	defer cleanup()
 
 	channels := []string{"alpha"}
@@ -178,12 +179,12 @@ func OperatorAnnotationsAllNamespaces(t *testing.T) {
 	assert.NoError(t, opcmd.Run())
 }
 
-func OperatorPackageManifestBasic(t *testing.T) {
+func OperatorPackageManifestsBasic(t *testing.T) {
 
 	csvConfig := CSVTemplateConfig{
 		OperatorName:    defaultOperatorName,
 		OperatorVersion: defaultOperatorVersion,
-		TestImageTag:    defaultTestImageTag,
+		TestImageTag:    testImageTag,
 		ReplacesCSVName: "",
 		CRDKeys: []DefinitionKey{
 			{
@@ -202,7 +203,7 @@ func OperatorPackageManifestBasic(t *testing.T) {
 			{Type: operatorsv1alpha1.InstallModeTypeAllNamespaces, Supported: false},
 		},
 	}
-	tmp, cleanup := mkTempDirWithCleanup(t, "sdk-integration.")
+	tmp, cleanup := mkTempDirWithCleanup(t, "")
 	defer cleanup()
 
 	channels := []registry.PackageChannel{
@@ -245,5 +246,101 @@ func OperatorPackageManifestBasic(t *testing.T) {
 	// "Remove operator after deploy"
 	assert.NoError(t, opcmd.Cleanup())
 	// "Remove operator after removal"
+	assert.NoError(t, opcmd.Cleanup())
+}
+
+func OperatorPackageManifestsMultiplePackages(t *testing.T) {
+
+	operatorVersion1 := defaultOperatorVersion
+	operatorVersion2 := "0.0.3"
+	csvConfigs := []CSVTemplateConfig{
+		{
+			OperatorName:    defaultOperatorName,
+			OperatorVersion: operatorVersion1,
+			TestImageTag:    testImageTag,
+			ReplacesCSVName: "",
+			CRDKeys: []DefinitionKey{
+				{
+					Kind:  "Memcached",
+					Name:  "memcacheds.cache.example.com",
+					Group: "cache.example.com",
+					Versions: []apiextv1beta1.CustomResourceDefinitionVersion{
+						{Name: "v1alpha1", Storage: true, Served: true},
+					},
+				},
+			},
+			InstallModes: []operatorsv1alpha1.InstallMode{
+				{Type: operatorsv1alpha1.InstallModeTypeOwnNamespace, Supported: true},
+				{Type: operatorsv1alpha1.InstallModeTypeSingleNamespace, Supported: false},
+				{Type: operatorsv1alpha1.InstallModeTypeMultiNamespace, Supported: false},
+				{Type: operatorsv1alpha1.InstallModeTypeAllNamespaces, Supported: false},
+			},
+		},
+		{
+			OperatorName:    defaultOperatorName,
+			OperatorVersion: operatorVersion2,
+			TestImageTag:    testImageTag,
+			ReplacesCSVName: fmt.Sprintf("%s.v%s", defaultOperatorName, operatorVersion1),
+			CRDKeys: []DefinitionKey{
+				{
+					Kind:  "Memcached",
+					Name:  "memcacheds.cache.example.com",
+					Group: "cache.example.com",
+					Versions: []apiextv1beta1.CustomResourceDefinitionVersion{
+						// TODO(estroz): uncomment after the following is merged and
+						// api version is bumped:
+						// https://github.com/operator-framework/api/pull/32
+						//
+						// {Name: "v1alpha1", Storage: false, Served: true},
+						{Name: "v1alpha2", Storage: true, Served: true},
+					},
+				},
+			},
+			InstallModes: []operatorsv1alpha1.InstallMode{
+				{Type: operatorsv1alpha1.InstallModeTypeOwnNamespace, Supported: true},
+				{Type: operatorsv1alpha1.InstallModeTypeSingleNamespace, Supported: false},
+				{Type: operatorsv1alpha1.InstallModeTypeMultiNamespace, Supported: false},
+				{Type: operatorsv1alpha1.InstallModeTypeAllNamespaces, Supported: false},
+			},
+		},
+	}
+
+	tmp, cleanup := mkTempDirWithCleanup(t, "")
+	defer cleanup()
+
+	channels := []registry.PackageChannel{
+		{Name: "stable", CurrentCSVName: fmt.Sprintf("%s.v%s", defaultOperatorName, operatorVersion2)},
+		{Name: "alpha", CurrentCSVName: fmt.Sprintf("%s.v%s", defaultOperatorName, operatorVersion1)},
+	}
+	manifestsDir := filepath.Join(tmp, defaultOperatorName)
+	for _, config := range csvConfigs {
+		err := writeOperatorManifests(manifestsDir, config)
+		if err != nil {
+			os.RemoveAll(tmp)
+			t.Fatal(err)
+		}
+	}
+	err := writePackageManifest(manifestsDir, defaultOperatorName, channels)
+	if err != nil {
+		os.RemoveAll(tmp)
+		t.Fatal(err)
+	}
+	opcmd := operator.OLMCmd{
+		ManifestsDir:    manifestsDir,
+		OperatorVersion: operatorVersion2,
+		KubeconfigPath:  kubeconfigPath,
+		Timeout:         defaultTimeout,
+		OLMNamespace:    olm.DefaultOLMNamespace,
+	}
+	// Cleanup.
+	defer func() {
+		if err := opcmd.Cleanup(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// "Deploy operator"
+	assert.NoError(t, opcmd.Run())
+	// "Remove operator after deploy"
 	assert.NoError(t, opcmd.Cleanup())
 }


### PR DESCRIPTION
**Description of the change:**
* internal/olm/operator: create one ConfigMap per package in a package manifests format, and deploy the registry with all ConfigMaps mounted

**Motivation for the change:** the package manifests format must be replicated in a pod's file system for consistent registry initialization.

Closes #2923 

/kind bug
