### PR TITLE
[scorecard] inject scorecard config to bundle image

### DIFF
--- a/cmd/operator-sdk/bundle/create.go
+++ b/cmd/operator-sdk/bundle/create.go
@@ -25,14 +25,10 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
+	scorecard "github.com/operator-framework/operator-sdk/internal/scorecard/alpha"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-)
-
-const (
-	scorecardConfigPath = "scorecard/"
-	scorecardBundlePath = "/tests/scorecard/"
 )
 
 type bundleCreateCmd struct {
@@ -225,7 +221,7 @@ func (c bundleCreateCmd) runGenerate() error {
 		return fmt.Errorf("error generating bundle image files: %v", err)
 	}
 	if err = copyScorecardConfig(); err != nil {
-		return fmt.Errorf("%v", err)
+		return err
 	}
 	return nil
 }
@@ -311,8 +307,8 @@ func isPackageManifestsDir(dir, operatorName string) bool {
 // image.
 // TODO: Add labels to annotations.yaml and bundle.dockerfile.
 func copyScorecardConfig() error {
-	if isExist(bundle.DockerFile) && isExist(scorecardConfigPath) {
-		scorecardFileContent := fmt.Sprintf("COPY %s %s\n", scorecardConfigPath, scorecardBundlePath)
+	if isExist(bundle.DockerFile) && isExist(scorecard.ConfigDirName) {
+		scorecardFileContent := fmt.Sprintf("COPY %s %s\n", scorecard.ConfigDirName, scorecard.ConfigDirPath)
 		err := projutil.RewriteFileContents(bundle.DockerFile, "COPY", scorecardFileContent)
 		if err != nil {
 			return fmt.Errorf("error rewriting dockerfile, %v", err)

--- a/cmd/operator-sdk/bundle/create.go
+++ b/cmd/operator-sdk/bundle/create.go
@@ -30,6 +30,11 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const (
+	scorecardConfigPath = "scorecard/"
+	scorecardBundlePath = "/tests/scorecard/"
+)
+
 type bundleCreateCmd struct {
 	bundleCmd
 
@@ -115,6 +120,7 @@ bundle.Dockerfile for your latest operator version without building the image:
 				c.imageTag = args[0]
 				err = c.runBuild()
 			}
+
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -124,7 +130,6 @@ bundle.Dockerfile for your latest operator version without building the image:
 	}
 
 	c.addToFlagSet(cmd.Flags())
-
 	return cmd
 }
 
@@ -208,12 +213,19 @@ func (c bundleCreateCmd) validate(args []string) error {
 	return nil
 }
 
-// runGenerate generates a bundle.Dockerfile, and manifests/ and metadata/ dirs,
-// always overwriting their contents.
+// runGenerate generates a bundle.Dockerfile, and manifests/ and metadata/ dirs with scorecard config
+// copied to the bundle image.
 func (c bundleCreateCmd) runGenerate() error {
-	err := bundle.GenerateFunc(c.directory, c.outputDir, c.packageName, c.channels, c.defaultChannel, true)
+	if c.generateOnly {
+		c.overwrite = true
+	}
+
+	err := bundle.GenerateFunc(c.directory, c.outputDir, c.packageName, c.channels, c.defaultChannel, c.overwrite)
 	if err != nil {
 		return fmt.Errorf("error generating bundle image files: %v", err)
+	}
+	if err = copyScorecardConfig(); err != nil {
+		return fmt.Errorf("%v", err)
 	}
 	return nil
 }
@@ -234,11 +246,36 @@ func (c bundleCreateCmd) runBuild() error {
 	}
 
 	// Build with overwrite-able option.
-	err := bundle.BuildFunc(c.directory, c.outputDir, c.imageTag, c.imageBuilder,
-		c.packageName, c.channels, c.defaultChannel, c.overwrite)
+	err := c.buildFunc()
 	if err != nil {
 		return fmt.Errorf("error building bundle image: %v", err)
 	}
+	return nil
+}
+
+// buildFunc is used to build a container image from a list of manifests and generates dockerfile and annotations.yaml.
+func (c bundleCreateCmd) buildFunc() error {
+	_, err := os.Stat(c.directory)
+	if os.IsNotExist(err) {
+		return err
+	}
+
+	err = c.runGenerate()
+	if err != nil {
+		return err
+	}
+
+	// Build bundle image
+	log.Info("Building bundle image")
+	buildCmd, err := bundle.BuildBundleImage(c.imageTag, c.imageBuilder)
+	if err != nil {
+		return err
+	}
+
+	if err := bundle.ExecuteCommand(buildCmd); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -267,4 +304,19 @@ func isPackageManifestsDir(dir, operatorName string) bool {
 	packageManifestPath := filepath.Join(filepath.Dir(dir), operatorName+".package.yaml")
 	_, err := semver.ParseTolerant(filepath.Clean(filepath.Base(dir)))
 	return isExist(packageManifestPath) && err == nil
+}
+
+// copyScorecardConfigToBundle checks if bundle.Dockerfile and scorecard config exists in
+// the operator project. If it does, it injects the scorecard configuration into bundle
+// image.
+// TODO: Add labels to annotations.yaml and bundle.dockerfile.
+func copyScorecardConfig() error {
+	if isExist(bundle.DockerFile) && isExist(scorecardConfigPath) {
+		scorecardFileContent := fmt.Sprintf("COPY %s %s\n", scorecardConfigPath, scorecardBundlePath)
+		err := projutil.RewriteFileContents(bundle.DockerFile, "COPY", scorecardFileContent)
+		if err != nil {
+			return fmt.Errorf("error rewriting dockerfile, %v", err)
+		}
+	}
+	return nil
 }

--- a/internal/scorecard/alpha/config.go
+++ b/internal/scorecard/alpha/config.go
@@ -20,6 +20,11 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const (
+	ConfigDirName = "scorecard"
+	ConfigDirPath = "/tests/" + ConfigDirName + "/"
+)
+
 type Test struct {
 	Name  string `yaml:"name"`  // The container test name
 	Image string `yaml:"image"` // The container image name

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -36,15 +36,16 @@ const (
 	GoModEnv   = "GO111MODULE"
 	SrcDir     = "src"
 
-	fsep             = string(filepath.Separator)
-	mainFile         = "main.go"
-	managerMainFile  = "cmd" + fsep + "manager" + fsep + mainFile
-	buildDockerfile  = "build" + fsep + "Dockerfile"
-	rolesDir         = "roles"
-	requirementsFile = "requirements.yml"
-	moleculeDir      = "molecule"
-	helmChartsDir    = "helm-charts"
-	goModFile        = "go.mod"
+	fsep              = string(filepath.Separator)
+	mainFile          = "main.go"
+	managerMainFile   = "cmd" + fsep + "manager" + fsep + mainFile
+	buildDockerfile   = "build" + fsep + "Dockerfile"
+	rolesDir          = "roles"
+	requirementsFile  = "requirements.yml"
+	moleculeDir       = "molecule"
+	helmChartsDir     = "helm-charts"
+	goModFile         = "go.mod"
+	defaultPermission = 0644
 
 	noticeColor = "\033[1;36m%s\033[0m"
 )
@@ -322,4 +323,35 @@ func CheckGoModules() error {
 func PrintDeprecationWarning(msg string) {
 	fmt.Printf(noticeColor, "[Deprecation Notice] "+msg+". Refer to the version upgrade guide "+
 		"for more information: https://sdk.operatorframework.io/docs/migration/version-upgrade-guide/\n\n")
+}
+
+// RewriteFileContents adds the provided content before the last occurrence of the word label
+// and rewrites the file with the new content.
+func RewriteFileContents(filename, instruction, content string) error {
+	text, err := ioutil.ReadFile(filename)
+
+	if err != nil {
+		return fmt.Errorf("error in getting contents from the file, %v", err)
+	}
+
+	existingContent := string(text)
+	labelIndex := strings.LastIndex(existingContent, instruction)
+
+	if labelIndex == -1 {
+		return fmt.Errorf("instruction not present previously in dockerfile")
+	}
+
+	separationIndex := strings.Index(existingContent[labelIndex:], "\n")
+	if labelIndex == -1 {
+		return fmt.Errorf("no new line at the end of dockerfile command %s", existingContent[labelIndex:])
+	}
+
+	index := labelIndex + separationIndex + 1
+
+	newContent := existingContent[:index] + content + existingContent[index:]
+	err = ioutil.WriteFile(filename, []byte(newContent), defaultPermission)
+	if err != nil {
+		return fmt.Errorf("error writing modified contents to file, %v", err)
+	}
+	return nil
 }

--- a/internal/util/projutil/projutil_test.go
+++ b/internal/util/projutil/projutil_test.go
@@ -1,0 +1,98 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projutil
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Testing projutil helpers", func() {
+	Describe("Testing RewriteFileContents", func() {
+		var (
+			fileContents   string
+			instruction    string
+			content        string
+			expectedOutput string
+		)
+		It("Should pass when file has instruction", func() {
+			fileContents = "LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \n" +
+				"LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/ \n" +
+				"LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/ \n" +
+				"COPY deploy/olm-catalog/memcached-operator/manifests /manifests/ \n"
+
+			instruction = "LABEL"
+
+			content = "LABEL operators.operatorframework.io.bundle.tests.v1=tests/ \n"
+
+			expectedOutput = "LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \n" +
+				"LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/ \n" +
+				"LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/ \n" +
+				"LABEL operators.operatorframework.io.bundle.tests.v1=tests/ \n" +
+				"COPY deploy/olm-catalog/memcached-operator/manifests /manifests/ \n"
+
+			Expect(appendContent(fileContents, instruction, content)).To(Equal(expectedOutput))
+		})
+
+		It("Should result in error when file does not have instruction", func() {
+			fileContents = "LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \n" +
+				"LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/ \n" +
+				"LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/ \n" +
+				"COPY deploy/olm-catalog/memcached-operator/manifests /manifests/ \n"
+
+			instruction = "ADD"
+
+			content = "ADD operators.operatorframework.io.bundle.tests.v1=tests/ \n"
+
+			expectedOutput = "LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \n" +
+				"LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/ \n" +
+				"LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/ \n" +
+				"LABEL operators.operatorframework.io.bundle.tests.v1=tests/ \n" +
+				"COPY deploy/olm-catalog/memcached-operator/manifests /manifests/ \n"
+
+			_, err := appendContent(fileContents, instruction, content)
+
+			Expect(err).Should(MatchError(errors.New("instruction not present previously in dockerfile")))
+		})
+
+		It("Should result in error as no new line at the end of dockerfile command", func() {
+			fileContents = "LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \n" +
+				"LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/ \n" +
+				"LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/"
+
+			instruction = "LABEL"
+
+			content = "LABEL operators.operatorframework.io.bundle.tests.v1=tests/ \n"
+
+			expectedOutput = "LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \n" +
+				"LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/ \n" +
+				"LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/ \n" +
+				"LABEL operators.operatorframework.io.bundle.tests.v1=tests/ \n"
+
+			_, err := appendContent(fileContents, instruction, content)
+
+			Expect(err).ShouldNot((BeNil()))
+		})
+
+	})
+})
+
+func TestMetadata(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Projutil Helpers suite")
+}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adds scorecard config to bundle image, by modying bundle.Dockerfile.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
