### PR TITLE
deps: bump operator-registry version

### DIFF
--- a/changelog/fragments/3221-bugfix.yaml
+++ b/changelog/fragments/3221-bugfix.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      Fix bug in `operator-sdk bundle validation` that causes erroneous validation errors when the number of
+      annotations in an existing `annotations.yaml` does not equal the number of default bundle annotations
+      by upgrading the `operator-registry` dependency.
+    kind: bugfix

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
 	github.com/operator-framework/api v0.3.7-0.20200602203552-431198de9fc2
-	github.com/operator-framework/operator-registry v1.12.6-0.20200605115407-01fa069730e2
+	github.com/operator-framework/operator-registry v1.12.6-0.20200611222234-275301b779f8
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -737,8 +737,8 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/operator-framework/api v0.3.7-0.20200602203552-431198de9fc2 h1:2KtDe3jI6ftXGj5M875WVvv6pBIk4K9DyrwPuE+XfOc=
 github.com/operator-framework/api v0.3.7-0.20200602203552-431198de9fc2/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
-github.com/operator-framework/operator-registry v1.12.6-0.20200605115407-01fa069730e2 h1:G7helxG2m7xgIsn4KX5qu62mqbgjK9kVUZC3AHiPnOQ=
-github.com/operator-framework/operator-registry v1.12.6-0.20200605115407-01fa069730e2/go.mod h1:loVINznYhgBIkmv83kU4yee88RS0BBk+hqOw9r4bhJk=
+github.com/operator-framework/operator-registry v1.12.6-0.20200611222234-275301b779f8 h1:F3zzxoBJJANdKMxmSOi5z/HWiVT+gwOdhROkEwDWD2M=
+github.com/operator-framework/operator-registry v1.12.6-0.20200611222234-275301b779f8/go.mod h1:loVINznYhgBIkmv83kU4yee88RS0BBk+hqOw9r4bhJk=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 h1:+OLn68pqasWca0z5ryit9KGfp3sUsW4Lqg32iRMJyzs=


### PR DESCRIPTION
**Description of the change:**
* deps: bump operator-registry
* cmd/operator-sdk/bundle/validate,internal/scorecard/alpha/tests: the NewImageValidator API changed such that the command must create an image registry first before creating a validator.

**Motivation for the change:** This version of operator-registry contains a fix for a bug that causes validation errors when an existing `annotations.yaml` does not exactly match the default annotations generated by `operator-sdk bundle create`.

/cc @camilamacedo86 @jmrodri @hasbro17 @varshaprasad96 

/kind bug