### PR TITLE
hugo: increase the timeout from 10 to 60s to render external links

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -85,6 +85,9 @@ gcs_engine_id = "015999847059016081733:wlfzxjx77h8"
 # Enable Algolia DocSearch
 algolia_docsearch = false
 
+# The default timeout is (10000). Increase it to avoid issues when we are checking the links from the docs
+# More info: https://www.engino.co.uk/content-text/configuration/
+timeout = 60000
 
 [[params.versions]]
   version = "master"


### PR DESCRIPTION
**Description of the change:**
The default timeout is (10000). Increase it to avoid issues when we are checking the links from the docs
More info: https://www.engino.co.uk/content-text/configuration/

**Motivation for the change:**

- Part of the changes made to try to solve intermittent timeout issues to check the docs which Hugo is shown not render the files with the default timeout. Such as:

```
- /target/404.html
  *  External link https://gohugo.io/templates/404/ failed: response code 0 means something's wrong.
             It's possible libcurl couldn't connect to the server or perhaps the request timed out.
             Sometimes, making too many requests at once also breaks things.
             Either way, the return message (if any) from the server is: Couldn't connect to server
- /target/docs/contribution-guidelines/local-docs/index.html
  *  External link https://gohugo.io/ failed: response code 0 means something's wrong.

```

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
