### PR TITLE
remove deprecated flags

### DIFF
--- a/changelog/fragments/remove-ns-deprecated-flag.yaml
+++ b/changelog/fragments/remove-ns-deprecated-flag.yaml
@@ -1,0 +1,34 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      The `--namespace` flag from `operator-sdk run --local`, `operator-sdk test --local` and `operator-sdk cleanup` command was removed. Use `--watch-namespace` and `--operator-namespace`  instead of. Also, the method `ctx.GetNamespace()` from the `pkg/test` was removed. Use `ctx.GetOperatorNamespace()` and `ctx.GetWatchNamespace()` instead of.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "removal"
+
+    # Is this a breaking change?
+    breaking: true
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: Replace of `ctx.GetNamespace()`
+      body: >
+        The method `ctx.GetNamespace()` from the `pkg/test` was removed. Use `ctx.GetOperatorNamespace()` and `ctx.GetWatchNamespace()` instead of.
+

--- a/cmd/operator-sdk/cleanup/cmd.go
+++ b/cmd/operator-sdk/cleanup/cmd.go
@@ -30,9 +30,6 @@ import (
 type cleanupCmd struct {
 	// Common options.
 	kubeconfig string
-	// TODO: remove --namespace and c.namespace
-	//Deprecated: use olmArgs.OperatorNamespace instead
-	namespace string
 
 	// Cleanup type.
 	olm bool
@@ -63,16 +60,6 @@ func NewCmd() *cobra.Command {
 			switch {
 			case c.olm:
 				c.olmArgs.KubeconfigPath = c.kubeconfig
-				//TODO: remove --namespace and c.namespace
-				//use olmArgs.OperatorNamespace directly
-				if cmd.Flags().Changed("namespace") {
-					log.Warn("--namespace is deprecates use --operator-namespace instead")
-					if !cmd.Flags().Changed("operator-namespace") {
-						c.olmArgs.OperatorNamespace = c.namespace
-					} else {
-						log.Warn("--operator-namespace present; ignoring --namespace")
-					}
-				}
 				if c.olmArgs.ManifestsDir == "" {
 					operatorName := filepath.Base(projutil.MustGetwd())
 					c.olmArgs.ManifestsDir = filepath.Join(olmcatalog.OLMCatalogDir, operatorName)
@@ -90,12 +77,6 @@ func NewCmd() *cobra.Command {
 		"The file path to kubernetes configuration file. Defaults to location "+
 			"specified by $KUBECONFIG, or to default file rules if not set")
 	err := cmd.Flags().MarkDeprecated("kubeconfig", "use this flag with 'cleanup packagemanifests' instead")
-	if err != nil {
-		panic(err)
-	}
-	cmd.Flags().StringVar(&c.namespace, "namespace", "",
-		"The namespace from which operator and namespaces resources are cleaned up")
-	err = cmd.Flags().MarkDeprecated("namespace", "use --operator-namespace instead")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/operator-sdk/run/cmd.go
+++ b/cmd/operator-sdk/run/cmd.go
@@ -37,9 +37,6 @@ import (
 type runCmd struct {
 	// Common options.
 	kubeconfig string
-	//TODO: remove namespace flag before 1.0.0
-	//namespace is deprecated
-	namespace string
 
 	// Run type.
 	olm, local bool
@@ -97,16 +94,6 @@ information on these subcommands.
 				// env var to configure the namespace that the operator watches. The default is all namespaces.
 				// So this flag is unsupported for the new layout.
 				if !kbutil.HasProjectFile() {
-					//TODO: remove namespace flag before 1.0.0
-					// set --watch-namespace flag if the --namespace flag is set
-					// (only if --watch-namespace flag is not set)
-					if cmd.Flags().Changed("namespace") { // not valid for te new layout
-						log.Info("--namespace is deprecated; use --watch-namespace instead.")
-						if !cmd.Flags().Changed("watch-namespace") {
-							err := cmd.Flags().Set("watch-namespace", c.namespace)
-							return err
-						}
-					}
 					// Get default namespace to watch if unset.
 					if !cmd.Flags().Changed("watch-namespace") {
 						_, defaultNamespace, err := k8sinternal.GetKubeconfigAndNamespace(c.kubeconfig)
@@ -134,17 +121,6 @@ information on these subcommands.
 		"use --kubeconfig with 'local' or 'packagemanifests' subcommands instead")
 	if err != nil {
 		panic(err)
-	}
-	// Deprecated: namespace exists for historical compatibility. Use watch-namespace instead.
-	//TODO: remove namespace flag before 1.0.0
-	if !kbutil.HasProjectFile() { // not show for the kb layout projects
-		cmd.Flags().StringVar(&c.namespace, "namespace", "",
-			"The namespace in which operator and namespaces resources are run")
-		err := cmd.Flags().MarkDeprecated("namespace", "use --watch-namespaces (with --local) "+
-			"or --operator-namespace (with --olm) instead")
-		if err != nil {
-			panic(err)
-		}
 	}
 
 	// 'run --olm' and related flags.

--- a/cmd/operator-sdk/test/local.go
+++ b/cmd/operator-sdk/test/local.go
@@ -43,14 +43,11 @@ import (
 var deployTestDir = filepath.Join(scaffold.DeployDir, "test")
 
 type testLocalConfig struct {
-	kubeconfig        string
-	globalManPath     string
-	namespacedManPath string
-	goTestFlags       string
-	moleculeTestFlags string
-	// TODO: remove before 1.0.0
-	// Namespace is deprecated
-	namespace          string
+	kubeconfig         string
+	globalManPath      string
+	namespacedManPath  string
+	goTestFlags        string
+	moleculeTestFlags  string
 	operatorNamespace  string
 	watchNamespace     string
 	image              string
@@ -78,9 +75,6 @@ func newTestLocalCmd() *cobra.Command {
 		"Additional flags to pass to go test")
 	testCmd.Flags().StringVar(&tlConfig.moleculeTestFlags, "molecule-test-flags", "",
 		"Additional flags to pass to molecule test")
-	// TODO: remove before 1.0.0. Namespace is deprecated
-	testCmd.Flags().StringVar(&tlConfig.namespace, "namespace", "",
-		"(Deprecated: use --operator-namespace instead) If non-empty, single namespace to run tests in")
 	testCmd.Flags().StringVar(&tlConfig.operatorNamespace, "operator-namespace", "",
 		"Namespace where the operator will be deployed, CRs will be created and tests will be executed "+
 			"(By default it will be in the default namespace defined in the kubeconfig)")
@@ -104,16 +98,6 @@ func newTestLocalCmd() *cobra.Command {
 }
 
 func testLocalFunc(cmd *cobra.Command, args []string) error {
-	//TODO: remove before 1.0.0
-	// set --operator-namespace flag if the --namespace flag is set
-	// (only if --operator-namespace flag is not set)
-	if cmd.Flags().Changed("namespace") {
-		log.Info("--namespace is deprecated; use --operator-namespace instead.")
-		if !cmd.Flags().Changed("operator-namespace") {
-			err := cmd.Flags().Set("operator-namespace", tlConfig.namespace)
-			return err
-		}
-	}
 	switch t := projutil.GetOperatorType(); t {
 	case projutil.OperatorTypeGo:
 		return testLocalGoFunc(cmd, args)

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -26,12 +26,8 @@ import (
 )
 
 type Context struct {
-	id         string
-	cleanupFns []cleanupFn
-	// the  namespace is deprecated
-	// todo: remove before 1.0.0
-	// use operatorNamespace or watchNamespace  instead
-	namespace         string
+	id                string
+	cleanupFns        []cleanupFn
 	operatorNamespace string
 	watchNamespace    string
 	t                 *testing.T
@@ -77,7 +73,6 @@ func (f *Framework) newContext(t *testing.T) *Context {
 	return &Context{
 		id:                 id,
 		t:                  t,
-		namespace:          operatorNamespace,
 		operatorNamespace:  operatorNamespace,
 		watchNamespace:     watchNamespace,
 		namespacedManPath:  *f.NamespacedManPath,

--- a/pkg/test/resource_creator.go
+++ b/pkg/test/resource_creator.go
@@ -33,15 +33,6 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
 )
 
-// TODO: remove before 1.0.0
-// Deprecated: GetNamespace() exists for historical compatibility.
-// Use GetOperatorNamespace() or GetWatchNamespace() instead
-func (ctx *Context) GetNamespace() (string, error) {
-	var err error
-	ctx.namespace, err = ctx.getNamespace(ctx.namespace)
-	return ctx.namespace, err
-}
-
 // GetOperatorNamespace will return an Operator Namespace,
 // if the flag --operator-namespace  not be used (TestOpeatorNamespaceEnv not set)
 // then it will create a new namespace with randon name and return that namespace

--- a/website/content/en/docs/cli/operator-sdk_test_local.md
+++ b/website/content/en/docs/cli/operator-sdk_test_local.md
@@ -24,7 +24,6 @@ operator-sdk test local <path to tests directory> [flags]
       --kubeconfig string             Kubeconfig path
       --local-operator-flags string   The flags that the operator needs (while using --up-local). Example: "--flag1 value1 --flag2=value2"
       --molecule-test-flags string    Additional flags to pass to molecule test
-      --namespace string              (Deprecated: use --operator-namespace instead) If non-empty, single namespace to run tests in
       --namespaced-manifest string    Path to manifest for per-test, namespaced resources (e.g. RBAC and Operator manifest)
       --no-setup                      Disable test resource creation
       --operator-namespace string     Namespace where the operator will be deployed, CRs will be created and tests will be executed (By default it will be in the default namespace defined in the kubeconfig)


### PR DESCRIPTION
**Description of the change:**

The `--namespace` flag from `operator-sdk run --local`, `operator-sdk test --local` and `operator-sdk cleanup` command was removed. Use `--watch-namespace` and `--operator-namespace`  instead of. Also, the method `ctx.GetNamespace()` from the `pkg/test` was removed. Use `ctx.GetOperatorNamespace()` and `ctx.GetWatchNamespace()` instead of.

**Motivation for the change:**
Clean the code in order to make things easier. 