### PR TITLE
Add CHANGELOG fragments for new CLI

### DIFF
--- a/changelog/fragments/3190-add-new-cli-for-go-operators.yaml
+++ b/changelog/fragments/3190-add-new-cli-for-go-operators.yaml
@@ -1,0 +1,13 @@
+entries:
+  - description: >
+      The `operator-sdk` binary has a new CLI workflow and project layout
+      for scaffolding Go operators that is aligned with Kubebuilder's CLI
+      and project layout.
+      See the new [Quickstart Guide](https://sdk.operatorframework.io/docs/golang/quickstart)
+      and the new [CLI reference](https://sdk.operatorframework.io/docs/new-cli) for more details.
+
+    kind: "addition"
+
+    breaking: false
+
+    pull_request_override: 3190

--- a/changelog/fragments/3190-deprecate-old-cli-for-go-operators.yaml
+++ b/changelog/fragments/3190-deprecate-old-cli-for-go-operators.yaml
@@ -2,7 +2,7 @@ entries:
   - description: >
       With the introduction of the new [Kubebuilder aligned CLI](https://sdk.operatorframework.io/docs/new-cli) 
       and project layout for Go operators, the [old CLI](https://sdk.operatorframework.io/docs/cli) 
-      will stil continue to work for Go projects scaffolded in the old layout with `operator-sdk new`.
+      will still continue to work for Go projects scaffolded in the old layout with `operator-sdk new`.
       However the old CLI is now deprecated and will be removed in a future release.
 
     kind: "deprecation"
@@ -15,4 +15,4 @@ entries:
       header: Migrating Go projects to the new Kubebuilder aligned project layout
       body: >
         See the [migration guide](https://sdk.operatorframework.io/docs/golang/project_migration_guide/) 
-        that walks through an example how to migrate a Go based operator project from the old layout to the new layout.
+        that walks through an example of how to migrate a Go based operator project from the old layout to the new layout.

--- a/changelog/fragments/3190-deprecate-old-cli-for-go-operators.yaml
+++ b/changelog/fragments/3190-deprecate-old-cli-for-go-operators.yaml
@@ -1,0 +1,18 @@
+entries:
+  - description: >
+      With the introduction of the new [Kubebuilder aligned CLI](https://sdk.operatorframework.io/docs/new-cli) 
+      and project layout for Go operators, the [old CLI](https://sdk.operatorframework.io/docs/cli) 
+      will stil continue to work for Go projects scaffolded in the old layout with `operator-sdk new`.
+      However the old CLI is now deprecated and will be removed in a future release.
+
+    kind: "deprecation"
+
+    breaking: false
+
+    pull_request_override: 3190
+
+    migration:
+      header: Migrating Go projects to the new Kubebuilder aligned project layout
+      body: >
+        See the [migration guide](https://sdk.operatorframework.io/docs/golang/project_migration_guide/) 
+        that walks through an example how to migrate a Go based operator project from the old layout to the new layout.

--- a/changelog/fragments/3190-remove-new-cmd-for-go-operators.yaml
+++ b/changelog/fragments/3190-remove-new-cmd-for-go-operators.yaml
@@ -1,0 +1,11 @@
+entries:
+  - description: >
+      The `operator-sdk new` command no longer supports scaffolding new Go projects with the `--type=Go` flag. 
+      To scaffold new projects, users are expected to use `operator-sdk init` as part of the 
+      [new CLI]((https://sdk.operatorframework.io/docs/new-cli)) for Go operators.
+
+    kind: "removal"
+
+    breaking: false
+
+    pull_request_override: 3190


### PR DESCRIPTION
**Description of the change:**
Add CHANGELOG fragments to document the changes for:
- removal of `--type=go` from `operator-sdk new` cmd.
- deprecation of the old CLI
- addition of the new CLI

**Motivation for the change:**
Follow up to #3190 