### PR TITLE
Fix links after kubernetes renamed access-kubernetes to extend-kuberntes-api

### DIFF
--- a/website/content/en/docs/ansible/reference/advanced_options.md
+++ b/website/content/en/docs/ansible/reference/advanced_options.md
@@ -145,7 +145,7 @@ spec: {}
 
 ## Custom Resources with OpenApi Validation
 
-Currently, SDK tool does not support and will not generate automatically the CRD's using the [OpenAPI](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#validation) spec to perform validations. 
+Currently, SDK tool does not support and will not generate automatically the CRD's using the [OpenAPI](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation) spec to perform validations. 
 
 However, it can be done manually by adding its validations as you can check in the following example.
 

--- a/website/content/en/docs/ansible/reference/finalizers.md
+++ b/website/content/en/docs/ansible/reference/finalizers.md
@@ -166,6 +166,6 @@ automatic deletion of dependent resources will be sufficient, so we can exit suc
 let the operator remove our finalizer and allow the resource to be deleted.
 
 ## Further reading
-• [Kubernetes finalizers](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#finalizers)
+• [Kubernetes finalizers](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers)
 
 [ansible-watches]:/docs/ansible/reference/watches/

--- a/website/content/en/docs/golang/migrating-existing-apis.md
+++ b/website/content/en/docs/golang/migrating-existing-apis.md
@@ -395,11 +395,11 @@ The Go toolchain can be your friend here too. Running `go vet ./...` can tell yo
 [k8s-versioning]:https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-versioning
 [deepcopy-gen]:https://godoc.org/k8s.io/gengo/examples/deepcopy-gen
 [client-gen]:https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/generating-clientset.md
-[crd-storage-version]:https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/#writing-reading-and-updating-versioned-customresourcedefinition-objects
+[crd-storage-version]:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#writing-reading-and-updating-versioned-customresourcedefinition-objects
 [crd-markers]:https://book.kubebuilder.io/reference/markers/crd.html
 [controller-tools]:https://github.com/kubernetes-sigs/controller-tools
-[crd-versions]:https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/
-[crd-conv]:https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/#webhook-conversion
-[crd-conv-webhook]:https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/#configure-customresourcedefinition-to-use-conversion-webhooks
+[crd-versions]:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/
+[crd-conv]:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#webhook-conversion
+[crd-conv-webhook]:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#configure-customresourcedefinition-to-use-conversion-webhooks
 [kubebuilder-api-annotations]:https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 [crd-version-deprecated]:https://github.com/kubernetes/apiextensions-apiserver/commit/d1c6536f26319513417b12245c6e3aee5ca005ca

--- a/website/content/en/docs/golang/quickstart.md
+++ b/website/content/en/docs/golang/quickstart.md
@@ -106,7 +106,7 @@ $ operator-sdk generate crds
 **Notes:**
 - Your CRD *must* specify exactly one [storage version][crd-storage-version]. Use the `+kubebuilder:storageversion` [marker][crd-markers] to indicate the GVK that should be used to store data by the API server. This marker should be in a comment above your `Memcached` type.
 
-[crd-storage-version]:https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/#writing-reading-and-updating-versioned-customresourcedefinition-objects
+[crd-storage-version]:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#writing-reading-and-updating-versioned-customresourcedefinition-objects
 [crd-markers]:https://book.kubebuilder.io/reference/markers/crd.html
 [api-rules]: https://github.com/kubernetes/kubernetes/tree/36981002246682ed7dc4de54ccc2a96c1a0cbbdb/api/api-rules
 
@@ -145,7 +145,7 @@ spec:
 
 To learn more about OpenAPI v3.0 validation schemas in Custom Resource Definitions, refer to the [Kubernetes Documentation][doc-validation-schema].
 
-[doc-validation-schema]: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#specifying-a-structural-schema
+[doc-validation-schema]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema
 [generating-crd]: https://book.kubebuilder.io/reference/generating-crd.html
 [markers]: https://book.kubebuilder.io/reference/markers.html
 [crd-markers]: https://book.kubebuilder.io/reference/markers/crd-validation.html
@@ -660,7 +660,7 @@ In this scenario, this error may occur because your Operator RBAC roles do not i
 
 To implement complex deletion logic, you can add a finalizer to your Custom Resource. This will prevent your Custom Resource from being
 deleted until you remove the finalizer (ie, after your cleanup logic has successfully run). For more information, see the
-[official Kubernetes documentation on finalizers](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#finalizers).
+[official Kubernetes documentation on finalizers](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers).
 
 **Example:**
 

--- a/website/content/en/docs/golang/references/client.md
+++ b/website/content/en/docs/golang/references/client.md
@@ -567,4 +567,4 @@ func labelsForApp(name string) map[string]string {
 [doc-reconcile-reconciler]:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Reconciler
 [doc-osdk-handle]:https://github.com/operator-framework/operator-sdk/blob/master/design/milestone-0.0.2/action-api.md#handler
 [doc-types-nsname]:https://godoc.org/k8s.io/apimachinery/pkg/types#NamespacedName
-[cr-status-subresource]:https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#status-subresource
+[cr-status-subresource]:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource

--- a/website/content/en/docs/operator-capabilities.md
+++ b/website/content/en/docs/operator-capabilities.md
@@ -17,7 +17,7 @@ Each capability level is associated with a certain set of management features th
 
 **Operand** - the managed workload provided by the Operator as a service
 
-**Custom Resource (CR)** - an instance of the [`CustomResourceDefinition`](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/) the Operator ships that represents the Operand or an Operation on an Operand (also known as primary resources)
+**Custom Resource (CR)** - an instance of the [`CustomResourceDefinition`](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/) the Operator ships that represents the Operand or an Operation on an Operand (also known as primary resources)
 
 **Managed resources** - the Kubernetes objects or off-cluster services the Operator uses to constitute an Operand (also known as secodary resources)
 


### PR DESCRIPTION
**Description of the change:**
Fixes broken links caused by kubernetes rename of a group of docs

**Motivation for the change:**
Our CI is failing