### PR TITLE
leader: get most recent lock owner when attempting a claim

### DIFF
--- a/changelog/fragments/3059-fixleader-election-message.yaml
+++ b/changelog/fragments/3059-fixleader-election-message.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: fix leader election of follower showing that an old leader will be evicted when the current leader is healthy
+    kind: bugfix
+    breaking: false

--- a/pkg/leader/leader.go
+++ b/pkg/leader/leader.go
@@ -108,6 +108,13 @@ func Become(ctx context.Context, lockName string) error {
 			log.Info("Became the leader.")
 			return nil
 		case apierrors.IsAlreadyExists(err):
+			// refresh the lock so we use current leader
+			key := crclient.ObjectKey{Namespace: ns, Name: lockName}
+			if err := client.Get(ctx, key, existing); err != nil {
+				log.Info("Leader lock configmap not found.")
+				continue // configmap got lost ... just wait a bit
+			}
+
 			existingOwners := existing.GetOwnerReferences()
 			switch {
 			case len(existingOwners) != 1:


### PR DESCRIPTION
**Description of the change:**
refresh configmap when existing leader gets killed

**Motivation for the change:**

non-leaders would claim that the old leader is "waiting to get evicted"  when in fact the leader is healthy

reproduction:
- 1 leader, 1 follower
- kill leader
- new pod comes up ... claims leader spot
- old follower claims old leader is waiting for eviction