### PR TITLE
generate bundle: enable interactive mode, set metadata default

### DIFF
--- a/cmd/operator-sdk/generate/internal/genutil.go
+++ b/cmd/operator-sdk/generate/internal/genutil.go
@@ -16,6 +16,7 @@ package genutil
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -125,4 +126,13 @@ func (w *multiManifestWriter) Write(b []byte) (int, error) {
 // if writing a package or bundle to stdout or a single file.
 func NewMultiManifestWriter(w io.Writer) io.Writer {
 	return &multiManifestWriter{w}
+}
+
+// IsNotExist returns true if path does not exist on disk.
+func IsNotExist(path string) bool {
+	if path == "" {
+		return true
+	}
+	_, err := os.Stat(path)
+	return err != nil && errors.Is(err, os.ErrNotExist)
 }

--- a/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
@@ -212,7 +212,6 @@ func mutatingToWebhookDescription(webhook admissionregv1.MutatingWebhook) operat
 func applyCustomResources(c *collector.Manifests, csv *operatorsv1alpha1.ClusterServiceVersion) error {
 	examples := []json.RawMessage{}
 	for _, cr := range c.CustomResources {
-		fmt.Println("applying", cr.GetName())
 		crBytes, err := cr.MarshalJSON()
 		if err != nil {
 			return err
@@ -228,7 +227,6 @@ func applyCustomResources(c *collector.Manifests, csv *operatorsv1alpha1.Cluster
 		csv.SetAnnotations(make(map[string]string))
 	}
 	csv.GetAnnotations()["alm-examples"] = string(examplesJSON)
-	fmt.Println("applied")
 
 	return nil
 }


### PR DESCRIPTION
**Description of the change:**
* cmd/operator-sdk/generate/bundle: set default and allow interactive prompts
* internal/generate/clusterserviceversion: change Options to accept `projutil.InteractiveLevel` arguments

**Motivation for the change:** `--interactive` was not added in #3065 

This command is still "hidden" so I don't think a changelog fragment is needed.

/cc @hasbro17 @camilamacedo86 @jmrodri 
