### PR TITLE
fix: remove max-workers flag for ansible

### DIFF
--- a/cmd/ansible-operator/main.go
+++ b/cmd/ansible-operator/main.go
@@ -67,13 +67,9 @@ func printVersion() {
 
 func main() {
 	f := &flags.Flags{}
-	err := f.AddTo(pflag.CommandLine)
-	if err != nil {
-		log.Error(err, "Failed to add ansible command line flags")
-	}
+	f.AddTo(pflag.CommandLine)
 	pflag.Parse()
 	logf.SetLogger(zap.Logger())
-	warningMsgForDeprecatedFlags()
 
 	printVersion()
 
@@ -299,16 +295,4 @@ func getAnsibleDebugLog() bool {
 			envVar, val)
 	}
 	return val
-}
-
-// warningMsgForDeprecatedFlags logs warning messages if deprecated flags are used. Currently,
-// "--max-workers" is deprecated. Any value provided using this flags will not be used. Instead
-// users are directed to use "--max-concurrent-reconciles".
-func warningMsgForDeprecatedFlags() {
-	if pflag.Lookup("max-workers").Changed {
-		log.Info("Flag --max-workers has been deprecated, use --max-concurrent-reconciles instead")
-		if pflag.Lookup("max-concurrent-reconciles").Changed {
-			log.Info("Ignoring --max-workers since --max-concurrent-reconciles is set")
-		}
-	}
 }

--- a/pkg/ansible/flags/flag.go
+++ b/pkg/ansible/flags/flag.go
@@ -15,7 +15,6 @@
 package flags
 
 import (
-	"fmt"
 	"runtime"
 	"time"
 
@@ -30,7 +29,6 @@ type Flags struct {
 	WatchesFile             string
 	InjectOwnerRef          bool
 	MaxConcurrentReconciles int
-	MaxWorkers              int
 	AnsibleVerbosity        int
 	AnsibleRolesPath        string
 	AnsibleCollectionsPath  string
@@ -40,7 +38,7 @@ const AnsibleRolesPathEnvVar = "ANSIBLE_ROLES_PATH"
 const AnsibleCollectionsPathEnvVar = "ANSIBLE_COLLECTIONS_PATH"
 
 // AddTo - Add the ansible operator flags to the the flagset
-func (f *Flags) AddTo(flagSet *pflag.FlagSet) error {
+func (f *Flags) AddTo(flagSet *pflag.FlagSet) {
 	flagSet.AddFlagSet(zap.FlagSet())
 	flagSet.DurationVar(&f.ReconcilePeriod,
 		"reconcile-period",
@@ -56,11 +54,6 @@ func (f *Flags) AddTo(flagSet *pflag.FlagSet) error {
 		"inject-owner-ref",
 		true,
 		"The ansible operator will inject owner references unless this flag is false",
-	)
-	flagSet.IntVar(&f.MaxWorkers,
-		"max-workers",
-		runtime.NumCPU(),
-		"Maximum number of workers to use. Overridden by environment variable.",
 	)
 	flagSet.IntVar(&f.MaxConcurrentReconciles,
 		"max-concurrent-reconciles",
@@ -82,9 +75,4 @@ func (f *Flags) AddTo(flagSet *pflag.FlagSet) error {
 		"",
 		"Path to installed Ansible Collections. If set, collections should be located in {{value}}/ansible_collections/. If unset, collections are assumed to be in ~/.ansible/collections or /usr/share/ansible/collections.",
 	)
-	err := flagSet.MarkDeprecated("max-workers", "use --max-concurrent-reconciles instead.")
-	if err != nil {
-		return fmt.Errorf("flag cannot be deprecated %v", err)
-	}
-	return nil
 }


### PR DESCRIPTION

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Removes max-workers flag for ansible operators. They have been
replaced by --max-concurrent-reconciles.


**Motivation for the change:**
Follow up of #3435 on changing an implementation. 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
