### PR TITLE
cmd/operator-sdk/generate/crds.go: check for existence of `pkg/apis`

### DIFF
--- a/changelog/fragments/generate-crds-non-go.yaml
+++ b/changelog/fragments/generate-crds-non-go.yaml
@@ -1,0 +1,7 @@
+entries:
+  - description: >
+      The `generate crds` subcommand now checks for the existence of the
+      `pkg/apis` directory and logs a descriptive fatal error message if
+      it does not exist or is not a directory.
+
+    kind: "bugfix"

--- a/cmd/operator-sdk/generate/crds.go
+++ b/cmd/operator-sdk/generate/crds.go
@@ -16,12 +16,15 @@ package generate
 
 import (
 	"fmt"
-
-	gencrd "github.com/operator-framework/operator-sdk/internal/generate/crd"
-	"github.com/operator-framework/operator-sdk/internal/genutil"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	gencrd "github.com/operator-framework/operator-sdk/internal/generate/crd"
+	"github.com/operator-framework/operator-sdk/internal/genutil"
+	"github.com/operator-framework/operator-sdk/internal/scaffold"
+	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 )
 
 var (
@@ -53,6 +56,16 @@ Example:
 func crdsFunc(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return fmt.Errorf("command %s doesn't accept any arguments", cmd.CommandPath())
+	}
+	projutil.MustInProjectRoot()
+
+	stat, err := os.Stat(scaffold.ApisDir)
+	if os.IsNotExist(err) {
+		log.Fatalf("Failed to generate CRDs; directory %q not found.", scaffold.ApisDir)
+	} else if err != nil {
+		log.Fatalf("Failed to generate CRDs; stat: %v", err)
+	} else if !stat.IsDir() {
+		log.Fatalf("Failed to generate CRDs; expected %q to be a directory.", scaffold.ApisDir)
 	}
 
 	// Skip usage printing on error, since this command will never fail from


### PR DESCRIPTION
**Description of the change:**
Emit error message when using `operator-sdk generate crds` and `pkg/apis` directory does not exist.

**Motivation for the change:**
`operator-sdk generate crds` is generally only supported for Go projects, which have a `pkg/apis` directory by default. Non-Go projects _could_ use this command, but only if they manually create `pkg/apis` and define Go types for their APIs.
