### PR TITLE
ansible: rename cmd line flag and add global variable

### DIFF
--- a/changelog/fragments/modify-ansible-flags.yaml
+++ b/changelog/fragments/modify-ansible-flags.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      Add "--max-concurrent-reconciles" flag and "MAX_CONCURRENT_RECONCILES_<Kind>_<Group>" global variable
+      to ansible binary. Also add deprecate message for "--max-workers" flag and "WORKERS_<Kind>_<Group>" 
+      global variable.
+    kind: "addition"

--- a/pkg/ansible/watches/watches_test.go
+++ b/pkg/ansible/watches/watches_test.go
@@ -65,8 +65,8 @@ func TestNew(t *testing.T) {
 				t.Fatalf("Unexpected maxRunnerArtifacts %v expected %v", watch.MaxRunnerArtifacts,
 					maxRunnerArtifactsDefault)
 			}
-			if watch.MaxWorkers != maxWorkersDefault {
-				t.Fatalf("Unexpected maxWorkers %v expected %v", watch.MaxWorkers, maxWorkersDefault)
+			if watch.MaxWorkers != maxConcurrentReconcilesDefault {
+				t.Fatalf("Unexpected maxWorkers %v expected %v", watch.MaxWorkers, maxConcurrentReconcilesDefault)
 			}
 			if watch.ReconcilePeriod != expectedReconcilePeriod {
 				t.Fatalf("Unexpected reconcilePeriod %v expected %v", watch.ReconcilePeriod,
@@ -563,8 +563,7 @@ func TestMaxWorkers(t *testing.T) {
 		defValue      int
 		expectedValue int
 		setEnv        bool
-		envKey        string
-		envValue      int
+		envVarMap     map[string]int
 	}{
 		{
 			name: "no env, use default value",
@@ -576,7 +575,9 @@ func TestMaxWorkers(t *testing.T) {
 			defValue:      1,
 			expectedValue: 1,
 			setEnv:        false,
-			envKey:        "WORKER_MEMCACHESERVICE_CACHE_EXAMPLE_COM",
+			envVarMap: map[string]int{
+				"WORKER_MEMCACHESERVICE_CACHE_EXAMPLE_COM": 0,
+			},
 		},
 		{
 			name: "invalid env, use default value",
@@ -588,11 +589,12 @@ func TestMaxWorkers(t *testing.T) {
 			defValue:      1,
 			expectedValue: 1,
 			setEnv:        true,
-			envKey:        "WORKER_MEMCACHESERVICE_CACHE_EXAMPLE_COM",
-			envValue:      0,
+			envVarMap: map[string]int{
+				"WORKER_MEMCACHESERVICE_CACHE_EXAMPLE_COM": 0,
+			},
 		},
 		{
-			name: "env set to 3, expect 3",
+			name: "worker_%s_%s env set to 3, expect 3",
 			gvk: schema.GroupVersionKind{
 				Group:   "cache.example.com",
 				Version: "v1alpha1",
@@ -601,18 +603,50 @@ func TestMaxWorkers(t *testing.T) {
 			defValue:      1,
 			expectedValue: 3,
 			setEnv:        true,
-			envKey:        "WORKER_MEMCACHESERVICE_CACHE_EXAMPLE_COM",
-			envValue:      3,
+			envVarMap: map[string]int{
+				"WORKER_MEMCACHESERVICE_CACHE_EXAMPLE_COM": 3,
+			},
+		},
+		{
+			name: "max_concurrent_reconciler_%s_%s set to 2, expect 2",
+			gvk: schema.GroupVersionKind{
+				Group:   "cache.example.com",
+				Version: "v1alpha1",
+				Kind:    "MemCacheService",
+			},
+			defValue:      1,
+			expectedValue: 2,
+			setEnv:        true,
+			envVarMap: map[string]int{
+				"MAX_CONCURRENT_RECONCILES_MEMCACHESERVICE_CACHE_EXAMPLE_COM": 2,
+			},
+		},
+		{
+			name: "set multiple env variables",
+			gvk: schema.GroupVersionKind{
+				Group:   "cache.example.com",
+				Version: "v1alpha1",
+				Kind:    "MemCacheService",
+			},
+			defValue:      1,
+			expectedValue: 3,
+			setEnv:        true,
+			envVarMap: map[string]int{
+				"MAX_CONCURRENT_RECONCILES_MEMCACHESERVICE_CACHE_EXAMPLE_COM": 3,
+				"WORKER_MEMCACHESERVICE_CACHE_EXAMPLE_COM":                    1,
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			os.Unsetenv(tc.envKey)
-			if tc.setEnv {
-				os.Setenv(tc.envKey, strconv.Itoa(tc.envValue))
+			for key, val := range tc.envVarMap {
+				os.Unsetenv(key)
+				if tc.setEnv {
+					os.Setenv(key, strconv.Itoa(val))
+				}
 			}
-			workers := getMaxWorkers(tc.gvk, tc.defValue)
+			workers := getMaxConcurrentReconciles(tc.gvk, tc.defValue)
 			if tc.expectedValue != workers {
 				t.Fatalf("Unexpected MaxWorkers: %v expected MaxWorkers: %v", workers, tc.expectedValue)
 			}

--- a/website/content/en/docs/ansible/reference/advanced_options.md
+++ b/website/content/en/docs/ansible/reference/advanced_options.md
@@ -29,14 +29,14 @@ If you have created resources without owner reference injection, it is
 possible to manually to update resources following [this
 guide.](../retroactively-owned-resources)
 
-## Max Workers
+## Max Concurrent Reconciles
 
-Increasing the number of workers allows events to be processed
+Increasing the number of concurrent reconciles allows events to be processed
 concurrently, which can improve reconciliation performance.
 
-Worker maximums can be set in two ways. Operator **authors and admins**
-can set the max workers default by including extra args to the operator
-container in `deploy/operator.yaml`. (Otherwise, the default is 1 worker.)
+The maximum number of concurrent reconciles can be set in two ways. Operator **authors and admins**
+can set the max concurrent reconciles default by including extra args to the operator
+container in `deploy/operator.yaml`. (Otherwise, the default is the maximum number of logical CPUs  available for the process obtained using `runtime.NumCPU()`.)
 
 **NOTE:** Admins using OLM should use the environment variable instead
 of the extra args.
@@ -46,12 +46,14 @@ of the extra args.
   image: "quay.io/asmacdo/memcached-operator:v0.0.0"
   imagePullPolicy: "Always"
   args:
-    - "--max-workers"
+    - "--max-concurrent-reconciles"
     - "3"
 ```
+**Note**
+Previously, `--max-workers` was used and is replaced by `--max-concurrent-reconciles`.
 
 Operator **admins** can override the value by setting an environment
-variable in the format `WORKER_<kind>_<group>`. This variable must be
+variable in the format `MAX_CONCURRENT_RECONCILES_<kind>_<group>`. This variable must be
 all uppercase, and periods (e.g. in the group name) are replaced with underscores.
 
 For the memcached operator example, the component parts are retrieved
@@ -68,7 +70,7 @@ metadata:
 ```
 
 From this data, we can see that the environment variable will be
-`WORKER_MEMCACHED_CACHE_EXAMPLE_COM`, which we can then add to
+`MAX_CONCURRENT_RECONCILES_MEMCACHED_CACHE_EXAMPLE_COM`, which we can then add to
 `deploy/operator.yaml`:
 
 ``` yaml
@@ -77,13 +79,15 @@ From this data, we can see that the environment variable will be
   imagePullPolicy: "Always"
   args:
     # This default is overridden.
-    - "--max-workers"
+    - "--max-reconciles"
     - "3"
   env:
     # This value is used
-    - name: WORKER_MEMCACHED_CACHE_EXAMPLE_COM
+    - name: MAX_CONCURRENT_RECONCILES_MEMCACHED_CACHE_EXAMPLE_COM
       value: "6"
 ```
+**Note**
+Previously, the naming convention for global variable was `WORKERS_%s_%s`. It has been updated to `MAX_CONCURRENT_RECONCILES_%s_%s`. Currently, though we accept inputs to both the variables, `MAX_CONCURRENT_RECONCILES_%s_%s` takes precedence over the formerly used one.
 
 ## Ansible Verbosity
 


### PR DESCRIPTION

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
This PR:
* Deprecates --max-workers flag
* Adds --max-concurrent-reconciles flag
* Adds MAX_CONCURRENT_RECONCILES_<group>_<kind> global variable
* Update relevant documentation

**Motivation for the change:**
Effort to change ansible operator flags to match controller-runtime constructs.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
