### PR TITLE
*: remove `lll` linter

### DIFF
--- a/cmd/operator-sdk/add/controller.go
+++ b/cmd/operator-sdk/add/controller.go
@@ -30,7 +30,6 @@ var (
 	crdVersion      string
 )
 
-//nolint:lll
 func newAddControllerCmd() *cobra.Command {
 	controllerCmd := &cobra.Command{
 		Use:   "controller",
@@ -38,14 +37,14 @@ func newAddControllerCmd() *cobra.Command {
 		Long: `
 Add a new controller package to your operator project.
 
-This command creates a new controller package under pkg/controller/<kind> that, by default, reconciles on a custom resource for the specified apiversion and kind. The controller will expect to use the custom resource type that should already be defined under pkg/apis/<group>/<version> via the "operator-sdk add api" command. 
+This command creates a new controller package under pkg/controller/<kind> that, by default, reconciles on a custom resource for the specified apiversion and kind. The controller will expect to use the custom resource type that should already be defined under pkg/apis/<group>/<version> via the "operator-sdk add api" command.
 
 Note that, if the controller pkg for that Kind already exists at pkg/controller/<kind> then the command will not overwrite and return an error.
 
 This command MUST be run from the project root directory.`,
 
 		Example: `
-The following example will create a controller to manage, watch and reconcile as primary resource the <v1.AppService> from the domain <app.example.com>.    
+The following example will create a controller to manage, watch and reconcile as primary resource the <v1.AppService> from the domain <app.example.com>.
 
 Example:
 
@@ -57,7 +56,7 @@ Example:
 	│   └── appservice_controller.go
 	└── controller.go
 
-The following example will create a controller to manage, watch and reconcile as a primary resource the <v1.Deployment> from the domain <k8s.io.api>, which is not defined in the project (external). Note that, it can be used to create controllers for any External API. 	
+The following example will create a controller to manage, watch and reconcile as a primary resource the <v1.Deployment> from the domain <k8s.io.api>, which is not defined in the project (external). Note that, it can be used to create controllers for any External API.
 
 Example:
 
@@ -66,7 +65,7 @@ Example:
 	pkg/controller/
 	├── add_deployment.go
 	├── deployment
-	│   └── deployment_controller.go 
+	│   └── deployment_controller.go
 	└── controller.go
 		`,
 		RunE: controllerRun,

--- a/cmd/operator-sdk/bundle/create.go
+++ b/cmd/operator-sdk/bundle/create.go
@@ -43,7 +43,6 @@ type bundleCreateCmd struct {
 
 // newCreateCmd returns a command that will build operator bundle image or
 // generate metadata for them.
-//nolint:lll
 func newCreateCmd() *cobra.Command {
 	c := &bundleCreateCmd{}
 

--- a/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/cmd/operator-sdk/generate/bundle/bundle.go
@@ -47,7 +47,6 @@ More information on bundles:
 https://github.com/operator-framework/operator-registry/#manifest-format
 `
 
-	//nolint:lll
 	examples = `
   # Generate bundle files and build your bundle image with these 'make' recipes:
   $ make bundle

--- a/cmd/operator-sdk/generate/csv.go
+++ b/cmd/operator-sdk/generate/csv.go
@@ -42,7 +42,6 @@ type csvCmd struct {
 	interactive      bool
 }
 
-//nolint:lll
 func newGenerateCSVCmd() *cobra.Command {
 	c := &csvCmd{}
 	cmd := &cobra.Command{

--- a/cmd/operator-sdk/generate/kustomize/manifests.go
+++ b/cmd/operator-sdk/generate/kustomize/manifests.go
@@ -37,7 +37,6 @@ This command will interactively ask for UI metadata, an important component of m
 by default unless a base already exists or you set '--interactive=false'.
 `
 
-//nolint:lll
 const examples = `
   $ operator-sdk generate kustomize manifests
 

--- a/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
+++ b/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
@@ -46,7 +46,6 @@ More information on the package manifests format:
 https://github.com/operator-framework/operator-registry/#manifest-format
 `
 
-	//nolint:lll
 	examples = `
   # Generate manifests then create the package manifests base:
   $ make manifests

--- a/hack/generate/changelog/util/fragment.go
+++ b/hack/generate/changelog/util/fragment.go
@@ -176,7 +176,6 @@ func (g *gitPullRequestNumberGetter) GetPullRequestNumberFor(filename string) (u
 }
 
 func (g *gitPullRequestNumberGetter) getCommitMessage(filename string) (string, error) {
-	//nolint:lll
 	args := fmt.Sprintf("log --follow --pretty=format:%%s --diff-filter=A --find-renames=90%% %s", filename)
 	line, err := exec.Command("git", strings.Split(args, " ")...).CombinedOutput()
 	if err != nil {

--- a/hack/tests/check-lint.sh
+++ b/hack/tests/check-lint.sh
@@ -61,9 +61,7 @@ golangci-lint run --disable-all \
     --enable=dupl \
     --enable=unparam \
     --enable=golint \
-    --enable=lll \
     --enable=staticcheck \
     --enable=unused \
     --enable=gosimple \
     ${LINTERS[@]}
-

--- a/hack/tests/scaffolding/scaffold-memcached.go
+++ b/hack/tests/scaffolding/scaffold-memcached.go
@@ -119,7 +119,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error: %v\nCommand Output: %s\n", err, string(cmdOut))
 	}
-	//nolint:lll
+
 	tmplFiles := map[string]string{
 		filepath.Join(localSDKPath, "example/memcached-operator/memcached_controller.go.tmpl"): "pkg/controller/memcached/memcached_controller.go",
 		filepath.Join(localSDKPath, "test/e2e/_incluster-test-code/main_test.go"):              "test/e2e/main_test.go",

--- a/internal/generate/collector/collect.go
+++ b/internal/generate/collector/collect.go
@@ -100,7 +100,6 @@ func (c *Manifests) UpdateFromDirs(deployDir, crdsDir string) error {
 
 	// Add CRDs from input.
 	if isDirExist(crdsDir) {
-		//nolint:lll
 		c.V1CustomResourceDefinitions, c.V1beta1CustomResourceDefinitions, err = k8sutil.GetCustomResourceDefinitions(crdsDir)
 		if err != nil {
 			return fmt.Errorf("error adding CustomResourceDefinitions to manifest collector: %v", err)

--- a/internal/generate/crd/crd.go
+++ b/internal/generate/crd/crd.go
@@ -302,17 +302,15 @@ func (g Generator) generateNonGo() (map[string][]byte, error) {
 	return fileMap, nil
 }
 
-//nolint:lll
 func convertv1Tov1beta1CustomResourceDefinition(in *apiextv1.CustomResourceDefinition) (*apiextv1beta1.CustomResourceDefinition, error) {
 	var unversioned apiext.CustomResourceDefinition
-	//nolint:lll
 	if err := apiextv1.Convert_v1_CustomResourceDefinition_To_apiextensions_CustomResourceDefinition(in, &unversioned, nil); err != nil {
 		return nil, err
 	}
+
 	var out apiextv1beta1.CustomResourceDefinition
 	out.TypeMeta.APIVersion = apiextv1beta1.SchemeGroupVersion.String()
 	out.TypeMeta.Kind = "CustomResourceDefinition"
-	//nolint:lll
 	if err := apiextv1beta1.Convert_apiextensions_CustomResourceDefinition_To_v1beta1_CustomResourceDefinition(&unversioned, &out, nil); err != nil {
 		return nil, err
 	}

--- a/internal/generate/crd/crd_test.go
+++ b/internal/generate/crd/crd_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:lll
 package crd
 
 import (

--- a/internal/generate/olm-catalog/descriptor/parse.go
+++ b/internal/generate/olm-catalog/descriptor/parse.go
@@ -249,7 +249,6 @@ func isPathIgnore(path string) bool {
 	return path == ignoredTag
 }
 
-//nolint:lll
 // From https://github.com/openshift/console/blob/feabd61/frontend/packages/operator-lifecycle-manager/src/components/descriptors/types.ts#L3-L26
 var specXDescriptors = map[string]string{
 	"size":                 "urn:alm:descriptor:com.tectonic.ui:podCount",
@@ -281,7 +280,6 @@ func getSpecXDescriptorsByPath(existingXDescs []string, path string) []string {
 	return getXDescriptorsByPath(specXDescriptors, existingXDescs, path)
 }
 
-//nolint:lll // the  following line is  a reference, if split it will not be clear if the whole line is a link
 // From https://github.com/openshift/console/blob/feabd61/frontend/packages/operator-lifecycle-manager/src/components/descriptors/types.ts#L28-L39
 var statusXDescriptors = map[string]string{
 	"podStatuses":        "urn:alm:descriptor:com.tectonic.ui:podStatuses",

--- a/internal/plugins/golang/v2/init.go
+++ b/internal/plugins/golang/v2/init.go
@@ -91,7 +91,6 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 `
 
-	//nolint:lll
 	makefileBundleFragment = `
 # Generate bundle manifests and metadata, then validate generated files.
 bundle: manifests

--- a/internal/scaffold/ansible/dockerfilehybrid.go
+++ b/internal/scaffold/ansible/dockerfilehybrid.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:lll
 package ansible
 
 import (

--- a/internal/scaffold/ansible/go_mod.go
+++ b/internal/scaffold/ansible/go_mod.go
@@ -36,7 +36,6 @@ func (s *GoMod) GetInput() (input.Input, error) {
 	return s.Input, nil
 }
 
-//nolint:lll
 const goModTmpl = `module {{ .Repo }}
 
 go 1.13

--- a/internal/scaffold/ansible/molecule_cluster_destroy.go
+++ b/internal/scaffold/ansible/molecule_cluster_destroy.go
@@ -39,7 +39,6 @@ func (m *MoleculeClusterDestroy) GetInput() (input.Input, error) {
 	return m.Input, nil
 }
 
-//nolint:lll
 const moleculeClusterDestroyAnsibleTmpl = `---
 - name: Destroy
   hosts: localhost

--- a/internal/scaffold/ansible/molecule_cluster_prepare.go
+++ b/internal/scaffold/ansible/molecule_cluster_prepare.go
@@ -39,7 +39,6 @@ func (m *MoleculeClusterPrepare) GetInput() (input.Input, error) {
 	return m.Input, nil
 }
 
-//nolint:lll
 const moleculeClusterPrepareAnsibleTmpl = `---
 - name: Prepare
   hosts: localhost

--- a/internal/scaffold/ansible/molecule_cluster_verify.go
+++ b/internal/scaffold/ansible/molecule_cluster_verify.go
@@ -39,7 +39,6 @@ func (m *MoleculeClusterVerify) GetInput() (input.Input, error) {
 	return m.Input, nil
 }
 
-//nolint:lll
 const moleculeClusterVerifyAnsibleTmpl = `---
 # This is an example playbook to execute Ansible tests.
 - name: Verify

--- a/internal/scaffold/ansible/molecule_test_local_converge.go
+++ b/internal/scaffold/ansible/molecule_test_local_converge.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:lll
 package ansible
 
 import (

--- a/internal/scaffold/ansible/molecule_test_local_prepare.go
+++ b/internal/scaffold/ansible/molecule_test_local_prepare.go
@@ -36,7 +36,6 @@ func (m *MoleculeTestLocalPrepare) GetInput() (input.Input, error) {
 	return m.Input, nil
 }
 
-//nolint:lll
 const moleculeTestLocalPrepareAnsibleTmpl = `---
 - import_playbook: ../default/prepare.yml
 - import_playbook: ../cluster/prepare.yml

--- a/internal/scaffold/controller_kind.go
+++ b/internal/scaffold/controller_kind.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:lll
 package scaffold
 
 import (

--- a/internal/scaffold/doc.go
+++ b/internal/scaffold/doc.go
@@ -43,7 +43,6 @@ func (s *Doc) GetInput() (input.Input, error) {
 	return s.Input, nil
 }
 
-//nolint:lll
 const docTemplate = `// Package {{.Resource.Version}} contains API Schema definitions for the {{ .Resource.Group }} {{.Resource.Version}} API group
 // +k8s:deepcopy-gen=package,register
 // +groupName={{ .Resource.FullGroup }}

--- a/internal/scaffold/entrypoint.go
+++ b/internal/scaffold/entrypoint.go
@@ -36,7 +36,6 @@ func (e *Entrypoint) GetInput() (input.Input, error) {
 	return e.Input, nil
 }
 
-//nolint:lll //affects the template fi the line is trimmed
 const entrypointTmpl = `#!/bin/sh -e
 
 exec ${OPERATOR} $@

--- a/internal/scaffold/entrypoint_test.go
+++ b/internal/scaffold/entrypoint_test.go
@@ -33,7 +33,6 @@ func TestEntrypointTest(t *testing.T) {
 	}
 }
 
-//nolint:lll
 const entrypointExp = `#!/bin/sh -e
 
 exec ${OPERATOR} $@

--- a/internal/scaffold/go_mod.go
+++ b/internal/scaffold/go_mod.go
@@ -35,7 +35,6 @@ func (s *GoMod) GetInput() (input.Input, error) {
 	return s.Input, nil
 }
 
-//nolint:lll
 const goModTmpl = `module {{ .Repo }}
 
 go 1.13

--- a/internal/scaffold/helm/go_mod.go
+++ b/internal/scaffold/helm/go_mod.go
@@ -36,7 +36,6 @@ func (s *GoMod) GetInput() (input.Input, error) {
 	return s.Input, nil
 }
 
-//nolint:lll
 const goModTmpl = `module {{ .Repo }}
 
 go 1.13

--- a/internal/scaffold/register.go
+++ b/internal/scaffold/register.go
@@ -44,7 +44,6 @@ func (s *Register) GetInput() (input.Input, error) {
 	return s.Input, nil
 }
 
-//nolint:lll
 const registerTemplate = `// NOTE: Boilerplate only.  Ignore this file.
 
 // Package {{.Resource.Version}} contains API Schema definitions for the {{ .Resource.Group }} {{.Resource.Version}} API group

--- a/internal/scaffold/role.go
+++ b/internal/scaffold/role.go
@@ -48,7 +48,6 @@ func (s *Role) GetInput() (input.Input, error) {
 	return s.Input, nil
 }
 
-//nolint:lll //references are not to be sliced
 func UpdateRoleForResource(r *Resource, absProjectPath string) error {
 	// append rbac rule to deploy/role.yaml
 	roleFilePath := filepath.Join(absProjectPath, DeployDir, RoleYamlFile)

--- a/internal/util/k8sutil/api.go
+++ b/internal/util/k8sutil/api.go
@@ -111,7 +111,6 @@ func GetCustomResourceDefinitions(crdsDir string) (
 
 // DefinitionsForV1CustomResourceDefinitions returns definition keys for all
 // custom resource versions in each crd in crds.
-//nolint:lll
 func DefinitionsForV1CustomResourceDefinitions(crds ...apiextv1.CustomResourceDefinition) (keys []registry.DefinitionKey) {
 	for _, crd := range crds {
 		for _, ver := range crd.Spec.Versions {
@@ -128,7 +127,6 @@ func DefinitionsForV1CustomResourceDefinitions(crds ...apiextv1.CustomResourceDe
 
 // DefinitionsForV1beta1CustomResourceDefinitions returns definition keys for all
 // custom resource versions in each crd in crds.
-//nolint:lll
 func DefinitionsForV1beta1CustomResourceDefinitions(crds ...apiextv1beta1.CustomResourceDefinition) (keys []registry.DefinitionKey) {
 	for _, crd := range crds {
 		if len(crd.Spec.Versions) == 0 {
@@ -166,7 +164,6 @@ func GVKsForV1CustomResourceDefinitions(crds ...apiextv1.CustomResourceDefinitio
 
 // GVKsForV1beta1CustomResourceDefinitions returns GroupVersionKind's for all
 // custom resource versions in each crd in crds.
-//nolint:lll
 func GVKsForV1beta1CustomResourceDefinitions(crds ...apiextv1beta1.CustomResourceDefinition) (gvks []schema.GroupVersionKind) {
 	for _, key := range DefinitionsForV1beta1CustomResourceDefinitions(crds...) {
 		gvks = append(gvks, schema.GroupVersionKind{
@@ -264,17 +261,15 @@ func (vs CRDVersions) Less(i, j int) bool {
 }
 func (vs CRDVersions) Swap(i, j int) { vs[i], vs[j] = vs[j], vs[i] }
 
-//nolint:lll
 func Convertv1beta1Tov1CustomResourceDefinition(in *apiextv1beta1.CustomResourceDefinition) (*apiextv1.CustomResourceDefinition, error) {
 	var unversioned apiext.CustomResourceDefinition
-	//nolint:lll
 	if err := apiextv1beta1.Convert_v1beta1_CustomResourceDefinition_To_apiextensions_CustomResourceDefinition(in, &unversioned, nil); err != nil {
 		return nil, err
 	}
+
 	var out apiextv1.CustomResourceDefinition
 	out.TypeMeta.APIVersion = apiextv1.SchemeGroupVersion.String()
 	out.TypeMeta.Kind = "CustomResourceDefinition"
-	//nolint:lll
 	if err := apiextv1.Convert_apiextensions_CustomResourceDefinition_To_v1_CustomResourceDefinition(&unversioned, &out, nil); err != nil {
 		return nil, err
 	}

--- a/pkg/helm/release/manager_test.go
+++ b/pkg/helm/release/manager_test.go
@@ -142,7 +142,7 @@ func TestManagerGenerateStrategicMergePatch(t *testing.T) {
 			o2: newTestDeployment([]v1.Container{
 				{Name: "test1"},
 			}),
-			patch:     `{"spec":{"template":{"spec":{"$setElementOrder/containers":[{"name":"test1"}]}}}}`, //nolint:lll
+			patch:     `{"spec":{"template":{"spec":{"$setElementOrder/containers":[{"name":"test1"}]}}}}`,
 			patchType: apitypes.StrategicMergePatchType,
 		},
 		{
@@ -153,7 +153,7 @@ func TestManagerGenerateStrategicMergePatch(t *testing.T) {
 				{Name: "test1"},
 				{Name: "test2"},
 			}),
-			patch:     `{"spec":{"template":{"spec":{"$setElementOrder/containers":[{"name":"test1"},{"name":"test2"}],"containers":[{"name":"test2","resources":{}}]}}}}`, //nolint:lll
+			patch:     `{"spec":{"template":{"spec":{"$setElementOrder/containers":[{"name":"test1"},{"name":"test2"}],"containers":[{"name":"test2","resources":{}}]}}}}`,
 			patchType: apitypes.StrategicMergePatchType,
 		},
 		{
@@ -173,7 +173,7 @@ func TestManagerGenerateStrategicMergePatch(t *testing.T) {
 			o2: newTestDeployment([]v1.Container{
 				{Name: "test2"},
 			}),
-			patch:     `{"spec":{"template":{"spec":{"$setElementOrder/containers":[{"name":"test2"}],"containers":[{"name":"test2","resources":{}}]}}}}`, //nolint:lll
+			patch:     `{"spec":{"template":{"spec":{"$setElementOrder/containers":[{"name":"test2"}],"containers":[{"name":"test2","resources":{}}]}}}}`,
 			patchType: apitypes.StrategicMergePatchType,
 		},
 		{
@@ -196,7 +196,7 @@ func TestManagerGenerateStrategicMergePatch(t *testing.T) {
 				},
 				Spec: appsv1.DeploymentSpec{},
 			},
-			patch:     `{}`, //nolint:lll
+			patch:     `{}`,
 			patchType: apitypes.StrategicMergePatchType,
 		},
 	}

--- a/website/content/en/docs/cli/operator-sdk_add_controller.md
+++ b/website/content/en/docs/cli/operator-sdk_add_controller.md
@@ -10,7 +10,7 @@ Adds a new controller pkg
 
 Add a new controller package to your operator project.
 
-This command creates a new controller package under pkg/controller/<kind> that, by default, reconciles on a custom resource for the specified apiversion and kind. The controller will expect to use the custom resource type that should already be defined under pkg/apis/<group>/<version> via the "operator-sdk add api" command. 
+This command creates a new controller package under pkg/controller/<kind> that, by default, reconciles on a custom resource for the specified apiversion and kind. The controller will expect to use the custom resource type that should already be defined under pkg/apis/<group>/<version> via the "operator-sdk add api" command.
 
 Note that, if the controller pkg for that Kind already exists at pkg/controller/<kind> then the command will not overwrite and return an error.
 
@@ -24,7 +24,7 @@ operator-sdk add controller [flags]
 
 ```
 
-The following example will create a controller to manage, watch and reconcile as primary resource the <v1.AppService> from the domain <app.example.com>.    
+The following example will create a controller to manage, watch and reconcile as primary resource the <v1.AppService> from the domain <app.example.com>.
 
 Example:
 
@@ -36,7 +36,7 @@ Example:
 	│   └── appservice_controller.go
 	└── controller.go
 
-The following example will create a controller to manage, watch and reconcile as a primary resource the <v1.Deployment> from the domain <k8s.io.api>, which is not defined in the project (external). Note that, it can be used to create controllers for any External API. 	
+The following example will create a controller to manage, watch and reconcile as a primary resource the <v1.Deployment> from the domain <k8s.io.api>, which is not defined in the project (external). Note that, it can be used to create controllers for any External API.
 
 Example:
 
@@ -45,7 +45,7 @@ Example:
 	pkg/controller/
 	├── add_deployment.go
 	├── deployment
-	│   └── deployment_controller.go 
+	│   └── deployment_controller.go
 	└── controller.go
 		
 ```


### PR DESCRIPTION
**Description of the change:** remove `lll` linter and nolint comments


**Motivation for the change:** based on consensus, the `lll` linter doesn't provide much value since any lines that are quite long tend to be necessarily so. Typically unnecessarily long lines are restricted by PR reviews.