### PR TITLE
website: Fix misspelled 'PodDsruptionBudget' in the operator capabilities documentation.

### DIFF
--- a/website/content/en/docs/operator-capabilities.md
+++ b/website/content/en/docs/operator-capabilities.md
@@ -134,7 +134,7 @@ It should be possible to backup and restore the operand from the operator itself
 
 8. Does your operand use a rolling deployment strategy?
 
-9. Does your operator create a PodDsruptionBudget resource for your operand pods?
+9. Does your operator create a PodDisruptionBudget resource for your operand pods?
 
 10. Does your operand have CPU requests and limits set?
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Add a changelog file by copying changelog/fragments/00-template.yaml 
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"

-->

**Description of the change:**


**Motivation for the change:**
