### PR TITLE
website: Fix typos on the main page

### DIFF
--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -26,7 +26,7 @@
             <aside class="of-section-whats-operator__video"></aside> 
            <div class="of-section-whats-operator__content">
             <h2 class="of-heading of-heading--md">WHAT CAN I DO WITH OPERATOR SDK?</h2>
-            <p>The Operator SDK provides the tools to build, test, and package Operators. Initially, the SDK facilitates the marriage of an application’s business logic (for example, how to scale, upgrade, or backup) with the Kubernetes API to execute those operations. Over time, the SDK can allow engineers to make aplications smarter and have the user expereience of cloud services. Leading practices and code patterns that are shared across Operators are inclued in the SDK to help prevent reinventing the wheel.</p>
+            <p>The Operator SDK provides the tools to build, test, and package Operators. Initially, the SDK facilitates the marriage of an application’s business logic (for example, how to scale, upgrade, or backup) with the Kubernetes API to execute those operations. Over time, the SDK can allow engineers to make applications smarter and have the user experience of cloud services. Leading practices and code patterns that are shared across Operators are included in the SDK to help prevent reinventing the wheel.</p>
         <p>The Operator SDK is a framework that uses the controller-runtime library to make writing operators easier by providing:</p>
         <ul class="of-list">
           <li>High level APIs and abstractions to write the operational logic more intuitively</li>
@@ -126,7 +126,7 @@
         </svg>
             </header>
             
-            <p class="of-section__contribute__content">The Operator SDK and its components are open source, so please feel encouraged to jump into each individually and learn what else you can do. If you want to discuss your experience, have questions, or want toget involved, join the <a href="https://groups.google.com/forum/#!forum/operator-framework" class="of-link of-link--inline">Operator SDK forum</a> and visit us on <a href="https://github.com/operator-framework/operator-sdk" class="of-link of-link--inline">GitHub</a>.</p>
+            <p class="of-section__contribute__content">The Operator SDK and its components are open source, so please feel encouraged to jump into each individually and learn what else you can do. If you want to discuss your experience, have questions, or want to get involved, join the <a href="https://groups.google.com/forum/#!forum/operator-framework" class="of-link of-link--inline">Operator SDK forum</a> and visit us on <a href="https://github.com/operator-framework/operator-sdk" class="of-link of-link--inline">GitHub</a>.</p>
           </section>
       </main>
       {{ partial "footer.html" . }}


### PR DESCRIPTION
This fixes various typos on the main page of the website which is
located at website/layouts/index.html

Fixes #2973

**Description of the change:**
Fixing of typos in various \<p\> tags on the above mentioned HTML page.

**Motivation for the change:**
Always better to not have typos!