### PR TITLE
Ansible Operator proxy now fails requests when virtual resource can't be determined

### DIFF
--- a/changelog/fragments/ansible-fail-if-cant-determine-vr.yaml
+++ b/changelog/fragments/ansible-fail-if-cant-determine-vr.yaml
@@ -1,0 +1,11 @@
+entries:
+  - description: >
+      The Ansible Operator proxy will now return a 500 if it cannot determine whether
+      a resource is virtual or not, instead of continuing on and skipping the cache.
+      This will prevent resources that should have ownerReferences injected from
+      being created without them, which would leave the user in a state that cannot be
+      recovered without manual intervention.
+
+    kind: "bugfix"
+
+    breaking: false


### PR DESCRIPTION
**Description of the change:**
Proxy will return 500 if it fails to get an API resource using the discovery client.

**Motivation for the change:**
This seems to be caused by some kind of race condition, but the result is that resources that should have ownerReferences injected do not, preventing dependent watches from being properly established and preventing garbage collection from working properly.

This is not a fix for the root cause of #2623 , but it should at least prevent us from putting the user into a state we can't recover from.