### PR TITLE
hack/lib/common.sh: use uname instead of arch, use explicit flags

### DIFF
--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -27,13 +27,13 @@ else
   reset_color=''
 fi
 # Operating system and architecture name of the local machine.
-ARCH_NAME="$(arch)"
+ARCH_NAME="$(uname -m)"
 case "$ARCH_NAME" in
   x86_64) ARCH_NAME="amd64" ;;
   aarch64) ARCH_NAME="arm64" ;;
   *);;
 esac
-OS_NAME="$(uname | awk '{ print tolower($0) }')"
+OS_NAME="$(uname -s | awk '{ print tolower($0) }')"
 
 # Roots used by tests.
 tmp_root=/tmp


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Change `arch` call to `uname -m` since not all distros have `arch` (not present in Arch Linux, ironically enough)
Change `uname` call to `uname -s` to be specific


**Motivation for the change:**
See above


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
