### PR TITLE
Closes #2378: Filtering of watched resources

### DIFF
--- a/changelog/fragments/predicateChanges.yaml
+++ b/changelog/fragments/predicateChanges.yaml
@@ -1,0 +1,8 @@
+entries:
+  - description: >
+      Added predicate filtering function for labels based on selectors specified in watches.yaml. 
+      Events of resources that match the selector's labels will be skipped.
+
+    kind: "addition"
+
+    breaking: false

--- a/pkg/ansible/run.go
+++ b/pkg/ansible/run.go
@@ -141,6 +141,7 @@ func Run(flags *aoflags.AnsibleOperatorFlags) error {
 			AnsibleDebugLogs: getAnsibleDebugLog(),
 			MaxWorkers:       w.MaxWorkers,
 			ReconcilePeriod:  w.ReconcilePeriod,
+			Selector:         w.Selector,
 		})
 		if ctr == nil {
 			return fmt.Errorf("failed to add controller for GVK %v", w.GroupVersionKind.String())

--- a/pkg/ansible/watches/watches.go
+++ b/pkg/ansible/watches/watches.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -52,6 +53,7 @@ type Watch struct {
 	ManageStatus                bool                      `yaml:"manageStatus"`
 	WatchDependentResources     bool                      `yaml:"watchDependentResources"`
 	WatchClusterScopedResources bool                      `yaml:"watchClusterScopedResources"`
+	Selector                    metav1.LabelSelector      `yaml:"selector"`
 
 	// Not configurable via watches.yaml
 	MaxWorkers       int `yaml:"-"`
@@ -74,11 +76,42 @@ var (
 	manageStatusDefault                = true
 	watchDependentResourcesDefault     = true
 	watchClusterScopedResourcesDefault = false
+	selectorDefault                    = metav1.LabelSelector{}
 
 	// these are overridden by cmdline flags
 	maxWorkersDefault       = 1
 	ansibleVerbosityDefault = 2
 )
+
+// Creates, populates and returns Label Selector object during UnmarshalYAML
+func parseLabelSelector(dls tempLabelSelector) metav1.LabelSelector {
+	obj := metav1.LabelSelector{}
+	obj.MatchLabels = dls.MatchLabels
+
+	for _, v := range dls.MatchExpressions {
+		requirement := metav1.LabelSelectorRequirement{
+			Key:      v.Key,
+			Operator: v.Operator,
+			Values:   v.Values,
+		}
+
+		obj.MatchExpressions = append(obj.MatchExpressions, requirement)
+	}
+
+	return obj
+}
+
+// Temporary structs created to store yaml parsing
+type tempLabelSelector struct {
+	MatchLabels      map[string]string `yaml:"matchLabels,omitempty"`
+	MatchExpressions []tempRequirement `yaml:"matchExpressions,omitempty"`
+}
+
+type tempRequirement struct {
+	Key      string                       `yaml:"key"`
+	Operator metav1.LabelSelectorOperator `yaml:"operator"`
+	Values   []string                     `yaml:"values,omitempty"`
+}
 
 // UnmarshalYAML - implements the yaml.Unmarshaler interface for Watch.
 // This makes it possible to verify, when loading, that the GroupVersionKind
@@ -86,6 +119,7 @@ var (
 // for values that were omitted.
 func (w *Watch) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// Use an alias struct to handle complex types
+
 	type alias struct {
 		Group                       string                    `yaml:"group"`
 		Version                     string                    `yaml:"version"`
@@ -100,6 +134,7 @@ func (w *Watch) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		WatchClusterScopedResources bool                      `yaml:"watchClusterScopedResources"`
 		Blacklist                   []schema.GroupVersionKind `yaml:"blacklist"`
 		Finalizer                   *Finalizer                `yaml:"finalizer"`
+		Selector                    tempLabelSelector         `yaml:"selector"`
 	}
 	var tmp alias
 
@@ -111,6 +146,7 @@ func (w *Watch) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	tmp.ReconcilePeriod = reconcilePeriodDefault
 	tmp.WatchClusterScopedResources = watchClusterScopedResourcesDefault
 	tmp.Blacklist = blacklistDefault
+	tmp.Selector = tempLabelSelector{}
 
 	if err := unmarshal(&tmp); err != nil {
 		return err
@@ -146,6 +182,7 @@ func (w *Watch) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	w.AnsibleVerbosity = getAnsibleVerbosity(gvk, ansibleVerbosityDefault)
 	w.Blacklist = tmp.Blacklist
 	w.addRolePlaybookPaths()
+	w.Selector = parseLabelSelector(tmp.Selector)
 
 	return nil
 }
@@ -270,6 +307,7 @@ func New(gvk schema.GroupVersionKind, role, playbook string, vars map[string]int
 		WatchClusterScopedResources: watchClusterScopedResourcesDefault,
 		Finalizer:                   finalizer,
 		AnsibleVerbosity:            ansibleVerbosityDefault,
+		Selector:                    selectorDefault,
 	}
 }
 

--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -15,6 +15,8 @@
 package predicate
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -26,6 +28,11 @@ var log = logf.Log.WithName("predicate").WithName("eventFilters")
 // (adapted from sigs.k8s.io/controller-runtime/pkg/predicate/predicate.ResourceVersionChangedPredicate)
 type GenerationChangedPredicate struct {
 	predicate.Funcs
+}
+
+type ResourceFilterPredicate struct {
+	predicate.Funcs
+	Selector labels.Selector
 }
 
 // Update implements default UpdateEvent filter for validating generation change
@@ -50,4 +57,33 @@ func (GenerationChangedPredicate) Update(e event.UpdateEvent) bool {
 		return false
 	}
 	return true
+}
+
+// Skips events that have labels matching selectors defined in watches.yaml
+func (r ResourceFilterPredicate) eventFilter(eventLabels map[string]string) bool {
+	return r.Selector.Matches(labels.Set(eventLabels))
+}
+
+func NewResourceFilterPredicate(s metav1.LabelSelector) (ResourceFilterPredicate, error) {
+	selectorSpecs, err := metav1.LabelSelectorAsSelector(&s)
+	requirements := ResourceFilterPredicate{Selector: selectorSpecs}
+	return requirements, err
+
+}
+
+// Predicate functions that call the EventFilter Function
+func (r ResourceFilterPredicate) Update(e event.UpdateEvent) bool {
+	return r.eventFilter(e.MetaNew.GetLabels())
+}
+
+func (r ResourceFilterPredicate) Create(e event.CreateEvent) bool {
+	return r.eventFilter(e.Meta.GetLabels())
+}
+
+func (r ResourceFilterPredicate) Delete(e event.DeleteEvent) bool {
+	return r.eventFilter(e.Meta.GetLabels())
+}
+
+func (r ResourceFilterPredicate) Generic(e event.GenericEvent) bool {
+	return r.eventFilter(e.Meta.GetLabels())
 }

--- a/test/ansible/deploy/crds/test.example.com_selectortest_crd.yaml
+++ b/test/ansible/deploy/crds/test.example.com_selectortest_crd.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: selectortests.test.example.com
+spec:
+  group: test.example.com
+  names:
+    kind: SelectorTest
+    listKind: SelectorTestList
+    plural: selectortests
+    singular: selectortest
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/ansible/molecule/cluster/tasks/selector_test.yml
+++ b/test/ansible/molecule/cluster/tasks/selector_test.yml
@@ -1,0 +1,54 @@
+---
+- name: Create the test.example.com/v1alpha1.SelectorTest
+  k8s:
+    state: present
+    definition:
+      apiVersion: test.example.com/v1alpha1
+      kind: SelectorTest
+      metadata:
+        name: selector-test
+        namespace: '{{ namespace }}'
+        labels:
+          testLabel: testValue
+      spec:
+        field: value
+    wait: yes
+    wait_timeout: 300
+    wait_condition:
+      type: Running
+      reason: Successful
+      status: "True"
+  register: selector_test
+
+- name: Assert sentinel ConfigMap has been created for Molecule Test
+  assert:
+    that: cm.data.hello == 'world'
+  vars:
+    cm: "{{ q('k8s', api_version='v1', kind='ConfigMap', namespace=namespace,
+    resource_name='selector-test').0 }}"
+
+- name: Create the test.example.com/v1alpha1.SelectorTest
+  k8s:
+    state: present
+    definition:
+      apiVersion: test.example.com/v1alpha1
+      kind: SelectorTest
+      metadata:
+        name: selector-test-fail
+        namespace: '{{ namespace }}'
+      spec:
+        field: value
+  register: selector_test
+
+- name: Wait for 30 seconds
+  wait_for:
+    timeout: 300
+
+- name: Assert sentinel ConfigMap has not been created for Molecule Test
+  assert:
+    that: not cm
+  vars:
+    cm: "{{ q('k8s', api_version='v1', kind='ConfigMap', namespace=namespace,
+    resource_name='selector-test-fail')}}"
+
+

--- a/test/ansible/playbooks/selector.yml
+++ b/test/ansible/playbooks/selector.yml
@@ -1,0 +1,16 @@
+---
+- hosts: localhost
+  gather_facts: no
+  collections:
+    - community.kubernetes
+  tasks:
+    - name: Create configmap
+      k8s:
+        definition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: '{{ meta.name }}'
+            namespace: '{{ meta.namespace }}'
+          data:
+            hello: "world"

--- a/test/ansible/watches.yaml
+++ b/test/ansible/watches.yaml
@@ -19,3 +19,12 @@
   kind: Secret
   playbook: playbooks/secret.yml
   manageStatus: false
+
+- version: v1alpha1
+  group: test.example.com
+  kind: SelectorTest
+  playbook: playbooks/selector.yml
+  selector:
+    matchExpressions:
+     - {key: testLabel, operator: Exists, values: []}
+


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Add a changelog file by copying changelog/fragments/00-template.yaml 
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"

-->

**Description of the change:**
Added a predicate that will filter resources by labels based on the selectors that are specified in watches.yaml

**Motivation for the  #change:**
Avoid having to do an Ansible initialization before skipping an event.
Fixes the issue: https://github.com/operator-framework/operator-sdk/issues/2378
