### PR TITLE
docs: update helm docs for the new layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Additions
 
 - Add "panic" level for --zap-stacktrace-level (allows "debug", "info", "error", "panic"). ([#3040](https://github.com/operator-framework/operator-sdk/pull/3040))
-- The `operator-sdk` binary has a new CLI workflow and project layout for scaffolding Go operators that is aligned with Kubebuilder's CLI and project layout. See the new [Quickstart Guide](https://master.sdk.operatorframework.io/docs/golang/quickstart) and the new [CLI reference](https://master.sdk.operatorframework.io/docs/new-cli) for more details. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
+- The `operator-sdk` binary has a new CLI workflow and project layout for scaffolding Go operators that is aligned with Kubebuilder's CLI and project layout. See the new [Quickstart Guide](https://master.sdk.operatorframework.io/docs/building-operators/golang/quickstart/) and the new [CLI reference](https://master.sdk.operatorframework.io/docs/cli) for more details. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
 - `bundle validate` can now use a containerd image ("none") tool to unpack images, removing the need for an external image tool like docker/podman. ([#3222](https://github.com/operator-framework/operator-sdk/pull/3222))
 - The SDK `scorecard` command adds a new test image, scorecard-test-kuttl, that allows end users to write and execute kuttl based tests. ([#3278](https://github.com/operator-framework/operator-sdk/pull/3278))
 - Add "--olm-namespace" flag to olm subcommands (install, uninstall) to allow users to specify the  namespace where olm is to be installed or uninstalled. ([#3300](https://github.com/operator-framework/operator-sdk/pull/3300))
@@ -29,11 +29,11 @@
 
 ### Removals
 
-- The `operator-sdk new` command no longer supports scaffolding new Go projects with the `--type=Go` flag.  To scaffold new projects, users are expected to use `operator-sdk init` as part of the  [new CLI](https://master.sdk.operatorframework.io/docs/new-cli) for Go operators. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
+- The `operator-sdk new` command no longer supports scaffolding new Go projects with the `--type=Go` flag.  To scaffold new projects, users are expected to use `operator-sdk init` as part of the  [new CLI](https://master.sdk.operatorframework.io/docs/cli) for Go operators. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
 
 ### Deprecations
 
-- With the introduction of the new [Kubebuilder aligned CLI](https://master.sdk.operatorframework.io/docs/new-cli)  and project layout for Go operators, the [old CLI](https://sdk.operatorframework.io/docs/cli)  will still continue to work for Go projects scaffolded in the old layout with `operator-sdk new`. However the old CLI is now deprecated and will be removed in a future release. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
+- With the introduction of the new [Kubebuilder aligned CLI](https://master.sdk.operatorframework.io/docs/cli)  and project layout for Go operators, the [old CLI](https://sdk.operatorframework.io/docs/cli)  will still continue to work for Go projects scaffolded in the old layout with `operator-sdk new`. However the old CLI is now deprecated and will be removed in a future release. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
 - The migrate sub-command is deprecated. ([#3319](https://github.com/operator-framework/operator-sdk/pull/3319))
 - Deprecate 'operator-sdk add crd'. Use 'operator-sdk add api' instead. ([#3180](https://github.com/operator-framework/operator-sdk/pull/3180))
 - `bundle create` is deprecated in favor of a combination of `generate bundle` and `docker build -f bundle.Dockerfile ...`. ([#3323](https://github.com/operator-framework/operator-sdk/pull/3323))

--- a/website/content/en/docs/building-operators/helm/migration.md
+++ b/website/content/en/docs/building-operators/helm/migration.md
@@ -1,5 +1,10 @@
+---
+title: Helm migration for the new Layout
+linkTitle: Migration 
+weight: 3
+---
 
-This guide walks through an example of migrating a simple nginx-operator which was built by following the [legacy quick-start][quickstart] to the new layout.
+This guide walks through an example of migrating a simple nginx-operator which was built by following the [legacy quick-start][quickstart-legacy] to the new layout.
 
 ## Overview
 
@@ -38,7 +43,7 @@ $ operator-sdk init --plugins=helm.operator-sdk.io/v1 --domain=com --group=examp
 ```
 
 **Note** Ensure that you use the same values for the flags to recreate the same Helm Chart and API's. If you have
-more than one chart or API's you can add them via `operator-sdk create api` command. For further information check the [quick-start][quickstart-new]. 
+more than one chart or API's you can add them via `operator-sdk create api` command. For further information check the [quick-start][quickstart]. 
  
 ### Replacing the content
 
@@ -51,9 +56,8 @@ more than one chart or API's you can add them via `operator-sdk create api` comm
 
 Now, follow the steps in the section [Build and run the operator][build-run-quick] to verify your project is running. 
 
-<!--  todo: update the following link to /docs/helm/legacy/quickstart when the PR #3326 get merged -->
+[quickstart-legacy]: https://v0-19-x.sdk.operatorframework.io/docs/helm/quickstart/
 [quickstart]: /docs/building-operators/helm/quickstart
-[quickstart-new]: /docs/building-operators/helm/quickstart
 [integration-doc]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/integrating-kubebuilder-and-osdk.md
 [build-run-quick]: /docs/building-operators/helm/quickstart#build-and-run-the-operator
 [kustomize]: https://github.com/kubernetes-sigs/kustomize 

--- a/website/content/en/docs/building-operators/helm/reference/scaffolding.md
+++ b/website/content/en/docs/building-operators/helm/reference/scaffolding.md
@@ -5,14 +5,18 @@ weight: 20
 ---
 
 After creating a new operator project using
-`operator-sdk new --type helm`, the project directory has numerous generated folders and files. The following table describes a basic rundown of each generated file/directory.
+`operator-sdk init --plugins=helm.operator-sdk.io/v1`, 
+the project directory has numerous generated folders and files.
+The following table describes a basic rundown of each generated file/directory.
 
 
 | File/Folders | Purpose |
 | :---         | :---    |
-| deploy | Contains a generic set of Kubernetes manifests for deploying this operator on a Kubernetes cluster. |
+| config | Contains kustomize manifests for deploying this operator on a Kubernetes cluster. |
 | helm-charts/\<kind> | Contains a Helm chart initialized using the equivalent of [`helm create`][docs_helm_create] |
-| build | Contains scripts that the operator-sdk uses for build and initialization. |
+| Dockerfile | Used to build the operator image with `make docker-build` |
 | watches.yaml | Contains Group, Version, Kind, and Helm chart location. |
+| Makefile | Contains the targets used to manage the project |
+| PROJECT  | Contains the project configuration used by the tool |
 
 [docs_helm_create]:https://helm.sh/docs/intro/using_helm/#creating-your-own-charts

--- a/website/content/en/docs/building-operators/helm/reference/watches.md
+++ b/website/content/en/docs/building-operators/helm/reference/watches.md
@@ -19,12 +19,14 @@ Please refer to [Using override values and passing environment variables to the 
 An example Watches file:
 
 ```yaml
----
-# Simple example mapping Foo to the Foo chart
-- version: v1alpha1
-  group: foo.example.com
+# Use the 'create api' subcommand to add watches to this file.
+- group: foo.example.com
+  version: v1alpha1
   kind: Foo
   chart: helm-charts/foo
+  overrideValues:
+    image.repository: quay.io/mycustomrepo
+  watchDependentResources: false   
 ```
 
 [override-values]: /docs/building-operators/helm/reference/advanced_features/#passing-environment-variables-to-the-helm-chart

--- a/website/content/en/docs/upgrading-sdk-version/v0.19.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v0.19.0.md
@@ -22,7 +22,7 @@ _See [#3265](https://github.com/operator-framework/operator-sdk/pull/3265) for m
 
 ## Migrating Go projects to the new Kubebuilder aligned project layout
 
-See the [migration guide](https://master.sdk.operatorframework.io/docs/golang/project_migration_guide/)
+See the [migration guide](https://master.sdk.operatorframework.io/docs/building-operators/golang/project_migration_guide/)
 that walks through an example of how to migrate a Go based operator project from the old layout to the new layout.
 
 _See [#3190](https://github.com/operator-framework/operator-sdk/pull/3190) for more details._


### PR DESCRIPTION
**Description of the change:**

Provide the same documentation and steps using the helm plugin. See the PR #3421 which adds the plugin. 

- Update all related info in the Helm documentation  
- Create a new sub-directory called Legacy to keep the previous docs

**Motivation**

SDK is in a process to be integrated with KB which means that its project layouts will be aligned. More info : [Integrating Kubebuilder and Operator SDK](https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/integrating-kubebuilder-and-osdk.md) and [Extensible CLI and Scaffolding Plugins](https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/extensible-cli-and-scaffolding-plugins-phase-1.md).
