### PR TITLE
bundle validate: add tool-less image validation

### DIFF
--- a/changelog/fragments/3222-none-tool.yaml
+++ b/changelog/fragments/3222-none-tool.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      `bundle validate` can now use a containerd image ("none") tool to unpack images,
+      removing the need for an external image tool like docker/podman
+
+    kind: addition

--- a/website/content/en/docs/cli/operator-sdk_bundle_validate.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle_validate.md
@@ -56,7 +56,7 @@ To build and validate an image:
 
 ```
   -h, --help                   help for validate
-  -b, --image-builder string   Tool to extract bundle image data. Only used when validating a bundle image. One of: [docker, podman] (default "docker")
+  -b, --image-builder string   Tool to pull and unpack bundle images. Only used when validating a bundle image. One of: [docker, podman, none] (default "docker")
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
**Description of the change:**
* cmd/operator-sdk/bundle/validate.go: add "none" option to available image builder tools

**Motivation for the change:** `ImageValidator` can now use a containerd image ("none") tool to unpack images, removing the need for an external image tool like docker/podman.

/cc @hasbro17 @jmccormick2001 @joelanford 

~Blocked by #3221~

/kind feature