### PR TITLE
Versioned doc links

### DIFF
--- a/hack/check-links.sh
+++ b/hack/check-links.sh
@@ -7,5 +7,5 @@ source ./hack/lib/common.sh
 header_text "Building the site and checking links"
 docker volume create sdk-html
 docker run --rm -v "$(pwd):/src" -v sdk-html:/target klakegg/hugo:0.70.0-ext-ubuntu -s website
-docker run --rm -v sdk-html:/target mtlynch/htmlproofer /target --empty-alt-ignore --http-status-ignore 429
+docker run --rm -v sdk-html:/target mtlynch/htmlproofer /target --empty-alt-ignore --http-status-ignore 429 --allow_hash_href
 docker volume rm sdk-html

--- a/website/config.toml
+++ b/website/config.toml
@@ -78,12 +78,19 @@ github_repo = "https://github.com/operator-framework/operator-sdk"
 
 [[params.versions]]
   version = "master"
-  url = "/docs"
+  url = "https://master.sdk.operatorframework.io"
 
 [[params.versions]]
-  version = "v0.16"
-  url = "https://github.com/operator-framework/operator-sdk/tree/v0.16.x/doc"
+  version = "Latest Release"
+  url = "https://sdk.operatorframework.io"
 
+[[params.versions]]
+  version = "v0.18"
+  url = "https://v0-18-x.sdk.operatorframework.io"
+
+[[params.versions]]
+  version = "v0.17"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v0.17.x/doc"
 
 # Specify a value here if your content directory is not in your repo's root directory
 github_subdir = "website"

--- a/website/layouts/partials/navbar-version-selector.html
+++ b/website/layouts/partials/navbar-version-selector.html
@@ -1,0 +1,8 @@
+<a class="of-link-list__a nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+	{{ .Site.Params.version_menu }}
+</a>
+<div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+	{{ range .Site.Params.versions }}
+	<a class="dropdown-item" href="{{ .url }}">{{ .version }}</a>
+	{{ end }}
+</div>

--- a/website/layouts/partials/navbar.html
+++ b/website/layouts/partials/navbar.html
@@ -2,19 +2,23 @@
     <a href="/" class="of-brand">
       <picture class="of-brand__picture">
         <source srcset="/build/images/logo.svg" media="(min-width: 992px)">
-        <img src="/build/images/logo-sm.svg" alt="">  
-      </picture> 
+        <img src="/build/images/logo-sm.svg" alt="">
+      </picture>
         </a>
     <nav class="of-nav-main nav-collapse">
       <ul class="of-nav-main__items menu-items">
         <li class="of-nav-main__item"><a class="of-link-list__a {{ if eq .URL "/" }} of-m-active {{end}}" href="/">Home</a></li>
         {{ $currentPage := . }}
-    {{ range .Site.Menus.main }}
-    <li class="of-nav-main__item"><a class="of-link-list__a{{if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }} of-m-active{{end}}" href="{{ .URL }}" title="{{ .Title }}">{{ .Name }}</a></li>
-    {{ end }}
-    </ul>
+        {{ range .Site.Menus.main }}
+        <li class="of-nav-main__item"><a class="of-link-list__a{{if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }} of-m-active{{end}}" href="{{ .URL }}" title="{{ .Title }}">{{ .Name }}</a></li>
+        {{ end }}
+        {{ if  .Site.Params.versions }}
+        <li class="of-nav-main__item">
+        {{ partial "navbar-version-selector.html" . }}
+        </li>
+        {{ end }}
+      </ul>
     </nav>
-   
     <div class="of-header-main__search">
 		{{ partial "search-input.html" . }}
     </div>


### PR DESCRIPTION
Adds a releases tab which points to versioned documentation. These changes should be cherry picked back to all live versions of the docs (0.17.x, 0.18.x)