### PR TITLE
Build the manager directory package, not the cmdFile directly

### DIFF
--- a/pkg/test/framework.go
+++ b/pkg/test/framework.go
@@ -267,7 +267,7 @@ func (f *Framework) setupLocalCommand() (*exec.Cmd, error) {
 	outputBinName := filepath.Join(scaffold.BuildBinDir, projectName+"-local")
 	opts := projutil.GoCmdOptions{
 		BinName:     outputBinName,
-		PackagePath: filepath.Join(scaffold.ManagerDir, scaffold.CmdFile),
+		PackagePath: filepath.Join(projutil.GetGoPkg(), filepath.ToSlash(scaffold.ManagerDir)),
 	}
 	if err := projutil.GoBuild(opts); err != nil {
 		return nil, fmt.Errorf("failed to build local operator binary: %w", err)


### PR DESCRIPTION
Building the main.go file directly does not work if the main package is
split into multiple files.

Resolves: https://github.com/operator-framework/operator-sdk/issues/3187