### PR TITLE
Upgrade hugo from 0.70 to 0.73

### DIFF
--- a/hack/check-links.sh
+++ b/hack/check-links.sh
@@ -6,6 +6,6 @@ source ./hack/lib/common.sh
 
 header_text "Building the site and checking links"
 docker volume create sdk-html
-docker run --rm -v "$(pwd):/src" -v sdk-html:/target klakegg/hugo:0.70.0-ext-ubuntu -s website
+docker run --rm -v "$(pwd):/src" -v sdk-html:/target klakegg/hugo:0.73.0-ext-ubuntu -s website
 docker run --rm -v sdk-html:/target mtlynch/htmlproofer /target --empty-alt-ignore --http-status-ignore 429 --allow_hash_href
 docker volume rm sdk-html

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,4 +10,4 @@
 # "production" environment specific build settings
 [build.environment]
   HUGO_ENV = "production"
-  HUGO_VERSION = "0.70.0"
+  HUGO_VERSION = "0.73.0"


### PR DESCRIPTION
**Description of the change:**
- Upgrade hugo from 0.70 to 0.73

**Motivation for the change:**
- Part of the changes made to try to solve intermittent timeout issues to check the docs which Hugo is shown not render the files with the default timeout. Such as:

```
- /target/404.html
  *  External link https://gohugo.io/templates/404/ failed: response code 0 means something's wrong.
             It's possible libcurl couldn't connect to the server or perhaps the request timed out.
             Sometimes, making too many requests at once also breaks things.
             Either way, the return message (if any) from the server is: Couldn't connect to server
- /target/docs/contribution-guidelines/local-docs/index.html
  *  External link https://gohugo.io/ failed: response code 0 means something's wrong.

```