### PR TITLE
internal/plugins: move `go/v2-alpha` to its own package

### DIFF
--- a/cmd/operator-sdk/cli/cli.go
+++ b/cmd/operator-sdk/cli/cli.go
@@ -24,7 +24,7 @@ import (
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/olm"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/version"
 	"github.com/operator-framework/operator-sdk/internal/flags"
-	"github.com/operator-framework/operator-sdk/internal/plugins/golang"
+	golangv2 "github.com/operator-framework/operator-sdk/internal/plugins/golang/v2"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 
 	log "github.com/sirupsen/logrus"
@@ -63,9 +63,11 @@ func GetPluginsCLIAndRoot() (cli.CLI, *cobra.Command) {
 	c, err := cli.New(
 		cli.WithCommandName("operator-sdk"),
 		cli.WithPlugins(
-			&golang.Plugin{},
+			&golangv2.Plugin{},
 		),
-		cli.WithDefaultPlugins(&golang.Plugin{}),
+		cli.WithDefaultPlugins(
+			&golangv2.Plugin{},
+		),
 		cli.WithExtraCommands(commands...),
 	)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/controller-runtime v0.6.0
 	sigs.k8s.io/controller-tools v0.3.0
-	sigs.k8s.io/kubebuilder v1.0.9-0.20200604172714-cd5eed9f42b7
+	sigs.k8s.io/kubebuilder v1.0.9-0.20200618125005-36aa113dbe99
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1381,8 +1381,8 @@ sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPhJ4=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
-sigs.k8s.io/kubebuilder v1.0.9-0.20200604172714-cd5eed9f42b7 h1:1loZ7UPyGCEgDjuZgpb88h/omKDTb2/5uNe+KrqFC4U=
-sigs.k8s.io/kubebuilder v1.0.9-0.20200604172714-cd5eed9f42b7/go.mod h1:FGPx0hvP73+bapzWoy5ePuhAJYgJjrFbPxgvWyortM0=
+sigs.k8s.io/kubebuilder v1.0.9-0.20200618125005-36aa113dbe99 h1:wdt455ji+MywIGDGQVUQUEGHa8WiRy0sfr5YFn00HbA=
+sigs.k8s.io/kubebuilder v1.0.9-0.20200618125005-36aa113dbe99/go.mod h1:FGPx0hvP73+bapzWoy5ePuhAJYgJjrFbPxgvWyortM0=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/internal/plugins/golang/v2/api.go
+++ b/internal/plugins/golang/v2/api.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package golang
+package v2
 
 import (
 	"fmt"

--- a/internal/plugins/golang/v2/config.go
+++ b/internal/plugins/golang/v2/config.go
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package golang
+package v2
 
 import "sigs.k8s.io/kubebuilder/pkg/model/config"
 
+// Config configures this plugin, and is saved in the project config file.
 type Config struct{}
 
+// hasPluginConfig returns true if cfg.Plugins contains an exact match for this plugin's key.
 func hasPluginConfig(cfg *config.Config) bool {
 	if len(cfg.Plugins) == 0 {
 		return false

--- a/internal/plugins/golang/v2/init.go
+++ b/internal/plugins/golang/v2/init.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package golang
+package v2
 
 import (
 	"fmt"

--- a/internal/plugins/golang/v2/plugin.go
+++ b/internal/plugins/golang/v2/plugin.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package golang
+package v2
 
 import (
 	"github.com/operator-framework/operator-sdk/internal/plugins"
@@ -41,6 +41,8 @@ var (
 	_ plugin.CreateWebhookPluginGetter = Plugin{}
 )
 
+// Plugin defines an Operator SDK Go scaffold and CLI plugin. Its current purpose is to
+// add operator-framework features to the base kubebuilder Go scaffold and CLI.
 type Plugin struct{}
 
 func (Plugin) Name() string                       { return (kbgov2.Plugin{}).Name() }

--- a/website/content/en/docs/new-cli/operator-sdk_init.md
+++ b/website/content/en/docs/new-cli/operator-sdk_init.md
@@ -42,7 +42,7 @@ operator-sdk init [flags]
   -h, --help                     help for init
       --license string           license to use to boilerplate, may be one of 'apache2', 'none' (default "apache2")
       --owner string             owner to add to the copyright
-      --plugins strings          Name and optionally version of the plugin to initialize the project with. Available plugins: ("go.kubebuilder.io/v2", "go.kubebuilder.io/v2")
+      --plugins strings          Name and optionally version of the plugin to initialize the project with. Available plugins: ("go.kubebuilder.io/v2")
       --project-version string   project version, possible values: ("2", "3-alpha") (default "3-alpha")
       --repo string              name to use for go module (e.g., github.com/user/repo), defaults to the go package of the current working directory.
       --skip-go-version-check    if specified, skip checking the Go version


### PR DESCRIPTION
**Description of the change:**
* cmd/operator-sdk/cli: update import path for Go plugin
* go.mod,go.sum: bump kubebuilder version

**Motivation for the change:** the `go.operator-sdk.io/v2-alpha` plugin is now in its own package. See https://github.com/kubernetes-sigs/kubebuilder/pull/1550 for a reference as to why this was done.

/cc @camilamacedo86 @hasbro17 @joelanford 
