### PR TITLE
scorecard: fix label permission bug

### DIFF
--- a/changelog/fragments/scorecard-label-perms.yaml
+++ b/changelog/fragments/scorecard-label-perms.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Fixed a bug in scorecard that caused tests to fail with permission errors
+      when loading the bundle.
+    kind: "bugfix"

--- a/internal/scorecard/alpha/tar.go
+++ b/internal/scorecard/alpha/tar.go
@@ -194,7 +194,7 @@ func newTarDirHeader(path string) *tar.Header {
 		Typeflag: tar.TypeDir,
 		Name:     filepath.Clean(path) + "/",
 		ModTime:  time.Now(),
-		Mode:     0700,
+		Mode:     0755,
 		Uid:      os.Getuid(),
 		Gid:      os.Getgid(),
 	}


### PR DESCRIPTION
**Description of the change:**
Fixed issue with generation of the bundle.tar.gz config map that caused permission errors when the test pod tried to load the bundle.

**Motivation for the change:**
Fix a bug that causes the default test pods to fail.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
