### PR TITLE
[v0.18.x] ansible: use correct download URL for tini on aarch64 (#3234)

### DIFF
--- a/changelog/fragments/3234-arm64-tini-url.yaml
+++ b/changelog/fragments/3234-arm64-tini-url.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      Fix the download URL for the `tini` binary on ARM64 for the ansible
+      operator base image
+    kind: "bugfix"
+    breaking: false

--- a/internal/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/scaffold/ansible/dockerfilehybrid.go
@@ -88,7 +88,7 @@ RUN mkdir -p ${HOME}/.ansible/tmp \
  && chown -R ${USER_UID}:0 ${HOME} \
  && chmod -R ug+rwx ${HOME}
 
-RUN TINIARCH=$(case $(arch) in x86_64) echo -n amd64 ;; ppc64le) echo -n ppc64el ;; *) echo -n $(arch) ;; esac) \
+RUN TINIARCH=$(case $(arch) in x86_64) echo -n amd64 ;; ppc64le) echo -n ppc64el ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac) \
   && curl -L -o /tini https://github.com/krallin/tini/releases/latest/download/tini-$TINIARCH \
   && chmod +x /tini
 


### PR DESCRIPTION
Cherry pick #3234