### PR TITLE
scorecard,generate-csv: consider api "group" while checking for known types

### DIFF
--- a/changelog/fragments/crds-with-core-types.yaml
+++ b/changelog/fragments/crds-with-core-types.yaml
@@ -1,0 +1,5 @@
+entries:
+    - description: >
+        Use group and kind instead of only kind when parsing manifests in the CSV generator to avoid marshaling them into the wrong Go types.
+      kind: "bugfix"
+      breaking: false

--- a/internal/generate/collector/collect.go
+++ b/internal/generate/collector/collect.go
@@ -51,6 +51,17 @@ type Manifests struct {
 	Others []unstructured.Unstructured
 }
 
+var (
+	roleGK                 = rbacv1.SchemeGroupVersion.WithKind("Role").GroupKind()
+	clusterRoleGK          = rbacv1.SchemeGroupVersion.WithKind("ClusterRole").GroupKind()
+	deploymentGK           = appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind()
+	v1crdGK                = apiextv1.SchemeGroupVersion.WithKind("CustomResourceDefinition").GroupKind()
+	v1beta1crdGK           = apiextv1beta1.SchemeGroupVersion.WithKind("CustomResourceDefinition").GroupKind()
+	validatingWebhookCfgGK = admissionregv1.SchemeGroupVersion.WithKind("ValidatingWebhookConfiguration").GroupKind()
+	mutatingWebhookCfgGK   = admissionregv1.SchemeGroupVersion.WithKind("MutatingWebhookConfiguration").GroupKind()
+	v1alpha3ScorecardCfgGK = scorecardv1alpha3.SchemeGroupVersion.WithKind("Configuration").GroupKind()
+)
+
 // UpdateFromDirs adds Roles, ClusterRoles, Deployments, and Custom Resource examples
 // found in deployDir, and CustomResourceDefinitions found in crdsDir,
 // to their respective fields in a Manifests, then filters and deduplicates them.
@@ -76,23 +87,21 @@ func (c *Manifests) UpdateFromDirs(deployDir, crdsDir string) error {
 			}
 
 			gvk := typeMeta.GroupVersionKind()
-			switch gvk.Kind {
-			case "Role":
+			switch gvk.GroupKind() {
+			case roleGK:
 				err = c.addRoles(manifest)
-			case "ClusterRole":
+			case clusterRoleGK:
 				err = c.addClusterRoles(manifest)
-			case "Deployment":
+			case deploymentGK:
 				err = c.addDeployments(manifest)
-			case "CustomResourceDefinition":
+			case v1crdGK, v1beta1crdGK:
 				// Skip for now and add explicitly from CRDsDir input.
-			case "ValidatingWebhookConfiguration":
+			case validatingWebhookCfgGK:
 				err = c.addValidatingWebhookConfigurations(manifest)
-			case "MutatingWebhookConfiguration":
+			case mutatingWebhookCfgGK:
 				err = c.addMutatingWebhookConfigurations(manifest)
-			case scorecardv1alpha3.ConfigurationKind:
-				if gvk.GroupVersion() == scorecardv1alpha3.SchemeGroupVersion {
-					err = c.addScorecardConfig(manifest)
-				}
+			case v1alpha3ScorecardCfgGK:
+				err = c.addScorecardConfig(manifest)
 			default:
 				err = c.addOthers(manifest)
 			}
@@ -140,23 +149,21 @@ func (c *Manifests) UpdateFromReader(r io.Reader) error {
 		}
 
 		gvk := typeMeta.GroupVersionKind()
-		switch gvk.Kind {
-		case "Role":
+		switch gvk.GroupKind() {
+		case roleGK:
 			err = c.addRoles(manifest)
-		case "ClusterRole":
+		case clusterRoleGK:
 			err = c.addClusterRoles(manifest)
-		case "Deployment":
+		case deploymentGK:
 			err = c.addDeployments(manifest)
-		case "CustomResourceDefinition":
+		case v1crdGK, v1beta1crdGK:
 			err = c.addCustomResourceDefinitions(gvk.Version, manifest)
-		case "ValidatingWebhookConfiguration":
+		case validatingWebhookCfgGK:
 			err = c.addValidatingWebhookConfigurations(manifest)
-		case "MutatingWebhookConfiguration":
+		case mutatingWebhookCfgGK:
 			err = c.addMutatingWebhookConfigurations(manifest)
-		case scorecardv1alpha3.ConfigurationKind:
-			if gvk.GroupVersion() == scorecardv1alpha3.SchemeGroupVersion {
-				err = c.addScorecardConfig(manifest)
-			}
+		case v1alpha3ScorecardCfgGK:
+			err = c.addScorecardConfig(manifest)
 		default:
 			err = c.addOthers(manifest)
 		}

--- a/internal/generate/collector/collect_test.go
+++ b/internal/generate/collector/collect_test.go
@@ -1,0 +1,54 @@
+// Copyright 2018 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testDataDir   = filepath.Join("..", "testdata")
+	goTestDataDir = filepath.Join(testDataDir, "non-standard-layout")
+	goConfigDir   = filepath.Join(goTestDataDir, "config")
+)
+
+func TestUpdateFromReader(t *testing.T) {
+	c := &Manifests{}
+
+	err := filepath.Walk(goConfigDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		file, err := os.OpenFile(path, os.O_RDONLY, 0)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		return c.UpdateFromReader(file)
+	})
+
+	assert.Nil(t, err, "failed to read manifests")
+	assert.Equal(t, len(c.Roles), 1, "failed to read Role(s)")
+	assert.Equal(t, len(c.Deployments), 1, "failed to read Deployment(s)")
+	// 2 CR/CRDs:
+	// - memcached.cache.examples.com
+	// - deployment.foo.example.com
+	assert.Equal(t, len(c.V1beta1CustomResourceDefinitions), 2, "failed to read v1beta1 CRDs")
+	assert.Equal(t, len(c.CustomResources), 2, "failed to read CRs")
+}

--- a/internal/generate/testdata/non-standard-layout/config/crds-with-core-types/foo.example.com_deployment_crd.yaml
+++ b/internal/generate/testdata/non-standard-layout/config/crds-with-core-types/foo.example.com_deployment_crd.yaml
@@ -1,0 +1,57 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: deployment.foo.example.com
+spec:
+  group: foo.example.com
+  names:
+    kind: Deployment
+    listKind: DeploymentList
+    plural: deployments
+    singular: deployment
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Schema for the deployments API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DeploymentSpec defines the desired state of the Foo Deployment
+          properties:
+            size:
+              description: Size is the size of the Foo deployment nodes
+              format: int32
+              type: integer
+          required:
+          - size
+          type: object
+        status:
+          description: DeploymentStatus defines the observed state of the Foo Deployment
+          properties:
+            nodes:
+              description: Nodes are the names of the Foo pods
+              items:
+                type: string
+              type: array
+          required:
+          - nodes
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/internal/generate/testdata/non-standard-layout/config/crds-with-core-types/foo.example.com_v1alpha1_deployment_cr.yaml
+++ b/internal/generate/testdata/non-standard-layout/config/crds-with-core-types/foo.example.com_v1alpha1_deployment_cr.yaml
@@ -1,0 +1,7 @@
+apiVersion: foo.example.com/v1alpha1
+kind: Deployment
+metadata:
+  name: example-foo-deployment
+spec:
+  # Add fields here
+  size: 3


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Comparing only "kind" of the resource might lead to conflict where two resources might have same kind but in different api groups.
    
For example an operator could provide a custom resource with name "Deployment" in it's own group. On generating csv for this operator might not consider the provided CR for filling 'alm-examples'

**Motivation for the change:**

Observed this issue while integrating [PMEM-CSI operator](https://github.com/intel/pmem-csi) which provides `Deployment` CRD in `pmem-csi.intel.com` API group.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
