### PR TITLE
internal/plugins/helm: add `--project-name` and use `Config.ProjectName` in scaffold

### DIFF
--- a/changelog/fragments/operator-name-config-file.yaml
+++ b/changelog/fragments/operator-name-config-file.yaml
@@ -1,0 +1,10 @@
+entries:
+  - description: >
+      Added `projectName` key to the PROJECT config file (v3-alpha+).
+    kind: addition
+    breaking: false
+    migration:
+      header: Add the `projectName` config key to your PROJECT file
+      body: >
+        Set the `projectName` key in your PROJECT file. If this key is not set,
+        the current working directory's base name will be used in various subcommands.

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/controller-runtime v0.6.0
 	sigs.k8s.io/controller-tools v0.3.0
-	sigs.k8s.io/kubebuilder v1.0.9-0.20200618125005-36aa113dbe99
+	sigs.k8s.io/kubebuilder v1.0.9-0.20200723213622-353f7a6ba73b
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1024,8 +1024,8 @@ sigs.k8s.io/controller-runtime v0.6.0 h1:Fzna3DY7c4BIP6KwfSlrfnj20DJ+SeMBK8HSFvO
 sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2cftPHndTroo=
 sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPhJ4=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
-sigs.k8s.io/kubebuilder v1.0.9-0.20200618125005-36aa113dbe99 h1:wdt455ji+MywIGDGQVUQUEGHa8WiRy0sfr5YFn00HbA=
-sigs.k8s.io/kubebuilder v1.0.9-0.20200618125005-36aa113dbe99/go.mod h1:FGPx0hvP73+bapzWoy5ePuhAJYgJjrFbPxgvWyortM0=
+sigs.k8s.io/kubebuilder v1.0.9-0.20200723213622-353f7a6ba73b h1:FhUDioJh37CVomwCLftxP4AbW+gy/lw0QObz8QYe2VY=
+sigs.k8s.io/kubebuilder v1.0.9-0.20200723213622-353f7a6ba73b/go.mod h1:lkExAOdnNf9BGrvi4lWHCMo1fa6xtENt/QVwDhWpK+c=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/internal/plugins/helm/v1/chartutil/chart.go
+++ b/internal/plugins/helm/v1/chartutil/chart.go
@@ -152,7 +152,7 @@ func CreateChart(projectDir string, opts CreateOptions) (*resource.Options, *cha
 		return nil, nil, fmt.Errorf("failed to load chart: %v", err)
 	}
 
-	log.Infof("Created %s", relChartPath)
+	fmt.Printf("Created %s\n", relChartPath)
 	return r, c, nil
 }
 

--- a/internal/plugins/helm/v1/plugin.go
+++ b/internal/plugins/helm/v1/plugin.go
@@ -26,6 +26,7 @@ const pluginName = "helm" + plugins.DefaultNameQualifier
 var (
 	supportedProjectVersions = []string{config.Version3Alpha}
 	pluginVersion            = plugin.Version{Number: 1}
+	pluginKey                = plugin.KeyFor(Plugin{})
 )
 
 var (

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/config/kdefault/auth_proxy_patch.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/config/kdefault/auth_proxy_patch.go
@@ -18,8 +18,6 @@ limitations under the License.
 package kdefault
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
@@ -31,8 +29,7 @@ var _ file.Template = &AuthProxyPatch{}
 // prometheus metrics for manager Pod.
 type AuthProxyPatch struct {
 	file.TemplateMixin
-
-	OperatorName string
+	file.ProjectNameMixin
 }
 
 // SetTemplateDefaults implements input.Template
@@ -45,18 +42,10 @@ func (f *AuthProxyPatch) SetTemplateDefaults() error {
 
 	f.IfExistsAction = file.Error
 
-	if f.OperatorName == "" {
-		dir, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("error to get the current path: %v", err)
-		}
-		f.OperatorName = filepath.Base(dir)
-	}
-
 	return nil
 }
 
-const kustomizeAuthProxyPatchTemplate = `# This patch inject a sidecar container which is a HTTP proxy for the 
+const kustomizeAuthProxyPatchTemplate = `# This patch inject a sidecar container which is a HTTP proxy for the
 # controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
 apiVersion: apps/v1
 kind: Deployment
@@ -81,5 +70,5 @@ spec:
         args:
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"
-        - "--leader-election-id={{ .OperatorName }}"
+        - "--leader-election-id={{ .ProjectName }}"
 `

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -17,9 +17,7 @@ limitations under the License.
 package kdefault
 
 import (
-	"os"
 	"path/filepath"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -29,9 +27,7 @@ var _ file.Template = &Kustomization{}
 // Kustomization scaffolds the Kustomization file for the default overlay
 type Kustomization struct {
 	file.TemplateMixin
-
-	// Prefix to use for name prefix customization
-	Prefix string
+	file.ProjectNameMixin
 }
 
 // SetTemplateDefaults implements input.Template
@@ -44,27 +40,18 @@ func (f *Kustomization) SetTemplateDefaults() error {
 
 	f.IfExistsAction = file.Error
 
-	if f.Prefix == "" {
-		// use directory name as prefix
-		dir, err := os.Getwd()
-		if err != nil {
-			return err
-		}
-		f.Prefix = strings.ToLower(filepath.Base(dir))
-	}
-
 	return nil
 }
 
 const kustomizeTemplate = `# Adds namespace to all resources.
-namespace: {{ .Prefix }}-system
+namespace: {{ .ProjectName }}-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: {{ .Prefix }}-
+namePrefix: {{ .ProjectName }}-
 
 # Labels to add to all resources and selectors.
 #commonLabels:
@@ -74,7 +61,7 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
 patchesStrategicMerge:

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/config/manager/manager.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/config/manager/manager.go
@@ -18,8 +18,6 @@ limitations under the License.
 package manager
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
@@ -30,12 +28,10 @@ var _ file.Template = &Manager{}
 // Manager scaffolds yaml config for the manager.
 type Manager struct {
 	file.TemplateMixin
+	file.ProjectNameMixin
 
 	// Image is controller manager image name
 	Image string
-
-	// OperatorName will be used to create the pods
-	OperatorName string
 }
 
 // SetTemplateDefaults implements input.Template
@@ -46,13 +42,6 @@ func (f *Manager) SetTemplateDefaults() error {
 
 	f.TemplateBody = managerTemplate
 
-	if f.OperatorName == "" {
-		dir, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("error getting working directory: %v", err)
-		}
-		f.OperatorName = filepath.Base(dir)
-	}
 	return nil
 }
 
@@ -84,7 +73,7 @@ spec:
       - image: {{ .Image }}
         args:
         - "--enable-leader-election"
-        - "--leader-election-id={{ .OperatorName }}"
+        - "--leader-election-id={{ .ProjectName }}"
         name: manager
         resources:
           limits:

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/config/rbac/manager_role.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/config/rbac/manager_role.go
@@ -248,7 +248,7 @@ type roleDiscoveryInterface interface {
 // discovery API to lookup each resource in the resulting manifest.
 // The role scaffold will have IsClusterScoped=true if the chart lists cluster scoped resources
 func (f *ManagerRoleUpdater) updateForChart(dc roleDiscoveryInterface) {
-	log.Info("Generating RBAC rules")
+	fmt.Println("Generating RBAC rules")
 
 	clusterResourceRules, namespacedResourceRules, err := generateRoleRules(dc, f.Chart)
 	if err != nil {

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -103,6 +103,7 @@ func CheckProjectRoot() error {
 	return nil
 }
 
+// TODO: remove this (should use os.Getwd() or Config.ProjectName).
 func MustGetwd() string {
 	wd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
**Description of the change:**
* go.sum,go.mod: bump kubebuilder dep
* internal/plugins/helm: add `--project-name` flag, and use `Config.ProjectName` in scaffolds


**Motivation for the change:** This commit bumps sigs.k8s.io/kubebuilder to the latest commit so `Config.ProjectName` is available, and adds `--project-name` to Go (indirectly) and Helm (directly) to set this field on `init`. See https://github.com/kubernetes-sigs/kubebuilder/pull/1603 and https://github.com/kubernetes-sigs/kubebuilder/pull/1609 for details and changes to the Go plugin.

@asmacdo @fabianvf this might also be nice to have in an Ansible plugin too.

/cc @camilamacedo86 @joelanford

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
