### PR TITLE
`run packagemanifests`: alias as `run pm`

### DIFF
--- a/changelog/fragments/alias-run-packagemanifests.yaml
+++ b/changelog/fragments/alias-run-packagemanifests.yaml
@@ -1,0 +1,3 @@
+entries:
+  - description: Alias `run packagemanifests` as `run pm`
+    kind: addition

--- a/cmd/operator-sdk/run/packagemanifests/packagemanifests.go
+++ b/cmd/operator-sdk/run/packagemanifests/packagemanifests.go
@@ -39,6 +39,7 @@ func NewCmd() *cobra.Command {
 		Short: "Deploy an Operator in the package manifests format with OLM",
 		Long: `'run packagemanifests' deploys an Operator's package manifests with OLM. The command's argument
 must be set to a valid package manifests root directory, ex. '<project-root>/packagemanifests'.`,
+		Aliases: []string{"pm"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				if len(args) > 1 {


### PR DESCRIPTION
**Description of the change:** alias `run packagemanifests` as `run pm`.

**Motivation for the change:** the raw command name is long.

/cc @joelanford @hasbro17 

/kind feature
