### PR TITLE
log: fix "panic" loglevel parsing for --zap-stacktrace-level option

### DIFF
--- a/changelog/fragments/3040-fix-loglevel.yaml
+++ b/changelog/fragments/3040-fix-loglevel.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      Add "panic" level for --zap-stacktrace-level (allows "debug", "info", "error", "panic")
+    kind: "addition"
+    # Is this a breaking change?
+    breaking: false

--- a/pkg/log/zap/flags.go
+++ b/pkg/log/zap/flags.go
@@ -26,6 +26,13 @@ import (
 	"k8s.io/klog"
 )
 
+const (
+	logLevelDebug string = "debug"
+	logLevelInfo  string = "info"
+	logLevelError string = "error"
+	logLevelPanic string = "panic"
+)
+
 var (
 	zapFlagSet *pflag.FlagSet
 
@@ -109,9 +116,20 @@ type levelValue struct {
 
 func (v *levelValue) Set(l string) error {
 	v.set = true
-	lvl, err := intLogLevel(l)
-	if err != nil {
-		return err
+	lower := strings.ToLower(l)
+	var lvl int
+	var err error
+	switch lower {
+	case logLevelDebug:
+		lvl = -1
+	case logLevelInfo:
+		lvl = 0
+	case logLevelError:
+		lvl = 2
+	default:
+		if lvl, err = parseIntLogLevel(lower); err != nil {
+			return err
+		}
 	}
 
 	v.level = zapcore.Level(int8(lvl))
@@ -142,9 +160,22 @@ type stackLevelValue struct {
 
 func (v *stackLevelValue) Set(l string) error {
 	v.set = true
-	lvl, err := intLogLevel(l)
-	if err != nil {
-		return err
+	lower := strings.ToLower(l)
+	var lvl int
+	var err error
+	switch lower {
+	case logLevelDebug:
+		lvl = -1
+	case logLevelInfo:
+		lvl = 0
+	case logLevelError:
+		lvl = 2
+	case logLevelPanic:
+		lvl = 4
+	default:
+		if lvl, err = parseIntLogLevel(lower); err != nil {
+			return err
+		}
 	}
 
 	v.level = zapcore.Level(int8(lvl))
@@ -156,34 +187,24 @@ func (v stackLevelValue) String() string {
 		return v.level.String()
 	}
 
-	return "error"
+	return logLevelError
 }
 
 func (v stackLevelValue) Type() string {
 	return "level"
 }
 
-func intLogLevel(l string) (int, error) {
-	lower := strings.ToLower(l)
+func parseIntLogLevel(l string) (int, error) {
 	var lvl int
-	switch lower {
-	case "debug":
-		lvl = -1
-	case "info":
-		lvl = 0
-	case "error":
-		lvl = 2
-	default:
-		i, err := strconv.Atoi(lower)
-		if err != nil {
-			return lvl, fmt.Errorf("invalid log level \"%s\"", l)
-		}
+	i, err := strconv.Atoi(l)
+	if err != nil {
+		return lvl, fmt.Errorf("invalid log level \"%s\"", l)
+	}
 
-		if i > 0 {
-			lvl = -1 * i
-		} else {
-			return lvl, fmt.Errorf("invalid log level \"%s\"", l)
-		}
+	if i > 0 {
+		lvl = -1 * i
+	} else {
+		return lvl, fmt.Errorf("invalid log level \"%s\"", l)
 	}
 	return lvl, nil
 }

--- a/pkg/log/zap/flags_test.go
+++ b/pkg/log/zap/flags_test.go
@@ -91,6 +91,82 @@ func TestLevel(t *testing.T) {
 	}
 }
 
+func TestStackTraceLevel(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		expStr    string
+		expSet    bool
+		expLevel  zapcore.Level
+		shouldErr bool
+	}{
+		{
+			name:     "debug level set",
+			input:    "debug",
+			expStr:   "debug",
+			expSet:   true,
+			expLevel: zapcore.DebugLevel,
+		},
+		{
+			name:     "info level set",
+			input:    "info",
+			expStr:   "info",
+			expSet:   true,
+			expLevel: zapcore.InfoLevel,
+		},
+		{
+			name:     "error level set",
+			input:    "error",
+			expStr:   "error",
+			expSet:   true,
+			expLevel: zapcore.ErrorLevel,
+		},
+		{
+			name:     "panic level set",
+			input:    "panic",
+			expStr:   "panic",
+			expSet:   true,
+			expLevel: zapcore.PanicLevel,
+		},
+		{
+			name:      "negative number should error",
+			input:     "-10",
+			shouldErr: true,
+			expSet:    false,
+		},
+		{
+			name:     "positive number level results in negative level set",
+			input:    "8",
+			expStr:   "Level(-8)",
+			expSet:   true,
+			expLevel: zapcore.Level(int8(-8)),
+		},
+		{
+			name:      "non-integer should cause error",
+			input:     "invalid",
+			shouldErr: true,
+			expSet:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stackLvl := stackLevelValue{}
+			err := stackLvl.Set(tc.input)
+			if err != nil && !tc.shouldErr {
+				t.Fatalf("Unknown error - %v", err)
+			}
+			if err != nil && tc.shouldErr {
+				return
+			}
+			assert.Equal(t, tc.expSet, stackLvl.set)
+			assert.Equal(t, tc.expLevel, stackLvl.level)
+			assert.Equal(t, "level", stackLvl.Type())
+			assert.Equal(t, tc.expStr, stackLvl.String())
+		})
+	}
+}
+
 func TestSample(t *testing.T) {
 	testCases := []struct {
 		name      string


### PR DESCRIPTION
**Description of the change:**
Delegate string parsing to zap, allowing any zap-supported level (for both `--zap-level` and `--zap-stacktrace-level`)

**Motivation for the change:**
The `--zap-stacktrace-level` option (#2319) is currently not working for any level > error as the parsing will not allow it.

I also think it's cleaner to delegate this level parsing to zap itself, it allows anything supported upstream.