### PR TITLE
generate bundle (new CLI): write a `kustomization.yaml`

### DIFF
--- a/cmd/operator-sdk/generate/bundle/bundle_legacy.go
+++ b/cmd/operator-sdk/generate/bundle/bundle_legacy.go
@@ -28,27 +28,7 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 )
 
-const (
-	examplesLegacy = `
-  # Using the example 'memcached-operator' and assuming a directory structure
-  # similar to the following exists:
-  $ tree pkg/apis/ deploy/
-  pkg/apis/
-  ├── ...
-  └── cache
-      ├── group.go
-      └── v1alpha1
-          ├── ...
-          └── memcached_types.go
-  deploy/
-  ├── crds
-  │   ├── cache.example.com_memcacheds_crd.yaml
-  │   └── cache.example.com_v1alpha1_memcached_cr.yaml
-  ├── operator.yaml
-  ├── role.yaml
-  ├── role_binding.yaml
-  └── service_account.yaml
-
+const examplesLegacy = `
   # Create bundle manifests, metadata, and a bundle.Dockerfile:
   $ operator-sdk generate bundle --version 0.0.1
   INFO[0000] Generating bundle manifest version 0.0.1
@@ -76,7 +56,6 @@ const (
   ...
   $ docker push $BUNDLE_IMG
 `
-)
 
 // setCommonDefaultsLegacy sets defaults useful to all modes of this subcommand.
 func (c *bundleCmd) setCommonDefaultsLegacy() {

--- a/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/cmd/operator-sdk/generate/bundle/cmd.go
@@ -25,8 +25,7 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 )
 
-const (
-	longHelp = `
+const longHelp = `
   Running 'generate bundle' is the first step to publishing your operator to a catalog
   and/or deploying it with OLM. This command generates a set of bundle manifests,
   metadata, and a bundle.Dockerfile for your operator, and will interactively ask
@@ -42,7 +41,6 @@ const (
   More information on bundles:
   https://github.com/operator-framework/operator-registry/#manifest-format
 `
-)
 
 //nolint:maligned
 type bundleCmd struct {

--- a/internal/plugins/golang/init.go
+++ b/internal/plugins/golang/init.go
@@ -17,13 +17,10 @@ package golang
 import (
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
 
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/kubebuilder/pkg/model/config"
 	"sigs.k8s.io/kubebuilder/pkg/plugin"
-
-	"github.com/operator-framework/operator-sdk/internal/scaffold/kustomize"
 )
 
 type initPlugin struct {
@@ -59,11 +56,6 @@ func (p *initPlugin) Run() error {
 		return fmt.Errorf("error writing plugin config for %s: %v", pluginConfigKey, err)
 	}
 
-	// Write a kustomization.yaml to the config directory.
-	if err := kustomize.Write(filepath.Join("config", "bundle"), bundleKustomization); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -82,12 +74,6 @@ func initUpdateMakefile(filePath string) error {
 
 	return ioutil.WriteFile(filePath, makefileBytes, 0644)
 }
-
-// kustomization for bundles.
-const bundleKustomization = `resources:
-- ../default
-- ../samples
-`
 
 // Makefile fragments to add to the base Makefile.
 const (

--- a/website/content/en/docs/cli/operator-sdk_generate_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_bundle.md
@@ -32,25 +32,6 @@ operator-sdk generate bundle [flags]
 
 ```
 
-  # Using the example 'memcached-operator' and assuming a directory structure
-  # similar to the following exists:
-  $ tree pkg/apis/ deploy/
-  pkg/apis/
-  ├── ...
-  └── cache
-      ├── group.go
-      └── v1alpha1
-          ├── ...
-          └── memcached_types.go
-  deploy/
-  ├── crds
-  │   ├── cache.example.com_memcacheds_crd.yaml
-  │   └── cache.example.com_v1alpha1_memcached_cr.yaml
-  ├── operator.yaml
-  ├── role.yaml
-  ├── role_binding.yaml
-  └── service_account.yaml
-
   # Create bundle manifests, metadata, and a bundle.Dockerfile:
   $ operator-sdk generate bundle --version 0.0.1
   INFO[0000] Generating bundle manifest version 0.0.1


### PR DESCRIPTION
**Description of the change:**
* cmd/operator-sdk/generate/bundle/bundle.go: move `kustomization.yaml` template and write logic here
* internal/plugins/golang/init.go: remove the above logic

**Motivation for the change:** `generate bundle`, not `init`, now scaffolds `config/bundle/kustomization.yaml` if one does not exist. This is done so both `bundle` and `packagemanifests` subcommands can generate their own kustomize files.
