### PR TITLE
bundle create: set default channel if only one channel is set

### DIFF
--- a/changelog/fragments/bundle-default-channel.yaml
+++ b/changelog/fragments/bundle-default-channel.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      Set a default channel to the channel supplied to 'bundle create --channels=<c>'
+      if exactly one channel is set.
+
+    kind: addition

--- a/cmd/operator-sdk/bundle/create.go
+++ b/cmd/operator-sdk/bundle/create.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	catalog "github.com/operator-framework/operator-sdk/internal/generate/olm-catalog"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
@@ -169,6 +170,12 @@ func (c *bundleCreateCmd) setDefaults() (err error) {
 	// an error if we cannot.
 	if dir, err := relWd(c.directory); err == nil {
 		c.directory = dir
+	}
+
+	// Ensure a default channel is present if there only one channel. Don't infer
+	// default otherwise; the user must set this value.
+	if c.defaultChannel == "" && strings.Count(c.channels, ",") == 0 {
+		c.defaultChannel = c.channels
 	}
 
 	return nil


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Add a changelog file by copying changelog/fragments/00-template.yaml 
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"

-->

**Description of the change:** set default channel if only one channel is set

**Motivation for the change:** a default channel should always be set, and we can infer which one it is if there is only one channel.

See https://github.com/operator-framework/operator-sdk/pull/3106#issuecomment-634431106

/cc @hasbro17 @camilamacedo86 