### PR TITLE
Remove metrics logic from cmd/helm-operator/main.go

### DIFF
--- a/changelog/fragments/rm-helm-metrics.yml
+++ b/changelog/fragments/rm-helm-metrics.yml
@@ -1,0 +1,11 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+    - description: >
+        Remove legacy metrics generation code.
+      kind: "removal"
+      # Is this a breaking change?
+      breaking: true
+      migration:
+        header: Remove legacy metrics generation code from cmd/helm-operator/main.go, and test-e2e-helm.sh checks for servicemonitor.
+        body: TBD

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,12 +39,7 @@ import (
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 )
 
-var (
-	metricsHost               = "0.0.0.0"
-	operatorMetricsPort int32 = 8686
-
-	log = logf.Log.WithName("cmd")
-)
+var log = logf.Log.WithName("cmd")
 
 func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
@@ -129,7 +123,6 @@ func main() {
 		log.Error(err, "Failed to create new manager factories.")
 		os.Exit(1)
 	}
-	var gvks []schema.GroupVersionKind
 	for _, w := range ws {
 		// Register the controller with the factory.
 		err := controller.Add(mgr, controller.WatchOptions{
@@ -145,7 +138,6 @@ func main() {
 			log.Error(err, "Failed to add manager factory to controller.")
 			os.Exit(1)
 		}
-		gvks = append(gvks, w.GroupVersionKind)
 	}
 
 	// Start the Cmd

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -15,18 +15,14 @@
 package main
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"os"
 	"runtime"
 	"strings"
 
 	"github.com/spf13/pflag"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,9 +36,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/helm/release"
 	"github.com/operator-framework/operator-sdk/pkg/helm/watches"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
-	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 )
 
@@ -154,73 +148,9 @@ func main() {
 		gvks = append(gvks, w.GroupVersionKind)
 	}
 
-	addMetrics(context.TODO(), cfg, gvks)
-
 	// Start the Cmd
 	if err = mgr.Start(signals.SetupSignalHandler()); err != nil {
 		log.Error(err, "Manager exited non-zero.")
 		os.Exit(1)
 	}
-}
-
-// addMetrics will create the Services and Service Monitors to allow the operator export the metrics by using
-// the Prometheus operator
-func addMetrics(ctx context.Context, cfg *rest.Config, gvks []schema.GroupVersionKind) {
-	// Get the namespace the operator is currently deployed in.
-	operatorNs, err := k8sutil.GetOperatorNamespace()
-	if err != nil {
-		if errors.Is(err, k8sutil.ErrRunLocal) {
-			log.Info("Skipping CR metrics server creation; not running in a cluster.")
-			return
-		}
-	}
-
-	if err := serveCRMetrics(cfg, operatorNs, gvks); err != nil {
-		log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
-	}
-
-	// Add to the below struct any other metrics ports you want to expose.
-	servicePorts := []v1.ServicePort{
-		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP,
-			TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
-	}
-
-	// Create Service object to expose the metrics port(s).
-	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
-	if err != nil {
-		log.Info("Could not create metrics Service", "error", err.Error())
-	}
-
-	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
-	// necessary to configure Prometheus to scrape metrics from this operator.
-	services := []*v1.Service{service}
-
-	// The ServiceMonitor is created in the same namespace where the operator is deployed
-	_, err = metrics.CreateServiceMonitors(cfg, operatorNs, services)
-	if err != nil {
-		log.Info("Could not create ServiceMonitor object", "error", err.Error())
-		// If this operator is deployed to a cluster without the prometheus-operator running, it will return
-		// ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.
-		if err == metrics.ErrServiceMonitorNotPresent {
-			log.Info("Install prometheus-operator in your cluster to create ServiceMonitor objects", "error", err.Error())
-		}
-	}
-}
-
-// serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
-// It serves those metrics on "http://metricsHost:operatorMetricsPort".
-func serveCRMetrics(cfg *rest.Config, operatorNs string, gvks []schema.GroupVersionKind) error {
-	// The metrics will be generated from the namespaces which are returned here.
-	// NOTE that passing nil or an empty list of namespaces in GenerateAndServeCRMetrics will result in an error.
-	ns, err := kubemetrics.GetNamespacesForMetrics(operatorNs)
-	if err != nil {
-		return err
-	}
-
-	// Generate and serve custom resource specific metrics.
-	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, gvks, metricsHost, operatorMetricsPort)
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/hack/tests/e2e-helm.sh
+++ b/hack/tests/e2e-helm.sh
@@ -20,14 +20,12 @@ operator_namespace="nginx-operator-system"
 deploy_operator() {
     make install
     make deploy IMG="$DEST_IMAGE"
-    kubectl create clusterrolebinding nginx-operator-system-metrics-reader --clusterrole=nginx-operator-metrics-reader --serviceaccount=${operator_namespace}:default
     kubectl create namespace ${test_namespace}
 }
 
 remove_operator() {
     kubectl delete --ignore-not-found=true --namespace=${test_namespace} -f "$OPERATORDIR/config/samples/helm.example_v1alpha1_nginx.yaml"
     kubectl delete --ignore-not-found=true namespace ${test_namespace}
-    kubectl delete --ignore-not-found=true clusterrolebinding nginx-operator-system-metrics-reader
     make undeploy
 }
 

--- a/internal/plugins/helm/v1/scaffolds/templates/manager/config.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/manager/config.go
@@ -93,14 +93,5 @@ spec:
           requests:
             cpu: 100m
             memory: 60Mi
-        env:
-          - name: WATCH_NAMESPACE
-            value: ""
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: OPERATOR_NAME
-            value: "{{ .OperatorName }}"
       terminationGracePeriodSeconds: 10
 `


### PR DESCRIPTION
Description: Remove kubemetrics package reference logic from `cmd/helm-operator/main.go`.

Motivation: Now that we have handler to setup metrics on primary resources using `handler.InstrumentedEnqueueRequestForObject{}`, we do not separate `KubeMetrics` to setup metrics.

Partially closes, #3354 