### PR TITLE
remove test cmd in new CLI

### DIFF
--- a/cmd/operator-sdk/cli/cli.go
+++ b/cmd/operator-sdk/cli/cli.go
@@ -23,7 +23,6 @@ import (
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/olm"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/run"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/scorecard"
-	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/test"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/version"
 	"github.com/operator-framework/operator-sdk/internal/flags"
 	"github.com/operator-framework/operator-sdk/internal/plugins/golang"
@@ -47,7 +46,6 @@ var commands = []*cobra.Command{
 	olm.NewCmd(),
 	run.NewCmd(),
 	scorecard.NewCmd(),
-	test.NewCmd(),
 	version.NewCmd(),
 	build.NewCmd(),
 


### PR DESCRIPTION
**Description of the change:**
Hide `operator-sdk test` cmd in the new Kubebuilder integrated CLI.

**Motivation for the change:**
Replaces #2959 since it was decided that in the new layout [envtest](https://book.kubebuilder.io/reference/testing/envtest.html) would be the preferred way of writing operator integration tests instead of test-framework.