### PR TITLE
OLM client: correctly get packageserver version

### DIFF
--- a/changelog/fragments/2969-bugfix.yaml
+++ b/changelog/fragments/2969-bugfix.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      the internal OLM client retrieves existing OLM versions correctly now
+      that the returned list of CSVs is indexed properly
+
+    kind: "bugfix"

--- a/internal/olm/client/client.go
+++ b/internal/olm/client/client.go
@@ -228,7 +228,8 @@ func (c Client) GetInstalledVersion(ctx context.Context, namespace string) (stri
 		return "", fmt.Errorf("failed to list CSVs in namespace %q: %v", namespace, err)
 	}
 	var pkgServerCSV *olmapiv1alpha1.ClusterServiceVersion
-	for _, csv := range csvs.Items {
+	for i := range csvs.Items {
+		csv := csvs.Items[i]
 		name := csv.GetName()
 		// Check old and new name possibilities.
 		if name == pkgServerCSVNewName || strings.HasPrefix(name, pkgServerCSVOldNamePrefix) {


### PR DESCRIPTION
**Description of the change:** use indexed CSV in list instead of an iterator value in `internal/olm/client.Client.GetInstalledVersion`.

**Motivation for the change:** if more than one CSV is installed in OLM's namespace, as is the case in some k8s distros, the list operation in `GetInstalledVersion` will return multiple CSV's. The bug resulted in the last CSV in the returned list, not necessarily the packageserver's, to be inspected for OLM's version.

/kind bug

/cc @raffaelespazzoli 
