### PR TITLE
add unit tests for cmd/completion

### DIFF
--- a/cmd/operator-sdk/completion/bash_test.go
+++ b/cmd/operator-sdk/completion/bash_test.go
@@ -1,0 +1,31 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package completion
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Running a completion bash command", func() {
+	Describe("newBashCmd", func() {
+		It("creates a cobra command", func() {
+			cmd := newBashCmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).NotTo(Equal(""))
+			Expect(cmd.Short).NotTo(Equal(""))
+		})
+	})
+})

--- a/cmd/operator-sdk/completion/cmd_test.go
+++ b/cmd/operator-sdk/completion/cmd_test.go
@@ -1,0 +1,34 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package completion
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Running a completion command", func() {
+	Describe("NewCmd", func() {
+		It("creates a cobra command with the correct subcommands", func() {
+			cmd := NewCmd()
+			Expect(cmd).NotTo(BeNil())
+
+			subcommands := cmd.Commands()
+			Expect(len(subcommands)).To(Equal(2))
+			Expect(subcommands[0].Use).To(Equal("bash"))
+			Expect(subcommands[1].Use).To(Equal("zsh"))
+		})
+	})
+})

--- a/cmd/operator-sdk/completion/completion_suite_test.go
+++ b/cmd/operator-sdk/completion/completion_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package completion
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCompletion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Completion Suite")
+}

--- a/cmd/operator-sdk/completion/zsh_test.go
+++ b/cmd/operator-sdk/completion/zsh_test.go
@@ -1,0 +1,31 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package completion
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Running a completion zsh command", func() {
+	Describe("newZshCmd", func() {
+		It("creates a cobra command", func() {
+			cmd := newZshCmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).NotTo(Equal(""))
+			Expect(cmd.Short).NotTo(Equal(""))
+		})
+	})
+})


### PR DESCRIPTION
**Description of the change:**
Unit tests for cmd/completion. Super simple, I couldn't really think of a good way to test the actual completion bit without a text comparison.

**Motivation for the change:**
See #3246 