### PR TITLE
bundle generate: ensure default channel exists

### DIFF
--- a/cmd/operator-sdk/bundle/create.go
+++ b/cmd/operator-sdk/bundle/create.go
@@ -108,7 +108,7 @@ bundle.Dockerfile for your latest operator version without building the image:
 			}
 
 			if err = c.validate(args); err != nil {
-				return fmt.Errorf("error validating args: %v", err)
+				return fmt.Errorf("invalid command args: %v", err)
 			}
 
 			if c.generateOnly {
@@ -172,7 +172,7 @@ func (c *bundleCreateCmd) setDefaults() (err error) {
 		c.directory = dir
 	}
 
-	// Ensure a default channel is present if there only one channel. Don't infer
+	// A default channel can be inferred if there is only one channel. Don't infer
 	// default otherwise; the user must set this value.
 	if c.defaultChannel == "" && strings.Count(c.channels, ",") == 0 {
 		c.defaultChannel = c.channels
@@ -199,11 +199,18 @@ func (c bundleCreateCmd) validate(args []string) error {
 	if c.packageName == "" {
 		return fmt.Errorf("--package must be set")
 	}
+
+	// Ensure a default channel is present.
+	if c.defaultChannel == "" {
+		return fmt.Errorf("--default-channel must be set")
+	}
+
 	// Bundle commands only work with bundle directory formats, not package
 	// manifests formats.
 	if isPackageManifestsDir(c.directory, c.packageName) {
 		return fmt.Errorf("bundle commands can only be used on bundle directory formats")
 	}
+
 	if c.generateOnly {
 		if len(args) != 0 {
 			return errors.New("the command does not accept any arguments if --generate-only=true")

--- a/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/cmd/operator-sdk/generate/bundle/bundle.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
 	"sigs.k8s.io/kubebuilder/pkg/model/config"
@@ -32,6 +33,11 @@ import (
 func (c *bundleCmd) setCommonDefaults(cfg *config.Config) {
 	if c.operatorName == "" {
 		c.operatorName = filepath.Base(cfg.Repo)
+	}
+	// A default channel can be inferred if there is only one channel. Don't infer
+	// default otherwise; the user must set this value.
+	if c.defaultChannel == "" && strings.Count(c.channels, ",") == 0 {
+		c.defaultChannel = c.channels
 	}
 }
 
@@ -184,6 +190,16 @@ func (c bundleCmd) runManifests(cfg *config.Config) (err error) {
 
 	if !c.quiet && !c.stdout {
 		fmt.Println("Bundle manifests generated successfully in", c.outputDir)
+	}
+
+	return nil
+}
+
+// validateMetadata validates c for bundle metadata generation.
+func (c bundleCmd) validateMetadata(*config.Config) (err error) {
+	// Ensure a default channel is present.
+	if c.defaultChannel == "" {
+		return fmt.Errorf("--default-channel must be set if setting multiple channels")
 	}
 
 	return nil

--- a/cmd/operator-sdk/generate/bundle/bundle_legacy.go
+++ b/cmd/operator-sdk/generate/bundle/bundle_legacy.go
@@ -17,6 +17,7 @@ package bundle
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
 	log "github.com/sirupsen/logrus"
@@ -31,6 +32,11 @@ import (
 func (c *bundleCmd) setCommonDefaultsLegacy() {
 	if c.operatorName == "" {
 		c.operatorName = filepath.Base(projutil.MustGetwd())
+	}
+	// A default channel can be inferred if there is only one channel. Don't infer
+	// default otherwise; the user must set this value.
+	if c.defaultChannel == "" && strings.Count(c.channels, ",") == 0 {
+		c.defaultChannel = c.channels
 	}
 }
 
@@ -107,6 +113,17 @@ func (c bundleCmd) runManifestsLegacy() (err error) {
 
 	if !c.quiet {
 		log.Infoln("Bundle manifests generated successfully in", c.outputDir)
+	}
+
+	return nil
+}
+
+// validateMetadataLegacy validates c for bundle metadata generation for
+// legacy project layouts.
+func (c bundleCmd) validateMetadataLegacy() (err error) {
+	// Ensure a default channel is present.
+	if c.defaultChannel == "" {
+		return fmt.Errorf("--default-channel must be set if setting multiple channels")
 	}
 
 	return nil

--- a/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/cmd/operator-sdk/generate/bundle/cmd.go
@@ -104,6 +104,9 @@ func NewCmd() *cobra.Command {
 				}
 			}
 			if c.metadata {
+				if err = c.validateMetadata(cfg); err != nil {
+					return fmt.Errorf("invalid command options: %v", err)
+				}
 				if err = c.runMetadata(); err != nil {
 					log.Fatalf("Error generating bundle metadata: %v", err)
 				}
@@ -164,6 +167,9 @@ func NewCmdLegacy() *cobra.Command {
 				}
 			}
 			if c.metadata {
+				if err = c.validateMetadataLegacy(); err != nil {
+					return fmt.Errorf("invalid command options: %v", err)
+				}
 				if err = c.runMetadataLegacy(); err != nil {
 					log.Fatalf("Error generating bundle metadata: %v", err)
 				}


### PR DESCRIPTION
**Description of the change:**
* cmd/operator-sdk/generate/bundle: validate that default channel exists, and set it if only one channel is passed

**Motivation for the change:** `bundle validate` will error if a default channel is not set in a bundle. Follow-up from #3124.

/cc @hasbro17 @jmrodri @jmccormick2001 

/kind bug
