### PR TITLE
cli (new): add `cleanup packagemanifests`

### DIFF
--- a/cmd/operator-sdk/cleanup/cmd.go
+++ b/cmd/operator-sdk/cleanup/cmd.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"path/filepath"
 
+	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/cleanup/packagemanifests"
 	olmcatalog "github.com/operator-framework/operator-sdk/internal/generate/olm-catalog"
 	olmoperator "github.com/operator-framework/operator-sdk/internal/olm/operator"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
@@ -26,6 +27,23 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cleanup",
+		Short: "Clean up an Operator deployed with the 'run' subcommand",
+		Long: `This command has subcommands that will destroy an Operator deployed with OLM.
+Currently only the package manifests format is supported via the 'packagemanifests' subcommand.
+Run 'operator-sdk cleanup --help' for more information.
+`,
+	}
+
+	cmd.AddCommand(
+		packagemanifests.NewCmd(),
+	)
+
+	return cmd
+}
 
 type cleanupCmd struct {
 	// Common options.
@@ -49,7 +67,7 @@ func (c *cleanupCmd) checkCleanupType() error {
 	return nil
 }
 
-func NewCmd() *cobra.Command {
+func NewCmdLegacy() *cobra.Command {
 	c := &cleanupCmd{}
 	cmd := &cobra.Command{
 		Use:   "cleanup",
@@ -122,7 +140,7 @@ func NewCmd() *cobra.Command {
 	cmd.Flags().AddFlagSet(fs)
 
 	cmd.AddCommand(
-		newPackageManifestsCmdLegacy(),
+		packagemanifests.NewCmd(),
 	)
 
 	return cmd

--- a/cmd/operator-sdk/cli/cli.go
+++ b/cmd/operator-sdk/cli/cli.go
@@ -18,6 +18,7 @@ import (
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/alpha"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/build"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/bundle"
+	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/cleanup"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/completion"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/generate"
 	"github.com/operator-framework/operator-sdk/cmd/operator-sdk/new"
@@ -42,8 +43,7 @@ var commands = []*cobra.Command{
 	alpha.NewCmd(),
 	build.NewCmd(),
 	bundle.NewCmd(),
-	// Add back when implemented for new project layouts.
-	// cleanup.NewCmd(),
+	cleanup.NewCmd(),
 	completion.NewCmd(),
 	generate.NewCmd(),
 	olm.NewCmd(),

--- a/cmd/operator-sdk/cli/legacy.go
+++ b/cmd/operator-sdk/cli/legacy.go
@@ -74,7 +74,7 @@ func GetCLIRoot() *cobra.Command {
 		alpha.NewCmd(),
 		build.NewCmd(),
 		bundle.NewCmdLegacy(),
-		cleanup.NewCmd(),
+		cleanup.NewCmdLegacy(),
 		completion.NewCmd(),
 		execentrypoint.NewCmd(),
 		generate.NewCmdLegacy(),

--- a/test/e2e-new/e2e_suite.go
+++ b/test/e2e-new/e2e_suite.go
@@ -199,7 +199,13 @@ var _ = Describe("operator-sdk", func() {
 			_, err = tc.Run(runPkgManCmd)
 			Expect(err).NotTo(HaveOccurred())
 
-			// TODO: run 'cleanup packagemanifests' when added to the new CLI.
+			By("destroying the deployed package manifests-formatted operator")
+			cleanupPkgManCmd := exec.Command(tc.BinaryName, "cleanup", "packagemanifests",
+				"--operator-namespace", tc.Kubectl.Namespace,
+				"--operator-version", operatorVersion,
+				"--timeout", "4m")
+			_, err = tc.Run(cleanupPkgManCmd)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/website/content/en/docs/cli/operator-sdk_cleanup.md
+++ b/website/content/en/docs/cli/operator-sdk_cleanup.md
@@ -22,5 +22,5 @@ operator-sdk cleanup [flags]
 ### SEE ALSO
 
 * [operator-sdk](../operator-sdk)	 - An SDK for building operators with ease
-* [operator-sdk cleanup packagemanifests](../operator-sdk_cleanup_packagemanifests)	 - Clean up after an Operator organized in the package manifests format running with OLM
+* [operator-sdk cleanup packagemanifests](../operator-sdk_cleanup_packagemanifests)	 - Clean up an Operator in the package manifests format deployed with OLM
 

--- a/website/content/en/docs/new-cli/operator-sdk.md
+++ b/website/content/en/docs/new-cli/operator-sdk.md
@@ -69,6 +69,7 @@ operator-sdk [flags]
 * [operator-sdk alpha](../operator-sdk_alpha)	 - Run an alpha subcommand
 * [operator-sdk build](../operator-sdk_build)	 - Compiles code and builds artifacts
 * [operator-sdk bundle](../operator-sdk_bundle)	 - Manage operator bundle metadata
+* [operator-sdk cleanup](../operator-sdk_cleanup)	 - Clean up an Operator deployed with the 'run' subcommand
 * [operator-sdk completion](../operator-sdk_completion)	 - Generators for shell completions
 * [operator-sdk create](../operator-sdk_create)	 - Scaffold a Kubernetes API or webhook
 * [operator-sdk generate](../operator-sdk_generate)	 - Invokes a specific generator

--- a/website/content/en/docs/new-cli/operator-sdk_cleanup.md
+++ b/website/content/en/docs/new-cli/operator-sdk_cleanup.md
@@ -1,0 +1,31 @@
+---
+title: "operator-sdk cleanup"
+---
+## operator-sdk cleanup
+
+Clean up an Operator deployed with the 'run' subcommand
+
+### Synopsis
+
+This command has subcommands that will destroy an Operator deployed with OLM.
+Currently only the package manifests format is supported via the 'packagemanifests' subcommand.
+Run 'operator-sdk cleanup --help' for more information.
+
+
+### Options
+
+```
+  -h, --help   help for cleanup
+```
+
+### Options inherited from parent commands
+
+```
+      --verbose   Enable verbose logging
+```
+
+### SEE ALSO
+
+* [operator-sdk](../operator-sdk)	 - Development kit for building Kubernetes extensions and tools.
+* [operator-sdk cleanup packagemanifests](../operator-sdk_cleanup_packagemanifests)	 - Clean up an Operator in the package manifests format deployed with OLM
+

--- a/website/content/en/docs/new-cli/operator-sdk_cleanup_packagemanifests.md
+++ b/website/content/en/docs/new-cli/operator-sdk_cleanup_packagemanifests.md
@@ -28,7 +28,13 @@ operator-sdk cleanup packagemanifests [flags]
       --timeout duration            Time to wait for the command to complete before failing (default 2m0s)
 ```
 
+### Options inherited from parent commands
+
+```
+      --verbose   Enable verbose logging
+```
+
 ### SEE ALSO
 
-* [operator-sdk cleanup](../operator-sdk_cleanup)	 - Delete and clean up after a running Operator
+* [operator-sdk cleanup](../operator-sdk_cleanup)	 - Clean up an Operator deployed with the 'run' subcommand
 


### PR DESCRIPTION
**Description of the change:**
* cmd/operator-sdk: enable `cleanup packagemanifests` subcommand for the new CLI.
* test/e2e-new: test `cleanup packagemanifests`

**Motivation for the change:** enable `cleanup packagemanifests` for the new CLI.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
	- Not needed since the new CLI hasn't been released yet.
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
	- Done in #3320.

/cc @joelanford @hasbro17 @camilamacedo86 @jmrodri 
