### PR TITLE
helm-operator: use "Upgrade" instead of "Update" in var/fn names

### DIFF
--- a/changelog/fragments/helm-upgrade-rename.yaml
+++ b/changelog/fragments/helm-upgrade-rename.yaml
@@ -1,5 +1,0 @@
-entries:
-  - description: >
-      In Helm-based operators, usages of the verb `Update` were renamed to `Upgrade` to better align with Helm nomenclature.
-    kind: "change"
-    breaking: false

--- a/changelog/fragments/helm-upgrade-rename.yaml
+++ b/changelog/fragments/helm-upgrade-rename.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      In Helm-based operators, usages of the verb `Update` were renamed to `Upgrade` to better align with Helm nomenclature.
+    kind: "change"
+    breaking: false


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

**Description of the change:**
- Follow up of: https://github.com/operator-framework/operator-sdk/pull/3345 and https://github.com/operator-framework/operator-sdk/pull/3269
- Renamed verb usage for Helm-based operators from "Update" to "Upgrade" 
- For https://github.com/operator-framework/operator-sdk/issues/3346

**Motivation for the change:**
to better align with Helm nomenclature.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [Not applicable] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
