### PR TITLE
generate: add `bundle` subcommand for current project layouts

### DIFF
--- a/changelog/fragments/3088-addition.yaml
+++ b/changelog/fragments/3088-addition.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      'bundle generate' generates bundles for current project layouts; this
+      has the same behavior as 'generate csv --make-manifests=true'
+
+    kind: addition

--- a/cmd/operator-sdk/generate/bundle/bundle_legacy.go
+++ b/cmd/operator-sdk/generate/bundle/bundle_legacy.go
@@ -1,0 +1,131 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
+	log "github.com/sirupsen/logrus"
+
+	genutil "github.com/operator-framework/operator-sdk/cmd/operator-sdk/generate/internal"
+	gencsv "github.com/operator-framework/operator-sdk/internal/generate/clusterserviceversion"
+	"github.com/operator-framework/operator-sdk/internal/generate/collector"
+	"github.com/operator-framework/operator-sdk/internal/util/projutil"
+)
+
+// setCommonDefaultsLegacy sets defaults useful to all modes of this subcommand.
+func (c *bundleCmd) setCommonDefaultsLegacy() {
+	if c.operatorName == "" {
+		c.operatorName = filepath.Base(projutil.MustGetwd())
+	}
+}
+
+// validateManifestsLegacy validates c for bundle manifests generation for
+// legacy project layouts.
+func (c bundleCmd) validateManifestsLegacy() error {
+	if c.version != "" {
+		if err := genutil.ValidateVersion(c.version); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runManifestsLegacy generates bundle manifests for legacy project layouts.
+func (c bundleCmd) runManifestsLegacy() (err error) {
+
+	if !c.quiet {
+		if c.version == "" {
+			log.Info("Generating bundle manifests")
+		} else {
+			log.Info("Generating bundle manifests version", c.version)
+		}
+	}
+
+	if c.apisDir == "" {
+		c.apisDir = filepath.Join("pkg", "apis")
+	}
+	if c.manifestRoot == "" {
+		c.manifestRoot = "deploy"
+	}
+	if c.crdsDir == "" {
+		c.crdsDir = filepath.Join(c.manifestRoot, "crds")
+	}
+	defaultBundleDir := filepath.Join(c.manifestRoot, "olm-catalog", c.operatorName)
+	if c.inputDir == "" {
+		c.inputDir = defaultBundleDir
+	}
+	if c.outputDir == "" {
+		c.outputDir = defaultBundleDir
+	}
+
+	col := &collector.Manifests{}
+	if err := col.UpdateFromDirs(c.manifestRoot, c.crdsDir); err != nil {
+		return err
+	}
+
+	csvGen := gencsv.Generator{
+		OperatorName: c.operatorName,
+		OperatorType: projutil.GetOperatorType(),
+		Version:      c.version,
+		Collector:    col,
+	}
+
+	opts := []gencsv.LegacyOption{
+		gencsv.WithBundleBase(c.inputDir, c.apisDir, c.interactiveLevel),
+		gencsv.LegacyOption(gencsv.WithBundleWriter(c.outputDir)),
+	}
+	if err := csvGen.GenerateLegacy(opts...); err != nil {
+		return fmt.Errorf("error generating ClusterServiceVersion: %v", err)
+	}
+
+	dir := filepath.Join(c.outputDir, bundle.ManifestsDir)
+	if err := genutil.WriteCRDFilesLegacy(dir, col.CustomResourceDefinitions...); err != nil {
+		return err
+	}
+
+	if !c.quiet {
+		log.Infoln("Bundle manifests generated successfully in", c.outputDir)
+	}
+
+	return nil
+}
+
+// runMetadataLegacy generates a bundle.Dockerfile and bundle metadata for
+// legacy project layouts.
+func (c bundleCmd) runMetadataLegacy() error {
+
+	directory := c.inputDir
+	if directory == "" {
+		// There may be no existing bundle at the default path, so assume manifests
+		// were generated in the output directs.
+		defaultDirectory := filepath.Join("deploy", "olm-catalog", c.operatorName, bundle.ManifestsDir)
+		if c.outputDir != "" && genutil.IsNotExist(defaultDirectory) {
+			directory = filepath.Join(c.outputDir, bundle.ManifestsDir)
+		} else {
+			directory = defaultDirectory
+		}
+	} else {
+		directory = filepath.Join(directory, bundle.ManifestsDir)
+	}
+	outputDir := c.outputDir
+	if filepath.Clean(outputDir) == filepath.Clean(directory) {
+		outputDir = ""
+	}
+
+	return c.generateMetadata(directory, outputDir)
+}

--- a/cmd/operator-sdk/generate/cmd.go
+++ b/cmd/operator-sdk/generate/cmd.go
@@ -29,7 +29,7 @@ code or manifests.`,
 	}
 }
 
-// NewCmdLegacy returns the 'generate' command configured for the new project layout.
+// NewCmd returns the 'generate' command configured for the new project layout.
 func NewCmd() *cobra.Command {
 	cmd := newCmd()
 	cmd.AddCommand(
@@ -45,6 +45,7 @@ func NewCmdLegacy() *cobra.Command {
 		newGenerateK8SCmd(),
 		newGenerateCRDsCmd(),
 		newGenerateCSVCmd(),
+		bundle.NewCmdLegacy(),
 	)
 	return cmd
 }

--- a/cmd/operator-sdk/generate/internal/genutil.go
+++ b/cmd/operator-sdk/generate/internal/genutil.go
@@ -83,17 +83,37 @@ func WriteCRDFiles(dir string, crds ...v1beta1.CustomResourceDefinition) error {
 		return err
 	}
 	for _, crd := range crds {
-		if err := writeCRDFile(dir, crd); err != nil {
+		if err := writeCRDFile(dir, crd, makeCRDFileName(crd)); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// writeCRDFile marshals crd to bytes and writes them to dir in a file named
-// <full group>_<resource>.yaml.
-func writeCRDFile(dir string, crd v1beta1.CustomResourceDefinition) error {
-	file := fmt.Sprintf("%s_%s.yaml", crd.Spec.Group, crd.Spec.Names.Plural)
+func makeCRDFileName(crd v1beta1.CustomResourceDefinition) string {
+	return fmt.Sprintf("%s_%s.yaml", crd.Spec.Group, crd.Spec.Names.Plural)
+}
+
+// WriteCRDFilesLegacy creates dir then writes each CustomResourceDefinition
+// in crds to a file in legacy format in dir.
+func WriteCRDFilesLegacy(dir string, crds ...v1beta1.CustomResourceDefinition) error {
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	for _, crd := range crds {
+		if err := writeCRDFile(dir, crd, makeCRDFileNameLegacy(crd)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func makeCRDFileNameLegacy(crd v1beta1.CustomResourceDefinition) string {
+	return fmt.Sprintf("%s_%s_crd.yaml", crd.Spec.Group, crd.Spec.Names.Plural)
+}
+
+// writeCRDFile marshals crd to bytes and writes them to dir in file.
+func writeCRDFile(dir string, crd v1beta1.CustomResourceDefinition, file string) error {
 	f, err := os.Create(filepath.Join(dir, file))
 	if err != nil {
 		return err

--- a/hack/tests/subcommand-generate-csv.sh
+++ b/hack/tests/subcommand-generate-csv.sh
@@ -41,8 +41,11 @@ function check_crd_files() {
 }
 
 function generate_csv() {
-  echo "operator-sdk generate csv --operator-name $OPERATOR_NAME --interactive=false $@"
-  operator-sdk generate csv --operator-name $OPERATOR_NAME --interactive=false $@
+  echo_run operator-sdk generate csv --operator-name $OPERATOR_NAME --interactive=false $@
+}
+
+function generate_bundle() {
+  echo_run operator-sdk generate bundle --operator-name $OPERATOR_NAME --interactive=false $@
 }
 
 pushd "$TEST_DIR" > /dev/null
@@ -96,3 +99,40 @@ check_crd_files "$TEST_NAME" "$OUTPUT_DIR/manifests" 1
 cleanup_case
 
 header_text "All 'operator-sdk generate csv' subcommand tests passed."
+
+header_text "Running 'operator-sdk generate bundle' subcommand tests in $TEST_DIR."
+
+TEST_NAME="generate with version $OPERATOR_VERSION"
+header_text "$TEST_NAME"
+generate_bundle --version $OPERATOR_VERSION
+check_dir "$TEST_NAME" "$DEFAULT_BUNDLE_DIR" 0
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/manifests" 1
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/metadata" 1
+check_csv_file "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/manifests" 1
+check_crd_files "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/manifests" 1
+check_file "$TEST_NAME" "bundle.Dockerfile" 1
+cleanup_case
+
+TEST_NAME="generate manifests only with version $OPERATOR_VERSION"
+header_text "$TEST_NAME"
+generate_bundle --version $OPERATOR_VERSION --manifests
+check_dir "$TEST_NAME" "$DEFAULT_BUNDLE_DIR" 0
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/manifests" 1
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/metadata" 0
+check_csv_file "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/manifests" 1
+check_crd_files "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/manifests" 1
+check_file "$TEST_NAME" "bundle.Dockerfile" 0
+cleanup_case
+
+TEST_NAME="generate with version $OPERATOR_VERSION and output-dir"
+header_text "$TEST_NAME"
+generate_bundle --version $OPERATOR_VERSION --output-dir "$OUTPUT_DIR"
+check_dir "$TEST_NAME" "$OPERATOR_BUNDLE_ROOT_DIR/manifests" 0
+check_dir "$TEST_NAME" "$OUTPUT_DIR/manifests" 1
+check_dir "$TEST_NAME" "$OUTPUT_DIR/metadata" 1
+check_csv_file "$TEST_NAME" "$OUTPUT_DIR/manifests" 1
+check_crd_files "$TEST_NAME" "$OUTPUT_DIR/manifests" 1
+check_file "$TEST_NAME" "bundle.Dockerfile" 1
+cleanup_case
+
+header_text "All 'operator-sdk generate bundle' subcommand tests passed."

--- a/internal/generate/clusterserviceversion/clusterserviceversion_test.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_test.go
@@ -153,6 +153,23 @@ var _ = Describe("Generating a ClusterServiceVersion", func() {
 				Expect(outputFile).To(BeAnExistingFile())
 				Expect(string(readFileHelper(outputFile))).To(MatchYAML(newCSVStr))
 			})
+
+			It("should write a ClusterServiceVersion manifest to a legacy base/bundle file", func() {
+				g = Generator{
+					OperatorName: operatorName,
+					OperatorType: operatorType,
+					Version:      version,
+					Collector:    col,
+				}
+				opts := []LegacyOption{
+					WithBundleBase(csvBasesDir, goAPIsDir, projutil.InteractiveHardOff),
+					LegacyOption(WithBundleWriter(tmp)),
+				}
+				Expect(g.GenerateLegacy(opts...)).ToNot(HaveOccurred())
+				outputFile := filepath.Join(tmp, bundle.ManifestsDir, makeCSVFileName(operatorName))
+				Expect(outputFile).To(BeAnExistingFile())
+				Expect(string(readFileHelper(outputFile))).To(MatchYAML(newCSVStr))
+			})
 		})
 
 		Context("with incorrect Options", func() {
@@ -181,6 +198,23 @@ var _ = Describe("Generating a ClusterServiceVersion", func() {
 					WithWriter(&bytes.Buffer{}),
 				}
 				Expect(g.Generate(cfg, opts...)).To(MatchError(noGetBaseError))
+			})
+
+			It("should return an error without any LegacyOptions", func() {
+				opts := []LegacyOption{}
+				Expect(g.GenerateLegacy(opts...)).To(MatchError(noGetWriterError))
+			})
+			It("should return an error without a getWriter (legacy)", func() {
+				opts := []LegacyOption{
+					WithBundleBase(csvBasesDir, goAPIsDir, projutil.InteractiveHardOff),
+				}
+				Expect(g.GenerateLegacy(opts...)).To(MatchError(noGetWriterError))
+			})
+			It("should return an error without a getBase (legacy)", func() {
+				opts := []LegacyOption{
+					LegacyOption(WithWriter(&bytes.Buffer{})),
+				}
+				Expect(g.GenerateLegacy(opts...)).To(MatchError(noGetBaseError))
 			})
 		})
 

--- a/website/content/en/docs/cli/operator-sdk_generate.md
+++ b/website/content/en/docs/cli/operator-sdk_generate.md
@@ -19,6 +19,7 @@ code or manifests.
 ### SEE ALSO
 
 * [operator-sdk](../operator-sdk)	 - An SDK for building operators with ease
+* [operator-sdk generate bundle](../operator-sdk_generate_bundle)	 - Generates bundle data for the operator
 * [operator-sdk generate crds](../operator-sdk_generate_crds)	 - Generates CRDs for API's
 * [operator-sdk generate csv](../operator-sdk_generate_csv)	 - Generates a ClusterServiceVersion YAML file for the operator
 * [operator-sdk generate k8s](../operator-sdk_generate_k8s)	 - Generates Kubernetes code for custom resource

--- a/website/content/en/docs/cli/operator-sdk_generate_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_bundle.md
@@ -1,0 +1,38 @@
+---
+title: "operator-sdk generate bundle"
+---
+## operator-sdk generate bundle
+
+Generates bundle data for the operator
+
+### Synopsis
+
+Generates bundle data for the operator
+
+```
+operator-sdk generate bundle [flags]
+```
+
+### Options
+
+```
+      --apis-dir string          Root directory for API type defintions
+      --channels string          A comma-separated list of channels the bundle belongs to (default "alpha")
+      --crds-dir string          Root directory for CustomResoureDefinition manifests
+      --default-channel string   The default channel for the bundle
+  -h, --help                     help for bundle
+      --input-dir string         Directory to read an existing bundle from. This directory is the parent of your bundle 'manifests' directory, and different from --manifest-root
+      --interactive              When set or no bundle base exists, an interactive command prompt will be presented to accept bundle ClusterServiceVersion metadata
+      --manifests                Generate bundle manifests
+      --metadata                 Generate bundle metadata and Dockerfile
+      --operator-name string     Name of the bundle's operator
+      --output-dir string        Directory to write the bundle to
+      --overwrite                Overwrite the bundle's metadata and Dockerfile if they exist
+  -q, --quiet                    Run in quiet mode
+  -v, --version string           Semantic version of the operator in the generated bundle. Only set if creating a new bundle or upgrading your operator
+```
+
+### SEE ALSO
+
+* [operator-sdk generate](../operator-sdk_generate)	 - Invokes a specific generator
+


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Add a changelog file by copying changelog/fragments/00-template.yaml 
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"

-->

**Description of the change:**
* cmd/operator-sdk/generate/bundle: add `NewCmdLegacy` that returns a `bundle` subcommand configured to generate bundles for current project layouts.
* internal/generate/clusterserviceversion: add `GenerateLegacy` and `LegacyOption` to generate CSVs for legacy projects.

**Motivation for the change:** current project layouts should have a `generate bundle` command to differentiate between bundle and package manifests formats.

/cc @hasbro17 @jmrodri @camilamacedo86 

/kind feature
