### PR TITLE
deprecate git-init flag

### DIFF
--- a/changelog/fragments/gitnit.yaml
+++ b/changelog/fragments/gitnit.yaml
@@ -1,0 +1,13 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      The flag `--git-init` in the `new` command was deprecated.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "deprecation"

--- a/cmd/operator-sdk/new/cmd.go
+++ b/cmd/operator-sdk/new/cmd.go
@@ -97,8 +97,16 @@ generates a default directory layout based on the input <project-name>.
 	if err := newCmd.MarkFlagRequired("type"); err != nil {
 		log.Fatalf("Failed to mark `type` flag for `new` subcommand as required")
 	}
+
+	// todo(camilamacedo86): remove before 1.0.0
 	newCmd.Flags().BoolVar(&gitInit, "git-init", false,
 		"Initialize the project directory as a git repository (default false)")
+	err := newCmd.Flags().MarkDeprecated("git-init",
+		"instead run `git init` once your project is created to use git")
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	newCmd.Flags().BoolVar(&generatePlaybook, "generate-playbook", false,
 		"Generate a playbook skeleton. (Only used for --type ansible)")
 
@@ -162,7 +170,7 @@ func newFunc(cmd *cobra.Command, args []string) error {
 			log.Fatal(err)
 		}
 	}
-
+	//todo: remove before 1.0.0
 	if gitInit {
 		if err := initGit(); err != nil {
 			log.Fatal(err)
@@ -309,12 +317,18 @@ func verifyFlags() error {
 	return nil
 }
 
+// todo(camilamacedo86): remove before 1.0.0
+// Deprecated: the git-init flag was deprecated since has no need to make the command run the git init.
+// users are allowed to easily do that when they wish. This func is just used here to run the git-init
 func execProjCmd(cmd string, args ...string) error {
 	dc := exec.Command(cmd, args...)
 	dc.Dir = filepath.Join(projutil.MustGetwd(), projectName)
 	return projutil.ExecCmd(dc)
 }
 
+// todo(camilamacedo86): remove before 1.0.0
+// Deprecated: the git-init flag was deprecated since has no need to make the command run the git init.
+// users are allowed to easily do that when they wish.
 func initGit() error {
 	log.Info("Running git init")
 	if err := execProjCmd("git", "init"); err != nil {

--- a/website/content/en/docs/cli/operator-sdk_new.md
+++ b/website/content/en/docs/cli/operator-sdk_new.md
@@ -69,7 +69,6 @@ operator-sdk new <project-name> [flags]
       --api-version string          Kubernetes apiVersion and has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)
       --crd-version string          CRD version to generate (default "v1")
       --generate-playbook           Generate a playbook skeleton. (Only used for --type ansible)
-      --git-init                    Initialize the project directory as a git repository (default false)
       --helm-chart string           Initialize helm operator with existing helm chart (<URL>, <repo>/<name>, or local path). Valid only for --type helm
       --helm-chart-repo string      Chart repository URL for the requested helm chart, Valid only for --type helm
       --helm-chart-version string   Specific version of the helm chart (default is latest version). Valid only for --type helm

--- a/website/content/en/docs/new-cli/operator-sdk_new.md
+++ b/website/content/en/docs/new-cli/operator-sdk_new.md
@@ -69,7 +69,6 @@ operator-sdk new <project-name> [flags]
       --api-version string          Kubernetes apiVersion and has a format of $GROUP_NAME/$VERSION (e.g app.example.com/v1alpha1)
       --crd-version string          CRD version to generate (default "v1")
       --generate-playbook           Generate a playbook skeleton. (Only used for --type ansible)
-      --git-init                    Initialize the project directory as a git repository (default false)
       --helm-chart string           Initialize helm operator with existing helm chart (<URL>, <repo>/<name>, or local path). Valid only for --type helm
       --helm-chart-repo string      Chart repository URL for the requested helm chart, Valid only for --type helm
       --helm-chart-version string   Specific version of the helm chart (default is latest version). Valid only for --type helm


### PR DESCRIPTION
**Description of the change:**
deprecate git-init flag in the new cmd 

**Motivation for the change:**
Has no need for we have a flag for it. Users are able to run git init when they wish. 