### PR TITLE
docs: Added the selector feature to docs

### DIFF
--- a/website/content/en/docs/ansible/reference/watches.md
+++ b/website/content/en/docs/ansible/reference/watches.md
@@ -93,8 +93,7 @@ Some features can be overridden per resource via an annotation on that CR. The o
 | Watching Cluster-Scoped Resources | `watchClusterScopedResources` | Allows the ansible operator to watch cluster-scoped resources that are created by ansible | | false | |
 | Max Runner Artifacts | `maxRunnerArtifacts` | Manages the number of [artifact directories](https://ansible-runner.readthedocs.io/en/latest/intro.html#runner-artifacts-directory-hierarchy) that ansible runner will keep in the operator container for each individual resource. | ansible.operator-sdk/max-runner-artifacts | 20 | |
 | Finalizer | `finalizer`  | Sets a finalizer on the CR and maps a deletion event to a playbook or role | | | [finalizers](../finalizers)|
-
-
+| Selector | `selector`  | Identifies a set of objects based on their labels | | None Applied | [Labels and Selectors] (https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)|
 #### Example
 ```YaML
 ---

--- a/website/content/en/docs/ansible/reference/watches.md
+++ b/website/content/en/docs/ansible/reference/watches.md
@@ -93,7 +93,7 @@ Some features can be overridden per resource via an annotation on that CR. The o
 | Watching Cluster-Scoped Resources | `watchClusterScopedResources` | Allows the ansible operator to watch cluster-scoped resources that are created by ansible | | false | |
 | Max Runner Artifacts | `maxRunnerArtifacts` | Manages the number of [artifact directories](https://ansible-runner.readthedocs.io/en/latest/intro.html#runner-artifacts-directory-hierarchy) that ansible runner will keep in the operator container for each individual resource. | ansible.operator-sdk/max-runner-artifacts | 20 | |
 | Finalizer | `finalizer`  | Sets a finalizer on the CR and maps a deletion event to a playbook or role | | | [finalizers](../finalizers)|
-| Selector | `selector`  | Identifies a set of objects based on their labels | | None Applied | [Labels and Selectors] (https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)|
+| Selector | `selector`  | Identifies a set of objects based on their labels | | None Applied | [Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)|
 #### Example
 ```YaML
 ---
@@ -109,6 +109,17 @@ Some features can be overridden per resource via an annotation on that CR. The o
     name: finalizer.app.example.com
     vars:
       state: absent
+```
+#### Example
+```YaML
+---
+- version: v1alpha1
+  group: test.example.com
+  kind: SelectorTest
+  playbook: playbooks/selector.yml
+  selector:
+    matchExpressions:
+     - {key: testLabel, operator: Exists, values: []}
 ```
 
 

--- a/website/content/en/docs/ansible/reference/watches.md
+++ b/website/content/en/docs/ansible/reference/watches.md
@@ -77,6 +77,18 @@ An example Watches file:
   group: bar.example.com
   kind: Bar
   role: myNamespace.myCollection.myRole
+
+# Example filtering of resources with specific labels
+- version: v1alpha1
+  group: bar.example.com
+  kind: Bar
+  playbook: playbook.yml
+  selector:
+    matchLabels:
+      foo: bar
+    matchExpressions:
+      - {key: foo, operator: In, values: [bar]}
+      - {key: baz, operator: Exists, values: []}
 ```
 
 
@@ -110,16 +122,3 @@ Some features can be overridden per resource via an annotation on that CR. The o
     vars:
       state: absent
 ```
-#### Example
-```YaML
----
-- version: v1alpha1
-  group: test.example.com
-  kind: SelectorTest
-  playbook: playbooks/selector.yml
-  selector:
-    matchExpressions:
-     - {key: testLabel, operator: Exists, values: []}
-```
-
-


### PR DESCRIPTION
Selectors help clients/users can identify a set of objects based on their labels.

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Add a changelog file by copying changelog/fragments/00-template.yaml 
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"

-->

**Description of the change:**
Added the selector feature to docs table with description, default, and link to Kubernetes API.

