### PR TITLE
ci: pin kind version

### DIFF
--- a/hack/ci/setup-k8s.sh
+++ b/hack/ci/setup-k8s.sh
@@ -6,11 +6,12 @@ set -eux
 # images at:
 # https://hub.docker.com/r/kindest/node/tags
 K8S_VERSION=$1
+KIND_VERSION="v0.8.1"
 KIND_IMAGE="docker.io/kindest/node:${K8S_VERSION}"
 
 # Download the latest version of kind, which supports all versions of
 # Kubernetes v1.11+.
-curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/latest/download/kind-$(uname)-amd64
+curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
 chmod +x kind
 sudo mv kind /usr/local/bin/
 


### PR DESCRIPTION
**Description of the change:**
* hack/ci/setup-k8s.sh: pin kind version 

**Motivation for the change:** `kind` is still a fairly young project and can break between minor versions, which is what happened between v0.7 and [v0.8](https://github.com/kubernetes-sigs/kind/releases/tag/v0.8.0). This breaking change is breaking patch releases of old SDK versions. Its version should be pinned and updated on each k8s dep bump if possible.
