### PR TITLE
Scorecard kuttl image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -332,6 +332,8 @@ jobs:
         - make image-push-scorecard-test-multiarch
 
     # Build and deploy scorecard-test-kuttl multi-arch manifest list
+    # only amd64 is supported in base kudobuilder/kuttl image
+    # which is why we only support amd64 for scorecard-test-kuttl
     - <<: *manifest-deploy
       name: Manifest list for scorecard-test-kuttl
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -298,33 +298,10 @@ jobs:
         - make image-build-scorecard-test
         - make image-push-scorecard-test
 
-    # Build and deploy arm64 scorecard-test-kuttl docker image 
-    - <<: *deploy
-      name: Docker image for scorecard-test-kuttl (arm64)
-      arch: arm64
-      script:
-        - make image-build-scorecard-test-kuttl
-        - make image-push-scorecard-test-kuttl
-
     # Build and deploy amd64 scorecard-test-kuttl docker image
     - <<: *deploy
       name: Docker image for scorecard-test-kuttl (amd64)
       arch: amd64
-      script:
-        - make image-build-scorecard-test-kuttl
-        - make image-push-scorecard-test-kuttl
-    # Build and deploy ppc64le scorecard-test-kuttl docker image
-    - <<: *deploy
-      name: Docker image for scorecard-test-kuttl (ppc64le)
-      arch: ppc64le
-      script:
-        - make image-build-scorecard-test-kuttl
-        - make image-push-scorecard-test-kuttl
-
-    # Build and deploy s390x scorecard-test-kuttl docker image
-    - <<: *deploy
-      name: Docker image for scorecard-test-kuttl (s390x)
-      arch: s390x
       script:
         - make image-build-scorecard-test-kuttl
         - make image-push-scorecard-test-kuttl

--- a/.travis.yml
+++ b/.travis.yml
@@ -312,7 +312,6 @@ jobs:
       script:
         - make image-build-scorecard-test-kuttl
         - make image-push-scorecard-test-kuttl
-
     # Build and deploy ppc64le scorecard-test-kuttl docker image
     - <<: *deploy
       name: Docker image for scorecard-test-kuttl (ppc64le)

--- a/.travis.yml
+++ b/.travis.yml
@@ -297,6 +297,38 @@ jobs:
         - make image-build-scorecard-test
         - make image-push-scorecard-test
 
+    # Build and deploy arm64 scorecard-test-kuttl docker image 
+    - <<: *deploy
+      name: Docker image for scorecard-test-kuttl (arm64)
+      arch: arm64
+      script:
+        - make image-build-scorecard-test-kuttl
+        - make image-push-scorecard-test-kuttl
+
+    # Build and deploy amd64 scorecard-test-kuttl docker image
+    - <<: *deploy
+      name: Docker image for scorecard-test-kuttl (amd64)
+      arch: amd64
+      script:
+        - make image-build-scorecard-test-kuttl
+        - make image-push-scorecard-test-kuttl
+
+    # Build and deploy ppc64le scorecard-test-kuttl docker image
+    - <<: *deploy
+      name: Docker image for scorecard-test-kuttl (ppc64le)
+      arch: ppc64le
+      script:
+        - make image-build-scorecard-test-kuttl
+        - make image-push-scorecard-test-kuttl
+
+    # Build and deploy s390x scorecard-test-kuttl docker image
+    - <<: *deploy
+      name: Docker image for scorecard-test-kuttl (s390x)
+      arch: s390x
+      script:
+        - make image-build-scorecard-test-kuttl
+        - make image-push-scorecard-test-kuttl
+
     # Build and deploy ansible multi-arch manifest list
     - stage: deploy-manifest-multiarch
       <<: *manifest-deploy
@@ -321,3 +353,9 @@ jobs:
       name: Manifest list for scorecard-test
       script:
         - make image-push-scorecard-test-multiarch
+
+    # Build and deploy scorecard-test-kuttl multi-arch manifest list
+    - <<: *manifest-deploy
+      name: Manifest list for scorecard-test-kuttl
+      script:
+        - make image-push-scorecard-test-kuttl-multiarch

--- a/.travis.yml
+++ b/.travis.yml
@@ -168,6 +168,7 @@ jobs:
 
     ## Image deploy/push stage jobs ##
 
+
     # Build and deploy arm64 ansible-operator docker image
     - stage: deploy
       <<: *deploy


### PR DESCRIPTION

**Description of the change:**
this PR adds the scorecard-test-kuttl image to the travis configuration.  It will deploy the scorecard-test-kuttl (amd64) image to quay.io.  Other architectures will require kuttl base images to also support more than just amd64 architectures and will be added in follow on work if required.

**Motivation for the change:**
a new scorecard-test-kuttl image is made available and meant to be released.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
