### PR TITLE
Add unit tests for cmd/version

### DIFF
--- a/cmd/operator-sdk/version/cmd.go
+++ b/cmd/operator-sdk/version/cmd.go
@@ -27,13 +27,17 @@ func NewCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Prints the version of operator-sdk",
 		Run: func(cmd *cobra.Command, args []string) {
-			version := ver.GitVersion
-			if version == "unknown" {
-				version = ver.Version
-			}
-			fmt.Printf("operator-sdk version: %q, commit: %q, kubernetes version: %q, go version: %q\n",
-				version, ver.GitCommit, ver.KubernetesVersion, ver.GoVersion)
+			run()
 		},
 	}
 	return versionCmd
+}
+
+func run() {
+	version := ver.GitVersion
+	if version == "unknown" {
+		version = ver.Version
+	}
+	fmt.Printf("operator-sdk version: %q, commit: %q, kubernetes version: %q, go version: %q\n",
+		version, ver.GitCommit, ver.KubernetesVersion, ver.GoVersion)
 }

--- a/cmd/operator-sdk/version/cmd_test.go
+++ b/cmd/operator-sdk/version/cmd_test.go
@@ -1,0 +1,61 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	ver "github.com/operator-framework/operator-sdk/version"
+)
+
+var _ = Describe("Running a version command", func() {
+	Describe("NewCmd", func() {
+		It("builds a cobra command", func() {
+			cmd := NewCmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).NotTo(Equal(""))
+			Expect(cmd.Short).NotTo(Equal(""))
+		})
+	})
+	Describe("run", func() {
+		It("prints the correct version info", func() {
+			r, w, _ := os.Pipe()
+			tmp := os.Stdout
+			defer func() {
+				os.Stdout = tmp
+			}()
+			os.Stdout = w
+			go func() {
+				run()
+				w.Close()
+			}()
+			stdout, err := ioutil.ReadAll(r)
+			Expect(err).To(BeNil())
+			stdoutString := string(stdout)
+			if ver.GitVersion == "unknown" {
+				Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("version: %q", ver.Version)))
+			} else {
+				Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("version: %q", ver.GitVersion)))
+			}
+			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("commit: %q", ver.GitCommit)))
+			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("kubernetes version: %q", ver.KubernetesVersion)))
+			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("go version: %q", ver.GoVersion)))
+		})
+	})
+})

--- a/cmd/operator-sdk/version/cmd_test.go
+++ b/cmd/operator-sdk/version/cmd_test.go
@@ -48,11 +48,11 @@ var _ = Describe("Running a version command", func() {
 			stdout, err := ioutil.ReadAll(r)
 			Expect(err).To(BeNil())
 			stdoutString := string(stdout)
-			if ver.GitVersion == "unknown" {
-				Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("version: %q", ver.Version)))
-			} else {
-				Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("version: %q", ver.GitVersion)))
+			version := ver.GitVersion
+			if version == "unknown" {
+				version = ver.Version
 			}
+			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("version: %q", version)))
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("commit: %q", ver.GitCommit)))
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("kubernetes version: %q", ver.KubernetesVersion)))
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("go version: %q", ver.GoVersion)))

--- a/cmd/operator-sdk/version/version_suite_test.go
+++ b/cmd/operator-sdk/version/version_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestVersion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Version Suite")
+}


### PR DESCRIPTION
**Description of the change:**
Add unit tests for cmd/version. Also includes a small refactor, putting the cmd logic into a run() method so it can be tested.

**Motivation for the change:**
Ongoing work as part of #3246