### PR TITLE
Add netlify configuration, bump hugo version to 0.70.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+# Hugo build configuration for Netlify 
+# (https://gohugo.io/hosting-and-deployment/hosting-on-netlify/#configure-hugo-version-in-netlify)
+
+# Default build settings
+[build]
+  publish = "public"
+  base = "website"
+  command = "cd themes/docsy && git submodule update -f --init && cd ../.. && npm install postcss-cli autoprefixer && hugo version && hugo"
+
+# "production" environment specific build settings
+[build.environment]
+  HUGO_ENV = "production"

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,4 @@
 # "production" environment specific build settings
 [build.environment]
   HUGO_ENV = "production"
+  HUGO_VERSION = "0.70.0"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
-# Hugo build configuration for Netlify 
+# Hugo build configuration for Netlify
 # (https://gohugo.io/hosting-and-deployment/hosting-on-netlify/#configure-hugo-version-in-netlify)
 
 # Default build settings


### PR DESCRIPTION
Configure netlify with `netlify.toml`

This pulls some of the configuration out of the netlify UI and allows it
to be managed with version control.

FYI: hugo version history
Original site used the default Hugo version (0.54) which had some problems rendering tables and lists. Bumping to latest (0.70.0) exposed a layout/content discrepancy, so we temporarily rolled back to 0.62.2. The discrepancy has been fixed, so we can now bump to latest version. The early version bumps were done by setting an environment variable in the netlify UI, but this value is overridden by `netlify.toml`, allowing us to keep the hugo version in version control (and leverage deploy previews to test a bumped version)
