### PR TITLE
website/assets/scss/_variables.scss: fix duplicate color

### DIFF
--- a/website/assets/scss/_variables.scss
+++ b/website/assets/scss/_variables.scss
@@ -20,9 +20,9 @@
     //color
     --of--color-brand--50: #73C5C5;
     --of--color-brand--100: #009596;
-    --of--color-brand--200: #009596;
-    --of--color-brand--300: #005F60;
-    --of--color-brand--400: #003737;
+    --of--color-brand--200: #005F60;
+    --of--color-brand--300: #003737;
+    --of--color-brand--400: #001F22;
     --of--color-white--100: #FFF;
     --of--color-white--150: #F0F0F0;
     --of--color-white--200: #EDEDED;


### PR DESCRIPTION
**Description of the change:**
Updates the color variables to align with the colors in the graphic on the main SDK landing page.

**Motivation for the change:**
Some colors were slightly off due to the 200 and 300 level color variables being duplicate.
An example of this is on the main page where two of the headers in the Go, Helm, and Ansible columns had the same color.