### PR TITLE
generate csv: do not generate a package manifest for bundles

### DIFF
--- a/changelog/fragments/csv-package-manifests-bugfix.yaml
+++ b/changelog/fragments/csv-package-manifests-bugfix.yaml
@@ -1,0 +1,7 @@
+entries:
+  - description: >
+      do not generate a package manifest when 'generate csv --make-manifests=true'
+
+    kind: "bugfix"
+
+    breaking: false

--- a/cmd/operator-sdk/generate/csv.go
+++ b/cmd/operator-sdk/generate/csv.go
@@ -282,15 +282,19 @@ func (c csvCmd) run() error {
 	if err := csv.Generate(); err != nil {
 		return fmt.Errorf("error generating CSV: %v", err)
 	}
-	pkg := gencatalog.PkgGenerator{
-		OperatorName:     c.operatorName,
-		CSVVersion:       c.csvVersion,
-		OutputDir:        c.outputDir,
-		Channel:          c.csvChannel,
-		ChannelIsDefault: c.defaultChannel,
-	}
-	if err := pkg.Generate(); err != nil {
-		return fmt.Errorf("error generating package manifest: %v", err)
+
+	// A package manifest file is not a part of the bundle format.
+	if !c.makeManifests {
+		pkg := gencatalog.PkgGenerator{
+			OperatorName:     c.operatorName,
+			CSVVersion:       c.csvVersion,
+			OutputDir:        c.outputDir,
+			Channel:          c.csvChannel,
+			ChannelIsDefault: c.defaultChannel,
+		}
+		if err := pkg.Generate(); err != nil {
+			return fmt.Errorf("error generating package manifest: %v", err)
+		}
 	}
 
 	log.Info("CSV manifest generated successfully")


### PR DESCRIPTION
**Description of the change:**
* cmd/operator-sdk/generate: skip package manifest generation if `--make-manifests=true` (the default)

**Motivation for the change:** package manifests are not part of bundles

/kind bug
