### PR TITLE
*: release v0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.17.2
+
+### Bug Fixes
+
+- Fix the download URL for the `tini` binary on ARM64 for the ansible operator base image. ([#3291](https://github.com/operator-framework/operator-sdk/pull/3291))
+
 ## v0.17.1
 
 ### Changes

--- a/changelog/fragments/3234-arm64-tini-url.yaml
+++ b/changelog/fragments/3234-arm64-tini-url.yaml
@@ -1,6 +1,0 @@
-entries:
-  - description: >
-      Fix the download URL for the `tini` binary on ARM64 for the ansible
-      operator base image
-    kind: "bugfix"
-    breaking: false

--- a/internal/scaffold/ansible/go_mod.go
+++ b/internal/scaffold/ansible/go_mod.go
@@ -42,7 +42,7 @@ const goModTmpl = `module {{ .Repo }}
 go 1.13
 
 require (
-	github.com/operator-framework/operator-sdk v0.17.x
+	github.com/operator-framework/operator-sdk v0.17.2
 	sigs.k8s.io/controller-runtime v0.5.2
 )
 

--- a/internal/scaffold/go_mod.go
+++ b/internal/scaffold/go_mod.go
@@ -41,7 +41,7 @@ const goModTmpl = `module {{ .Repo }}
 go 1.13
 
 require (
-	github.com/operator-framework/operator-sdk v0.17.x
+	github.com/operator-framework/operator-sdk v0.17.2
 	sigs.k8s.io/controller-runtime v0.5.2
 )
 

--- a/internal/scaffold/helm/go_mod.go
+++ b/internal/scaffold/helm/go_mod.go
@@ -42,7 +42,7 @@ const goModTmpl = `module {{ .Repo }}
 go 1.13
 
 require (
-	github.com/operator-framework/operator-sdk v0.17.x
+	github.com/operator-framework/operator-sdk v0.17.2
 	sigs.k8s.io/controller-runtime v0.5.2
 )
 

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ import (
 
 //var needs to be used instead of const for ldflags
 var (
-	Version           = "v0.17.1+git"
+	Version           = "v0.17.2"
 	GitVersion        = "unknown"
 	GitCommit         = "unknown"
 	KubernetesVersion = "unknown"

--- a/website/content/en/docs/install-operator-sdk.md
+++ b/website/content/en/docs/install-operator-sdk.md
@@ -27,7 +27,7 @@ $ brew install operator-sdk
 
 ```sh
 # Set the release version variable
-$ RELEASE_VERSION=v0.17.1
+$ RELEASE_VERSION=v0.17.2
 # Linux
 $ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
 # macOS

--- a/website/content/en/docs/migration/v0.17.2.md
+++ b/website/content/en/docs/migration/v0.17.2.md
@@ -1,0 +1,6 @@
+---
+title: v0.17.2
+weight: 999982998
+---
+
+There are no migrations for this release! :tada:


### PR DESCRIPTION
Needed because v0.17.1's tag returns go module errors.
