### PR TITLE
Add documentation for operator version

### DIFF
--- a/internal/scaffold/version.go
+++ b/internal/scaffold/version.go
@@ -40,6 +40,7 @@ func (s *Version) GetInput() (input.Input, error) {
 const versionTemplate = `package version
 
 var (
+	// Version defines the project version.
 	Version = "0.0.1"
 )
 `

--- a/internal/scaffold/version_test.go
+++ b/internal/scaffold/version_test.go
@@ -36,6 +36,7 @@ func TestVersion(t *testing.T) {
 const versionExp = `package version
 
 var (
+	// Version defines the project version.
 	Version = "0.0.1"
 )
 `

--- a/website/content/en/docs/golang/references/project-layout.md
+++ b/website/content/en/docs/golang/references/project-layout.md
@@ -16,7 +16,7 @@ The `operator-sdk` CLI generates a number of packages for each project. The foll
 | deploy | Contains various YAML manifests for registering CRDs, setting up [RBAC][RBAC], and deploying the operator as a Deployment.
 | go.mod go.sum | The [Go mod][go_mod] manifests that describe the external dependencies of this operator. |
 | vendor | The golang [vendor][Vendor] directory that contains local copies of external dependencies that satisfy Go imports in this project. [Go modules][go_mod] manages the vendor directory directly. This directory will not exist unless the project is initialized with the `--vendor` flag, or `go mod vendor` is run in the project root. |
-
+| version | Contains version information of the operator.
 [RBAC]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 [Vendor]: https://golang.org/cmd/go/#hdr-Vendor_Directories
 [go_mod]: https://github.com/golang/go/wiki/Modules


### PR DESCRIPTION
**Description of the change:**
Add documentation for generated operator version.

**Motivation for the change:**

Motivation is to add documentation on the operation version so users of the SDK know what this version is. Happy to change wording if needed.