### PR TITLE
changelog/fragments: add rm-legacy-go.yaml and rm-legacy-run.yaml

### DIFF
--- a/changelog/fragments/rm-legacy-go.yaml
+++ b/changelog/fragments/rm-legacy-go.yaml
@@ -1,0 +1,10 @@
+entries:
+  - description: >
+      Removed legacy go CLI subcommands and features: `add`, `migrate`
+      `print-deps`, `generate k8s`, `generate crds`, and `scorecard`.
+    kind: removal
+    breaking: true
+    pull_request_override: 3385
+    migration:
+      header: Migrate to kubebuilder-style Go project
+      body: TBD

--- a/changelog/fragments/rm-legacy-run.yaml
+++ b/changelog/fragments/rm-legacy-run.yaml
@@ -2,7 +2,7 @@
 # release notes and/or the migration guide
 entries:
   - description: >
-      Remove legacy run amd cleanup commands
+      Remove legacy `run` and `cleanup` subcommands
 
     kind: "removal"
 
@@ -10,5 +10,5 @@ entries:
     breaking: true
 
     migration:
-      header: Remove legacy run amd cleanup commands
+      header: Migrate to kubebuilder-style Go project
       body: TBD


### PR DESCRIPTION
**Description of the change:**
Add missing fragment file for #3385, fix typo for #3406 

**Motivation for the change:**
1.0 prep


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
