### PR TITLE
refactor cmd/build to be more testable

### DIFF
--- a/cmd/operator-sdk/build/cmd.go
+++ b/cmd/operator-sdk/build/cmd.go
@@ -31,16 +31,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	imageBuildArgs string
-	imageBuilder   string
+type buildCmd struct {
+	image               string
+	imageBuildArgs      string
+	imageBuilder        string
+	splitImageBuildArgs []string
 
 	// todo: remove when the legacy layout is no longer supported
 	// Deprecated
 	goBuildArgs string
-)
+}
 
 func NewCmd() *cobra.Command {
+	c := &buildCmd{}
 	buildCmd := &cobra.Command{
 		Use:   "build <image>",
 		Short: "Compiles code and builds artifacts",
@@ -57,75 +60,100 @@ For example:
 	$ operator-sdk build quay.io/example/operator:v0.0.1
 	$ docker push quay.io/example/operator:v0.0.1
 `,
-		RunE: buildFunc,
+		PreRunE: func(cmd *cobra.Command, args []string) (err error) {
+			return c.validate(args)
+		},
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			return c.run()
+		},
 	}
-	buildCmd.Flags().StringVar(&imageBuildArgs, "image-build-args", "",
+	buildCmd.Flags().StringVar(&c.imageBuildArgs, "image-build-args", "",
 		"Extra image build arguments as one string such as \"--build-arg https_proxy=$https_proxy\"")
-	buildCmd.Flags().StringVar(&imageBuilder, "image-builder", "docker",
+	buildCmd.Flags().StringVar(&c.imageBuilder, "image-builder", "docker",
 		"Tool to build OCI images. One of: [docker, podman, buildah]")
 
 	// todo: remove when the legacy layout is no longer supported
 	if !kbutil.HasProjectFile() {
-		buildCmd.Flags().StringVar(&goBuildArgs, "go-build-args", "",
+		buildCmd.Flags().StringVar(&c.goBuildArgs, "go-build-args", "",
 			"Extra Go build arguments as one string such as \"-ldflags -X=main.xyz=abc\"")
 	}
 	return buildCmd
 }
 
-func createBuildCommand(imageBuilder, context, dockerFile, image string, imageBuildArgs ...string) (*exec.Cmd, error) {
-	var args []string
-	switch imageBuilder {
-	case "docker", "podman":
-		args = append(args, "build", "-f", dockerFile, "-t", image)
-	case "buildah":
-		args = append(args, "bud", "--format=docker", "-f", dockerFile, "-t", image)
-	default:
-		return nil, fmt.Errorf("%s is not supported image builder", imageBuilder)
+func (c *buildCmd) validate(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("an image name is required")
 	}
+	c.image = args[0]
 
-	for _, bargs := range imageBuildArgs {
-		if bargs != "" {
-			splitArgs, err := shlex.Split(bargs)
-			if err != nil {
-				return nil, fmt.Errorf("image-build-args is not parseable: %v", err)
-			}
-			args = append(args, splitArgs...)
+	var err error
+	if c.imageBuildArgs != "" {
+		c.splitImageBuildArgs, err = shlex.Split(c.imageBuildArgs)
+		if err != nil {
+			return fmt.Errorf("image-build-args is not parseable: %v", err)
 		}
 	}
-
-	args = append(args, context)
-
-	return exec.Command(imageBuilder, args...), nil
-}
-
-func buildFunc(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("command %s requires exactly one argument", cmd.CommandPath())
+	for i, v := range c.splitImageBuildArgs {
+		fmt.Println(i, v)
 	}
 
-	image := args[0]
+	return nil
+}
+
+func (c *buildCmd) run() error {
 	projutil.MustInProjectRoot()
 
 	if kbutil.HasProjectFile() {
-		if err := doImageBuild("Dockerfile", image); err != nil {
-			log.Fatalf("Failed to build image %s: %v", image, err)
+		if err := c.doImageBuild("Dockerfile"); err != nil {
+			log.Fatalf("Failed to build image %s: %v", c.image, err)
 		}
 		return nil
 	}
 
 	// todo: remove when the legacy layout is no longer supported
 	// note that the above if will no longer be required as well.
-	if err := doLegacyBuild(image); err != nil {
-		log.Fatalf("Failed to build image %s: %v", image, err)
+	if err := c.doLegacyBuild(); err != nil {
+		log.Fatalf("Failed to build image %s: %v", c.image, err)
 	}
 	return nil
+}
+
+// doImageBuild will execute the build command for the given Dockerfile path and image
+func (c *buildCmd) doImageBuild(dockerFilePath string) error {
+	log.Infof("Building OCI image %s", c.image)
+	buildCmd, err := c.createBuildCommand(c.imageBuilder, ".", dockerFilePath)
+	if err != nil {
+		return err
+	}
+	if err := projutil.ExecCmd(buildCmd); err != nil {
+		return err
+	}
+	log.Info("Operator build complete.")
+	return nil
+}
+
+func (c *buildCmd) createBuildCommand(imageBuilder, context, dockerFile string) (*exec.Cmd, error) {
+	var args []string
+	switch imageBuilder {
+	case "docker", "podman":
+		args = append(args, "build", "-f", dockerFile, "-t", c.image)
+	case "buildah":
+		args = append(args, "bud", "--format=docker", "-f", dockerFile, "-t", c.image)
+	default:
+		return nil, fmt.Errorf("%s is not supported image builder", imageBuilder)
+	}
+
+	args = append(args, c.splitImageBuildArgs...)
+	args = append(args, context)
+
+	return exec.Command(imageBuilder, args...), nil
 }
 
 // todo: remove when the legacy layout is no longer supported
 // Deprecated: Used just for the legacy layout
 // --
 // doLegacyBuild will build projects with the legacy layout.
-func doLegacyBuild(image string) error {
+func (c *buildCmd) doLegacyBuild() error {
 	goBuildEnv := append(os.Environ(), "GOOS=linux")
 	// If CGO_ENABLED is not set, set it to '0'.
 	if _, ok := os.LookupEnv("CGO_ENABLED"); !ok {
@@ -139,8 +167,8 @@ func doLegacyBuild(image string) error {
 		trimPath := fmt.Sprintf("all=-trimpath=%s", filepath.Dir(absProjectPath))
 		args := []string{"-gcflags", trimPath, "-asmflags", trimPath}
 
-		if goBuildArgs != "" {
-			splitArgs := strings.Fields(goBuildArgs)
+		if c.goBuildArgs != "" {
+			splitArgs := strings.Fields(c.goBuildArgs)
 			args = append(args, splitArgs...)
 		}
 
@@ -154,19 +182,5 @@ func doLegacyBuild(image string) error {
 			log.Fatalf("Failed to build operator binary: %v", err)
 		}
 	}
-	return doImageBuild("build/Dockerfile", image)
-}
-
-// doImageBuild will execute the build command for the given Dockerfile path and image
-func doImageBuild(dockerFilePath, image string) error {
-	log.Infof("Building OCI image %s", image)
-	buildCmd, err := createBuildCommand(imageBuilder, ".", dockerFilePath, image, imageBuildArgs)
-	if err != nil {
-		return err
-	}
-	if err := projutil.ExecCmd(buildCmd); err != nil {
-		return err
-	}
-	log.Info("Operator build complete.")
-	return nil
+	return c.doImageBuild("build/Dockerfile")
 }


### PR DESCRIPTION
**Description of the change:**
Refactor cmd/build to be more testable. This includes making a struct to contain the info needed to execute the command, a validate method that parses the args, and a run method containing the execution.

I actually have a question about the project root check that is currently [here.](https://github.com/operator-framework/operator-sdk/blob/master/cmd/operator-sdk/build/cmd.go#L107). That helper method appears to exit directly instead of bubbling an error up, which makes it extremely difficult to test, as the test process just blows up. What is the reasoning for exiting directly instead of returning an error and letting the calling environment handle it, which seems to be the more normal golang style?

**Motivation for the change:**
See #3246


