### PR TITLE
String error fix

### DIFF
--- a/internal/scorecard/interfaces.go
+++ b/internal/scorecard/interfaces.go
@@ -51,9 +51,9 @@ func (p basicOrOLMPlugin) Run() scapiv1alpha2.ScorecardOutput {
 	if err != nil {
 		var name string
 		if p.pluginType == scplugins.BasicOperator {
-			name = fmt.Sprintf("Basic Tests")
+			name = "Basic Tests"
 		} else if p.pluginType == scplugins.OLMIntegration {
-			name = fmt.Sprintf("OLM Integration")
+			name = "OLM Integration"
 		}
 		logs := fmt.Sprintf("%s:\nLogs: %s", err, pluginLogs.String())
 		// output error to main logger as well for human-readable output

--- a/pkg/apis/scorecard/v1alpha2/formatter.go
+++ b/pkg/apis/scorecard/v1alpha2/formatter.go
@@ -55,7 +55,7 @@ func (s ScorecardOutput) MarshalText() (string, error) {
 		} else if result.State == FailState {
 			sb.WriteString(fmt.Sprintf(failColor, FailState))
 		} else {
-			sb.WriteString(fmt.Sprintf("\n"))
+			sb.WriteString("\n")
 		}
 
 		sb.WriteString(fmt.Sprintf("\tCR: %s\n", result.CRName))
@@ -82,14 +82,14 @@ func (s ScorecardOutput) MarshalText() (string, error) {
 		}
 
 		if result.Log != "" {
-			sb.WriteString(fmt.Sprintf("\tLog:\n"))
+			sb.WriteString("\tLog:\n")
 			scanner := bufio.NewScanner(strings.NewReader(result.Log))
 			for scanner.Scan() {
 				sb.WriteString(fmt.Sprintf("\t\t%s\n", scanner.Text()))
 			}
 		}
 
-		sb.WriteString(fmt.Sprintf("\n"))
+		sb.WriteString("\n")
 	}
 
 	return sb.String(), nil

--- a/pkg/apis/scorecard/v1alpha3/formatter.go
+++ b/pkg/apis/scorecard/v1alpha3/formatter.go
@@ -58,7 +58,7 @@ func (s Test) MarshalText() (string, error) {
 		} else if result.State == ErrorState {
 			sb.WriteString(fmt.Sprintf(failColor, ErrorState))
 		} else {
-			sb.WriteString(fmt.Sprintf("\n"))
+			sb.WriteString("\n")
 		}
 		if len(result.Suggestions) > 0 {
 			sb.WriteString(fmt.Sprintf(warnColor, "Suggestions:"))
@@ -76,13 +76,13 @@ func (s Test) MarshalText() (string, error) {
 			sb.WriteString(fmt.Sprintf("\t\t%s\n", err))
 		}
 		if result.Log != "" {
-			sb.WriteString(fmt.Sprintf("\tLog:\n"))
+			sb.WriteString("\tLog:\n")
 			scanner := bufio.NewScanner(strings.NewReader(result.Log))
 			for scanner.Scan() {
 				sb.WriteString(fmt.Sprintf("\t\t%s\n", scanner.Text()))
 			}
 		}
-		sb.WriteString(fmt.Sprintf("\n"))
+		sb.WriteString("\n")
 	}
 
 	return sb.String(), nil


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Add a changelog file by copying changelog/fragments/00-template.yaml 
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"

-->

**Description of the change:**
The change has fmt.Sprintf("...") removed from sb.WriteString(fmt.Sprintf("...")) and two other variable assignment in 3 files at various places.

This is because the latest version throws error stating that fmt.Sprintf() is doing an extra step of converting a string to a string. 

I have also done formatting of code in one of the section due to this error:
internal/plugins/golang/plugin.go:46: File is not `goimports`-ed (goimports)

after pretty print I am able to make the sdk.



**Motivation for the change:**

I have installed the latest version of Go and a couple of features are throwing errors making it difficult to build.
