### PR TITLE
*: handle both v1 and v1beta1 CRD versions

### DIFF
--- a/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/cmd/operator-sdk/generate/bundle/bundle.go
@@ -164,13 +164,20 @@ func (c bundleCmd) runManifests(cfg *config.Config) (err error) {
 		return fmt.Errorf("error generating ClusterServiceVersion: %v", err)
 	}
 
+	var objs []interface{}
+	for _, crd := range col.V1CustomResourceDefinitions {
+		objs = append(objs, crd)
+	}
+	for _, crd := range col.V1beta1CustomResourceDefinitions {
+		objs = append(objs, crd)
+	}
 	if c.stdout {
-		if err := genutil.WriteCRDs(stdout, col.CustomResourceDefinitions...); err != nil {
+		if err := genutil.WriteObjects(stdout, objs...); err != nil {
 			return err
 		}
 	} else {
 		dir := filepath.Join(c.outputDir, bundle.ManifestsDir)
-		if err := genutil.WriteCRDFiles(dir, col.CustomResourceDefinitions...); err != nil {
+		if err := genutil.WriteObjectsToFiles(dir, objs...); err != nil {
 			return err
 		}
 	}

--- a/cmd/operator-sdk/generate/bundle/bundle_legacy.go
+++ b/cmd/operator-sdk/generate/bundle/bundle_legacy.go
@@ -93,8 +93,15 @@ func (c bundleCmd) runManifestsLegacy() (err error) {
 		return fmt.Errorf("error generating ClusterServiceVersion: %v", err)
 	}
 
+	var objs []interface{}
+	for _, crd := range col.V1CustomResourceDefinitions {
+		objs = append(objs, crd)
+	}
+	for _, crd := range col.V1beta1CustomResourceDefinitions {
+		objs = append(objs, crd)
+	}
 	dir := filepath.Join(c.outputDir, bundle.ManifestsDir)
-	if err := genutil.WriteCRDFilesLegacy(dir, col.CustomResourceDefinitions...); err != nil {
+	if err := genutil.WriteObjectsToFilesLegacy(dir, objs...); err != nil {
 		return err
 	}
 

--- a/cmd/operator-sdk/generate/internal/genutil.go
+++ b/cmd/operator-sdk/generate/internal/genutil.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/yaml"
 
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
@@ -67,7 +67,7 @@ func PluginKeyToOperatorType(pluginKey string) projutil.OperatorType {
 }
 
 // WriteCRDs writes each CustomResourceDefinition in crds to w.
-func WriteCRDs(w io.Writer, crds ...v1beta1.CustomResourceDefinition) error {
+func WriteCRDs(w io.Writer, crds ...apiextv1.CustomResourceDefinition) error {
 	for _, crd := range crds {
 		if err := writeCRD(w, crd); err != nil {
 			return err
@@ -78,7 +78,7 @@ func WriteCRDs(w io.Writer, crds ...v1beta1.CustomResourceDefinition) error {
 
 // WriteCRDFiles creates dir then writes each CustomResourceDefinition in crds
 // to a file in dir.
-func WriteCRDFiles(dir string, crds ...v1beta1.CustomResourceDefinition) error {
+func WriteCRDFiles(dir string, crds ...apiextv1.CustomResourceDefinition) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
@@ -90,13 +90,13 @@ func WriteCRDFiles(dir string, crds ...v1beta1.CustomResourceDefinition) error {
 	return nil
 }
 
-func makeCRDFileName(crd v1beta1.CustomResourceDefinition) string {
+func makeCRDFileName(crd apiextv1.CustomResourceDefinition) string {
 	return fmt.Sprintf("%s_%s.yaml", crd.Spec.Group, crd.Spec.Names.Plural)
 }
 
 // WriteCRDFilesLegacy creates dir then writes each CustomResourceDefinition
 // in crds to a file in legacy format in dir.
-func WriteCRDFilesLegacy(dir string, crds ...v1beta1.CustomResourceDefinition) error {
+func WriteCRDFilesLegacy(dir string, crds ...apiextv1.CustomResourceDefinition) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
@@ -108,12 +108,12 @@ func WriteCRDFilesLegacy(dir string, crds ...v1beta1.CustomResourceDefinition) e
 	return nil
 }
 
-func makeCRDFileNameLegacy(crd v1beta1.CustomResourceDefinition) string {
+func makeCRDFileNameLegacy(crd apiextv1.CustomResourceDefinition) string {
 	return fmt.Sprintf("%s_%s_crd.yaml", crd.Spec.Group, crd.Spec.Names.Plural)
 }
 
 // writeCRDFile marshals crd to bytes and writes them to dir in file.
-func writeCRDFile(dir string, crd v1beta1.CustomResourceDefinition, file string) error {
+func writeCRDFile(dir string, crd apiextv1.CustomResourceDefinition, file string) error {
 	f, err := os.Create(filepath.Join(dir, file))
 	if err != nil {
 		return err
@@ -123,7 +123,7 @@ func writeCRDFile(dir string, crd v1beta1.CustomResourceDefinition, file string)
 }
 
 // writeCRD marshals crd to bytes and writes them to w.
-func writeCRD(w io.Writer, crd v1beta1.CustomResourceDefinition) error {
+func writeCRD(w io.Writer, crd apiextv1.CustomResourceDefinition) error {
 	b, err := yaml.Marshal(crd)
 	if err != nil {
 		return err

--- a/internal/generate/clusterserviceversion/clusterserviceversion.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion.go
@@ -29,6 +29,7 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/generate/clusterserviceversion/bases"
 	"github.com/operator-framework/operator-sdk/internal/generate/collector"
 	genutil "github.com/operator-framework/operator-sdk/internal/generate/internal"
+	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 )
 
@@ -263,15 +264,10 @@ func (g Generator) makeBundleBaseGetterLegacy(inputDir, apisDir string, ilvl pro
 func (g Generator) makeBaseGetterLegacy(basePath, apisDir string, interactive bool) getBaseFunc {
 	var gvks []schema.GroupVersionKind
 	if g.Collector != nil {
-		for _, crd := range g.Collector.CustomResourceDefinitions {
-			for _, version := range crd.Spec.Versions {
-				gvks = append(gvks, schema.GroupVersionKind{
-					Group:   crd.Spec.Group,
-					Version: version.Name,
-					Kind:    crd.Spec.Names.Kind,
-				})
-			}
-		}
+		v1crdGVKs := k8sutil.GVKsForV1CustomResourceDefinitions(g.Collector.V1CustomResourceDefinitions...)
+		gvks = append(gvks, v1crdGVKs...)
+		v1beta1crdGVKs := k8sutil.GVKsForV1beta1CustomResourceDefinitions(g.Collector.V1beta1CustomResourceDefinitions...)
+		gvks = append(gvks, v1beta1crdGVKs...)
 	}
 
 	return func() (*operatorsv1alpha1.ClusterServiceVersion, error) {

--- a/internal/generate/collector/collect.go
+++ b/internal/generate/collector/collect.go
@@ -26,6 +26,7 @@ import (
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
@@ -38,7 +39,7 @@ type Manifests struct {
 	Roles                     []rbacv1.Role
 	ClusterRoles              []rbacv1.ClusterRole
 	Deployments               []appsv1.Deployment
-	CustomResourceDefinitions []apiextv1beta1.CustomResourceDefinition
+	CustomResourceDefinitions []apiextv1.CustomResourceDefinition
 	ValidatingWebhooks        []admissionregv1.ValidatingWebhook
 	MutatingWebhooks          []admissionregv1.MutatingWebhook
 	CustomResources           []unstructured.Unstructured
@@ -68,7 +69,9 @@ func (c *Manifests) UpdateFromDirs(manifestRoot, crdsDir string) error {
 				log.Debugf("No TypeMeta in %s, skipping file", path)
 				continue
 			}
-			switch typeMeta.GroupVersionKind().Kind {
+
+			gvk := typeMeta.GroupVersionKind()
+			switch gvk.Kind {
 			case "Role":
 				err = c.addRoles(manifest)
 			case "ClusterRole":
@@ -85,7 +88,7 @@ func (c *Manifests) UpdateFromDirs(manifestRoot, crdsDir string) error {
 				err = c.addOthers(manifest)
 			}
 			if err != nil {
-				return err
+				return fmt.Errorf("error adding %s to manifest collector: %v", gvk, err)
 			}
 		}
 		return scanner.Err()
@@ -98,7 +101,7 @@ func (c *Manifests) UpdateFromDirs(manifestRoot, crdsDir string) error {
 	if isDirExist(crdsDir) {
 		c.CustomResourceDefinitions, err = k8sutil.GetCustomResourceDefinitions(crdsDir)
 		if err != nil {
-			return err
+			return fmt.Errorf("error adding CustomResourceDefinitions to manifest collector: %v", err)
 		}
 	}
 
@@ -126,7 +129,9 @@ func (c *Manifests) UpdateFromReader(r io.Reader) error {
 			log.Debug("No TypeMeta found, skipping manifest")
 			continue
 		}
-		switch typeMeta.GroupVersionKind().Kind {
+
+		gvk := typeMeta.GroupVersionKind()
+		switch gvk.Kind {
 		case "Role":
 			err = c.addRoles(manifest)
 		case "ClusterRole":
@@ -134,7 +139,7 @@ func (c *Manifests) UpdateFromReader(r io.Reader) error {
 		case "Deployment":
 			err = c.addDeployments(manifest)
 		case "CustomResourceDefinition":
-			err = c.addCustomResourceDefinitions(manifest)
+			err = c.addCustomResourceDefinitions(gvk.Version, manifest)
 		case "ValidatingWebhookConfiguration":
 			err = c.addValidatingWebhookConfigurations(manifest)
 		case "MutatingWebhookConfiguration":
@@ -143,7 +148,7 @@ func (c *Manifests) UpdateFromReader(r io.Reader) error {
 			err = c.addOthers(manifest)
 		}
 		if err != nil {
-			return err
+			return fmt.Errorf("error adding %s to manifest collector: %v", gvk, err)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -167,7 +172,7 @@ func (c *Manifests) addRoles(rawManifests ...[]byte) error {
 	for _, rawManifest := range rawManifests {
 		role := rbacv1.Role{}
 		if err := yaml.Unmarshal(rawManifest, &role); err != nil {
-			return fmt.Errorf("error adding Role to manifest collector: %v", err)
+			return err
 		}
 		c.Roles = append(c.Roles, role)
 	}
@@ -180,7 +185,7 @@ func (c *Manifests) addClusterRoles(rawManifests ...[]byte) error {
 	for _, rawManifest := range rawManifests {
 		role := rbacv1.ClusterRole{}
 		if err := yaml.Unmarshal(rawManifest, &role); err != nil {
-			return fmt.Errorf("error adding ClusterRole to manifest collector: %v", err)
+			return err
 		}
 		c.ClusterRoles = append(c.ClusterRoles, role)
 	}
@@ -193,7 +198,7 @@ func (c *Manifests) addDeployments(rawManifests ...[]byte) error {
 	for _, rawManifest := range rawManifests {
 		dep := appsv1.Deployment{}
 		if err := yaml.Unmarshal(rawManifest, &dep); err != nil {
-			return fmt.Errorf("error adding Deployment to manifest collector: %v", err)
+			return err
 		}
 		c.Deployments = append(c.Deployments, dep)
 	}
@@ -201,14 +206,28 @@ func (c *Manifests) addDeployments(rawManifests ...[]byte) error {
 }
 
 // addCustomResourceDefinitions assumes add manifest data in rawManifests are
-// CustomResourceDefinitions and adds them to the collector.
-func (c *Manifests) addCustomResourceDefinitions(rawManifests ...[]byte) error {
+// CustomResourceDefinitions and adds them to the collector. version determines
+// which CustomResourceDefinition type is used for all manifests in rawManifests.
+func (c *Manifests) addCustomResourceDefinitions(version string, rawManifests ...[]byte) (err error) {
 	for _, rawManifest := range rawManifests {
-		crd := apiextv1beta1.CustomResourceDefinition{}
-		if err := yaml.Unmarshal(rawManifest, &crd); err != nil {
-			return fmt.Errorf("error adding Deployment to manifest collector: %v", err)
+		crd := &apiextv1.CustomResourceDefinition{}
+		switch version {
+		case "v1":
+			if err = yaml.Unmarshal(rawManifest, crd); err != nil {
+				return err
+			}
+		case "v1beta1":
+			in := &apiextv1beta1.CustomResourceDefinition{}
+			if err := yaml.Unmarshal(rawManifest, &in); err != nil {
+				return err
+			}
+			if crd, err = k8sutil.Convertv1beta1Tov1CustomResourceDefinition(in); err != nil {
+				return fmt.Errorf("error converting CustomResourceDefinition v1beta1 to v1: %v", err)
+			}
+		default:
+			return fmt.Errorf("unrecognized CustomResourceDefinition version %q", version)
 		}
-		c.CustomResourceDefinitions = append(c.CustomResourceDefinitions, crd)
+		c.CustomResourceDefinitions = append(c.CustomResourceDefinitions, *crd)
 	}
 	return nil
 }
@@ -219,7 +238,7 @@ func (c *Manifests) addValidatingWebhookConfigurations(rawManifests ...[]byte) e
 	for _, rawManifest := range rawManifests {
 		webhookConfig := admissionregv1.ValidatingWebhookConfiguration{}
 		if err := yaml.Unmarshal(rawManifest, &webhookConfig); err != nil {
-			return fmt.Errorf("error adding ValidatingWebhookConfig to manifest collection: %v", err)
+			return err
 		}
 		c.ValidatingWebhooks = append(c.ValidatingWebhooks, webhookConfig.Webhooks...)
 	}
@@ -232,7 +251,7 @@ func (c *Manifests) addMutatingWebhookConfigurations(rawManifests ...[]byte) err
 	for _, rawManifest := range rawManifests {
 		webhookConfig := admissionregv1.MutatingWebhookConfiguration{}
 		if err := yaml.Unmarshal(rawManifest, &webhookConfig); err != nil {
-			return fmt.Errorf("error adding MutatingWebhookConfig to manifest collection: %v", err)
+			return err
 		}
 		c.MutatingWebhooks = append(c.MutatingWebhooks, webhookConfig.Webhooks...)
 	}
@@ -245,7 +264,7 @@ func (c *Manifests) addOthers(rawManifests ...[]byte) error {
 	for _, rawManifest := range rawManifests {
 		u := unstructured.Unstructured{}
 		if err := yaml.Unmarshal(rawManifest, &u); err != nil {
-			return fmt.Errorf("error adding manifest collector: %v", err)
+			return err
 		}
 		c.Others = append(c.Others, u)
 	}

--- a/internal/generate/collector/filter.go
+++ b/internal/generate/collector/filter.go
@@ -20,7 +20,7 @@ import (
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -95,7 +95,7 @@ func (c *Manifests) deduplicate() error {
 	}
 	c.Deployments = deps
 
-	crds := []apiextv1beta1.CustomResourceDefinition{}
+	crds := []apiextv1.CustomResourceDefinition{}
 	for _, crd := range c.CustomResourceDefinitions {
 		hasHash, err := addToHashes(&crd, hashes)
 		if err != nil {

--- a/internal/generate/crd/crd_test.go
+++ b/internal/generate/crd/crd_test.go
@@ -22,7 +22,6 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -202,7 +201,7 @@ func TestCRDNonGo(t *testing.T) {
 		},
 		{
 			"existing v1 to v1beta1 CRD with custom structural schema",
-			filepath.Join(testGoDataDir, scaffold.CRDsDir+"_v1"), "v1beta1", asV1beta1(crdCustomExpV1),
+			filepath.Join(testGoDataDir, scaffold.CRDsDir+"_v1"), "v1beta1", crdCustomExpV1beta1,
 		},
 	}
 
@@ -225,10 +224,6 @@ func TestCRDNonGo(t *testing.T) {
 			}
 		})
 	}
-}
-
-func asV1beta1(crdV1 string) string {
-	return strings.ReplaceAll(crdV1, "apiVersion: apiextensions.k8s.io/v1", "apiVersion: apiextensions.k8s.io/v1beta1")
 }
 
 // crdNonGoDefaultExpV1beta1 is the default non-go v1beta1 CRD. Non-go projects don't have the

--- a/internal/generate/olm-catalog/csv.go
+++ b/internal/generate/olm-catalog/csv.go
@@ -271,20 +271,15 @@ func (g BundleGenerator) generateCSV() (fileMap map[string][]byte, err error) {
 
 // getBase either reads an existing CSV from fromBundleDir or creates a new one.
 func (g BundleGenerator) getBase() (*olmapiv1alpha1.ClusterServiceVersion, error) {
-	crds, err := k8sutil.GetCustomResourceDefinitions(g.CRDsDir)
+	v1crds, v1beta1crds, err := k8sutil.GetCustomResourceDefinitions(g.CRDsDir)
 	if err != nil {
 		return nil, err
 	}
 	var gvks []schema.GroupVersionKind
-	for _, crd := range crds {
-		for _, version := range crd.Spec.Versions {
-			gvks = append(gvks, schema.GroupVersionKind{
-				Group:   crd.Spec.Group,
-				Version: version.Name,
-				Kind:    crd.Spec.Names.Kind,
-			})
-		}
-	}
+	v1crdGVKs := k8sutil.GVKsForV1CustomResourceDefinitions(v1crds...)
+	gvks = append(gvks, v1crdGVKs...)
+	v1beta1crdGVKs := k8sutil.GVKsForV1beta1CustomResourceDefinitions(v1beta1crds...)
+	gvks = append(gvks, v1beta1crdGVKs...)
 
 	b := bases.ClusterServiceVersion{
 		OperatorName: g.OperatorName,

--- a/internal/generate/olm-catalog/csv.go
+++ b/internal/generate/olm-catalog/csv.go
@@ -277,14 +277,9 @@ func (g BundleGenerator) getBase() (*olmapiv1alpha1.ClusterServiceVersion, error
 	}
 	var gvks []schema.GroupVersionKind
 	for _, crd := range crds {
-		nameSplit := strings.SplitN(crd.GetName(), ".", 2)
-		group := crd.GetName()
-		if len(nameSplit) > 1 {
-			group = nameSplit[1]
-		}
 		for _, version := range crd.Spec.Versions {
 			gvks = append(gvks, schema.GroupVersionKind{
-				Group:   group,
+				Group:   crd.Spec.Group,
 				Version: version.Name,
 				Kind:    crd.Spec.Names.Kind,
 			})

--- a/internal/scorecard/plugins/olm_tests.go
+++ b/internal/scorecard/plugins/olm_tests.go
@@ -32,6 +32,7 @@ import (
 	olmapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -218,7 +219,7 @@ func (t *BundleValidationTest) Run(ctx context.Context) *schelpers.TestResult {
 // Run - implements Test interface
 func (t *CRDsHaveValidationTest) Run(ctx context.Context) *schelpers.TestResult {
 	res := &schelpers.TestResult{Test: t, CRName: t.CR.GetName(), State: scapiv1alpha2.PassState}
-	crds, err := k8sutil.GetCustomResourceDefinitions(t.CRDsDir)
+	v1crds, v1beta1crds, err := k8sutil.GetCustomResourceDefinitions(t.CRDsDir)
 	if err != nil {
 		res.Errors = append(res.Errors, fmt.Errorf("failed to get CRDs in %s directory: %v", t.CRDsDir, err))
 		res.State = scapiv1alpha2.ErrorState
@@ -233,18 +234,72 @@ func (t *CRDsHaveValidationTest) Run(ctx context.Context) *schelpers.TestResult 
 
 	// check if the CRD matches the testing CR
 	gvk := t.CR.GroupVersionKind()
-	for _, crd := range crds {
+	for _, crd := range v1crds {
 		for _, ver := range crd.Spec.Versions {
 			// Only check the validation block if the CRD and CR have the same Kind and Version
 			if strings.EqualFold(gvk.Version, ver.Name) && matchKind(gvk.Kind, crd.Spec.Names.Kind) {
-				checkCRDVersion(res, t.CR, ver.Schema)
+				checkV1CRDVersion(res, t.CR, ver.Schema)
+			}
+		}
+	}
+	for _, crd := range v1beta1crds {
+		if len(crd.Spec.Versions) == 0 {
+			// Only check the validation block if the CRD and CR have the same Kind and Version
+			if strings.EqualFold(gvk.Version, crd.Spec.Version) && matchKind(gvk.Kind, crd.Spec.Names.Kind) {
+				checkV1beta1CRDVersion(res, t.CR, crd.Spec.Validation)
+			}
+		} else {
+			for _, ver := range crd.Spec.Versions {
+				// Only check the validation block if the CRD and CR have the same Kind and Version
+				if strings.EqualFold(gvk.Version, ver.Name) && matchKind(gvk.Kind, crd.Spec.Names.Kind) {
+					checkV1beta1CRDVersion(res, t.CR, ver.Schema)
+				}
 			}
 		}
 	}
 	return res
 }
 
-func checkCRDVersion(res *schelpers.TestResult, cr *unstructured.Unstructured, val *apiextv1.CustomResourceValidation) {
+//nolint:dupl
+func checkV1CRDVersion(res *schelpers.TestResult, cr *unstructured.Unstructured,
+	val *apiextv1.CustomResourceValidation) {
+
+	gvk := cr.GroupVersionKind()
+	if val == nil {
+		res.Suggestions = append(res.Suggestions, fmt.Sprintf("Add CRD validation for %s/%s", gvk.Kind, gvk.Version))
+		return
+	}
+	failed := false
+	if cr.Object["spec"] != nil {
+		spec := cr.Object["spec"].(map[string]interface{})
+		for key := range spec {
+			if _, ok := val.OpenAPIV3Schema.Properties["spec"].Properties[key]; !ok {
+				failed = true
+				res.Suggestions = append(res.Suggestions,
+					fmt.Sprintf("Add CRD validation for spec field `%s` in %s/%s", key, gvk.Kind, gvk.Version))
+			}
+		}
+	}
+	if cr.Object["status"] != nil {
+		status := cr.Object["status"].(map[string]interface{})
+		for key := range status {
+			if _, ok := val.OpenAPIV3Schema.Properties["status"].Properties[key]; !ok {
+				failed = true
+				res.Suggestions = append(res.Suggestions,
+					fmt.Sprintf("Add CRD validation for status field `%s` in %s/%s", key, gvk.Kind, gvk.Version))
+			}
+		}
+	}
+
+	if failed {
+		res.State = scapiv1alpha2.FailState
+	}
+}
+
+//nolint:dupl
+func checkV1beta1CRDVersion(res *schelpers.TestResult, cr *unstructured.Unstructured,
+	val *apiextv1beta1.CustomResourceValidation) {
+
 	gvk := cr.GroupVersionKind()
 	if val == nil {
 		res.Suggestions = append(res.Suggestions, fmt.Sprintf("Add CRD validation for %s/%s", gvk.Kind, gvk.Version))

--- a/internal/util/k8sutil/api.go
+++ b/internal/util/k8sutil/api.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/operator-framework/operator-registry/pkg/registry"
 	log "github.com/sirupsen/logrus"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -31,24 +32,32 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// GetCustomResourceDefinitions returns all CRD manifests in the directory
-// crdsDir.
-func GetCustomResourceDefinitions(crdsDir string) (crds []apiextv1.CustomResourceDefinition, err error) {
+// GetCustomResourceDefinitions returns all CRD manifests of both v1 and v1beta1
+// versions in the directory crdsDir. If a duplicate object with different API
+// versions is found, and error is returned.
+func GetCustomResourceDefinitions(crdsDir string) (
+	v1crds []apiextv1.CustomResourceDefinition,
+	v1beta1crds []apiextv1beta1.CustomResourceDefinition,
+	err error) {
+
 	infos, err := ioutil.ReadDir(crdsDir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// The set of all custom resource GVKs in found CRDs.
 	crGVKSet := map[schema.GroupVersionKind]struct{}{}
 	for _, info := range infos {
+		path := filepath.Join(crdsDir, info.Name())
+
 		if info.IsDir() {
+			log.Debugf("Skipping dir: %s", path)
 			continue
 		}
-		path := filepath.Join(crdsDir, info.Name())
+
 		b, err := ioutil.ReadFile(path)
 		if err != nil {
-			return nil, fmt.Errorf("error reading manifest %s: %w", path, err)
+			return nil, nil, fmt.Errorf("error reading manifest %s: %w", path, err)
 		}
 
 		scanner := NewYAMLScanner(bytes.NewBuffer(b))
@@ -64,44 +73,109 @@ func GetCustomResourceDefinitions(crdsDir string) (crds []apiextv1.CustomResourc
 			}
 
 			// Unmarshal based on CRD version.
-			crd := &apiextv1.CustomResourceDefinition{}
+			var crGVKs []schema.GroupVersionKind
 			switch gvk := typeMeta.GroupVersionKind(); gvk.Version {
-			case "v1":
-				if err = yaml.Unmarshal(manifest, crd); err != nil {
-					return nil, err
+			case apiextv1.SchemeGroupVersion.Version:
+				crd := apiextv1.CustomResourceDefinition{}
+				if err = yaml.Unmarshal(manifest, &crd); err != nil {
+					return nil, nil, err
 				}
-			case "v1beta1":
-				in := &apiextv1beta1.CustomResourceDefinition{}
-				if err := yaml.Unmarshal(manifest, &in); err != nil {
-					return nil, err
+				v1crds = append(v1crds, crd)
+				crGVKs = append(crGVKs, GVKsForV1CustomResourceDefinitions(crd)...)
+			case apiextv1beta1.SchemeGroupVersion.Version:
+				crd := apiextv1beta1.CustomResourceDefinition{}
+				if err := yaml.Unmarshal(manifest, &crd); err != nil {
+					return nil, nil, err
 				}
-				if crd, err = Convertv1beta1Tov1CustomResourceDefinition(in); err != nil {
-					return nil, fmt.Errorf("error converting CustomResourceDefinition v1beta1 to v1: %v", err)
-				}
+				v1beta1crds = append(v1beta1crds, crd)
+				crGVKs = append(crGVKs, GVKsForV1beta1CustomResourceDefinitions(crd)...)
 			default:
-				return nil, fmt.Errorf("unrecognized CustomResourceDefinition version %q", gvk.Version)
+				return nil, nil, fmt.Errorf("unrecognized CustomResourceDefinition version %q", gvk.Version)
 			}
 
 			// Check if any GVK in crd is a duplicate.
-			for _, ver := range crd.Spec.Versions {
-				gvk := schema.GroupVersionKind{
-					Group:   crd.Spec.Group,
-					Version: ver.Name,
-					Kind:    crd.Spec.Names.Kind,
-				}
+			for _, gvk := range crGVKs {
 				if _, hasGVK := crGVKSet[gvk]; hasGVK {
-					return nil, fmt.Errorf("duplicate custom resource GVK %s in %s", gvk, path)
+					return nil, nil, fmt.Errorf("duplicate custom resource GVK %s in %s", gvk, path)
 				}
 				crGVKSet[gvk] = struct{}{}
 			}
 
-			crds = append(crds, *crd)
 		}
 		if err = scanner.Err(); err != nil {
-			return nil, fmt.Errorf("error scanning %s: %w", path, err)
+			return nil, nil, fmt.Errorf("error scanning %s: %w", path, err)
 		}
 	}
-	return crds, nil
+	return v1crds, v1beta1crds, nil
+}
+
+// DefinitionsForV1CustomResourceDefinitions returns definition keys for all
+// custom resource versions in each crd in crds.
+//nolint:lll
+func DefinitionsForV1CustomResourceDefinitions(crds ...apiextv1.CustomResourceDefinition) (keys []registry.DefinitionKey) {
+	for _, crd := range crds {
+		for _, ver := range crd.Spec.Versions {
+			keys = append(keys, registry.DefinitionKey{
+				Name:    crd.GetName(),
+				Group:   crd.Spec.Group,
+				Version: ver.Name,
+				Kind:    crd.Spec.Names.Kind,
+			})
+		}
+	}
+	return keys
+}
+
+// DefinitionsForV1beta1CustomResourceDefinitions returns definition keys for all
+// custom resource versions in each crd in crds.
+//nolint:lll
+func DefinitionsForV1beta1CustomResourceDefinitions(crds ...apiextv1beta1.CustomResourceDefinition) (keys []registry.DefinitionKey) {
+	for _, crd := range crds {
+		if len(crd.Spec.Versions) == 0 {
+			keys = append(keys, registry.DefinitionKey{
+				Name:    crd.GetName(),
+				Group:   crd.Spec.Group,
+				Version: crd.Spec.Version,
+				Kind:    crd.Spec.Names.Kind,
+			})
+		}
+		for _, ver := range crd.Spec.Versions {
+			keys = append(keys, registry.DefinitionKey{
+				Name:    crd.GetName(),
+				Group:   crd.Spec.Group,
+				Version: ver.Name,
+				Kind:    crd.Spec.Names.Kind,
+			})
+		}
+	}
+	return keys
+}
+
+// GVKsForV1CustomResourceDefinitions returns GroupVersionKind's for all
+// custom resource versions in each crd in crds.
+func GVKsForV1CustomResourceDefinitions(crds ...apiextv1.CustomResourceDefinition) (gvks []schema.GroupVersionKind) {
+	for _, key := range DefinitionsForV1CustomResourceDefinitions(crds...) {
+		gvks = append(gvks, schema.GroupVersionKind{
+			Group:   key.Group,
+			Version: key.Version,
+			Kind:    key.Kind,
+		})
+	}
+	return gvks
+}
+
+// GVKsForV1beta1CustomResourceDefinitions returns GroupVersionKind's for all
+// custom resource versions in each crd in crds.
+//nolint:lll
+func GVKsForV1beta1CustomResourceDefinitions(crds ...apiextv1beta1.CustomResourceDefinition) (gvks []schema.GroupVersionKind) {
+	for _, key := range DefinitionsForV1beta1CustomResourceDefinitions(crds...) {
+		gvks = append(gvks, schema.GroupVersionKind{
+			Group:   key.Group,
+			Version: key.Version,
+			Kind:    key.Kind,
+		})
+	}
+	return gvks
 }
 
 // ParseGroupSubpackages parses the apisDir directory tree and returns a map of

--- a/internal/util/k8sutil/manifest.go
+++ b/internal/util/k8sutil/manifest.go
@@ -110,12 +110,19 @@ func GenerateCombinedGlobalManifest(crdsDir string) (*os.File, error) {
 		}
 	}()
 
-	crds, err := GetCustomResourceDefinitions(crdsDir)
+	v1crds, v1beta1crds, err := GetCustomResourceDefinitions(crdsDir)
 	if err != nil {
 		return nil, fmt.Errorf("error getting CRD's from %s: %v", crdsDir, err)
 	}
 	combined := []byte{}
-	for _, crd := range crds {
+	for _, crd := range v1crds {
+		b, err := yaml.Marshal(crd)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling %s: %v", crd.GetObjectKind().GroupVersionKind(), err)
+		}
+		combined = CombineManifests(combined, b)
+	}
+	for _, crd := range v1beta1crds {
 		b, err := yaml.Marshal(crd)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling %s: %v", crd.GetObjectKind().GroupVersionKind(), err)

--- a/internal/util/k8sutil/manifest.go
+++ b/internal/util/k8sutil/manifest.go
@@ -118,7 +118,7 @@ func GenerateCombinedGlobalManifest(crdsDir string) (*os.File, error) {
 	for _, crd := range crds {
 		b, err := yaml.Marshal(crd)
 		if err != nil {
-			return nil, fmt.Errorf("error marshalling CRD %s bytes: %v", crd.GetName(), err)
+			return nil, fmt.Errorf("error marshaling %s: %v", crd.GetObjectKind().GroupVersionKind(), err)
 		}
 		combined = CombineManifests(combined, b)
 	}

--- a/pkg/helm/release/manager.go
+++ b/pkg/helm/release/manager.go
@@ -22,16 +22,16 @@ import (
 	"fmt"
 	"strings"
 
-	"gomodules.xyz/jsonpatch/v3"
-	helmkube "helm.sh/helm/v3/pkg/kube"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-
+	jsonpatch "gomodules.xyz/jsonpatch/v3"
 	"helm.sh/helm/v3/pkg/action"
 	cpb "helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/kube"
+	helmkube "helm.sh/helm/v3/pkg/kube"
 	rpb "helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -301,8 +301,10 @@ func createPatch(existing runtime.Object, expected *resource.Info) ([]byte, apit
 	// on objects like CRDs.
 	_, isUnstructured := versionedObject.(runtime.Unstructured)
 
-	// On newer K8s versions, CRDs aren't unstructured but has this dedicated type
-	_, isCRD := versionedObject.(*apiextv1beta1.CustomResourceDefinition)
+	// On newer K8s versions, CRDs aren't unstructured but have a dedicated type
+	_, isV1CRD := versionedObject.(*apiextv1.CustomResourceDefinition)
+	_, isV1beta1CRD := versionedObject.(*apiextv1beta1.CustomResourceDefinition)
+	isCRD := isV1CRD || isV1beta1CRD
 
 	if isUnstructured || isCRD {
 		// fall back to generic JSON merge patch


### PR DESCRIPTION
**Description of the change:** either use a v1 CRD directly or convert between v1beta1 and v1.

**Motivation for the change:** the SDK should support both v1 and v1beta1 CRDs anywhere relevant because `operator-sdk generate crds` generates both types. Instead of converting to v1 in all cases, which could be error prone ex. validation keys differ, these changes handle both explicitly.

Closes #3005