### PR TITLE
add ansible debug logs env options

### DIFF
--- a/pkg/ansible/run.go
+++ b/pkg/ansible/run.go
@@ -275,18 +275,25 @@ func serveCRMetrics(cfg *rest.Config, operatorNs string, gvks []schema.GroupVers
 // getAnsibleDebugLog return the value from the ANSIBLE_DEBUG_LOGS it order to
 // print the full Ansible logs
 func getAnsibleDebugLog() bool {
-	const envVar = "ANSIBLE_DEBUG_LOGS"
+	envVars := []string{"ANSIBLE_DEBUG_LOGS", "ANSIBLE_ENABLE_TASK_DEBUGGER"}
 	val := false
-	if envVal, ok := os.LookupEnv(envVar); ok {
-		if i, err := strconv.ParseBool(envVal); err != nil {
-			log.Info("Could not parse environment variable as an boolean; using default value",
-				"envVar", envVar, "default", val)
-		} else {
-			val = i
+	unset := true
+	for _, env := range envVars {
+		envVal, ok := os.LookupEnv(env)
+		if !ok {
+			continue
 		}
-	} else if !ok {
-		log.Info("Environment variable not set; using default value", "envVar", envVar,
-			envVar, val)
+		if i, err := strconv.ParseBool(envVal); err != nil {
+			unset = false
+			log.Info("Could not parse environment variable as an boolean; using default value",
+				"envVar", env, "default", val)
+		} else {
+			return i
+		}
+	}
+	if unset {
+		log.Info("Environment variables not set; using default value", "envVar", envVars,
+			envVars, val)
 	}
 	return val
 }


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Add a changelog file by copying changelog/fragments/00-template.yaml 
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"

-->

**Description of the change:**
Add a environment variable options.

**Motivation for the change:**
According to ansible official page, set ``ANSIBLE_ENABLE_TASK_DEBUGGER=True`` to enable task debugger, normally ansible developer would set this env variable instead of ``ANSIBLE_DEBUG_LOGS``, so keep the old env variable also add a new option for ansible developer.
