### PR TITLE
doc: add modules step for 0.18.0 migration guide

### DIFF
--- a/website/content/en/docs/migration/v0.18.0.md
+++ b/website/content/en/docs/migration/v0.18.0.md
@@ -3,6 +3,24 @@ title: v0.18.0
 weight: 999982000
 ---
 
+## Modules
+
+- Ensure that the following `require` and `replace` directives with these specific versions are present in your `go.mod` file:
+
+```go
+require (
+	github.com/operator-framework/operator-sdk v0.18.0
+	k8s.io/api v0.18.2
+	k8s.io/apimachinery v0.18.2
+	sigs.k8s.io/controller-runtime v0.6.0
+)
+
+replace (
+	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM
+	k8s.io/client-go => k8s.io/client-go v0.18.2 // Required by prometheus-operator
+)
+```
+
 ## (Optional) Add livenessProbe check for Ansible-based operators
 
 Existing operators will have a healthz endpoint without intervention, but to take advantage of it, a liveness probe should be manually added to the operator manifest. For example, the `deploy/operator.yaml` file would need to include:


### PR DESCRIPTION
**Description**
add the modules step to the migration guide for 0.18
**Motivation**
closes: https://github.com/operator-framework/operator-sdk/issues/3238
See: https://deploy-preview-3311--operator-sdk.netlify.app/docs/migration/v0.18.0/
