### PR TITLE
docs: fix go version

### DIFF
--- a/website/content/en/docs/golang/installation.md
+++ b/website/content/en/docs/golang/installation.md
@@ -9,7 +9,7 @@ Follow the steps in the [installation guide][install-guide] to learn how to inst
 ## Additional Prerequisites
 
 - [git][git_tool]
-- [go][go_tool] version v1.12+.
+- [go][go_tool] version v1.13+.
 - [mercurial][mercurial_tool] version 3.9+
 - [docker][docker_tool] version 17.03+.
 - [kubectl][kubectl_tool] version v1.11.3+.

--- a/website/content/en/docs/golang/project_migration_guide.md
+++ b/website/content/en/docs/golang/project_migration_guide.md
@@ -12,7 +12,8 @@ The document considers [memcached operator][memcached-operator] as an example to
 
 ## Prerequisites
 - [git][git_tool].
-- [go][go_tool] version 17.03+.
+- [go][go_tool] version 1.13+.
+- [docker][docker_tool] version 17.03+.
 - [kubectl][kubectl_tool] version v1.11.3+.
 - [kustomize][kustomize_tool] v3.1.0+.
 - Access to a Kubernetes v1.11.3+ cluster.


### PR DESCRIPTION
**Description of the change:** fix go version in docs

**Motivation for the change:** go version is incorrect.

Closes #3400 

/kind documentation
