### PR TITLE
add unit tests for cmd/bundle

### DIFF
--- a/cmd/operator-sdk/bundle/bundle_suite_test.go
+++ b/cmd/operator-sdk/bundle/bundle_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBundle(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Bundle Suite")
+}

--- a/cmd/operator-sdk/bundle/cmd_test.go
+++ b/cmd/operator-sdk/bundle/cmd_test.go
@@ -1,0 +1,45 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Running a bundle command", func() {
+	Describe("NewCmd", func() {
+		It("builds and returns a cobra command with the correct subcommand", func() {
+			cmd := NewCmd()
+			Expect(cmd).NotTo(BeNil())
+
+			subcommands := cmd.Commands()
+			Expect(len(subcommands)).To(Equal(1))
+			Expect(subcommands[0].Use).To(Equal("validate"))
+		})
+	})
+
+	Describe("NewCmdLegacy", func() {
+		It("builds and returns a cobra command with the correct subcommands", func() {
+			cmd := NewCmdLegacy()
+			Expect(cmd).NotTo(BeNil())
+
+			subcommands := cmd.Commands()
+			Expect(len(subcommands)).To(Equal(2))
+			Expect(subcommands[0].Use).To(Equal("create"))
+			Expect(subcommands[1].Use).To(Equal("validate"))
+		})
+	})
+})

--- a/cmd/operator-sdk/bundle/create_test.go
+++ b/cmd/operator-sdk/bundle/create_test.go
@@ -1,0 +1,145 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Checking operator-sdk bundle create command", func() {
+	Describe("newCreateCmd", func() {
+		It("builds and returns a cobra command", func() {
+			cmd := newCreateCmd()
+			Expect(cmd).NotTo(BeNil())
+
+			flag := cmd.Flags().Lookup("directory")
+			Expect(flag).NotTo(BeNil())
+			Expect(flag.Shorthand).To(Equal("d"))
+
+			flag = cmd.Flags().Lookup("output-dir")
+			Expect(flag).NotTo(BeNil())
+
+			flag = cmd.Flags().Lookup("tag")
+			Expect(flag).NotTo(BeNil())
+			Expect(flag.Shorthand).To(Equal("t"))
+
+			flag = cmd.Flags().Lookup("package")
+			Expect(flag).NotTo(BeNil())
+
+			flag = cmd.Flags().Lookup("channels")
+			Expect(flag).NotTo(BeNil())
+			Expect(flag.Shorthand).To(Equal("c"))
+			Expect(flag.DefValue).To(Equal("stable"))
+
+			flag = cmd.Flags().Lookup("generate-only")
+			Expect(flag).NotTo(BeNil())
+			Expect(flag.DefValue).To(Equal("false"))
+
+			flag = cmd.Flags().Lookup("overwrite")
+			Expect(flag).NotTo(BeNil())
+			Expect(flag.DefValue).To(Equal("false"))
+
+			flag = cmd.Flags().Lookup("image-builder")
+			Expect(flag).NotTo(BeNil())
+			Expect(flag.Shorthand).To(Equal("b"))
+			Expect(flag.DefValue).To(Equal("docker"))
+
+			flag = cmd.Flags().Lookup("default-channel")
+			Expect(flag).NotTo(BeNil())
+			Expect(flag.Shorthand).To(Equal("e"))
+		})
+	})
+
+	Describe("validate", func() {
+		var cmd bundleCreateCmd
+		BeforeEach(func() {
+			cmd = bundleCreateCmd{}
+		})
+
+		It("fails if directory is not set", func() {
+			err := cmd.validate([]string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--directory must be set"))
+		})
+
+		It("fails if package is not set", func() {
+			cmd.directory = "apple"
+
+			err := cmd.validate([]string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--package must be set"))
+		})
+
+		It("fails if default channel is not set", func() {
+			cmd.directory = "banana"
+			cmd.packageName = "cherry"
+
+			err := cmd.validate([]string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("--default-channel must be set"))
+		})
+
+		It("fails if GenerateOnly is false but a bundle image tag is not provided", func() {
+			cmd.directory = "durian"
+			cmd.packageName = "elderberry"
+			cmd.defaultChannel = "fig"
+
+			err := cmd.validate([]string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("a bundle image tag is a required argument if --generate-only=true"))
+		})
+
+		It("fails if GenerateOnly is false and more than one arg is provided", func() {
+			cmd.directory = "grapefruit"
+			cmd.packageName = "honeydew"
+			cmd.defaultChannel = "imbe"
+
+			err := cmd.validate([]string{"aaa", "bbb"})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("a bundle image tag is a required argument if --generate-only=true"))
+		})
+
+		It("succeeds if GenerateOnly is false and a bundle image tag is provided", func() {
+			cmd.directory = "jackfruit"
+			cmd.packageName = "kiwi"
+			cmd.defaultChannel = "lime"
+
+			err := cmd.validate([]string{"aaa"})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("fails if GenerateOnly is true and any args are provided", func() {
+			cmd.directory = "mango"
+			cmd.packageName = "	nectarine"
+			cmd.defaultChannel = "orange"
+			cmd.generateOnly = true
+
+			err := cmd.validate([]string{"aaa"})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("the command does not accept any arguments if --generate-only=true"))
+		})
+
+		It("succeeds if GenerateOnly is true and no args are provided", func() {
+			cmd.directory = "pineapple"
+			cmd.packageName = "quince"
+			cmd.defaultChannel = "raspberry"
+			cmd.generateOnly = true
+
+			err := cmd.validate([]string{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/cmd/operator-sdk/bundle/validate.go
+++ b/cmd/operator-sdk/bundle/validate.go
@@ -126,7 +126,9 @@ func (c bundleValidateCmd) validate(args []string) error {
 	}
 	if c.outputFormat != internal.JSONAlpha1 && c.outputFormat != internal.Text {
 		return fmt.Errorf("invalid value for output flag: %v", c.outputFormat)
+
 	}
+
 	return nil
 }
 

--- a/cmd/operator-sdk/bundle/validate_test.go
+++ b/cmd/operator-sdk/bundle/validate_test.go
@@ -1,0 +1,76 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/bundle/internal"
+)
+
+var _ = Describe("Running a bundle validate command", func() {
+	Describe("newValidateCmd", func() {
+		It("builds and returns a cobra command", func() {
+			cmd := newValidateCmd()
+			Expect(cmd).NotTo(BeNil())
+
+			flag := cmd.Flags().Lookup("image-builder")
+			Expect(flag).NotTo(BeNil())
+			Expect(flag.Shorthand).To(Equal("b"))
+			Expect(flag.DefValue).To(Equal("docker"))
+
+			flag = cmd.Flags().Lookup("output")
+			Expect(flag).NotTo(BeNil())
+			Expect(flag.Shorthand).To(Equal("o"))
+			Expect(flag.DefValue).To(Equal(internal.Text))
+		})
+	})
+
+	Describe("validate", func() {
+		var cmd bundleValidateCmd
+		BeforeEach(func() {
+			cmd = bundleValidateCmd{}
+		})
+
+		It("fails with no args", func() {
+			err := cmd.validate([]string{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("an image tag or directory is a required argument"))
+		})
+		It("fails with more than one arg", func() {
+			err := cmd.validate([]string{"a", "b"})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("an image tag or directory is a required argument"))
+		})
+
+		It("fails if the output format isnt text or json-alpha1", func() {
+			wrongArg := "json-alpha2"
+			cmd.outputFormat = wrongArg
+			err := cmd.validate([]string{"quay.io/person/example"})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("invalid value for output flag: " + wrongArg))
+		})
+
+		It("succeeds if the arg is text or json-alpha1", func() {
+			cmd.outputFormat = "text"
+			err := cmd.validate([]string{"quay.io/person/example"})
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd.outputFormat = "json-alpha1"
+			err = cmd.validate([]string{"quay.io/person/example"})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
**Description of the change:**
Add unit tests for the `bundle validate` and `bundle create` commands.

**Motivation for the change:**
Golang unit tests are another layer of robust CI when paired with the e2e and script testing we currently have.