### PR TITLE
[olm-cmd] Add "version" flag to olm commands

### DIFF
--- a/changelog/fragments/add-version-to-olm-subcommands.yaml
+++ b/changelog/fragments/add-version-to-olm-subcommands.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Add "--version" flag to olm subcommands (uninstall, status) to allow users to override the version
+      of olm inferred from packageserver's CSV.
+    kind: "addition"

--- a/cmd/operator-sdk/olm/status.go
+++ b/cmd/operator-sdk/olm/status.go
@@ -35,6 +35,7 @@ func newStatusCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&mgr.OLMNamespace, "olm-namespace", olm.DefaultOLMNamespace, "namespace where OLM is installed")
+	cmd.Flags().StringVar(&mgr.Version, "version", "", "version of OLM installed on cluster; if unset, operator-sdk attempts to auto-discover the version")
 	mgr.AddToFlagSet(cmd.Flags())
 	return cmd
 }

--- a/cmd/operator-sdk/olm/status.go
+++ b/cmd/operator-sdk/olm/status.go
@@ -35,7 +35,8 @@ func newStatusCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&mgr.OLMNamespace, "olm-namespace", olm.DefaultOLMNamespace, "namespace where OLM is installed")
-	cmd.Flags().StringVar(&mgr.Version, "version", "", "version of OLM installed on cluster; if unset, operator-sdk attempts to auto-discover the version")
+	cmd.Flags().StringVar(&mgr.Version, "version", "", "version of OLM installed on cluster; if unset"+
+		"operator-sdk attempts to auto-discover the version")
 	mgr.AddToFlagSet(cmd.Flags())
 	return cmd
 }

--- a/cmd/operator-sdk/olm/uninstall.go
+++ b/cmd/operator-sdk/olm/uninstall.go
@@ -34,6 +34,7 @@ func newUninstallCmd() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVar(&mgr.Version, "version", "", "version of OLM resources to uninstall.")
 	mgr.AddToFlagSet(cmd.Flags())
 	return cmd
 }

--- a/hack/tests/subcommand-olm-install.sh
+++ b/hack/tests/subcommand-olm-install.sh
@@ -13,11 +13,11 @@ test_version() {
 
     # Status should fail with OLM not installed
     commandoutput=$(operator-sdk olm status 2>&1 || true)
-    echo $commandoutput | grep -F "Failed to get OLM status: no existing installation found"
+    echo $commandoutput | grep -F "Failed to get OLM status"
 
     # Uninstall should fail with OLM not installed
     commandoutput=$(operator-sdk olm uninstall 2>&1 || true)
-    echo $commandoutput | grep -F "Failed to uninstall OLM: no existing installation found"
+    echo $commandoutput | grep -F "Failed to uninstall OLM"
 
     # Install should succeed with nothing installed
     commandoutput=$(operator-sdk olm install $ver_flag 2>&1)

--- a/internal/olm/manager.go
+++ b/internal/olm/manager.go
@@ -56,9 +56,6 @@ func (m *Manager) initialize() (err error) {
 			}
 			m.Client = client
 		}
-		if m.Version == "" {
-			m.Version = DefaultVersion
-		}
 		if m.Timeout <= 0 {
 			m.Timeout = DefaultTimeout
 		}
@@ -96,16 +93,23 @@ func (m *Manager) Uninstall() error {
 	ctx, cancel := context.WithTimeout(context.Background(), m.Timeout)
 	defer cancel()
 
-	version, err := m.Client.GetInstalledVersion(ctx, m.OLMNamespace)
-	if err != nil {
+	if version, err := m.Client.GetInstalledVersion(ctx, m.OLMNamespace); err != nil {
+		if m.Version == "" {
+			return fmt.Errorf("error getting installed OLM version (set --version to override the default version): %v", err)
+		}
+	} else if m.Version != "" {
+		if version != m.Version {
+			return fmt.Errorf("mismatched installed version %q vs. supplied version %q", version, m.Version)
+		}
+	} else {
+		m.Version = version
+	}
+
+	if err := m.Client.UninstallVersion(ctx, m.OLMNamespace, m.Version); err != nil {
 		return err
 	}
 
-	if err := m.Client.UninstallVersion(ctx, m.OLMNamespace, version); err != nil {
-		return err
-	}
-
-	log.Infof("Successfully uninstalled OLM version %q", version)
+	log.Infof("Successfully uninstalled OLM version %q", m.Version)
 	return nil
 }
 
@@ -117,17 +121,24 @@ func (m *Manager) Status() error {
 	ctx, cancel := context.WithTimeout(context.Background(), m.Timeout)
 	defer cancel()
 
-	version, err := m.Client.GetInstalledVersion(ctx, m.OLMNamespace)
+	if version, err := m.Client.GetInstalledVersion(ctx, m.OLMNamespace); err != nil {
+		if m.Version == "" {
+			return fmt.Errorf("error getting installed OLM version (set --version to override the default version): %v", err)
+		}
+	} else if m.Version != "" {
+		if version != m.Version {
+			return fmt.Errorf("mismatched installed version %q vs. supplied version %q", version, m.Version)
+		}
+	} else {
+		m.Version = version
+	}
+
+	status, err := m.Client.GetStatus(ctx, m.OLMNamespace, m.Version)
 	if err != nil {
 		return err
 	}
 
-	status, err := m.Client.GetStatus(ctx, m.OLMNamespace, version)
-	if err != nil {
-		return err
-	}
-
-	log.Infof("Successfully got OLM status for version %q", version)
+	log.Infof("Successfully got OLM status for version %q", m.Version)
 	fmt.Print("\n")
 	fmt.Println(status)
 	return nil

--- a/website/content/en/docs/cli/operator-sdk_olm_status.md
+++ b/website/content/en/docs/cli/operator-sdk_olm_status.md
@@ -19,7 +19,7 @@ operator-sdk olm status [flags]
   -h, --help                   help for status
       --olm-namespace string   namespace where OLM is installed (default "olm")
       --timeout duration       time to wait for the command to complete before failing (default 2m0s)
-      --version string         version of OLM installed on cluster
+      --version string         version of OLM installed on cluster; if unsetoperator-sdk attempts to auto-discover the version
 ```
 
 ### SEE ALSO

--- a/website/content/en/docs/cli/operator-sdk_olm_status.md
+++ b/website/content/en/docs/cli/operator-sdk_olm_status.md
@@ -19,6 +19,7 @@ operator-sdk olm status [flags]
   -h, --help                   help for status
       --olm-namespace string   namespace where OLM is installed (default "olm")
       --timeout duration       time to wait for the command to complete before failing (default 2m0s)
+      --version string         version of OLM installed on cluster
 ```
 
 ### SEE ALSO

--- a/website/content/en/docs/cli/operator-sdk_olm_uninstall.md
+++ b/website/content/en/docs/cli/operator-sdk_olm_uninstall.md
@@ -18,6 +18,7 @@ operator-sdk olm uninstall [flags]
 ```
   -h, --help               help for uninstall
       --timeout duration   time to wait for the command to complete before failing (default 2m0s)
+      --version string     version of OLM resources to uninstall.
 ```
 
 ### SEE ALSO

--- a/website/content/en/docs/new-cli/operator-sdk_olm_status.md
+++ b/website/content/en/docs/new-cli/operator-sdk_olm_status.md
@@ -19,6 +19,7 @@ operator-sdk olm status [flags]
   -h, --help                   help for status
       --olm-namespace string   namespace where OLM is installed (default "olm")
       --timeout duration       time to wait for the command to complete before failing (default 2m0s)
+      --version string         version of OLM installed on cluster
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/new-cli/operator-sdk_olm_status.md
+++ b/website/content/en/docs/new-cli/operator-sdk_olm_status.md
@@ -19,7 +19,7 @@ operator-sdk olm status [flags]
   -h, --help                   help for status
       --olm-namespace string   namespace where OLM is installed (default "olm")
       --timeout duration       time to wait for the command to complete before failing (default 2m0s)
-      --version string         version of OLM installed on cluster
+      --version string         version of OLM installed on cluster; if unsetoperator-sdk attempts to auto-discover the version
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/new-cli/operator-sdk_olm_uninstall.md
+++ b/website/content/en/docs/new-cli/operator-sdk_olm_uninstall.md
@@ -18,6 +18,7 @@ operator-sdk olm uninstall [flags]
 ```
   -h, --help               help for uninstall
       --timeout duration   time to wait for the command to complete before failing (default 2m0s)
+      --version string     version of OLM resources to uninstall.
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/olm-integration/user-guide.md
+++ b/website/content/en/docs/olm-integration/user-guide.md
@@ -66,7 +66,7 @@ catalogsources.operators.coreos.com                          CustomResourceDefin
 ```
 
 **Note:**
-By default the latest version of OLM is installed. However, the version of OLM can be specified in all the [olm subcommands][cli-olm] using the `--version` flag. This allows users to specify the version of OLM to install, uninstall or fetch its current status in the cluster.
+By default, `olm status` and `olm uninstall` auto-detect the OLM version installed in your cluster. This can fail if the installation is broken in some way, so the version of OLM can be overridden using the `--version` flag provided with these commands.
 
 ## Creating a bundle
 

--- a/website/content/en/docs/olm-integration/user-guide.md
+++ b/website/content/en/docs/olm-integration/user-guide.md
@@ -65,6 +65,9 @@ catalogsources.operators.coreos.com                          CustomResourceDefin
 ...
 ```
 
+**Note:**
+By default the latest version of OLM is installed. However, the version of OLM can be specified in all the [olm subcommands][cli-olm] using the `--version` flag. This allows users to specify the version of OLM to install, uninstall or fetch its current status in the cluster.
+
 ## Creating a bundle
 
 Now that we have a working, simple memcached-operator, we can generate manifests


### PR DESCRIPTION
**Description of the change:**
This PR adds "--version" flag to olm sub-commands, thereby enabling
users to specify the version of olm to uninstall or look up for
while fetching the status of its resources.

**Motivation for the change:**
Allow users to override the version of OLM inferred from packageservers's CSV

Closes : #3095 
