### PR TITLE
Modify scorecard --list output format. 

### DIFF
--- a/internal/scorecard/alpha/formatting.go
+++ b/internal/scorecard/alpha/formatting.go
@@ -51,9 +51,9 @@ func (o Scorecard) ListTests() (output v1alpha2.ScorecardOutput, err error) {
 
 	for _, test := range tests {
 		testResult := v1alpha2.ScorecardTestResult{}
-		testResult.Name = test.Name
+		testResult.Name = test.Image
 		testResult.Labels = test.Labels
-		testResult.Description = test.Description
+		testResult.EntryPoint = test.Entrypoint
 		output.Results = append(output.Results, testResult)
 	}
 

--- a/internal/scorecard/alpha/formatting.go
+++ b/internal/scorecard/alpha/formatting.go
@@ -51,7 +51,7 @@ func (o Scorecard) ListTests() (output v1alpha2.ScorecardOutput, err error) {
 
 	for _, test := range tests {
 		testResult := v1alpha2.ScorecardTestResult{}
-		testResult.Name = test.Image
+		testResult.Image = test.Image
 		testResult.Labels = test.Labels
 		testResult.EntryPoint = test.Entrypoint
 		output.Results = append(output.Results, testResult)

--- a/pkg/apis/scorecard/v1alpha2/types.go
+++ b/pkg/apis/scorecard/v1alpha2/types.go
@@ -34,16 +34,18 @@ const (
 
 // ScorecardTestResult contains the results of an individual scorecard test.
 type ScorecardTestResult struct {
-	// Name is the name of the test
+	// Name is the name of the test image
 	Name string `json:"name"`
 	// Description describes what the test does
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 	// Labels that further describe the test and enable selection
 	Labels map[string]string `json:"labels,omitempty"`
 	// State is the final state of the test
 	State State `json:"state,omitempty"`
 	// Errors is a list of the errors that occurred during the test (this can include both fatal and non-fatal errors)
 	Errors []string `json:"errors,omitempty"`
+	// EntryPoint is list of commands and arguments passed to the test image
+	EntryPoint []string
 	// Suggestions is a list of suggestions for the user to improve their score (if applicable)
 	Suggestions []string `json:"suggestions,omitempty"`
 	// Log holds a log produced from the test (if applicable)

--- a/pkg/apis/scorecard/v1alpha2/types.go
+++ b/pkg/apis/scorecard/v1alpha2/types.go
@@ -34,8 +34,10 @@ const (
 
 // ScorecardTestResult contains the results of an individual scorecard test.
 type ScorecardTestResult struct {
-	// Name is the name of the test image
-	Name string `json:"name"`
+	// Name is the name of the test
+	Name string `json:"name,omitempty"`
+	// Image is name of the test image
+	Image string `json:"image,omitempty"`
 	// Description describes what the test does
 	Description string `json:"description,omitempty"`
 	// Labels that further describe the test and enable selection
@@ -45,7 +47,7 @@ type ScorecardTestResult struct {
 	// Errors is a list of the errors that occurred during the test (this can include both fatal and non-fatal errors)
 	Errors []string `json:"errors,omitempty"`
 	// EntryPoint is list of commands and arguments passed to the test image
-	EntryPoint []string
+	EntryPoint []string `json:"entrypoint,omitempty"`
 	// Suggestions is a list of suggestions for the user to improve their score (if applicable)
 	Suggestions []string `json:"suggestions,omitempty"`
 	// Log holds a log produced from the test (if applicable)


### PR DESCRIPTION
**Description:** This PR is to remove the name and description from the scorecard2 output when a user specifies the `--list` command flag, but instead list out the image name, entrypoint, and labels which are more precise.

**Motivation for the change:**
For scorecard2, the `config.yaml` file holds information about each test, name, description, labels, image name, entrypoint command/arguments

the test image itself holds the 'truth' as to the name and description however, and in the normal case when tests are executed, the test results hold the name and description that are supplied by the test image itself. So, the `config.yaml` name/desc could get out of sync with those in the test image.

https://issues.redhat.com/browse/OSDK-1246