### PR TITLE
generate csv: un-deprecate --csv-channel and --default-channel

### DIFF
--- a/cmd/operator-sdk/generate/csv.go
+++ b/cmd/operator-sdk/generate/csv.go
@@ -194,11 +194,6 @@ Flags that change project default paths:
 		"Semantic version of the CSV. This flag must be set if a package manifest exists")
 	cmd.Flags().StringVar(&c.fromVersion, "from-version", "",
 		"Semantic version of an existing CSV to use as a base")
-	err := cmd.Flags().MarkDeprecated("from-version",
-		"Use --csv-version to update your bundled CSV in `manifests/`")
-	if err != nil {
-		panic(err)
-	}
 
 	// TODO: Allow multiple paths
 	// Deployment and RBAC manifests might be in different dirs e.g kubebuilder
@@ -217,21 +212,12 @@ Flags that change project default paths:
 			"If --make-manifests=true, the bundle directory will be <output-dir>/manifests")
 	cmd.Flags().StringVar(&c.operatorName, "operator-name", "",
 		"Operator name to use while generating CSV")
+
 	cmd.Flags().StringVar(&c.csvChannel, "csv-channel", "",
 		"Channel the CSV should be registered under in the package manifest")
-	err = cmd.Flags().MarkDeprecated("csv-channel", "Package manifests are deprecated. "+
-		"Run `operator-sdk bundle create --generate-only` to create operator metadata")
-	if err != nil {
-		panic(err)
-	}
 	cmd.Flags().BoolVar(&c.defaultChannel, "default-channel", false,
 		"Use the channel passed to --csv-channel as the package manifests' default channel. "+
 			"Only valid when --csv-channel is set")
-	err = cmd.Flags().MarkDeprecated("default-channel", "Package manifests are deprecated. "+
-		"Run `operator-sdk bundle create --generate-only` to create operator metadata")
-	if err != nil {
-		panic(err)
-	}
 
 	cmd.Flags().BoolVar(&c.updateCRDs, "update-crds", true,
 		"Update CRD manifests in deploy/<operator-name>/<csv-version> from the default "+

--- a/website/content/en/docs/cli/operator-sdk_generate_csv.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_csv.md
@@ -128,8 +128,11 @@ operator-sdk generate csv [flags]
 ```
       --apis-dir string        Project relative path to root directory for API type defintions (default "pkg/apis")
       --crd-dir string         Project relative path to root directory for CRD and CR manifests
+      --csv-channel string     Channel the CSV should be registered under in the package manifest
       --csv-version string     Semantic version of the CSV. This flag must be set if a package manifest exists
+      --default-channel        Use the channel passed to --csv-channel as the package manifests' default channel. Only valid when --csv-channel is set
       --deploy-dir string      Project relative path to root directory for operator manifests (Deployment and RBAC) (default "deploy")
+      --from-version string    Semantic version of an existing CSV to use as a base
   -h, --help                   help for csv
       --interactive            When set, will enable the interactive command prompt feature to fill the UI metadata fields in CSV
       --make-manifests         When set, the generator will create or update a CSV manifest in a 'manifests' directory. This directory is intended to be used for your latest bundle manifests. The default location is deploy/olm-catalog/<operator-name>/manifests. If --output-dir is set, the directory will be <output-dir>/manifests (default true)


### PR DESCRIPTION
**Description of the change:**
cmd/operator-sdk/generate: remove deprecations on `--csv-channel` and `--default-channel`.

**Motivation for the change:** package manifests are not deprecated. See #2944.
