### PR TITLE
WIP: Call create api plugin in sdk command

### DIFF
--- a/cmd/operator-sdk/cli/cli.go
+++ b/cmd/operator-sdk/cli/cli.go
@@ -24,6 +24,7 @@ import (
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/version"
 	"github.com/operator-framework/operator-sdk/internal/flags"
 	"github.com/operator-framework/operator-sdk/internal/plugins/golang"
+	"github.com/operator-framework/operator-sdk/internal/plugins/helm"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 
 	log "github.com/sirupsen/logrus"
@@ -63,6 +64,7 @@ func GetPluginsCLIAndRoot() (cli.CLI, *cobra.Command) {
 		cli.WithCommandName("operator-sdk"),
 		cli.WithPlugins(
 			&golang.Plugin{},
+			&helm.Plugin{},
 		),
 		cli.WithDefaultPlugins(&golang.Plugin{}),
 		cli.WithExtraCommands(commands...),

--- a/internal/plugins/helm/api.go
+++ b/internal/plugins/helm/api.go
@@ -1,0 +1,205 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package helm
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
+	"sigs.k8s.io/kubebuilder/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/pkg/scaffold"
+
+	gencrd "github.com/operator-framework/operator-sdk/internal/generate/crd"
+	cmdutil "github.com/operator-framework/operator-sdk/internal/plugins/helm/internal"
+	sdkscaffold "github.com/operator-framework/operator-sdk/internal/scaffold"
+	"github.com/operator-framework/operator-sdk/internal/scaffold/helm"
+	"github.com/operator-framework/operator-sdk/internal/scaffold/input"
+	"github.com/operator-framework/operator-sdk/internal/util/projutil"
+)
+
+type createAPIPlugin struct {
+	config *config.Config
+
+	// For help text.
+	commandName string
+
+	// Helm flags
+	//todo: Domain should be removed when the legacy layout be no longer supported
+	Domain           string
+	Group            string
+	Version          string
+	Kind             string
+	CRDVersion       string
+	HelmChartRef     string
+	HelmChartVersion string
+	HelmChartRepo    string
+}
+
+var (
+	_ plugin.CreateAPI   = &createAPIPlugin{}
+	_ cmdutil.RunOptions = &createAPIPlugin{}
+)
+
+func (p *createAPIPlugin) UpdateContext(ctx *plugin.Context) {
+	ctx.Description = `Create a Kubernetes API by creating a CR and CRD with the Helm Chart package directories.`
+	ctx.Examples = fmt.Sprintf(`# Scaffold a new API for a Helm project 
+	
+  $ opeator-sdk create api --plugins=helm.kubebuilder.io/v1-alpha \
+  --group=app \
+  --version=v1alpha1 \	
+  --kind=AppService
+
+  $ opeator-sdk create api --plugins=helm.kubebuilder.io/v1-alpha \
+  --domain=app.example \	
+  --group=app \
+  --version=v1alpha1 \	
+  --kind=AppService \
+  --helm-chart=myrepo/app
+
+  $ opeator-sdk create api --plugins=helm.kubebuilder.io/v1-alpha \
+  --helm-chart=myrepo/app
+
+  $ opeator-sdk create api --plugins=helm.kubebuilder.io/v1-alpha \
+  --helm-chart=myrepo/app \
+  --helm-chart-version=1.2.3
+
+  $ opeator-sdk create api --plugins=helm.kubebuilder.io/v1-alpha \
+  --helm-chart=app \
+  --helm-chart-repo=https://charts.mycompany.com/
+
+  $ opeator-sdk create api --plugins=helm.kubebuilder.io/v1-alpha \
+  --helm-chart=app \
+  --helm-chart-repo=https://charts.mycompany.com/ \
+  --helm-chart-version=1.2.3
+
+  $ opeator-sdk create api  --plugins=helm.kubebuilder.io/v1-alpha \
+  --helm-chart=/path/to/local/chart-directories/app/
+
+  $ opeator-sdk create api  --plugins=helm.kubebuilder.io/v1-alpha \
+  --helm-chart=/path/to/local/chart-archives/app-1.2.3.tgz
+`)
+	p.commandName = ctx.CommandName
+}
+
+func (p *createAPIPlugin) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&p.Group, "group", "", "Kubernetes resource Kind Group. (e.g app)")
+	fs.StringVar(&p.Version, "version", "", "Kubernetes resource Version. (e.g v1alpha1)")
+	fs.StringVar(&p.Kind, "kind", "",
+		"Kubernetes resource Kind name. (e.g AppService)")
+	fs.StringVar(&p.CRDVersion, "crd-version", gencrd.DefaultCRDVersion,
+		"CRD version to generate")
+	fs.StringVar(&p.HelmChartRef, "helm-chart", "",
+		"Initialize helm operator with existing helm chart (<URL>, <repo>/<name>, or local path).")
+	fs.StringVar(&p.HelmChartVersion, "helm-chart-version", "",
+		"Specific version of the helm chart (default is latest version)")
+	fs.StringVar(&p.HelmChartRepo, "helm-chart-repo", "",
+		"Chart repository URL for the requested helm chart")
+
+	// The domain flag is added hidden because now is not mandatory have the PROJECT file with this information
+	fs.StringVar(&p.Domain, "domain", "", "Kubernetes domain for groups. (e.g example.com)")
+	_ = fs.MarkHidden("domain")
+}
+
+func (p *createAPIPlugin) InjectConfig(c *config.Config) {
+	c.Layout = plugin.KeyFor(Plugin{})
+	p.config = c
+}
+
+func (p *createAPIPlugin) Run() error {
+	return cmdutil.Run(p)
+}
+
+func (p *createAPIPlugin) Validate() error {
+	// Check if the project name is a valid namespace according to k8s
+	dir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("error to get the current path: %v", err)
+	}
+	projectName := filepath.Base(dir)
+
+	if err := validation.IsDNS1123Label(strings.ToLower(projectName)); err != nil {
+		return fmt.Errorf("project name (%s) is invalid: %v", projectName, err)
+	}
+
+	if len(p.HelmChartRef) == 0 {
+		if len(p.HelmChartRepo) != 0 {
+			return fmt.Errorf("value of --helm-chart-repo can only be used with --helm-chart")
+		} else if len(p.HelmChartVersion) != 0 {
+			return fmt.Errorf("value of --helm-chart-version can only be used with --helm-chart")
+		}
+	}
+
+	// Until we support the legacy layout the PROJECT file is not mandatory
+	if hasPluginConfig(p.config) && len(p.config.Domain) > 0 {
+		p.Domain = p.config.Domain
+	}
+
+	if len(p.HelmChartRef) == 0 {
+		if len(p.Domain) == 0 { // the domain from config was set here for the new layout
+			return fmt.Errorf("value of --domain must not have empty value")
+		}
+		if len(p.Group) == 0 {
+			return fmt.Errorf("value of --group must not have empty value")
+		}
+		if len(p.Version) == 0 {
+			return fmt.Errorf("value of --version must not have empty value")
+		}
+		if len(p.Kind) == 0 {
+			return fmt.Errorf("value of --kind must not have empty value")
+		}
+		// To validate the resource
+		_, err := sdkscaffold.NewResource(path.Join(p.Group+"."+p.Domain, p.Version), p.Kind)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *createAPIPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
+	// Check if the project name is a valid namespace according to k8s
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("error to get the current path: %v", err)
+	}
+
+	cfg := input.Config{
+		AbsProjectPath: filepath.Join(projutil.MustGetwd()),
+		ProjectName:    filepath.Base(dir),
+	}
+
+	createOpts := helm.CreateChartOptions{
+		ResourceAPIVersion: fmt.Sprintf("%s.%s/%s", p.Domain, p.Group, p.Version),
+		ResourceKind:       p.Kind,
+		Chart:              p.HelmChartRef,
+		Version:            p.HelmChartVersion,
+		Repo:               p.HelmChartRepo,
+		CRDVersion:         p.CRDVersion,
+	}
+
+	if err := helm.API(cfg, createOpts); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (p *createAPIPlugin) PostScaffold() error {
+	return nil
+}

--- a/internal/plugins/helm/config.go
+++ b/internal/plugins/helm/config.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import "sigs.k8s.io/kubebuilder/pkg/model/config"
+
+type Config struct{}
+
+func hasPluginConfig(cfg *config.Config) bool {
+	if len(cfg.Plugins) == 0 {
+		return false
+	}
+	_, hasKey := cfg.Plugins[pluginConfigKey]
+	return hasKey
+}

--- a/internal/plugins/helm/internal/cmdutil.go
+++ b/internal/plugins/helm/internal/cmdutil.go
@@ -1,0 +1,62 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// todo: check if we can use it directly from kb or if we need to have our own
+// it is the same implementation of kubebuilder/internal/cmdutil
+package cmdutil
+
+import (
+	"sigs.k8s.io/kubebuilder/pkg/scaffold"
+)
+
+// RunOptions represent the types used to implement the different commands
+type RunOptions interface {
+	// - Step 1: verify that the command can be run (e.g., go version, project version, arguments, ...)
+	Validate() error
+	// - Step 2: create the Scaffolder instance
+	// todo: check if we will use the scaffold.Scaffolder or have our own in the future
+	GetScaffolder() (scaffold.Scaffolder, error)
+	// - Step 3: call the Scaffold method of the Scaffolder instance. Doesn't need any method
+	// - Step 4: finish the command execution
+	PostScaffold() error
+}
+
+// Run executes a command
+func Run(options RunOptions) error {
+	// Step 1: validate
+	if err := options.Validate(); err != nil {
+		return err
+	}
+
+	// Step 2: get scaffolder
+	scaffolder, err := options.GetScaffolder()
+	if err != nil {
+		return err
+	}
+	// Step 3: scaffold
+	// for the helm plugin the scaffolder for now has not been returned
+	// it might change after we replace model and business layers for the new layout
+	if scaffolder != nil {
+		if err := scaffolder.Scaffold(); err != nil {
+			return err
+		}
+	}
+
+	// Step 4: finish
+	if err := options.PostScaffold(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/plugins/helm/plugin.go
+++ b/internal/plugins/helm/plugin.go
@@ -1,0 +1,42 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helm
+
+import (
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
+	"sigs.k8s.io/kubebuilder/pkg/plugin"
+)
+
+const pluginName = "helm" + plugin.DefaultNameQualifier
+
+var (
+	supportedProjectVersions = []string{config.Version3Alpha}
+	pluginVersion            = plugin.Version{Number: 1, Stage: plugin.AlphaStage}
+	pluginConfigKey          = plugin.Key(pluginName, pluginVersion.String())
+)
+
+var (
+	_ plugin.Base                  = Plugin{}
+	_ plugin.CreateAPIPluginGetter = Plugin{}
+)
+
+type Plugin struct {
+	createAPIPlugin
+}
+
+func (Plugin) Name() string                           { return pluginName }
+func (Plugin) Version() plugin.Version                { return pluginVersion }
+func (Plugin) SupportedProjectVersions() []string     { return supportedProjectVersions }
+func (p Plugin) GetCreateAPIPlugin() plugin.CreateAPI { return &p.createAPIPlugin }


### PR DESCRIPTION
**Description**
Call the plugin to execute the sdk command. 

**Steps to check it locally**
- Run `operator-sdk add api --api-version=cache.example.com/v1alpha1 --kind=Memcached` in a Helm project. It should create the API. 

/hold
Blocked by: https://github.com/operator-framework/operator-sdk/pull/3229
