### PR TITLE
cmd/operator-sdk/bundle/cmd.go: uncomment previously broken docs link

### DIFF
--- a/cmd/operator-sdk/bundle/cmd.go
+++ b/cmd/operator-sdk/bundle/cmd.go
@@ -46,11 +46,10 @@ https://github.com/operator-framework/operator-registry/blob/master/docs/design/
 
 func NewCmdLegacy() *cobra.Command {
 	cmd := newCmd()
-	// TODO(estroz): uncomment this once OLM integration docs are updated.
-	// 	cmd.Long += `
-	// More information about the integration with OLM via SDK:
-	// https://sdk.operatorframework.io/docs/olm-integration/legacy
-	// `
+	cmd.Long += `
+More information about the integration with OLM via SDK:
+https://sdk.operatorframework.io/docs/olm-integration/legacy
+`
 	cmd.AddCommand(
 		newCreateCmd(),
 		newValidateCmdLegacy(),

--- a/website/content/en/docs/cli/operator-sdk_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle.md
@@ -14,6 +14,9 @@ native software, like the Operator Lifecycle Manager.
 More information about operator bundles and metadata:
 https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md
 
+More information about the integration with OLM via SDK:
+https://sdk.operatorframework.io/docs/olm-integration/legacy
+
 
 ### Options
 


### PR DESCRIPTION
**Description of the change:**
* cmd/operator-sdk/bundle/cmd.go: uncomment previously broken docs link

**Motivation for the change:** from #3320 

/kind documentation
