### PR TITLE
Bug fix: helm operator uninstall is not properly checking for existing release

### DIFF
--- a/changelog/fragments/helm-uninstall-fix.yaml
+++ b/changelog/fragments/helm-uninstall-fix.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: Fixed a bug that caused the Helm operator to remove the finalizer without doing a helm uninstall.
+    kind: "bugfix"
+    breaking: false

--- a/internal/helm/release/manager.go
+++ b/internal/helm/release/manager.go
@@ -352,8 +352,7 @@ func createJSONMergePatch(existingJSON, expectedJSON []byte) ([]byte, error) {
 // UninstallRelease performs a Helm release uninstall.
 func (m manager) UninstallRelease(ctx context.Context, opts ...UninstallOption) (*rpb.Release, error) {
 	// Get history of this release
-	_, err := m.storageBackend.History(m.releaseName)
-	if err != nil {
+	if _, err := m.storageBackend.History(m.releaseName); err != nil {
 		return nil, fmt.Errorf("failed to get release history: %w", err)
 	}
 

--- a/internal/helm/release/manager.go
+++ b/internal/helm/release/manager.go
@@ -352,15 +352,9 @@ func createJSONMergePatch(existingJSON, expectedJSON []byte) ([]byte, error) {
 // UninstallRelease performs a Helm release uninstall.
 func (m manager) UninstallRelease(ctx context.Context, opts ...UninstallOption) (*rpb.Release, error) {
 	// Get history of this release
-	h, err := m.storageBackend.History(m.releaseName)
+	_, err := m.storageBackend.History(m.releaseName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get release history: %w", err)
-	}
-
-	// If there is no history, the release has already been uninstalled,
-	// so return ErrReleaseNotFound.
-	if len(h) == 0 {
-		return nil, driver.ErrReleaseNotFound
 	}
 
 	uninstall := action.NewUninstall(m.actionConfig)

--- a/internal/helm/release/manager.go
+++ b/internal/helm/release/manager.go
@@ -351,11 +351,6 @@ func createJSONMergePatch(existingJSON, expectedJSON []byte) ([]byte, error) {
 
 // UninstallRelease performs a Helm release uninstall.
 func (m manager) UninstallRelease(ctx context.Context, opts ...UninstallOption) (*rpb.Release, error) {
-	// Get history of this release
-	if _, err := m.storageBackend.History(m.releaseName); err != nil {
-		return nil, fmt.Errorf("failed to get release history: %w", err)
-	}
-
 	uninstall := action.NewUninstall(m.actionConfig)
 	for _, o := range opts {
 		if err := o(uninstall); err != nil {


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

**Description of the change:**
The Helm `History()` function already returns a ErrReleaseNotFound error if no such release name exists.
see https://github.com/helm/helm/blob/v3.2.4/pkg/storage/storage.go#L148-L154

The current additional check of `if len(h) == 0 ` might cause an issue where the release might actually exist but during decoding of the release, it ran into an error and not append it to the list of return result.
see https://github.com/helm/helm/blob/v3.2.4/pkg/storage/driver/secrets.go#L125-L138
Which leads to the Helm operator incorrectly determines that the release doesn't exist and skips the actual helm uninstall call.

**Motivation for the change:**
In some cases, the Helm-operator doesn't call the equivalent of the `helm uninstall` command before deleting the CR.
Some resources are removed due to Kubernetes garbage collection. But it leaves behind (at least) cluster scope resources that doesn't have the CR as the owner and can't be garbage collected.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [NA] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [NA] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
