### PR TITLE
generate bundle: unhide `--manifest-root` and rename to `--deploy-dir`

### DIFF
--- a/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/cmd/operator-sdk/generate/bundle/bundle.go
@@ -163,8 +163,8 @@ func (c bundleCmd) validateManifests(*config.Config) (err error) {
 	}
 
 	if !genutil.IsPipeReader() {
-		if c.manifestRoot == "" {
-			return errors.New("--manifest-root must be set if not reading from stdin")
+		if c.deployDir == "" {
+			return errors.New("--deploy-dir must be set if not reading from stdin")
 		}
 		if c.crdsDir == "" {
 			return errors.New("--crds-dir must be set if not reading from stdin")
@@ -215,8 +215,8 @@ func (c bundleCmd) runManifests(cfg *config.Config) (err error) {
 			return err
 		}
 	}
-	if c.manifestRoot != "" {
-		if err := col.UpdateFromDirs(c.manifestRoot, c.crdsDir); err != nil {
+	if c.deployDir != "" {
+		if err := col.UpdateFromDirs(c.deployDir, c.crdsDir); err != nil {
 			return err
 		}
 	}

--- a/cmd/operator-sdk/generate/bundle/bundle_legacy.go
+++ b/cmd/operator-sdk/generate/bundle/bundle_legacy.go
@@ -115,13 +115,13 @@ func (c bundleCmd) runManifestsLegacy() (err error) {
 	if c.apisDir == "" {
 		c.apisDir = filepath.Join("pkg", "apis")
 	}
-	if c.manifestRoot == "" {
-		c.manifestRoot = "deploy"
+	if c.deployDir == "" {
+		c.deployDir = "deploy"
 	}
 	if c.crdsDir == "" {
-		c.crdsDir = filepath.Join(c.manifestRoot, "crds")
+		c.crdsDir = filepath.Join(c.deployDir, "crds")
 	}
-	defaultBundleDir := filepath.Join(c.manifestRoot, "olm-catalog", c.operatorName)
+	defaultBundleDir := filepath.Join(c.deployDir, "olm-catalog", c.operatorName)
 	if c.inputDir == "" {
 		c.inputDir = defaultBundleDir
 	}
@@ -130,7 +130,7 @@ func (c bundleCmd) runManifestsLegacy() (err error) {
 	}
 
 	col := &collector.Manifests{}
-	if err := col.UpdateFromDirs(c.manifestRoot, c.crdsDir); err != nil {
+	if err := col.UpdateFromDirs(c.deployDir, c.crdsDir); err != nil {
 		return err
 	}
 

--- a/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/cmd/operator-sdk/generate/bundle/cmd.go
@@ -56,7 +56,7 @@ type bundleCmd struct {
 	version      string
 	inputDir     string
 	outputDir    string
-	manifestRoot string
+	deployDir    string
 	apisDir      string
 	crdsDir      string
 	stdout       bool
@@ -232,18 +232,10 @@ func (c *bundleCmd) addCommonFlagsTo(fs *pflag.FlagSet) {
 	fs.StringVarP(&c.version, "version", "v", "", "Semantic version of the operator in the generated bundle. "+
 		"Only set if creating a new bundle or upgrading your operator")
 	fs.StringVar(&c.inputDir, "input-dir", "", "Directory to read an existing bundle from. "+
-		"This directory is the parent of your bundle 'manifests' directory, and different from --manifest-root")
+		"This directory is the parent of your bundle 'manifests' directory, and different from --deploy-dir")
 	fs.StringVar(&c.outputDir, "output-dir", "", "Directory to write the bundle to")
-
-	fs.StringVar(&c.manifestRoot, "manifest-root", "", "Root directory for operator manifests such as "+
-		"Deployments and RBAC, ex. 'deploy' or 'config'. This directory is different from that passed to --input-dir")
-	// NB(estroz): still debating the name of this flag. For now, hide it as an
-	// "alpha" flag so we do not have to deprecate it if we change this name.
-	// TODO(estroz): decide on this flag's name before making 'init' default.
-	if err := fs.MarkHidden("manifest-root"); err != nil {
-		panic(err)
-	}
-
+	fs.StringVar(&c.deployDir, "deploy-dir", "", "Root directory for operator manifests such as "+
+		"Deployments and RBAC, ex. 'deploy'. This directory is different from that passed to --input-dir")
 	fs.StringVar(&c.apisDir, "apis-dir", "", "Root directory for API type defintions")
 	fs.StringVar(&c.crdsDir, "crds-dir", "", "Root directory for CustomResoureDefinition manifests")
 	fs.StringVar(&c.channels, "channels", "alpha", "A comma-separated list of channels the bundle belongs to")

--- a/website/content/en/docs/cli/operator-sdk_generate_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_bundle.md
@@ -87,8 +87,9 @@ operator-sdk generate bundle [flags]
       --channels string          A comma-separated list of channels the bundle belongs to (default "alpha")
       --crds-dir string          Root directory for CustomResoureDefinition manifests
       --default-channel string   The default channel for the bundle
+      --deploy-dir string        Root directory for operator manifests such as Deployments and RBAC, ex. 'deploy'. This directory is different from that passed to --input-dir
   -h, --help                     help for bundle
-      --input-dir string         Directory to read an existing bundle from. This directory is the parent of your bundle 'manifests' directory, and different from --manifest-root
+      --input-dir string         Directory to read an existing bundle from. This directory is the parent of your bundle 'manifests' directory, and different from --deploy-dir
       --interactive              When set or no bundle base exists, an interactive command prompt will be presented to accept bundle ClusterServiceVersion metadata
       --manifests                Generate bundle manifests
       --metadata                 Generate bundle metadata and Dockerfile


### PR DESCRIPTION
**Description of the change:** The `--manifest-root` flag in `generate bundle` is now `--deploy-dir` and unhidden.


**Motivation for the change:** `--deploy-dir` is a less confusing name for this flag since it is intended for a) legacy support with `deploy/` b) use with a custom directory for new project layouts (not `config/`).
