### PR TITLE
docs: section about dropped openapi option

### DIFF
--- a/website/content/en/docs/faq.md
+++ b/website/content/en/docs/faq.md
@@ -142,7 +142,7 @@ $ export GOROOT=$(go env GOROOT)
 
 This will work for the current environment. To persist this fix, add the above line to your environment's config file, ex. `bashrc` file.
 
-# I cannot use the command `operator-sdk generate openapi`
+## I cannot use the command `operator-sdk generate openapi`
 The command `operator-sdk generate openapi` was removed from the SDK tool in the version `v0.17.0`. It is now recommended to use [openapi-gen][openapi-gen] directly for OpenAPI code generation. 
 
 Note that the file `./hack/boilerplate.go.txt` is used to allow add the LICENCE comment on the top of the documents and then, it can be removed.

--- a/website/content/en/docs/faq.md
+++ b/website/content/en/docs/faq.md
@@ -154,5 +154,4 @@ A decision was made to extract this tool outside of operator-sdk in version v0.1
 [client.Reader]:https://godoc.org/sigs.k8s.io/controller-runtime/pkg/client#Reader
 [rbac]:https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 [goroot-github-issue]:https://github.com/operator-framework/operator-sdk/issues/1854#issuecomment-525132306
-[version_17x]: /docs/migration/version-upgrade-guide/#v017x
-
+[openapi-gen]: https://github.com/kubernetes/kube-openapi/tree/master/cmd/openapi-gen

--- a/website/content/en/docs/faq.md
+++ b/website/content/en/docs/faq.md
@@ -142,6 +142,10 @@ $ export GOROOT=$(go env GOROOT)
 
 This will work for the current environment. To persist this fix, add the above line to your environment's config file, ex. `bashrc` file.
 
+# I cannot use the command `operator-sdk generate openapi`
+A decision was made to extract this tool outside of operator-sdk in version v0.17, see migration guide on for that version [here][version_17x] and you should know that file file `./hack/boilerplate.go.txt` is for adding a LICENCE file to the top of documents, and can be removed
+
+
 [kube-apiserver_options]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/#options
 [controller-runtime_faq]: https://github.com/kubernetes-sigs/controller-runtime/blob/master/FAQ.md#q-how-do-i-have-different-logic-in-my-reconciler-for-different-types-of-events-eg-create-update-delete
 [finalizer]: /docs/golang/quickstart/#handle-cleanup-on-deletion
@@ -150,3 +154,5 @@ This will work for the current environment. To persist this fix, add the above l
 [client.Reader]:https://godoc.org/sigs.k8s.io/controller-runtime/pkg/client#Reader
 [rbac]:https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 [goroot-github-issue]:https://github.com/operator-framework/operator-sdk/issues/1854#issuecomment-525132306
+[version_17x]: /docs/migration/version-upgrade-guide/#v017x
+

--- a/website/content/en/docs/faq.md
+++ b/website/content/en/docs/faq.md
@@ -145,7 +145,7 @@ This will work for the current environment. To persist this fix, add the above l
 ## I cannot use the command `operator-sdk generate openapi`
 The command `operator-sdk generate openapi` was removed from the SDK tool in the version `v0.17.0`. It is now recommended to use [openapi-gen][openapi-gen] directly for OpenAPI code generation. 
 
-Note that the file `./hack/boilerplate.go.txt` is used to allow add the LICENCE comment on the top of the documents and then, it can be removed.
+Note that in the example on the docs, the flag `-h ./hack/boilerplate.go.txt` is used to allow add the LICENCE comment on the top of the documents and then, it can be removed.
 
 
 [kube-apiserver_options]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/#options

--- a/website/content/en/docs/faq.md
+++ b/website/content/en/docs/faq.md
@@ -143,7 +143,9 @@ $ export GOROOT=$(go env GOROOT)
 This will work for the current environment. To persist this fix, add the above line to your environment's config file, ex. `bashrc` file.
 
 # I cannot use the command `operator-sdk generate openapi`
-A decision was made to extract this tool outside of operator-sdk in version v0.17, see migration guide on for that version [here][version_17x] and you should know that file file `./hack/boilerplate.go.txt` is for adding a LICENCE file to the top of documents, and can be removed
+The command `operator-sdk generate openapi` was removed from the SDK tool in the version `v0.17.0`. It is now recommended to use [openapi-gen][openapi-gen] directly for OpenAPI code generation. 
+
+Note that the file `./hack/boilerplate.go.txt` is used to allow add the LICENCE comment on the top of the documents and then, it can be removed.
 
 
 [kube-apiserver_options]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/#options

--- a/website/content/en/docs/faq.md
+++ b/website/content/en/docs/faq.md
@@ -142,8 +142,8 @@ $ export GOROOT=$(go env GOROOT)
 
 This will work for the current environment. To persist this fix, add the above line to your environment's config file, ex. `bashrc` file.
 
-## I cannot use the command `operator-sdk generate openapi`
-The command `operator-sdk generate openapi` was removed from the SDK tool in the version `v0.17.0`. It is now recommended to use [openapi-gen][openapi-gen] directly for OpenAPI code generation. 
+## How do I generate OpenAPI Go source files for my APIs?
+It is recommended to use [openapi-gen][openapi-gen] for OpenAPI code generation.
 
 Note that in the example on the docs, the flag `-h ./hack/boilerplate.go.txt` is used to allow add the LICENCE comment on the top of the documents and then, it can be removed.
 


### PR DESCRIPTION
Because `operator-sdk generate openapi` has been dropped, it is good to add here a section on how to work with openapi from now on

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

[x] Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
[x] Rebase your branch on the latest upstream master
[] Add a changelog file by copying changelog/fragments/00-template.yaml 
[] Link any relevant issues, PR's, or documentation
[x] When fixing an issue, add "Closes #<ISSUE_NUMBER>"

-->

**Description of the change:**


**Motivation for the change:**
