### PR TITLE
docs: regenerate 'bundle validate' cli docs

### DIFF
--- a/website/content/en/docs/new-cli/operator-sdk_bundle_validate.md
+++ b/website/content/en/docs/new-cli/operator-sdk_bundle_validate.md
@@ -56,7 +56,7 @@ To build and validate an image:
 
 ```
   -h, --help                   help for validate
-  -b, --image-builder string   Tool to extract bundle image data. Only used when validating a bundle image. One of: [docker, podman] (default "docker")
+  -b, --image-builder string   Tool to pull and unpack bundle images. Only used when validating a bundle image. One of: [docker, podman, none] (default "docker")
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
**Description of the change:** regenerate CLI docs.

**Motivation for the change:** missed in #3222 due to new CLI docs being made public before that PR was rebased.

/kind documentation
