### PR TITLE
changelog generation: fix for incorrect PR links 

### DIFF
--- a/hack/generate/changelog/util/fragment.go
+++ b/hack/generate/changelog/util/fragment.go
@@ -176,7 +176,8 @@ func (g *gitPullRequestNumberGetter) GetPullRequestNumberFor(filename string) (u
 }
 
 func (g *gitPullRequestNumberGetter) getCommitMessage(filename string) (string, error) {
-	args := fmt.Sprintf("log --follow --pretty=format:%%s --diff-filter=A --find-renames=40%% %s", filename)
+	//nolint:lll
+	args := fmt.Sprintf("log --follow --pretty=format:%%s --diff-filter=A --find-renames=90%% %s", filename)
 	line, err := exec.Command("git", strings.Split(args, " ")...).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to locate git commit for PR discovery: %v", err)

--- a/hack/generate/changelog/util/fragment_test.go
+++ b/hack/generate/changelog/util/fragment_test.go
@@ -370,3 +370,33 @@ func TestGitPullRequestNumberGetter_parsePRNumber(t *testing.T) {
 		})
 	}
 }
+
+func Test_gitPullRequestNumberGetter_getCommitMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		wantErr  bool
+	}{
+		{
+			name:     "should fail when the fragment file cannot be found in any commit",
+			filename: "/does/not/exist",
+			wantErr:  true,
+		},
+		{
+			name:     "should work successfully when there is a commit with the fragment file",
+			filename: "testdata/valid/fragment1.yaml",
+			wantErr:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			g := &gitPullRequestNumberGetter{}
+			_, err := g.getCommitMessage(tt.filename)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getCommitMessage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description of the change:**
- Generation of CHANGELOG from the fragments is causing some lines referencing incorrect PR links
- For the releases v0.17.1 and v0.18.1, CHANGELOG had some incorrect PR links which had to be manually fixed

**Motivation for the change:**
- Bug is in getCommitMessage which uses `git log` command with some flags to find the pull request in which the fragment file was initially added. It uses `--find-renames `option for detecting renames for a commit. The threshold is currently set to 40% which sometimes results in incorrect PR. Setting it to 90% yields the correct PR link for all the cases I've tried
- Added a unit test for getCommitMessage and mock the exec.Command function to return a mock output which is the commit string
- Manually tested that CHANEGLOG generation results in correct PR links by reseting an experimental branch to before v0.18.1 and adding one fragment at a time under changelog/fragments and running the new `git log` command with the fix and made sure that it returns the correct PR link (also changed it back to 40% and noticed that it was linking to the wrong one, for a few fragments) 

Closes [#314](https://github.com/operator-framework/operator-sdk/issues/3141)
