### PR TITLE
Update CLI reference doc

### DIFF
--- a/website/content/en/docs/new-cli/operator-sdk_generate_bundle.md
+++ b/website/content/en/docs/new-cli/operator-sdk_generate_bundle.md
@@ -32,31 +32,6 @@ operator-sdk generate bundle [flags]
 
 ```
 
-  # Using the example 'memcached-operator' and assuming a directory structure
-  # similar to the following exists:
-  $ tree api/ config/
-  api/
-  └── v1alpha1
-      ├── groupversion_info.go
-      ├── memcached_types.go
-      └── zz_generated.deepcopy.go
-  config/
-  ├── bundle
-  │   └── kustomization.yaml
-  ├── crd
-  │   ├── bases
-  │   │   └── cache.my.domain_memcacheds.yaml
-  │   ├── kustomization.yaml
-  │   ├── kustomizeconfig.yaml
-  │   ...
-  ├── default
-  │   ├── kustomization.yaml
-  │   ...
-  ├── manager
-  │   ├── kustomization.yaml
-  │   └── manager.yaml
-  ...
-
   # Generate bundle files and build your bundle image with these 'make' recipes:
   $ make bundle
   $ export USERNAME=<your registry username>


### PR DESCRIPTION
Missing some CLI reference updates on the master branch.

Also not sure what's going on with the ` --project-version string` reshuffling the args.

/cc @estroz 