### PR TITLE
.gitignore: ignore scorecard example go.sum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,7 +103,7 @@ images/scorecard-test-kuttl/scorecard-test-kuttl
 # Test artifacts
 pkg/ansible/runner/testdata/valid.yaml
 /bin
-internal/scorecard/alpha/examples/custom-scorecard-tests/go.sum
+internal/scorecard/examples/custom-scorecard-tests/go.sum
 
 # Website
 website/public/


### PR DESCRIPTION
**Description of the change:**
One-liner to fix gitignore path for scorecard example

**Motivation for the change:**
Follow-up on moving alpha scorecard to scorecard.
