### PR TITLE
bump kuttl version, handle a kuttl report file name change with the n…

### DIFF
--- a/changelog/fragments/scorecard2-bump-kuttl.yaml
+++ b/changelog/fragments/scorecard2-bump-kuttl.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: >
+      The scorecard-test-kuttl image was updated to be based off the v0.5.1 version of kudobuilder/kuttl.  This update fixes bugs found in kuttl v0.5.0.
+    kind: "change"

--- a/images/scorecard-test-kuttl/Dockerfile
+++ b/images/scorecard-test-kuttl/Dockerfile
@@ -1,6 +1,6 @@
 # Base image
-FROM docker.io/kudobuilder/kuttl@sha256:970fcac6cf2eeba433a9e00eb9e24a7ecb0a313c2f1d0cc120cfd206210cd0ba
-#FROM kuttl:latest
+FROM docker.io/kudobuilder/kuttl@sha256:d23368441f313107954e80a3a5f2884f374bd5a4746193e304c7733f98d6915e
+#FROM kudobuilder/kuttl:latest
 
 ENV TESTKUTTL=/usr/local/bin/scorecard-test-kuttl \
     USER_UID=1001 \

--- a/images/scorecard-test-kuttl/cmd/test-kuttl/main.go
+++ b/images/scorecard-test-kuttl/cmd/test-kuttl/main.go
@@ -31,10 +31,10 @@ import (
 // scorecard v1alpha3.TestStatus json format.
 //
 // The kuttl output is expected to be produced by kubectl-kuttl
-// at /tmp/kuttl-report.json.
+// at /tmp/kuttl-test.json.
 func main() {
 
-	jsonFile, err := os.Open("/tmp/kuttl-report.json")
+	jsonFile, err := os.Open("/tmp/kuttl-test.json")
 	if err != nil {
 		printErrorStatus(fmt.Errorf("could not open kuttl report %v", err))
 		return

--- a/website/content/en/docs/scorecard/kuttl-tests.md
+++ b/website/content/en/docs/scorecard/kuttl-tests.md
@@ -145,6 +145,12 @@ operator-sdk alpha scorecard --namespace=mycustomns
 If you do not specify either of these flags, the default namespace
 and service account will be used by the scorecard to run test pods.
 
+It is worth noting that scorecard-test-kuttl specifies a namespace
+to the kubectl-kuttl command which causes kuttl to not create a
+namespace for each test.  This might impact your kuttl tests in 
+that you might need to perform resource cleanup in your tests
+instead of depending upon namespace deletion to perform that cleanup.
+
 [client_go]: https://github.com/kubernetes/client-go
 [kuttl]: https://kuttl.dev
 [kuttl_yaml]: https://kuttl.dev/docs/cli.html#examples


### PR DESCRIPTION


**Description of the change:**
this PR changes scorecard-test-kuttl image to be based off of the kudobuilder/kuttl v0.5.1 version, it also
updates scorecard-test-kuttl to handle the new report name produced by this version of kuttl, and lastly it updates
the kuttl user facing website doc to add a note about resource cleanup requirements in kuttl tests.

**Motivation for the change:**
a bug was found in the previous version of kuttl v0.5.0

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
