### PR TITLE
[scorecard] scorecard tests add suggestions when operator self-regist…

### DIFF
--- a/changelog/fragments/add-scorecard-self-registered-crd-test.yaml
+++ b/changelog/fragments/add-scorecard-self-registered-crd-test.yaml
@@ -1,0 +1,4 @@
+entries:
+   - description: >
+       Add scorecard test to check if CRDs present in bundle are referenced in CSVs and
+       notify the user through suggestions.

--- a/images/scorecard-test/cmd/test/main.go
+++ b/images/scorecard-test/cmd/test/main.go
@@ -69,6 +69,8 @@ func main() {
 		result = tests.StatusDescriptorsTest(cfg)
 	case tests.BasicCheckSpecTest:
 		result = tests.CheckSpecTest(cfg)
+	case tests.BasicCheckSelfRegisteredCRDTest:
+		result = tests.CheckSelfRegisteredCRDTest(cfg)
 	default:
 		result = printValidTests()
 	}
@@ -88,13 +90,14 @@ func printValidTests() scapiv1alpha3.TestStatus {
 	result.Errors = make([]string, 0)
 	result.Suggestions = make([]string, 0)
 
-	str := fmt.Sprintf("Valid tests for this image include: %s, %s, %s, %s, %s, %s",
+	str := fmt.Sprintf("Valid tests for this image include: %s, %s, %s, %s, %s, %s %s",
 		tests.OLMBundleValidationTest,
 		tests.OLMCRDsHaveValidationTest,
 		tests.OLMCRDsHaveResourcesTest,
 		tests.OLMSpecDescriptorsTest,
 		tests.OLMStatusDescriptorsTest,
-		tests.BasicCheckSpecTest)
+		tests.BasicCheckSpecTest,
+		tests.BasicCheckSelfRegisteredCRDTest)
 	result.Errors = append(result.Errors, str)
 	return scapiv1alpha3.TestStatus{
 		Results: []scapiv1alpha3.TestResult{result},

--- a/internal/scorecard/alpha/testdata/bundle/tests/scorecard/config.yaml
+++ b/internal/scorecard/alpha/testdata/bundle/tests/scorecard/config.yaml
@@ -8,6 +8,15 @@ tests:
     suite: basic
     test: basic-check-spec-test
   description: check the spec test
+- name: "basic-self-registered-crd"
+  image: quay.io/operator-framework/scorecard-test:dev
+  entrypoint: 
+  - scorecard-test
+  - basic-self-registered-crd
+  labels:
+    suite: basic
+    test: basic-self-registered-crd-test
+  description: check the self registered crd test
 - name: "olm-bundle-validation"
   image: quay.io/operator-framework/scorecard-test:dev
   entrypoint: 


### PR DESCRIPTION


<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
This commit adds a scorecard test, to check if the CRDs included in the bundle
are referenced in the CSV. If not, the names of those CRDs are added and the
user is notified through suggestions.

**Motivation for the change:**
Discourage the use self-registered CRDs

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
