### PR TITLE
hidden plugins flag

### DIFF
--- a/cmd/operator-sdk/cli/cli.go
+++ b/cmd/operator-sdk/cli/cli.go
@@ -86,7 +86,28 @@ func GetPluginsCLIAndRoot() (cli.CLI, *cobra.Command) {
 	}
 	root.PersistentPreRun = rootPersistentPreRun
 
+	hidePluginsFlagFromInit(root)
+
 	return c, root
+}
+
+// hidePluginsFlagFromInit will hide the --plugins from operator-sdk init
+func hidePluginsFlagFromInit(root *cobra.Command) {
+	// Looking for init command
+	var initCmd *cobra.Command
+	for _, cmd := range root.Commands() {
+		if cmd.Name() == "init" {
+			initCmd = cmd
+			break
+		}
+	}
+	// This wil hidden the plugins flag since it should not be visible to user
+	if initCmd != nil {
+		puginsFlag := initCmd.Flag("plugins")
+		if puginsFlag != nil {
+			puginsFlag.Hidden = true
+		}
+	}
 }
 
 func rootPersistentPreRun(cmd *cobra.Command, args []string) {

--- a/cmd/operator-sdk/cli/legacy.go
+++ b/cmd/operator-sdk/cli/legacy.go
@@ -108,6 +108,7 @@ func getInitCmd() *cobra.Command {
 	for _, cmd := range root.Commands() {
 		if cmd.Name() == "init" {
 			initCmd = cmd
+			break
 		}
 	}
 	return initCmd

--- a/website/content/en/docs/new-cli/operator-sdk_init.md
+++ b/website/content/en/docs/new-cli/operator-sdk_init.md
@@ -42,7 +42,6 @@ operator-sdk init [flags]
   -h, --help                     help for init
       --license string           license to use to boilerplate, may be one of 'apache2', 'none' (default "apache2")
       --owner string             owner to add to the copyright
-      --plugins strings          Name and optionally version of the plugin to initialize the project with. Available plugins: ("go.kubebuilder.io/v2")
       --project-version string   project version, possible values: ("2", "3-alpha") (default "3-alpha")
       --repo string              name to use for go module (e.g., github.com/user/repo), defaults to the go package of the current working directory.
       --skip-go-version-check    if specified, skip checking the Go version


### PR DESCRIPTION
**Description of the change:**
The flag `plugins` should not be visible to the users in the `operator-sdk init` command.  

**Motivations:**
- SDK has no plugins which should be used by users  due to this flag currently
- Allow us to work and test the helm/ansible plugins without making it visible to users
- Do not gen SDK docs with --plugins flag and helm/ansible options if we decide to add then in the work in progress to gen the plugins since they are done automatically (make generate)