### PR TITLE
internal/plugins: remove minor/patch version, add "-alpha"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	k8s.io/kubectl v0.18.2
 	sigs.k8s.io/controller-runtime v0.6.0
 	sigs.k8s.io/controller-tools v0.3.0
-	sigs.k8s.io/kubebuilder v1.0.9-0.20200529152716-2525aeb37a00
+	sigs.k8s.io/kubebuilder v1.0.9-0.20200604172714-cd5eed9f42b7
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1411,8 +1411,8 @@ sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPhJ4=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
-sigs.k8s.io/kubebuilder v1.0.9-0.20200529152716-2525aeb37a00 h1:Mn/M46Onl5KWQnKcPm1j3w9wreBVSi7L8tM/TEoFBb4=
-sigs.k8s.io/kubebuilder v1.0.9-0.20200529152716-2525aeb37a00/go.mod h1:FGPx0hvP73+bapzWoy5ePuhAJYgJjrFbPxgvWyortM0=
+sigs.k8s.io/kubebuilder v1.0.9-0.20200604172714-cd5eed9f42b7 h1:1loZ7UPyGCEgDjuZgpb88h/omKDTb2/5uNe+KrqFC4U=
+sigs.k8s.io/kubebuilder v1.0.9-0.20200604172714-cd5eed9f42b7/go.mod h1:FGPx0hvP73+bapzWoy5ePuhAJYgJjrFbPxgvWyortM0=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/internal/generate/testdata/non-standard-layout/PROJECT
+++ b/internal/generate/testdata/non-standard-layout/PROJECT
@@ -1,5 +1,5 @@
 domain: example.com
-layout: go.kubebuilder.io/v2.0.0
+layout: go.kubebuilder.io/v2
 repo: github.com/example/memcached-operator
 resources:
 - group: cache
@@ -7,4 +7,4 @@ resources:
   version: v1alpha1
 version: 3-alpha
 plugins:
-  go.operator-sdk.io/v2.0.0: {}
+  go.operator-sdk.io/v2-alpha: {}

--- a/internal/plugins/golang/plugin.go
+++ b/internal/plugins/golang/plugin.go
@@ -21,15 +21,18 @@ import (
 	kbgov2 "sigs.k8s.io/kubebuilder/pkg/plugin/v2"
 )
 
+// Plugin name/version used in this file will also be used in phase 2 plugins when we can
+// pipe kubebuilder's init/create api output into our scaffold modification
+// plugins. In phase 1 we wrap kubebuilder's Go plugin to have the same effect.
+
 const (
-	// These will be used as plugin name/version in phase 2 plugins when we can
-	// pipe kubebuilder's init/create api output into our scaffold modification
-	// plugins. In phase 1 we wrap kubebuilder's Go plugin to have the same effect.
-	pluginName    = "go" + plugins.DefaultNameQualifier
-	pluginVersion = "v2.0.0"
+	pluginName = "go" + plugins.DefaultNameQualifier
 )
 
-var pluginConfigKey = plugin.Key(pluginName, pluginVersion)
+var (
+	pluginVersion   = plugin.Version{Number: 2, Stage: plugin.AlphaStage}
+	pluginConfigKey = plugin.Key(pluginName, pluginVersion.String())
+)
 
 var (
 	_ plugin.Base                      = Plugin{}
@@ -41,7 +44,7 @@ var (
 type Plugin struct{}
 
 func (Plugin) Name() string                       { return (kbgov2.Plugin{}).Name() }
-func (Plugin) Version() string                    { return (kbgov2.Plugin{}).Version() }
+func (Plugin) Version() plugin.Version            { return (kbgov2.Plugin{}).Version() }
 func (Plugin) SupportedProjectVersions() []string { return (kbgov2.Plugin{}).SupportedProjectVersions() }
 
 func (p Plugin) GetInitPlugin() plugin.Init {

--- a/website/content/en/docs/kubebuilder/quickstart.md
+++ b/website/content/en/docs/kubebuilder/quickstart.md
@@ -69,7 +69,7 @@ If yes then add the line `multigroup: true` in the `PROJECT` file which should l
 
 ```YAML
 domain: example.com
-layout: go.kubebuilder.io/v2.0.0
+layout: go.kubebuilder.io/v2
 multigroup: true
 ...
 ```


### PR DESCRIPTION
**Description of the change:**
*: remove references to minor and patch versions for plugins, add "alpha" stage

**Motivation for the change:** Plugin versions have been removed and replaced with kubebuilder's plugin.Version type, which only contains a "major" version integer and an optional stage string. The "alpha" suffix is to denote that this plugin version might change soon. We can remove this when the plugin is stable.

This is a follow-up from https://github.com/kubernetes-sigs/kubebuilder/pull/1547.
