### PR TITLE
cli (new): add `run packagemanifests`

### DIFF
--- a/cmd/operator-sdk/cli/cli.go
+++ b/cmd/operator-sdk/cli/cli.go
@@ -22,6 +22,7 @@ import (
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/generate"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/new"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/olm"
+	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/run"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/version"
 	"github.com/operator-framework/operator-sdk/internal/flags"
 	golangv2 "github.com/operator-framework/operator-sdk/internal/plugins/golang/v2"
@@ -46,8 +47,7 @@ var commands = []*cobra.Command{
 	completion.NewCmd(),
 	generate.NewCmd(),
 	olm.NewCmd(),
-	// Add back when implemented for new project layouts.
-	// run.NewCmd(),
+	run.NewCmd(),
 	version.NewCmd(),
 }
 

--- a/cmd/operator-sdk/cli/legacy.go
+++ b/cmd/operator-sdk/cli/legacy.go
@@ -82,7 +82,7 @@ func GetCLIRoot() *cobra.Command {
 		new.NewCmd(),
 		olm.NewCmd(),
 		printdeps.NewCmd(),
-		run.NewCmd(),
+		run.NewCmdLegacy(),
 		scorecard.NewCmd(),
 		test.NewCmd(),
 		version.NewCmd(),

--- a/cmd/operator-sdk/run/cmd.go
+++ b/cmd/operator-sdk/run/cmd.go
@@ -34,6 +34,23 @@ import (
 	hoflags "github.com/operator-framework/operator-sdk/pkg/helm/flags"
 )
 
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run an Operator in a variety of environments",
+		Long: `This command has subcommands that will deploy your Operator with OLM.
+Currently only the package manifests format is supported via the 'packagemanifests' subcommand.
+Run 'operator-sdk run --help' for more information.
+`,
+	}
+
+	cmd.AddCommand(
+		packagemanifests.NewCmd(),
+	)
+
+	return cmd
+}
+
 type runCmd struct {
 	// Common options.
 	kubeconfig string
@@ -57,7 +74,7 @@ func (c *runCmd) checkRunType() error {
 	return nil
 }
 
-func NewCmd() *cobra.Command {
+func NewCmdLegacy() *cobra.Command {
 	c := &runCmd{}
 	cmd := &cobra.Command{
 		Use:   "run",

--- a/cmd/operator-sdk/run/packagemanifests/packagemanifests.go
+++ b/cmd/operator-sdk/run/packagemanifests/packagemanifests.go
@@ -23,6 +23,7 @@ import (
 
 	olmcatalog "github.com/operator-framework/operator-sdk/internal/generate/olm-catalog"
 	olmoperator "github.com/operator-framework/operator-sdk/internal/olm/operator"
+	kbutil "github.com/operator-framework/operator-sdk/internal/util/kubebuilder"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 )
 
@@ -35,7 +36,9 @@ func NewCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "packagemanifests",
-		Short: "Run an Operator organized in the package manifests format with OLM",
+		Short: "Deploy an Operator in the package manifests format with OLM",
+		Long: `'run packagemanifests' deploys an Operator's package manifests with OLM. The command's argument
+must be set to a valid package manifests root directory, ex. '<project-root>/packagemanifests'.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				if len(args) > 1 {
@@ -43,8 +46,13 @@ func NewCmd() *cobra.Command {
 				}
 				c.ManifestsDir = args[0]
 			} else {
-				operatorName := filepath.Base(projutil.MustGetwd())
-				c.ManifestsDir = filepath.Join(olmcatalog.OLMCatalogDir, operatorName)
+				// Choose the default path depending on project configuration.
+				if kbutil.HasProjectFile() {
+					c.ManifestsDir = "packagemanifests"
+				} else {
+					operatorName := filepath.Base(projutil.MustGetwd())
+					c.ManifestsDir = filepath.Join(olmcatalog.OLMCatalogDir, operatorName)
+				}
 			}
 
 			log.Infof("Running operator from directory %s", c.ManifestsDir)

--- a/internal/olm/operator/packagemanifests.go
+++ b/internal/olm/operator/packagemanifests.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/spf13/pflag"
 )
@@ -61,9 +62,18 @@ func (c *PackageManifestsCmd) validate() error {
 	if c.ManifestsDir == "" {
 		return errors.New("manifests dir must be set")
 	}
+	manDirInfo, err := os.Stat(c.ManifestsDir)
+	if err != nil {
+		return err
+	}
+	if !manDirInfo.IsDir() {
+		return fmt.Errorf("%s must be a directory", c.ManifestsDir)
+	}
+
 	if c.OperatorVersion == "" {
 		return errors.New("operator version must be set")
 	}
+
 	return c.OperatorCmd.validate()
 }
 

--- a/test/internal/utils.go
+++ b/test/internal/utils.go
@@ -1,0 +1,55 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"fmt"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo" //nolint:golint
+
+	kbtestutils "sigs.k8s.io/kubebuilder/test/e2e/utils"
+)
+
+// TestContext wraps kubebuilder's e2e TestContext.
+type TestContext struct {
+	*kbtestutils.TestContext
+}
+
+// NewTestContext returns a TestContext containing a new kubebuilder TestContext.
+func NewTestContext(env ...string) (tc TestContext, err error) {
+	tc.TestContext, err = kbtestutils.NewTestContext("operator-sdk", env...)
+	return tc, err
+}
+
+// InstallOLM runs 'operator-sdk olm install' and returns any errors emitted by that command.
+func (tc TestContext) InstallOLM() error {
+	cmd := exec.Command(tc.BinaryName, "olm", "install", "--timeout", "4m")
+	_, err := tc.Run(cmd)
+	return err
+}
+
+// InstallOLM runs 'operator-sdk olm uninstall' and logs any errors emitted by that command.
+func (tc TestContext) UninstallOLM() {
+	cmd := exec.Command(tc.BinaryName, "olm", "uninstall")
+	if _, err := tc.Run(cmd); err != nil {
+		fmt.Fprintln(GinkgoWriter, "warning: error when uninstalling OLM:", err)
+	}
+}
+
+// KustomizeBuild runs 'kustomize build <dir>' and returns its output and an error if any.
+func (tc TestContext) KustomizeBuild(dir string) ([]byte, error) {
+	return tc.Run(exec.Command("kustomize", "build", dir))
+}

--- a/website/content/en/docs/cli/operator-sdk_run.md
+++ b/website/content/en/docs/cli/operator-sdk_run.md
@@ -27,5 +27,5 @@ operator-sdk run [flags]
 
 * [operator-sdk](../operator-sdk)	 - An SDK for building operators with ease
 * [operator-sdk run local](../operator-sdk_run_local)	 - Run an Operator locally
-* [operator-sdk run packagemanifests](../operator-sdk_run_packagemanifests)	 - Run an Operator organized in the package manifests format with OLM
+* [operator-sdk run packagemanifests](../operator-sdk_run_packagemanifests)	 - Deploy an Operator in the package manifests format with OLM
 

--- a/website/content/en/docs/new-cli/operator-sdk.md
+++ b/website/content/en/docs/new-cli/operator-sdk.md
@@ -75,5 +75,6 @@ operator-sdk [flags]
 * [operator-sdk init](../operator-sdk_init)	 - Initialize a new project
 * [operator-sdk new](../operator-sdk_new)	 - Creates a new operator application
 * [operator-sdk olm](../operator-sdk_olm)	 - Manage the Operator Lifecycle Manager installation in your cluster
+* [operator-sdk run](../operator-sdk_run)	 - Run an Operator in a variety of environments
 * [operator-sdk version](../operator-sdk_version)	 - Prints the version of operator-sdk
 

--- a/website/content/en/docs/new-cli/operator-sdk_run.md
+++ b/website/content/en/docs/new-cli/operator-sdk_run.md
@@ -1,0 +1,31 @@
+---
+title: "operator-sdk run"
+---
+## operator-sdk run
+
+Run an Operator in a variety of environments
+
+### Synopsis
+
+This command has subcommands that will deploy your Operator with OLM.
+Currently only the package manifests format is supported via the 'packagemanifests' subcommand.
+Run 'operator-sdk run --help' for more information.
+
+
+### Options
+
+```
+  -h, --help   help for run
+```
+
+### Options inherited from parent commands
+
+```
+      --verbose   Enable verbose logging
+```
+
+### SEE ALSO
+
+* [operator-sdk](../operator-sdk)	 - Development kit for building Kubernetes extensions and tools.
+* [operator-sdk run packagemanifests](../operator-sdk_run_packagemanifests)	 - Deploy an Operator in the package manifests format with OLM
+

--- a/website/content/en/docs/new-cli/operator-sdk_run_packagemanifests.md
+++ b/website/content/en/docs/new-cli/operator-sdk_run_packagemanifests.md
@@ -27,6 +27,12 @@ operator-sdk run packagemanifests [flags]
       --timeout duration            Time to wait for the command to complete before failing (default 2m0s)
 ```
 
+### Options inherited from parent commands
+
+```
+      --verbose   Enable verbose logging
+```
+
 ### SEE ALSO
 
 * [operator-sdk run](../operator-sdk_run)	 - Run an Operator in a variety of environments


### PR DESCRIPTION
**Description of the change:** 
* cmd/operator-sdk: add `run packagemanifests` to new CLI, and set defaults for new project layouts
* test/e2e-new: test `run packagemanifests`
* test/utils: add utils to install/uninstall OLM

**Motivation for the change:** `run packagemanifests` should be available for new operator project layouts. This command must be used on operator projects with a package manifests format available.

/kind feature
