### PR TITLE
Makefile,hack/image: build and release targets for helm and ansible binaries

### DIFF
--- a/changelog/fragments/release-helm-ansible-binaries.yaml
+++ b/changelog/fragments/release-helm-ansible-binaries.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Add builds for `ansible-operator` and `helm-operator` binaries
+    kind: addition
+    breaking: false

--- a/hack/image/build-ansible-image.sh
+++ b/hack/image/build-ansible-image.sh
@@ -12,15 +12,12 @@ BASEIMAGEDIR="$TMPDIR/ansible-operator"
 mkdir -p "$BASEIMAGEDIR"
 go build -o $BASEIMAGEDIR/scaffold-ansible-image ./hack/image/ansible/scaffold-ansible-image.go
 
-# build binary for specific target platform (for purposes of base image only)
-env GOOS=linux GOARCH=amd64 go build -o $BASEIMAGEDIR/ansible-operator-dev-linux-gnu ./cmd/ansible-operator/main.go
-
 # build operator binary and base image
 pushd "$BASEIMAGEDIR"
 ./scaffold-ansible-image
 
 mkdir -p build/_output/bin/
-cp $BASEIMAGEDIR/ansible-operator-dev-linux-gnu build/_output/bin/ansible-operator
+cp $ROOTDIR/build/ansible-operator-dev-linux-gnu build/_output/bin/ansible-operator
 operator-sdk build $1
 # If using a kind cluster, load the image into all nodes.
 load_image_if_kind "$1"

--- a/hack/image/build-helm-image.sh
+++ b/hack/image/build-helm-image.sh
@@ -12,15 +12,12 @@ BASEIMAGEDIR="$TMPDIR/helm-operator"
 mkdir -p "$BASEIMAGEDIR"
 go build -o $BASEIMAGEDIR/scaffold-helm-image ./hack/image/helm/scaffold-helm-image.go
 
-# build binary for specific target platform (for purposes of base image only)
-env GOOS=linux GOARCH=amd64 go build -o $BASEIMAGEDIR/helm-operator-dev-linux-gnu ./cmd/helm-operator/main.go
-
 # build operator binary and base image
 pushd "$BASEIMAGEDIR"
 ./scaffold-helm-image
 
 mkdir -p build/_output/bin/
-cp $BASEIMAGEDIR/helm-operator-dev-linux-gnu build/_output/bin/helm-operator
+cp $ROOTDIR/build/helm-operator-dev-linux-gnu build/_output/bin/helm-operator
 operator-sdk build $1
 # If using a kind cluster, load the image into all nodes.
 load_image_if_kind "$1"

--- a/website/content/en/docs/install-operator-sdk.md
+++ b/website/content/en/docs/install-operator-sdk.md
@@ -18,24 +18,32 @@ $ brew install operator-sdk
 
 ## Install from GitHub release
 
-### Download the release binary
+### Download the release binaries
 
 ```sh
 # Set the release version variable
 $ RELEASE_VERSION=v0.18.0
 # Linux
 $ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
+$ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/ansible-operator-${RELEASE_VERSION}-x86_64-linux-gnu
+$ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/helm-operator-${RELEASE_VERSION}-x86_64-linux-gnu
 # macOS
 $ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin
+$ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/ansible-operator-${RELEASE_VERSION}-x86_64-apple-darwin
+$ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/helm-operator-${RELEASE_VERSION}-x86_64-apple-darwin
 ```
 
-#### Verify the downloaded release binary
+#### Verify the downloaded release binaries
 
 ```sh
 # Linux
 $ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu.asc
+$ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/ansible-operator-${RELEASE_VERSION}-x86_64-linux-gnu.asc
+$ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/helm-operator-${RELEASE_VERSION}-x86_64-linux-gnu.asc
 # macOS
 $ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin.asc
+$ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/ansible-operator-${RELEASE_VERSION}-x86_64-apple-darwin.asc
+$ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/helm-operator-${RELEASE_VERSION}-x86_64-apple-darwin.asc
 ```
 
 To verify a release binary using the provided asc files, place the binary and corresponding asc file into the same directory and use the corresponding command:
@@ -43,8 +51,12 @@ To verify a release binary using the provided asc files, place the binary and co
 ```sh
 # Linux
 $ gpg --verify operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu.asc
+$ gpg --verify ansible-operator-${RELEASE_VERSION}-x86_64-linux-gnu.asc
+$ gpg --verify helm-operator-${RELEASE_VERSION}-x86_64-linux-gnu.asc
 # macOS
 $ gpg --verify operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin.asc
+$ gpg --verify ansible-operator-${RELEASE_VERSION}-x86_64-apple-darwin.asc
+$ gpg --verify helm-operator-${RELEASE_VERSION}-x86_64-apple-darwin.asc
 ```
 
 If you do not have the maintainers public key on your machine, you will get an error message similar to this:
@@ -76,8 +88,12 @@ Now you should be able to verify the binary.
 ```sh
 # Linux
 $ chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu && sudo mkdir -p /usr/local/bin/ && sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk && rm operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
+$ chmod +x ansible-operator-${RELEASE_VERSION}-x86_64-linux-gnu && sudo mkdir -p /usr/local/bin/ && sudo cp ansible-operator-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/ansible-operator && rm ansible-operator-${RELEASE_VERSION}-x86_64-linux-gnu
+$ chmod +x helm-operator-${RELEASE_VERSION}-x86_64-linux-gnu && sudo mkdir -p /usr/local/bin/ && sudo cp helm-operator-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/helm-operator && rm helm-operator-${RELEASE_VERSION}-x86_64-linux-gnu
 # macOS
 $ chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin && sudo mkdir -p /usr/local/bin/ && sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin /usr/local/bin/operator-sdk && rm operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin
+$ chmod +x ansible-operator-${RELEASE_VERSION}-x86_64-apple-darwin && sudo mkdir -p /usr/local/bin/ && sudo cp ansible-operator-${RELEASE_VERSION}-x86_64-apple-darwin /usr/local/bin/ansible-operator && rm ansible-operator-${RELEASE_VERSION}-x86_64-apple-darwin
+$ chmod +x helm-operator-${RELEASE_VERSION}-x86_64-apple-darwin && sudo mkdir -p /usr/local/bin/ && sudo cp helm-operator-${RELEASE_VERSION}-x86_64-apple-darwin /usr/local/bin/helm-operator && rm helm-operator-${RELEASE_VERSION}-x86_64-apple-darwin
 ```
 
 ## Compile and install from master
@@ -95,6 +111,8 @@ $ cd operator-sdk
 $ git checkout master
 $ make tidy
 $ make install
+$ make install-ansible
+$ make install-helm
 ```
 
 **Note:** Ensure that your `GOPROXY` is set with its default value for Go


### PR DESCRIPTION
**Description of the change:**
Add build targets and rules for the `ansible-operator` and `helm-operator` binaries

**Motivation for the change:**
For 1.0, we want to remove the `operator-sdk run local` command. To continue supporting running helm and ansible operators locally, we will need these binaries to be released so that upcoming `make run` targets for those operator types can download and run the operator binaries locally.


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
