### PR TITLE
feat:  condition   status conditional UpdateSuccessful was renamed to UpgradeSuccessful

### DIFF
--- a/changelog/fragments/helm-conditional-reason.yaml
+++ b/changelog/fragments/helm-conditional-reason.yaml
@@ -1,0 +1,27 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      In Helm-based operators, the `UpdateSuccessful` condition reason was renamed to `UpgradeSuccessful` to better align with Helm nomenclature.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: yes
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: "Helm: rename condition reason `UpdateSuccessful` to `UpgradeSuccessful`"
+      body: |
+        For Helm-based operators to be more aligned with Helm, the `UpdateSuccessful` condition
+        reason was renamed to `UpgradeSuccessful` for the `ReleaseFailed` condition.
+        Note that this is **NOT** a breaking change for Helm-based operators themselves.
+        However, any script or code that is depending on this condition reason must be updated
+        to use `UpgradeSuccessful` instead of `UpdateSuccessful`.

--- a/pkg/helm/controller/reconcile.go
+++ b/pkg/helm/controller/reconcile.go
@@ -275,7 +275,7 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 		status.SetCondition(types.HelmAppCondition{
 			Type:    types.ConditionDeployed,
 			Status:  types.StatusTrue,
-			Reason:  types.ReasonUpdateSuccessful,
+			Reason:  types.ReasonUpgradeSuccessful,
 			Message: message,
 		})
 		status.DeployedRelease = &types.HelmAppRelease{

--- a/pkg/helm/internal/types/types.go
+++ b/pkg/helm/internal/types/types.go
@@ -66,7 +66,7 @@ const (
 	StatusUnknown ConditionStatus = "Unknown"
 
 	ReasonInstallSuccessful   HelmAppConditionReason = "InstallSuccessful"
-	ReasonUpdateSuccessful    HelmAppConditionReason = "UpdateSuccessful"
+	ReasonUpgradeSuccessful   HelmAppConditionReason = "UpgradeSuccessful"
 	ReasonUninstallSuccessful HelmAppConditionReason = "UninstallSuccessful"
 	ReasonInstallError        HelmAppConditionReason = "InstallError"
 	ReasonUpgradeError        HelmAppConditionReason = "UpgradeError"


### PR DESCRIPTION
**Description of the change:**
- Follow-up of : https://github.com/operator-framework/operator-sdk/pull/3269
- helm: rename status conditional UpdateSuccessful to UpgradeSuccessful
**Motivation for the change:**
related to the changes done in the transition to using the new layout.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs) - (has no docs to change)
