### PR TITLE
run: deprecate '--local' flag in favor of 'local' subcommand

### DIFF
--- a/changelog/fragments/run-local.yaml
+++ b/changelog/fragments/run-local.yaml
@@ -1,0 +1,14 @@
+entries:
+  - description: >
+      Add 'run local' subcommand, which has the same functionality of the
+      deprecated 'run --local' mode.
+
+    kind: addition
+
+    breaking: false
+  - description: >
+      Deprecate 'run --local' mode. Use 'run local' instead.
+
+    kind: deprecation
+
+    breaking: false

--- a/cmd/operator-sdk/execentrypoint/ansible.go
+++ b/cmd/operator-sdk/execentrypoint/ansible.go
@@ -35,7 +35,7 @@ func newRunAnsibleCmd() *cobra.Command {
 		Short: "Runs as an ansible operator",
 		Long: `Runs as an ansible operator. This is intended to be used when running
 in a Pod inside a cluster. Developers wanting to run their operator locally
-should use "run --local" instead.`,
+should use 'run local' instead.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logf.SetLogger(zap.Logger())
 			if err := setAnsibleEnvVars(flags); err != nil {

--- a/cmd/operator-sdk/execentrypoint/cmd.go
+++ b/cmd/operator-sdk/execentrypoint/cmd.go
@@ -24,7 +24,7 @@ func NewCmd() *cobra.Command {
 		Short: "Runs a generic operator",
 		Long: `Runs a generic operator. This is intended to be used when running
 in a Pod inside a cluster. Developers wanting to run their operator locally
-should use "run --local" instead.`,
+should use 'run local' instead.`,
 		Hidden: true,
 	}
 

--- a/cmd/operator-sdk/execentrypoint/helm.go
+++ b/cmd/operator-sdk/execentrypoint/helm.go
@@ -32,7 +32,7 @@ func newRunHelmCmd() *cobra.Command {
 		Short: "Runs as a helm operator",
 		Long: `Runs as a helm operator. This is intended to be used when running
 in a Pod inside a cluster. Developers wanting to run their operator locally
-should use "run --local" instead.`,
+should use 'run local' instead.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logf.SetLogger(zap.Logger())
 

--- a/cmd/operator-sdk/run/cmd.go
+++ b/cmd/operator-sdk/run/cmd.go
@@ -23,6 +23,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/run/local"
+	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/run/packagemanifests"
 	olmcatalog "github.com/operator-framework/operator-sdk/internal/generate/olm-catalog"
 	olmoperator "github.com/operator-framework/operator-sdk/internal/olm/operator"
 	k8sinternal "github.com/operator-framework/operator-sdk/internal/util/k8sutil"
@@ -44,7 +46,7 @@ type runCmd struct {
 
 	// Run type-specific options.
 	olmArgs   olmoperator.PackageManifestsCmd
-	localArgs runLocalArgs
+	localArgs local.RunLocalCmd
 }
 
 // checkRunType ensures exactly one run type has been selected.
@@ -60,13 +62,10 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run an Operator in a variety of environments",
-		Long: `This command will run or deploy your Operator in two different modes: locally
-and using OLM. These modes are controlled by setting --local and --olm run mode
-flags. Each run mode has a separate set of flags that configure 'run' for that
-mode. Run 'operator-sdk run --help' for more information on these flags.
-
-Read more about the --olm run mode and configuration options here:
-https://sdk.operatorframework.io/docs/olm-integration/cli-overview
+		Long: `This command has subcommands that will run or deploy your Operator in two
+different modes: locally and using OLM. These modes are controlled by using 'local'
+or 'packagemanifests' subcommands. Run 'operator-sdk run --help' for more
+information on these subcommands.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := c.checkRunType(); err != nil {
@@ -114,25 +113,28 @@ https://sdk.operatorframework.io/docs/olm-integration/cli-overview
 						if err != nil {
 							return fmt.Errorf("error getting kubeconfig and default namespace: %v", err)
 						}
-						c.localArgs.watchNamespace = defaultNamespace
+						c.localArgs.WatchNamespace = defaultNamespace
 					}
 				}
 
-				c.localArgs.kubeconfig = c.kubeconfig
-				if err := c.localArgs.run(); err != nil {
+				c.localArgs.Kubeconfig = c.kubeconfig
+				if err := c.localArgs.Run(); err != nil {
 					log.Fatalf("Failed to run operator locally: %v", err)
 				}
 			}
 			return nil
 		},
 	}
-	// Avoid sorting flags so we can group them according to run type.
-	cmd.Flags().SortFlags = false
 
 	// Shared flags.
 	cmd.Flags().StringVar(&c.kubeconfig, "kubeconfig", "",
 		"The file path to kubernetes configuration file. Defaults to location "+
 			"specified by $KUBECONFIG, or to default file rules if not set")
+	err := cmd.Flags().MarkDeprecated("kubeconfig",
+		"use --kubeconfig with 'local' or 'packagemanifests' subcommands instead")
+	if err != nil {
+		panic(err)
+	}
 	// Deprecated: namespace exists for historical compatibility. Use watch-namespace instead.
 	//TODO: remove namespace flag before 1.0.0
 	if !kbutil.HasProjectFile() { // not show for the kb layout projects
@@ -149,38 +151,48 @@ https://sdk.operatorframework.io/docs/olm-integration/cli-overview
 	cmd.Flags().BoolVar(&c.olm, "olm", false,
 		"The operator to be run will be managed by OLM in a cluster. "+
 			"Cannot be set with another run-type flag")
-	err := cmd.Flags().MarkDeprecated("olm", "use 'run packagemanifests' instead")
+	err = cmd.Flags().MarkDeprecated("olm", "use 'run packagemanifests' instead")
 	if err != nil {
 		panic(err)
 	}
 	// Mark all flags used with '--olm' as deprecated and hidden separately so
 	// all other 'run' flags are still available.
-	fs := pflag.NewFlagSet("olm", pflag.ExitOnError)
-	fs.SortFlags = false
-	fs.StringVar(&c.olmArgs.ManifestsDir, "manifests", "",
+	olmFS := pflag.NewFlagSet("olm", pflag.ExitOnError)
+	olmFS.StringVar(&c.olmArgs.ManifestsDir, "manifests", "",
 		"Directory containing operator package directories and a package manifest file")
-	c.olmArgs.AddToFlagSet(fs)
-	fs.VisitAll(func(f *pflag.Flag) {
+	c.olmArgs.AddToFlagSet(olmFS)
+	olmFS.VisitAll(func(f *pflag.Flag) {
 		f.Deprecated = "use this flag with 'run packagemanifests' instead"
 		f.Hidden = true
 	})
-	cmd.Flags().AddFlagSet(fs)
+	cmd.Flags().AddFlagSet(olmFS)
 
 	// 'run --local' and related flags.
 	cmd.Flags().BoolVar(&c.local, "local", false,
 		"The operator will be run locally by building the operator binary with "+
 			"the ability to access a kubernetes cluster using a kubeconfig file. "+
 			"Cannot be set with another run-type flag.")
-	c.localArgs.addToFlags(cmd.Flags())
+	err = cmd.Flags().MarkDeprecated("local", "use 'run local' instead")
+	if err != nil {
+		panic(err)
+	}
+	localFS := pflag.NewFlagSet("local", pflag.ExitOnError)
+	c.localArgs.AddToFlags(localFS)
 	switch projutil.GetOperatorType() {
 	case projutil.OperatorTypeAnsible:
-		c.localArgs.ansibleOperatorFlags = aoflags.AddTo(cmd.Flags(), "(ansible operator)")
+		c.localArgs.AnsibleOperatorFlags = aoflags.AddTo(localFS, "(ansible operator)")
 	case projutil.OperatorTypeHelm:
-		c.localArgs.helmOperatorFlags = hoflags.AddTo(cmd.Flags(), "(helm operator)")
+		c.localArgs.HelmOperatorFlags = hoflags.AddTo(localFS, "(helm operator)")
 	}
+	localFS.VisitAll(func(f *pflag.Flag) {
+		f.Deprecated = "use this flag with 'run local' instead"
+		f.Hidden = true
+	})
+	cmd.Flags().AddFlagSet(localFS)
 
 	cmd.AddCommand(
-		newPackageManifestsCmd(),
+		packagemanifests.NewCmd(),
+		local.NewCmd(),
 	)
 
 	return cmd

--- a/cmd/operator-sdk/run/local/cmd.go
+++ b/cmd/operator-sdk/run/local/cmd.go
@@ -1,0 +1,71 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	k8sinternal "github.com/operator-framework/operator-sdk/internal/util/k8sutil"
+	kbutil "github.com/operator-framework/operator-sdk/internal/util/kubebuilder"
+	"github.com/operator-framework/operator-sdk/internal/util/projutil"
+	aoflags "github.com/operator-framework/operator-sdk/pkg/ansible/flags"
+	hoflags "github.com/operator-framework/operator-sdk/pkg/helm/flags"
+)
+
+func NewCmd() *cobra.Command {
+	c := &RunLocalCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "local",
+		Short: "Run an Operator locally",
+		Long: `This command will run your Operator locally by building the operator binary
+with the ability to access a kubernetes cluster using a kubeconfig file`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			projutil.MustInProjectRoot()
+
+			// The main.go and manager.yaml scaffolds in the new layout do not support the WATCH_NAMESPACE
+			// env var to configure the namespace that the operator watches. The default is all namespaces.
+			// So this flag is unsupported for the new layout.
+			if !kbutil.HasProjectFile() {
+				// Get default namespace to watch if unset.
+				if !cmd.Flags().Changed("watch-namespace") {
+					_, defaultNamespace, err := k8sinternal.GetKubeconfigAndNamespace(c.Kubeconfig)
+					if err != nil {
+						return fmt.Errorf("error getting kubeconfig and default namespace: %v", err)
+					}
+					c.WatchNamespace = defaultNamespace
+				}
+			}
+
+			if err := c.Run(); err != nil {
+				log.Fatalf("Failed to run operator: %v", err)
+			}
+			return nil
+		},
+	}
+
+	c.AddToFlags(cmd.Flags())
+	switch projutil.GetOperatorType() {
+	case projutil.OperatorTypeAnsible:
+		c.AnsibleOperatorFlags = aoflags.AddTo(cmd.Flags(), "(ansible operator)")
+	case projutil.OperatorTypeHelm:
+		c.HelmOperatorFlags = hoflags.AddTo(cmd.Flags(), "(helm operator)")
+	}
+
+	return cmd
+}

--- a/cmd/operator-sdk/run/packagemanifests/packagemanifests.go
+++ b/cmd/operator-sdk/run/packagemanifests/packagemanifests.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Operator-SDK Authors
+// Copyright 2020 The Operator-SDK Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package run
+package packagemanifests
 
 import (
 	"fmt"
@@ -30,7 +30,7 @@ type packagemanifestsCmd struct {
 	olmoperator.PackageManifestsCmd
 }
 
-func newPackageManifestsCmd() *cobra.Command {
+func NewCmd() *cobra.Command {
 	c := &packagemanifestsCmd{}
 
 	cmd := &cobra.Command{

--- a/hack/tests/subcommand.sh
+++ b/hack/tests/subcommand.sh
@@ -23,7 +23,7 @@ trap_add 'kubectl delete namespace test-memcached || true' EXIT
 operator-sdk test local ./test/e2e --operator-namespace=test-memcached
 kubectl delete namespace test-memcached
 
-# test operator in 'run --local' mode
+# test operator in 'run local' mode
 kubectl create namespace test-memcached
 operator-sdk test local ./test/e2e --up-local --operator-namespace=test-memcached
 kubectl delete namespace test-memcached
@@ -33,7 +33,7 @@ kubectl create namespace test-memcached
 operator-sdk test local ./test/e2e --up-local --operator-namespace=test-memcached --watch-namespace=""
 kubectl delete namespace test-memcached
 
-# test operator in 'run --local' mode with kubeconfig
+# test operator in 'run local' mode with kubeconfig
 kubectl create namespace test-memcached
 operator-sdk test local ./test/e2e --up-local --operator-namespace=test-memcached --kubeconfig $KUBECONFIG
 kubectl delete namespace test-memcached

--- a/test/e2e/_incluster-test-code/memcached_test.go
+++ b/test/e2e/_incluster-test-code/memcached_test.go
@@ -217,8 +217,7 @@ func MemcachedLocal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command("operator-sdk", "run",
-		"--local",
+	cmd := exec.Command("operator-sdk", "run", "local",
 		"--watch-namespace="+watchNamespace)
 	stderr, err := os.Create("stderr.txt")
 	if err != nil {

--- a/website/content/en/docs/ansible/development-tips.md
+++ b/website/content/en/docs/ansible/development-tips.md
@@ -206,13 +206,13 @@ annotations:
 
 Once a developer is comfortable working with the above workflow, it will be
 beneficial to test the logic inside of an operator. To accomplish this, we can
-use `operator-sdk run --local` from the top-level directory of our project. The
-`run --local` command reads from `./watches.yaml` and uses `~/.kube/config` to
+use `operator-sdk run local` from the top-level directory of our project. The
+`run local` command reads from `./watches.yaml` and uses `~/.kube/config` to
 communicate with a Kubernetes cluster just as the `k8s` modules do. This
 section assumes the developer has read the [Ansible Operator user
 guide][ansible_operator_user_guide] and has the proper dependencies installed.
 
-**NOTE:** You can customize the roles path by setting the environment variable `ANSIBLE_ROLES_PATH` or using the flag `ansible-roles-path`. Note that, if the role not be found in the 
+**NOTE:** You can customize the roles path by setting the environment variable `ANSIBLE_ROLES_PATH` or using the flag `ansible-roles-path`. Note that, if the role not be found in the
 customized path informed in `ANSIBLE_ROLES_PATH` then, the operator will look for it in the `{{current directory}}/roles`.   
 
 Create a Custom Resource Definition (CRD) and proper Role-Based Access Control
@@ -225,9 +225,9 @@ $ kubectl create -f deploy/role.yaml
 $ kubectl create -f deploy/role_binding.yaml
 ```
 
-Run the `run --local` command:
+Run the `run local` command:
 ```bash
-$ operator-sdk run --local
+$ operator-sdk run local
 INFO[0000] Go Version: go1.10.3
 INFO[0000] Go OS/Arch: linux/amd64
 INFO[0000] operator-sdk Version: 0.0.6+git
@@ -334,13 +334,13 @@ foo-operator       1         1         1            1           1m
 In order to see the logs from a particular you can run:
 
 ```sh
-kubectl logs deployment/foo-operator 
+kubectl logs deployment/foo-operator
 ```
 
-The logs contain the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks. 
+The logs contain the information about the Ansible run and will make it much easier to debug issues within your Ansible tasks.
 Note that the logs will contain much more detailed information about the Ansible Operator's internals and interface with Kubernetes as well.
 
-Also, you can use the environment variable `ANSIBLE_DEBUG_LOGS` set as `True` to check the full Ansible result in the logs in order to be able to debug it. 
+Also, you can use the environment variable `ANSIBLE_DEBUG_LOGS` set as `True` to check the full Ansible result in the logs in order to be able to debug it.
 
 **Example**
 

--- a/website/content/en/docs/ansible/quickstart.md
+++ b/website/content/en/docs/ansible/quickstart.md
@@ -224,7 +224,7 @@ Run the operator locally with the default Kubernetes config file present at
 `$HOME/.kube/config`:
 
 ```sh
-$ operator-sdk run --local
+$ operator-sdk run local
 INFO[0000] Go Version: go1.10
 INFO[0000] Go OS/Arch: darwin/amd64
 INFO[0000] operator-sdk Version: 0.0.5+git
@@ -233,7 +233,7 @@ INFO[0000] operator-sdk Version: 0.0.5+git
 Run the operator locally with a provided Kubernetes config file:
 
 ```sh
-$ operator-sdk run --local --kubeconfig=config
+$ operator-sdk run local --kubeconfig=config
 INFO[0000] Go Version: go1.10
 INFO[0000] Go OS/Arch: darwin/amd64
 INFO[0000] operator-sdk Version: 0.0.5+git

--- a/website/content/en/docs/cli/operator-sdk_run.md
+++ b/website/content/en/docs/cli/operator-sdk_run.md
@@ -7,13 +7,10 @@ Run an Operator in a variety of environments
 
 ### Synopsis
 
-This command will run or deploy your Operator in two different modes: locally
-and using OLM. These modes are controlled by setting --local and --olm run mode
-flags. Each run mode has a separate set of flags that configure 'run' for that
-mode. Run 'operator-sdk run --help' for more information on these flags.
-
-Read more about the --olm run mode and configuration options here:
-https://sdk.operatorframework.io/docs/olm-integration/cli-overview
+This command has subcommands that will run or deploy your Operator in two
+different modes: locally and using OLM. These modes are controlled by using 'local'
+or 'packagemanifests' subcommands. Run 'operator-sdk run --help' for more
+information on these subcommands.
 
 
 ```
@@ -23,17 +20,12 @@ operator-sdk run [flags]
 ### Options
 
 ```
-      --kubeconfig string        The file path to kubernetes configuration file. Defaults to location specified by $KUBECONFIG, or to default file rules if not set
-      --local                    The operator will be run locally by building the operator binary with the ability to access a kubernetes cluster using a kubeconfig file. Cannot be set with another run-type flag.
-      --watch-namespace string   [local only] The namespace where the operator watches for changes. Set "" for AllNamespaces, set "ns1,ns2" for MultiNamespace
-      --operator-flags string    [local only] The flags that the operator needs. Example: "--flag1 value1 --flag2=value2"
-      --go-ldflags string        [local only] Set Go linker options
-      --enable-delve             [local only] Start the operator using the delve debugger
-  -h, --help                     help for run
+  -h, --help   help for run
 ```
 
 ### SEE ALSO
 
 * [operator-sdk](../operator-sdk)	 - An SDK for building operators with ease
+* [operator-sdk run local](../operator-sdk_run_local)	 - Run an Operator locally
 * [operator-sdk run packagemanifests](../operator-sdk_run_packagemanifests)	 - Run an Operator organized in the package manifests format with OLM
 

--- a/website/content/en/docs/cli/operator-sdk_run_local.md
+++ b/website/content/en/docs/cli/operator-sdk_run_local.md
@@ -1,0 +1,31 @@
+---
+title: "operator-sdk run local"
+---
+## operator-sdk run local
+
+Run an Operator locally
+
+### Synopsis
+
+This command will run your Operator locally by building the operator binary
+with the ability to access a kubernetes cluster using a kubeconfig file
+
+```
+operator-sdk run local [flags]
+```
+
+### Options
+
+```
+      --enable-delve             Start the operator using the delve debugger
+      --go-ldflags string        Set Go linker options
+  -h, --help                     help for local
+      --kubeconfig string        The file path to kubernetes configuration file. Defaults to location specified by $KUBECONFIG, or to default file rules if not set
+      --operator-flags string    The flags that the operator needs. Example: "--flag1 value1 --flag2=value2"
+      --watch-namespace string   The namespace where the operator watches for changes. Set "" for AllNamespaces, set "ns1,ns2" for MultiNamespace
+```
+
+### SEE ALSO
+
+* [operator-sdk run](../operator-sdk_run)	 - Run an Operator in a variety of environments
+

--- a/website/content/en/docs/contribution-guidelines/testing/travis-build.md
+++ b/website/content/en/docs/contribution-guidelines/testing/travis-build.md
@@ -48,7 +48,7 @@ The Go, Ansible, and Helm tests then differ in what tests they run.
 4. Run [go e2e tests][go-e2e].
     1. Scaffold a project using `hack/tests/scaffolding/e2e-go-scaffold.sh`
     2. Build `memcached-operator` image to be used in tests
-    3. Run scaffolded project e2e tests using `operator-sdk run --local`
+    3. Run scaffolded project e2e tests using `operator-sdk run local`
         1. Run cluster test (namespace is auto-generated and deleted by test framework).
             1. Deploy operator and required resources to the cluster.
             2. Run the leader election test.
@@ -70,7 +70,7 @@ The Go, Ansible, and Helm tests then differ in what tests they run.
                 3. Perform linting of the existing metrics.
                 4. Perform checks on each custom resource generated metric and makes sure the name, type, value, labels and metric are correct.
         2. Run local test (namespace is auto-generated and deleted by test framework).
-            1. Start operator using the `run --local` subcommand.
+            1. Start operator using the `run local` subcommand.
             2. Run memcached scale test (described in step 4.3.1.3)
     4. Run [TLS library tests][tls-tests].
         1. This test runs multiple simple tests of the operator-sdk's TLS library. The tests run in parallel and each tests runs in its own namespace.

--- a/website/content/en/docs/golang/quickstart.md
+++ b/website/content/en/docs/golang/quickstart.md
@@ -395,7 +395,7 @@ export OPERATOR_NAME=memcached-operator
 Run the operator locally with the default Kubernetes config file present at `$HOME/.kube/config`. And watch the namespace `default`:
 
 ```sh
-$ operator-sdk run --local --watch-namespace=default
+$ operator-sdk run local --watch-namespace=default
 2018/09/30 23:10:11 Go Version: go1.10.2
 2018/09/30 23:10:11 Go OS/Arch: darwin/amd64
 2018/09/30 23:10:11 operator-sdk Version: 0.0.6+git

--- a/website/content/en/docs/golang/references/logging.md
+++ b/website/content/en/docs/golang/references/logging.md
@@ -137,7 +137,7 @@ To test, the following print statement can be added in the main function:
 #### Output using custom zap logger
 
 ```console
-$ operator-sdk run --local
+$ operator-sdk run local
 ts=2020-02-27T23:10:33Z level=info msg="Printing at INFO level"
 ts=2020-02-27T23:10:33Z level=info msg="Operator Version: 0.0.1"
 ts=2020-02-27T23:10:33Z level=info msg="Go Version: go1.13.8"
@@ -149,10 +149,10 @@ By using `sigs.k8s.io/controller-runtime/pkg/log`, your logger is propagated thr
 
 ### Setting flags when running locally
 
-When running locally with `operator-sdk run --local`, you can use the `--operator-flags` flag to pass additional flags to your operator, including the zap flags. For example:
+When running locally with `operator-sdk run local`, you can use the `--operator-flags` flag to pass additional flags to your operator, including the zap flags. For example:
 
 ```console
-$ operator-sdk run --local --operator-flags="--zap-level=debug --zap-encoder=console"`
+$ operator-sdk run local --operator-flags="--zap-level=debug --zap-encoder=console"`
 ```
 
 ### Setting flags when deploying to a cluster

--- a/website/content/en/docs/helm/quickstart.md
+++ b/website/content/en/docs/helm/quickstart.md
@@ -205,7 +205,7 @@ Run the operator locally with the default Kubernetes config file present at
 `$HOME/.kube/config`:
 
 ```sh
-$ operator-sdk run --local
+$ operator-sdk run local
 INFO[0000] Go Version: go1.10.3
 INFO[0000] Go OS/Arch: linux/amd64
 INFO[0000] operator-sdk Version: v0.1.1+git
@@ -214,7 +214,7 @@ INFO[0000] operator-sdk Version: v0.1.1+git
 Run the operator locally with a provided Kubernetes config file:
 
 ```sh
-$ operator-sdk run --local --kubeconfig=<path_to_config>
+$ operator-sdk run local --kubeconfig=<path_to_config>
 INFO[0000] Go Version: go1.10.3
 INFO[0000] Go OS/Arch: linux/amd64
 INFO[0000] operator-sdk Version: v0.2.0+git


### PR DESCRIPTION
**Description of the change:**
* cmd/operator-sdk/run: deprecate 'run --loca' and related flags, and move 'local' and 'packagemanifests' subcommand code into their own packages
* *: s/--local/local/g in docs

**Motivation for the change:** follows the pattern of [`run packagemanifests`](#3016) and [`run bundle](https://github.com/operator-framework/enhancements/pull/19).

/kind feature