### PR TITLE
internal/generate/olm-catalog: read only one manifest at a time

### DIFF
--- a/changelog/fragments/get-csv-manifest-bugfix.yaml
+++ b/changelog/fragments/get-csv-manifest-bugfix.yaml
@@ -1,0 +1,9 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      CSV manifests read from disk are now properly marshaled into the CSV struct
+
+    kind: "bugfix"
+
+    breaking: false

--- a/internal/generate/olm-catalog/csv_util.go
+++ b/internal/generate/olm-catalog/csv_util.go
@@ -114,7 +114,7 @@ func getCSVFromDir(dir string) (*olmapiv1alpha1.ClusterServiceVersion, error) {
 			}
 			if typeMeta.Kind == olmapiv1alpha1.ClusterServiceVersionKind {
 				csv := &olmapiv1alpha1.ClusterServiceVersion{}
-				if err := yaml.Unmarshal(b, csv); err != nil {
+				if err := yaml.Unmarshal(manifest, csv); err != nil {
 					return nil, fmt.Errorf("error unmarshalling ClusterServiceVersion from manifest %s: %v", path, err)
 				}
 				return csv, nil


### PR DESCRIPTION
**Description of the change:**
* internal/generate/olm-catalog: use correct variable when reading CSV manifests

**Motivation for the change:** bug

Closes #3002 

/kind bug