### PR TITLE
internal/plugins/helm/v1/scaffolds/templates/makefile.go: fix make run target

### DIFF
--- a/internal/plugins/helm/v1/scaffolds/templates/makefile.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/makefile.go
@@ -74,7 +74,7 @@ all: docker-build
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: helm-operator
-	$(HELM_OPERATOR) run
+	OPERATOR_NAME=$(basename $$(pwd)) $(HELM_OPERATOR)
 
 # Install CRDs into a cluster
 install: kustomize


### PR DESCRIPTION
**Description of the change:**
Make `make run` for helm operator work

**Motivation for the change:**
`make run` (currently) requires OPERATOR_NAME to be set.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
