### PR TITLE
olm-integration: fix link to index image docs

### DIFF
--- a/website/content/en/docs/olm-integration/user-guide.md
+++ b/website/content/en/docs/olm-integration/user-guide.md
@@ -284,3 +284,4 @@ the OLM [docs][doc-olm-index] on adding an index to a cluster registry.
 [csv-markers]:/docs/golang/references/markers
 [doc-run-olm-explanation]:/docs/olm-integration/olm-deployment/#operator-sdk-run---olm-command-overview
 [doc-olm-index]:https://github.com/operator-framework/operator-registry#using-the-index-with-operator-lifecycle-manager
+[index-image]:https://github.com/operator-framework/operator-registry#building-an-index-of-operators-using-opm


### PR DESCRIPTION
**Description of the change:**
Fix missing link to index image docs on olm-integration docs.
See: https://sdk.operatorframework.io/docs/olm-integration/user-guide/#production
```
OLM and Operator Registry consumes Operator bundles via an [index image][index-image]
```