### PR TITLE
feat: upgrade lint version and fix gofmt

### DIFF
--- a/hack/tests/check-lint.sh
+++ b/hack/tests/check-lint.sh
@@ -7,7 +7,7 @@ function fetch_go_linter {
   header_text "Checking if golangci-lint is installed"
   if ! is_installed golangci-lint; then
     header_text "Installing golangci-lint"
-    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.22.2
+    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.27.0
   fi
 }
 

--- a/internal/plugins/golang/v2/plugin.go
+++ b/internal/plugins/golang/v2/plugin.go
@@ -45,9 +45,11 @@ var (
 // add operator-framework features to the base kubebuilder Go scaffold and CLI.
 type Plugin struct{}
 
-func (Plugin) Name() string                       { return (kbgov2.Plugin{}).Name() }
-func (Plugin) Version() plugin.Version            { return (kbgov2.Plugin{}).Version() }
-func (Plugin) SupportedProjectVersions() []string { return (kbgov2.Plugin{}).SupportedProjectVersions() }
+func (Plugin) Name() string            { return (kbgov2.Plugin{}).Name() }
+func (Plugin) Version() plugin.Version { return (kbgov2.Plugin{}).Version() }
+func (Plugin) SupportedProjectVersions() []string {
+	return (kbgov2.Plugin{}).SupportedProjectVersions()
+}
 
 func (p Plugin) GetInitPlugin() plugin.Init {
 	return &initPlugin{


### PR DESCRIPTION
**Description**
- Upgrade lint version used to the latest one
- Fix go fmt check. See that we are just changing the fmt of 3 lines according to go rules which are valid for 1.13 and 1.14. See that Travis is using 1.13 and passed in the git diff test in the sanity check as well. (btw, done automatically when we run make lint-fix too).

**Motivation**
- Allow us to work across the projects without the need to delete/install diff versions of the lint
- Solve tech debts
