### PR TITLE
cmd/helm-operator/main.go: add --metrics-addr flag

### DIFF
--- a/changelog/fragments/helm-metrics-addr.yaml
+++ b/changelog/fragments/helm-metrics-addr.yaml
@@ -1,0 +1,14 @@
+entries:
+  - description: >
+      Added `--metrics-addr` flag to helm operator to make it configurable, and
+      changed the default from `:8383` to `:8080`
+
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: true
+
+    migration:
+      header: Default helm operator metrics port changed
+      body: >
+        To continue using port 8383, specify `--metrics-addr=:8383` when you start the operator.

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -49,7 +49,6 @@ import (
 
 var (
 	metricsHost               = "0.0.0.0"
-	metricsPort         int32 = 8383
 	operatorMetricsPort int32 = 8686
 
 	log = logf.Log.WithName("cmd")
@@ -77,7 +76,7 @@ func main() {
 
 	// Set default manager options
 	options := manager.Options{
-		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		MetricsBindAddress: f.MetricsAddress,
 		NewClient: func(cache cache.Cache, config *rest.Config, options crclient.Options) (crclient.Client, error) {
 			c, err := crclient.New(config, options)
 			if err != nil {
@@ -184,8 +183,6 @@ func addMetrics(ctx context.Context, cfg *rest.Config, gvks []schema.GroupVersio
 
 	// Add to the below struct any other metrics ports you want to expose.
 	servicePorts := []v1.ServicePort{
-		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP,
-			TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
 		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP,
 			TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
 	}

--- a/internal/plugins/helm/v1/scaffolds/templates/manager/config.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/manager/config.go
@@ -87,9 +87,7 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - args:
-        - manager
-        image: {{ .Image }}
+      - image: {{ .Image }}
         name: manager
         resources:
           limits:

--- a/internal/plugins/helm/v1/scaffolds/templates/metricsauth/auth_proxy_patch.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/metricsauth/auth_proxy_patch.go
@@ -47,9 +47,6 @@ func (f *AuthProxyPatch) SetTemplateDefaults() error {
 // todo(camilamacedo86): add the arg --enable-leader-election for the manager
 // More info: https://github.com/operator-framework/operator-sdk/issues/3356
 
-// todo(camilamacedo86): add the arg --metrics-addr for the manager
-// More info: https://github.com/operator-framework/operator-sdk/issues/3358
-
 const kustomizeAuthProxyPatchTemplate = `# This patch inject a sidecar container which is a HTTP proxy for the 
 # controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
 apiVersion: apps/v1
@@ -65,11 +62,13 @@ spec:
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8383/"
+        - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
         - "--v=10"
         ports:
         - containerPort: 8443
           name: https
       - name: manager
+	    args:
+		- "--metrics-addr=127.0.0.1:8080"
 `

--- a/internal/plugins/helm/v1/scaffolds/templates/metricsauth/auth_proxy_patch.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/metricsauth/auth_proxy_patch.go
@@ -69,6 +69,6 @@ spec:
         - containerPort: 8443
           name: https
       - name: manager
-	    args:
-		- "--metrics-addr=127.0.0.1:8080"
+        args:
+        - "--metrics-addr=127.0.0.1:8080"
 `

--- a/pkg/helm/flags/flag.go
+++ b/pkg/helm/flags/flag.go
@@ -28,6 +28,7 @@ type Flags struct {
 	ReconcilePeriod time.Duration
 	WatchesFile     string
 	MaxWorkers      int
+	MetricsAddress  string
 }
 
 // AddTo - Add the helm operator flags to the the flagset
@@ -47,5 +48,10 @@ func (f *Flags) AddTo(flagSet *pflag.FlagSet) {
 		"max-workers",
 		runtime.NumCPU(),
 		"Maximum number of workers to use",
+	)
+	flagSet.StringVar(&f.MetricsAddress,
+		"metrics-addr",
+		":8080",
+		"The address the metric endpoint binds to",
 	)
 }


### PR DESCRIPTION
**Description of the change:**
Add `--metrics-addr` flag for Helm operator

**Motivation for the change:**
#2451 #3358 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
