### PR TITLE
*: release v0.18.1 (#3179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.18.1
+
+### Bug Fixes
+
+- fix leader election of follower showing that an old leader will be evicted when the current leader is healthy. ([#3164](https://github.com/operator-framework/operator-sdk/pull/3164))
+- bump api validation library to 431198de9fc2cf82f369efb5c4a90a9cc079a1c3 to fix "CRD key not found" validation bug. ([#3167](https://github.com/operator-framework/operator-sdk/pull/3167))
+
 ## v0.18.0
 
 ### Additions

--- a/changelog/fragments/3059-fixleader-election-message.yaml
+++ b/changelog/fragments/3059-fixleader-election-message.yaml
@@ -1,4 +1,0 @@
-entries:
-  - description: fix leader election of follower showing that an old leader will be evicted when the current leader is healthy
-    kind: bugfix
-    breaking: false

--- a/changelog/fragments/validation-bug-bump-api.yaml
+++ b/changelog/fragments/validation-bug-bump-api.yaml
@@ -1,5 +1,0 @@
-entries:
-  - description: >
-      bump api validation library to 431198de9fc2cf82f369efb5c4a90a9cc079a1c3 to
-      fix "CRD key not found" validation bug.
-    kind: bugfix

--- a/internal/scaffold/ansible/go_mod.go
+++ b/internal/scaffold/ansible/go_mod.go
@@ -42,7 +42,7 @@ const goModTmpl = `module {{ .Repo }}
 go 1.13
 
 require (
-	github.com/operator-framework/operator-sdk v0.18.x
+	github.com/operator-framework/operator-sdk v0.18.1
 	sigs.k8s.io/controller-runtime v0.6.0
 )
 

--- a/internal/scaffold/go_mod.go
+++ b/internal/scaffold/go_mod.go
@@ -41,7 +41,7 @@ const goModTmpl = `module {{ .Repo }}
 go 1.13
 
 require (
-	github.com/operator-framework/operator-sdk v0.18.x
+	github.com/operator-framework/operator-sdk v0.18.1
 	sigs.k8s.io/controller-runtime v0.6.0
 )
 

--- a/internal/scaffold/helm/go_mod.go
+++ b/internal/scaffold/helm/go_mod.go
@@ -42,7 +42,7 @@ const goModTmpl = `module {{ .Repo }}
 go 1.13
 
 require (
-	github.com/operator-framework/operator-sdk v0.18.x
+	github.com/operator-framework/operator-sdk v0.18.1
 	sigs.k8s.io/controller-runtime v0.6.0
 )
 

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ import (
 
 //var needs to be used instead of const for ldflags
 var (
-	Version           = "v0.18.0+git"
+	Version           = "v0.18.1"
 	GitVersion        = "unknown"
 	GitCommit         = "unknown"
 	KubernetesVersion = "unknown"

--- a/website/content/en/docs/install-operator-sdk.md
+++ b/website/content/en/docs/install-operator-sdk.md
@@ -22,7 +22,7 @@ $ brew install operator-sdk
 
 ```sh
 # Set the release version variable
-$ RELEASE_VERSION=v0.18.0
+$ RELEASE_VERSION=v0.18.1
 # Linux
 $ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
 # macOS

--- a/website/content/en/docs/migration/v0.18.1.md
+++ b/website/content/en/docs/migration/v0.18.1.md
@@ -1,0 +1,6 @@
+---
+title: v0.18.1
+weight: 999981999
+---
+
+There are no migrations for this release! :tada:


### PR DESCRIPTION
With the release of 0.18.1, we need the `latest` branch (which is the production branch for sdk.operatorframework.io) to mirror v0.18.x branch.