### PR TITLE
internal/registry/labels.go: FindMetadataDir fix

### DIFF
--- a/changelog/fragments/fix-find-metadata-dir.yaml
+++ b/changelog/fragments/fix-find-metadata-dir.yaml
@@ -1,0 +1,7 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Fixed issue that caused scorecard to fail loading local bundle due to a
+      bug search method for the bundle metadata directory.
+    kind: bugfix

--- a/internal/registry/labels.go
+++ b/internal/registry/labels.go
@@ -93,9 +93,8 @@ func FindMetadataDir(bundleRoot string) (metadataDir string, err error) {
 		_, err = os.Stat(filepath.Join(path, registrybundle.AnnotationsFile))
 		if err == nil || errors.Is(err, os.ErrExist) {
 			metadataDir = path
-			return nil
 		}
-		return err
+		return nil
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
**Description of the change:**
Bug fix for `regisry.FindMetadataDir`

**Motivation for the change:**
Fewer bugs :)

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
