### PR TITLE
replace hard-coded image with the test Image

### DIFF
--- a/cmd/operator-sdk/cli/cli.go
+++ b/cmd/operator-sdk/cli/cli.go
@@ -22,7 +22,6 @@ import (
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/completion"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/olm"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/run"
-	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/scorecard"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/version"
 	"github.com/operator-framework/operator-sdk/internal/flags"
 	"github.com/operator-framework/operator-sdk/internal/plugins/golang"
@@ -45,7 +44,6 @@ var commands = []*cobra.Command{
 	completion.NewCmd(),
 	olm.NewCmd(),
 	run.NewCmd(),
-	scorecard.NewCmd(),
 	version.NewCmd(),
 	build.NewCmd(),
 

--- a/internal/scorecard/alpha/testpod.go
+++ b/internal/scorecard/alpha/testpod.go
@@ -44,7 +44,7 @@ func getPodDefinition(configMapName string, test Test, r PodTestRunner) *v1.Pod 
 			Containers: []v1.Container{
 				{
 					Name:            "scorecard-test",
-					Image:           "quay.io/operator-framework/scorecard-test:dev",
+					Image:           test.Image,
 					ImagePullPolicy: v1.PullIfNotPresent,
 					Command:         test.Entrypoint,
 					VolumeMounts: []v1.VolumeMount{


### PR DESCRIPTION


**Description of the change:**
this PR replaces a hard-coded image path value with the image path
as found in the test config for scorecard2.  

**Motivation for the change:**

bug, fixing this allows custom test images to work.