### PR TITLE
hack/tests/e2e-ansible.sh: remove `-it` flags

### DIFF
--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -135,7 +135,7 @@ test_operator() {
 
 
     header_text "verify that metrics reflect cr creation"
-    if ! timeout 60s bash -c -- "until kubectl run -it --rm --restart=Never test-metrics --image=$metrics_test_image -- curl http://memcached-operator-metrics:8686/metrics | grep example-memcached; do sleep 1; done";
+    if ! timeout 60s bash -c -- "until kubectl run --attach --rm --restart=Never test-metrics --image=$metrics_test_image -- curl -sf http://memcached-operator-metrics:8686/metrics | grep example-memcached; do sleep 1; done";
     then
         error_text "FAIL: Failed to verify custom resource metrics"
         operator_logs


### PR DESCRIPTION
**Description of the change:** remove `-it` flags from the Ansible e2e test.

**Motivation for the change:** neither interactive mode nor a tty are needed.
