### PR TITLE
Modify default value of overwrite flag in generate-bundle cmd

### DIFF
--- a/changelog/fragments/modify-overwrite-flag.yaml
+++ b/changelog/fragments/modify-overwrite-flag.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: Change default value of `--overwrite` flag in `operator-sdk generate bundle` to true.
+    kind: change
+    breaking: false

--- a/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/cmd/operator-sdk/generate/bundle/cmd.go
@@ -210,6 +210,6 @@ func (c *bundleCmd) addCommonFlagsTo(fs *pflag.FlagSet) {
 	fs.StringVar(&c.crdsDir, "crds-dir", "", "Root directory for CustomResoureDefinition manifests")
 	fs.StringVar(&c.channels, "channels", "alpha", "A comma-separated list of channels the bundle belongs to")
 	fs.StringVar(&c.defaultChannel, "default-channel", "", "The default channel for the bundle")
-	fs.BoolVar(&c.overwrite, "overwrite", false, "Overwrite the bundle's metadata and Dockerfile if they exist")
+	fs.BoolVar(&c.overwrite, "overwrite", true, "Overwrite the bundle's metadata and Dockerfile if they exist")
 	fs.BoolVarP(&c.quiet, "quiet", "q", false, "Run in quiet mode")
 }

--- a/website/content/en/docs/cli/operator-sdk_generate_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_bundle.md
@@ -76,7 +76,7 @@ operator-sdk generate bundle [flags]
       --metadata                 Generate bundle metadata and Dockerfile
       --operator-name string     Name of the bundle's operator
       --output-dir string        Directory to write the bundle to
-      --overwrite                Overwrite the bundle's metadata and Dockerfile if they exist
+      --overwrite                Overwrite the bundle's metadata and Dockerfile if they exist (default true)
   -q, --quiet                    Run in quiet mode
   -v, --version string           Semantic version of the operator in the generated bundle. Only set if creating a new bundle or upgrading your operator
 ```

--- a/website/content/en/docs/new-cli/operator-sdk_generate_bundle.md
+++ b/website/content/en/docs/new-cli/operator-sdk_generate_bundle.md
@@ -90,7 +90,7 @@ operator-sdk generate bundle [flags]
       --metadata                 Generate bundle metadata and Dockerfile
       --operator-name string     Name of the bundle's operator
       --output-dir string        Directory to write the bundle to
-      --overwrite                Overwrite the bundle's metadata and Dockerfile if they exist
+      --overwrite                Overwrite the bundle's metadata and Dockerfile if they exist (default true)
   -q, --quiet                    Run in quiet mode
       --stdout                   Write bundle manifest to stdout
   -v, --version string           Semantic version of the operator in the generated bundle. Only set if creating a new bundle or upgrading your operator


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Add a changelog file by copying changelog/fragments/00-template.yaml 
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"

-->

**Description of the change:**
With this PR, "generate bundle" command by default will overwrite
metadata files if already present.

