### PR TITLE
cli: remove old scorecard cmd

### DIFF
--- a/cmd/operator-sdk/cli/cli.go
+++ b/cmd/operator-sdk/cli/cli.go
@@ -22,7 +22,6 @@ import (
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/completion"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/olm"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/run"
-	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/scorecard"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/version"
 	"github.com/operator-framework/operator-sdk/internal/flags"
 	"github.com/operator-framework/operator-sdk/internal/plugins/golang"
@@ -45,7 +44,6 @@ var commands = []*cobra.Command{
 	completion.NewCmd(),
 	olm.NewCmd(),
 	run.NewCmd(),
-	scorecard.NewCmd(),
 	version.NewCmd(),
 	build.NewCmd(),
 


### PR DESCRIPTION
**Description of the change:**
Remove scorecard1 `scorecard` cmd from the new KB aligned CLI.

scorecard2 is the new iteration of scorecard and that cmd should be enabled when it moves out of alpha.