### PR TITLE
changelog: update from v0.18.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.18.1
+
+### Bug Fixes
+
+- Fix leader election of follower showing that an old leader will be evicted when the current leader is healthy. ([#3164](https://github.com/operator-framework/operator-sdk/pull/3164))
+- Bump api validation library to fix "CRD key not found" [validation bug](https://github.com/operator-framework/api/pull/39). ([#3167](https://github.com/operator-framework/operator-sdk/pull/3167))
+
 ## v0.18.0
 
 ### Additions

--- a/changelog/fragments/validation-bug-bump-api.yaml
+++ b/changelog/fragments/validation-bug-bump-api.yaml
@@ -1,5 +1,4 @@
 entries:
   - description: >
-      bump api validation library to 431198de9fc2cf82f369efb5c4a90a9cc079a1c3 to
-      fix "CRD key not found" validation bug.
+      Bump api validation library to fix "CRD key not found" [validation bug](https://github.com/operator-framework/api/pull/39)
     kind: bugfix


### PR DESCRIPTION
**Description of the change:** update changelog and remove related fragments

**Motivation for the change:** changelog missing v0.18.1 entries.

There should be a step in the release doc to do this after every patch release, including removal of related fragments, so patched changes aren't duplicated in the following major/minor version release.
