### PR TITLE
Cleanup built html after link checking

### DIFF
--- a/hack/check-links.sh
+++ b/hack/check-links.sh
@@ -5,5 +5,7 @@ set -e
 source ./hack/lib/common.sh
 
 header_text "Building the site and checking links"
-docker run --rm -i -v "$(pwd):/src" -v "$(pwd)/website/public:/target" klakegg/hugo:0.70.0-ext-ubuntu -s website
-docker run -v "$(pwd)/website/public:/target" mtlynch/htmlproofer /target --empty-alt-ignore --http-status-ignore 429
+docker volume create sdk-html
+docker run --rm -v "$(pwd):/src" -v sdk-html:/target klakegg/hugo:0.70.0-ext-ubuntu -s website
+docker run --rm -v sdk-html:/target mtlynch/htmlproofer /target --empty-alt-ignore --http-status-ignore 429
+docker volume rm sdk-html


### PR DESCRIPTION
Previously, the hugo container built the html into website/public (owned
by root), which was not rebuilt cleanly.