### PR TITLE
CONTRIBUTING.md: fix broken hyperlink to the developer docs

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -9,7 +9,7 @@ Operator SDK is Apache 2.0 licensed and accepts contributions via GitHub pull re
 ## Getting started
 
 - Fork the repository on GitHub
-- See the [developer guide](./doc/dev/developer_guide.md) for build instructions
+- See the [developer guide](https://sdk.operatorframework.io/docs/contribution-guidelines/developer-guide/) for build instructions
 
 ## Reporting bugs and creating issues
 


### PR DESCRIPTION
This fixes the broken hyperlink to the developer docs in the
[CONTRIBUTING.md](https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD) file, which points to a former docs directory
inside the repo. Since that no longer exists, and the docs
have been moved onto the website, this fixes the hyperlink to
point to the same docs on the new website.

Fixes #2974 

**Description of the change:**
Substitute broken reference inside repo to a functional one on the doc website

**Motivation for the change:**
I don't like broken links!