### PR TITLE
util: set r/x permissions for bundle dirs

### DIFF
--- a/changelog/fragments/3129.yaml
+++ b/changelog/fragments/3129.yaml
@@ -1,0 +1,13 @@
+entries:
+  - description: >
+      Set bundle dir permissions to 0755 so they can be read by in-cluster tooling.
+
+    kind: change
+
+    breaking: true
+
+    migration:
+      header: Modify permissions on your bundle manifests directory
+      body: >
+        Run `chmod 0755 deploy/olm-catalog/<operator-name>/manifests` to update
+        your operator's bundle directory permissions.

--- a/cmd/operator-sdk/generate/internal/genutil.go
+++ b/cmd/operator-sdk/generate/internal/genutil.go
@@ -79,7 +79,7 @@ func WriteCRDs(w io.Writer, crds ...v1beta1.CustomResourceDefinition) error {
 // WriteCRDFiles creates dir then writes each CustomResourceDefinition in crds
 // to a file in dir.
 func WriteCRDFiles(dir string, crds ...v1beta1.CustomResourceDefinition) error {
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
 	for _, crd := range crds {
@@ -97,7 +97,7 @@ func makeCRDFileName(crd v1beta1.CustomResourceDefinition) string {
 // WriteCRDFilesLegacy creates dir then writes each CustomResourceDefinition
 // in crds to a file in legacy format in dir.
 func WriteCRDFilesLegacy(dir string, crds ...v1beta1.CustomResourceDefinition) error {
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
 	for _, crd := range crds {

--- a/internal/generate/internal/genutil.go
+++ b/internal/generate/internal/genutil.go
@@ -48,7 +48,7 @@ type File struct {
 // Open first creates dir then opens <dir>/<fileName> for reading and writing,
 // creating the file if it does not exist.
 func Open(dir, fileName string) (*File, error) {
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		return nil, err
 	}
 	f, err := os.OpenFile(filepath.Join(dir, fileName), os.O_RDWR|os.O_CREATE, 0666)

--- a/internal/generate/olm-catalog/csv.go
+++ b/internal/generate/olm-catalog/csv.go
@@ -199,7 +199,7 @@ func (g BundleGenerator) Generate() error {
 		}
 	}
 
-	if err := os.MkdirAll(g.toBundleDir, fileutil.DefaultDirFileMode); err != nil {
+	if err := os.MkdirAll(g.toBundleDir, 0755); err != nil {
 		return fmt.Errorf("error mkdir %s: %v", g.toBundleDir, err)
 	}
 

--- a/internal/generate/olm-catalog/package_manifest.go
+++ b/internal/generate/olm-catalog/package_manifest.go
@@ -74,7 +74,7 @@ func (g PkgGenerator) Generate() error {
 		return errors.New("error generating package manifest: no generated file found")
 	}
 	pkgManifestOutputDir := filepath.Join(g.OutputDir, OLMCatalogChildDir, g.OperatorName)
-	if err = os.MkdirAll(pkgManifestOutputDir, fileutil.DefaultDirFileMode); err != nil {
+	if err = os.MkdirAll(pkgManifestOutputDir, 0755); err != nil {
 		return fmt.Errorf("error mkdir %s: %v", pkgManifestOutputDir, err)
 	}
 	for fileName, b := range fileMap {


### PR DESCRIPTION
**Description of the change:** permissions for generated bundle directories now have r/x permissions for all users (`0755`).

**Motivation for the change:** automation tooling should be able to read bundle files.

/cc @camilamacedo86 @hasbro17 @jmrodri 

/kind bug
