### PR TITLE
[olm-cmd] Add option to specify namespace

### DIFF
--- a/changelog/add-namespace-to-olm-sucommands.yaml
+++ b/changelog/add-namespace-to-olm-sucommands.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Add "--olm-namespace" flag to olm subcommands (install, uninstall) to allow users to specify the 
+      namespace where olm is to be installed or uninstalled.
+    kind: "addition"

--- a/cmd/operator-sdk/olm/install.go
+++ b/cmd/operator-sdk/olm/install.go
@@ -35,6 +35,8 @@ func newInstallCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&mgr.Version, "version", olm.DefaultVersion, "version of OLM resources to install")
+	cmd.Flags().StringVar(&mgr.OLMNamespace, "olm-namespace", olm.DefaultOLMNamespace,
+		"namespace where OLM is to be installed.")
 	mgr.AddToFlagSet(cmd.Flags())
 	return cmd
 }

--- a/cmd/operator-sdk/olm/uninstall.go
+++ b/cmd/operator-sdk/olm/uninstall.go
@@ -35,6 +35,8 @@ func newUninstallCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&mgr.Version, "version", "", "version of OLM resources to uninstall.")
+	cmd.Flags().StringVar(&mgr.OLMNamespace, "olm-namespace", olm.DefaultOLMNamespace,
+		"namespace from where OLM is to be uninstalled.")
 	mgr.AddToFlagSet(cmd.Flags())
 	return cmd
 }

--- a/website/content/en/docs/cli/operator-sdk_olm_install.md
+++ b/website/content/en/docs/cli/operator-sdk_olm_install.md
@@ -16,9 +16,10 @@ operator-sdk olm install [flags]
 ### Options
 
 ```
-  -h, --help               help for install
-      --timeout duration   time to wait for the command to complete before failing (default 2m0s)
-      --version string     version of OLM resources to install (default "latest")
+  -h, --help                   help for install
+      --olm-namespace string   namespace where OLM is to be installed. (default "olm")
+      --timeout duration       time to wait for the command to complete before failing (default 2m0s)
+      --version string         version of OLM resources to install (default "latest")
 ```
 
 ### SEE ALSO

--- a/website/content/en/docs/cli/operator-sdk_olm_uninstall.md
+++ b/website/content/en/docs/cli/operator-sdk_olm_uninstall.md
@@ -16,9 +16,10 @@ operator-sdk olm uninstall [flags]
 ### Options
 
 ```
-  -h, --help               help for uninstall
-      --timeout duration   time to wait for the command to complete before failing (default 2m0s)
-      --version string     version of OLM resources to uninstall.
+  -h, --help                   help for uninstall
+      --olm-namespace string   namespace from where OLM is to be uninstalled. (default "olm")
+      --timeout duration       time to wait for the command to complete before failing (default 2m0s)
+      --version string         version of OLM resources to uninstall.
 ```
 
 ### SEE ALSO

--- a/website/content/en/docs/new-cli/operator-sdk_olm_install.md
+++ b/website/content/en/docs/new-cli/operator-sdk_olm_install.md
@@ -16,9 +16,10 @@ operator-sdk olm install [flags]
 ### Options
 
 ```
-  -h, --help               help for install
-      --timeout duration   time to wait for the command to complete before failing (default 2m0s)
-      --version string     version of OLM resources to install (default "latest")
+  -h, --help                   help for install
+      --olm-namespace string   namespace where OLM is to be installed. (default "olm")
+      --timeout duration       time to wait for the command to complete before failing (default 2m0s)
+      --version string         version of OLM resources to install (default "latest")
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/new-cli/operator-sdk_olm_uninstall.md
+++ b/website/content/en/docs/new-cli/operator-sdk_olm_uninstall.md
@@ -16,9 +16,10 @@ operator-sdk olm uninstall [flags]
 ### Options
 
 ```
-  -h, --help               help for uninstall
-      --timeout duration   time to wait for the command to complete before failing (default 2m0s)
-      --version string     version of OLM resources to uninstall.
+  -h, --help                   help for uninstall
+      --olm-namespace string   namespace from where OLM is to be uninstalled. (default "olm")
+      --timeout duration       time to wait for the command to complete before failing (default 2m0s)
+      --version string         version of OLM resources to uninstall.
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION


<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Add a changelog file by copying changelog/fragments/00-template.yaml 
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"

-->

**Description of the change:**
This PR adds the "--olm-namespace" flag to OLM subcommands
(install, uninstall) to allow users to specify the
namespace where olm is to be installed or uninstalled.

Follow-up of : PR [3729](https://github.com/operator-framework/operator-sdk/pull/3279)
