### PR TITLE
Helm: add leader election flags, use lease-based election

### DIFF
--- a/changelog/fragments/helm-leader-election.yaml
+++ b/changelog/fragments/helm-leader-election.yaml
@@ -1,0 +1,7 @@
+entries:
+  - description: >
+      In the Helm operator, use controller-runtime's lease-based leader
+      election instead of SDK's leader-for-life mechanism.
+
+    kind: "change"
+    breaking: false

--- a/internal/plugins/helm/v1/scaffolds/init.go
+++ b/internal/plugins/helm/v1/scaffolds/init.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scaffolds
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -67,18 +66,13 @@ func (s *initScaffolder) newUniverse() *model.Universe {
 
 // Scaffold implements Scaffolder
 func (s *initScaffolder) Scaffold() error {
-	switch {
-	case s.config.IsV3():
-		if err := s.scaffold(); err != nil {
-			return err
-		}
-		if s.apiScaffolder != nil {
-			return s.apiScaffolder.Scaffold()
-		}
-		return nil
-	default:
-		return fmt.Errorf("unknown project version %v", s.config.Version)
+	if err := s.scaffold(); err != nil {
+		return err
 	}
+	if s.apiScaffolder != nil {
+		return s.apiScaffolder.Scaffold()
+	}
+	return nil
 }
 
 func (s *initScaffolder) scaffold() error {

--- a/internal/plugins/helm/v1/scaffolds/templates/makefile.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/makefile.go
@@ -74,7 +74,7 @@ all: docker-build
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: helm-operator
-	$(HELM_OPERATOR) run
+	$(HELM_OPERATOR)
 
 # Install CRDs into a cluster
 install: kustomize

--- a/internal/plugins/helm/v1/scaffolds/templates/manager/config.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/manager/config.go
@@ -93,5 +93,14 @@ spec:
           requests:
             cpu: 100m
             memory: 60Mi
+        env:
+        - name: WATCH_NAMESPACE
+          value: ""
+        - name: OPERATOR_NAME
+          value: "{{ .OperatorName }}"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
       terminationGracePeriodSeconds: 10
 `

--- a/internal/plugins/helm/v1/scaffolds/templates/manager/config.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/manager/config.go
@@ -88,6 +88,9 @@ spec:
     spec:
       containers:
       - image: {{ .Image }}
+        args:
+        - "--enable-leader-election"
+        - "--leader-election-id={{ .OperatorName }}"
         name: manager
         resources:
           limits:
@@ -99,11 +102,5 @@ spec:
         env:
           - name: WATCH_NAMESPACE
             value: ""
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: OPERATOR_NAME
-            value: {{ .OperatorName }}
       terminationGracePeriodSeconds: 10
 `

--- a/internal/plugins/helm/v1/scaffolds/templates/manager/config.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/manager/config.go
@@ -56,12 +56,6 @@ func (f *Config) SetTemplateDefaults() error {
 	return nil
 }
 
-// todo(camilamacedo86): add the arg --enable-leader-election for the manager
-// More info: https://github.com/operator-framework/operator-sdk/issues/3356
-
-// todo(camilamacedo86): add the arg --metrics-addr for the manager
-// More info: https://github.com/operator-framework/operator-sdk/issues/3358
-
 const configTemplate = `apiVersion: v1
 kind: Namespace
 metadata:
@@ -99,6 +93,5 @@ spec:
           requests:
             cpu: 100m
             memory: 60Mi
-        env:
       terminationGracePeriodSeconds: 10
 `

--- a/internal/plugins/helm/v1/scaffolds/templates/manager/config.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/manager/config.go
@@ -100,7 +100,5 @@ spec:
             cpu: 100m
             memory: 60Mi
         env:
-          - name: WATCH_NAMESPACE
-            value: ""
       terminationGracePeriodSeconds: 10
 `

--- a/internal/plugins/helm/v1/scaffolds/templates/manager/config.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/manager/config.go
@@ -49,7 +49,7 @@ func (f *Config) SetTemplateDefaults() error {
 	if f.OperatorName == "" {
 		dir, err := os.Getwd()
 		if err != nil {
-			return fmt.Errorf("error to get the current path: %v", err)
+			return fmt.Errorf("error getting working directory: %v", err)
 		}
 		f.OperatorName = filepath.Base(dir)
 	}
@@ -94,13 +94,13 @@ spec:
             cpu: 100m
             memory: 60Mi
         env:
-        - name: WATCH_NAMESPACE
-          value: ""
-        - name: OPERATOR_NAME
-          value: "{{ .OperatorName }}"
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
+          - name: WATCH_NAMESPACE
+            value: ""
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: OPERATOR_NAME
+            value: "{{ .OperatorName }}"
       terminationGracePeriodSeconds: 10
 `

--- a/internal/plugins/helm/v1/scaffolds/templates/metricsauth/auth_proxy_patch.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/metricsauth/auth_proxy_patch.go
@@ -18,6 +18,8 @@ limitations under the License.
 package metricsauth
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
@@ -29,6 +31,8 @@ var _ file.Template = &AuthProxyPatch{}
 // prometheus metrics for manager Pod.
 type AuthProxyPatch struct {
 	file.TemplateMixin
+
+	OperatorName string
 }
 
 // SetTemplateDefaults implements input.Template
@@ -40,6 +44,14 @@ func (f *AuthProxyPatch) SetTemplateDefaults() error {
 	f.TemplateBody = kustomizeAuthProxyPatchTemplate
 
 	f.IfExistsAction = file.Error
+
+	if f.OperatorName == "" {
+		dir, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("error to get the current path: %v", err)
+		}
+		f.OperatorName = filepath.Base(dir)
+	}
 
 	return nil
 }
@@ -71,4 +83,6 @@ spec:
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election"
+        - "--leader-election-id={{ .OperatorName }}"
 `

--- a/internal/plugins/helm/v1/scaffolds/templates/metricsauth/auth_proxy_patch.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/metricsauth/auth_proxy_patch.go
@@ -56,9 +56,6 @@ func (f *AuthProxyPatch) SetTemplateDefaults() error {
 	return nil
 }
 
-// todo(camilamacedo86): add the arg --enable-leader-election for the manager
-// More info: https://github.com/operator-framework/operator-sdk/issues/3356
-
 const kustomizeAuthProxyPatchTemplate = `# This patch inject a sidecar container which is a HTTP proxy for the 
 # controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
 apiVersion: apps/v1

--- a/pkg/helm/flags/flag.go
+++ b/pkg/helm/flags/flag.go
@@ -25,10 +25,13 @@ import (
 
 // Flags - Options to be used by a helm operator
 type Flags struct {
-	ReconcilePeriod time.Duration
-	WatchesFile     string
-	MaxWorkers      int
-	MetricsAddress  string
+	ReconcilePeriod         time.Duration
+	WatchesFile             string
+	MaxWorkers              int
+	MetricsAddress          string
+	EnableLeaderElection    bool
+	LeaderElectionID        string
+	LeaderElectionNamespace string
 }
 
 // AddTo - Add the helm operator flags to the the flagset
@@ -53,5 +56,20 @@ func (f *Flags) AddTo(flagSet *pflag.FlagSet) {
 		"metrics-addr",
 		":8080",
 		"The address the metric endpoint binds to",
+	)
+	flagSet.BoolVar(&f.EnableLeaderElection,
+		"enable-leader-election",
+		false,
+		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.",
+	)
+	flagSet.StringVar(&f.LeaderElectionID,
+		"leader-election-id",
+		"",
+		"Name of the configmap that is used for holding the leader lock.",
+	)
+	flagSet.StringVar(&f.LeaderElectionNamespace,
+		"leader-election-namespace",
+		"",
+		"Namespace in which to create the leader election configmap for holding the leader lock (required if running locally with leader election enabled).",
 	)
 }


### PR DESCRIPTION
**Description of the change:**
Helm operator: add leader election flags, use controller-runtime leader election

**Motivation for the change:**
In general, the controller-runtime leader election method (lease-based) is preferable for most use cases. In the future, if there is a use case to support leader-for-life, we can add another flag to let operator developers choose their leader election mechanism.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
