### PR TITLE
feat: allow know the project type by the config file

### DIFF
--- a/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/cmd/operator-sdk/generate/bundle/bundle.go
@@ -173,7 +173,7 @@ func (c bundleCmd) runManifests(cfg *config.Config) (err error) {
 
 	csvGen := gencsv.Generator{
 		OperatorName: c.operatorName,
-		OperatorType: genutil.PluginKeyToOperatorType(cfg.Layout),
+		OperatorType: projutil.PluginKeyToOperatorType(cfg.Layout),
 		Version:      c.version,
 		Collector:    col,
 	}

--- a/cmd/operator-sdk/generate/internal/genutil.go
+++ b/cmd/operator-sdk/generate/internal/genutil.go
@@ -21,14 +21,11 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/blang/semver"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"sigs.k8s.io/yaml"
-
-	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 )
 
 // ValidateVersion returns an error if version is not a strict semantic version.
@@ -53,18 +50,6 @@ func IsPipeReader() bool {
 		return false
 	}
 	return info.Mode()&os.ModeNamedPipe != 0
-}
-
-// PluginKeyToOperatorType converts a plugin key string to an operator project
-// type.
-// TODO(estroz): this can probably be made more robust by checking known
-// plugin keys directly.
-func PluginKeyToOperatorType(pluginKey string) projutil.OperatorType {
-	switch {
-	case strings.HasPrefix(pluginKey, "go"):
-		return projutil.OperatorTypeGo
-	}
-	return ""
 }
 
 // WriteObjects writes each object in objs to w.

--- a/cmd/operator-sdk/generate/kustomize/manifests.go
+++ b/cmd/operator-sdk/generate/kustomize/manifests.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/kubebuilder/pkg/model/config"
 
-	genutil "github.com/operator-framework/operator-sdk/cmd/operator-sdk/generate/internal"
 	gencsv "github.com/operator-framework/operator-sdk/internal/generate/clusterserviceversion"
 	"github.com/operator-framework/operator-sdk/internal/scaffold/kustomize"
 	kbutil "github.com/operator-framework/operator-sdk/internal/util/kubebuilder"
@@ -165,7 +164,7 @@ func (c manifestsCmd) run(cfg *config.Config) error {
 
 	csvGen := gencsv.Generator{
 		OperatorName: c.operatorName,
-		OperatorType: genutil.PluginKeyToOperatorType(cfg.Layout),
+		OperatorType: projutil.PluginKeyToOperatorType(cfg.Layout),
 	}
 	opts := []gencsv.Option{
 		gencsv.WithBase(c.inputDir, c.apisDir, c.interactiveLevel),

--- a/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
+++ b/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
@@ -163,7 +163,7 @@ func (c packagemanifestsCmd) run(cfg *config.Config) error {
 
 	csvGen := gencsv.Generator{
 		OperatorName: c.operatorName,
-		OperatorType: genutil.PluginKeyToOperatorType(cfg.Layout),
+		OperatorType: projutil.PluginKeyToOperatorType(cfg.Layout),
 		Version:      c.version,
 		Collector:    col,
 	}

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -249,7 +249,7 @@ func IsOperatorGo() bool {
 // IsOperatorAnsible returns true when the layout field in PROJECT file has the Ansible prefix key.
 // NOTE: For the legacy, returns true when the project  contains the roles and the molecule directory.
 func IsOperatorAnsible() bool {
-	//
+	// If the project is in the new layout, check the config file's plugin type.
 	if kbutil.HasProjectFile() {
 		cfg, err := kbutil.ReadConfig()
 		if err != nil {


### PR DESCRIPTION
**Description of the change:**
- Make ProjectTypes helpers looking for the type in the PROJECT file when it exists. 

**Motivation for the change:**

- To allow the SDK CLI commands works properly for the new layout 
- Follow up the same standard for all types shows very beneficial and increase the manutence ability
