### PR TITLE
add unit tests for cmd/run

### DIFF
--- a/cmd/operator-sdk/run/cmd_test.go
+++ b/cmd/operator-sdk/run/cmd_test.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Running a run command", func() {
+	Describe("NewCmd", func() {
+		It("builds a cobra command with the correct subcommands", func() {
+			cmd := NewCmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).NotTo(BeNil())
+			Expect(cmd.Short).NotTo(BeNil())
+			Expect(cmd.Long).NotTo(BeNil())
+
+			subcommands := cmd.Commands()
+			Expect(len(subcommands)).To(Equal(1))
+			Expect(subcommands[0].Use).To(Equal("packagemanifests"))
+		})
+	})
+})

--- a/cmd/operator-sdk/run/packagemanifests/packagemanifests_suite_test.go
+++ b/cmd/operator-sdk/run/packagemanifests/packagemanifests_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packagemanifests
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestRun(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Packagemanifests Suite")
+}

--- a/cmd/operator-sdk/run/packagemanifests/packagemanifests_test.go
+++ b/cmd/operator-sdk/run/packagemanifests/packagemanifests_test.go
@@ -1,0 +1,70 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packagemanifests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Running a run packagemanifests command", func() {
+	Describe("NewCmd", func() {
+		It("builds a cobra command", func() {
+			cmd := NewCmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).NotTo(BeNil())
+			Expect(cmd.Short).NotTo(BeNil())
+			Expect(cmd.Long).NotTo(BeNil())
+			aliases := cmd.Aliases
+			Expect(len(aliases)).To(Equal(1))
+			Expect(aliases[0]).To(Equal("pm"))
+		})
+	})
+	Describe("validate", func() {
+		var (
+			c   packagemanifestsCmd
+			err error
+		)
+		BeforeEach(func() {
+			c = packagemanifestsCmd{}
+		})
+		It("fails if provided more than 1 arg", func() {
+			err = c.validate([]string{"foo", "bar"})
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(ContainSubstring("exactly one argument is required"))
+		})
+		It("succeeds and if exactly 1 arg is provided", func() {
+			arg := "baz"
+			err = c.validate([]string{arg})
+			Expect(err).To(BeNil())
+		})
+	})
+	Describe("setDefaults", func() {
+		var (
+			c packagemanifestsCmd
+		)
+		BeforeEach(func() {
+			c = packagemanifestsCmd{}
+		})
+		It("defaults to 'packagemanifests' if no args are provided", func() {
+			c.setDefaults([]string{})
+			Expect(c.ManifestsDir).To(Equal("packagemanifests"))
+		})
+		It("sets ManifestDir to the first arg if provided more than 0", func() {
+			c.setDefaults([]string{"config/potato"})
+			Expect(c.ManifestsDir).To(Equal("config/potato"))
+		})
+	})
+})

--- a/cmd/operator-sdk/run/run_suite_test.go
+++ b/cmd/operator-sdk/run/run_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestRun(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Run Suite")
+}


### PR DESCRIPTION
**Description of the change:**
Add unit tests for the stuff that's staying in cmd/run. Includes a minor refactor to put the arg parsing into a validate method so it's testable, but omitting a separate PR as no functionality changed. Hope that's OK?

Also added a dir with a dummy project file to test the behavior where it's supposed to automatically set the manifest dir if a project file is present. I opted to put a real file on disk and include it in the repo as opposed to writing something temp from the code. Let me know if the other way would be preferable.

**Motivation for the change:**
As part of ongoing work for #3246 
