### PR TITLE
Ansible: add leader election flags, use lease-based election

### DIFF
--- a/changelog/fragments/ansible-leader-election.yaml
+++ b/changelog/fragments/ansible-leader-election.yaml
@@ -1,0 +1,9 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      In the Ansible operator, use controller-runtime's lease-based leader
+      election instead of SDK's leader-for-life mechnism.
+
+    kind: "change"
+    breaking: false

--- a/internal/scaffold/ansible/deploy_operator.go
+++ b/internal/scaffold/ansible/deploy_operator.go
@@ -58,6 +58,9 @@ spec:
         - name: [[.ProjectName]]
           # Replace this with the built image name
           image: "REPLACE_IMAGE"
+          args:
+          - "--enable-leader-election"
+          - "--leader-election-id=[[.ProjectName]]"
           imagePullPolicy: "Always"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner

--- a/pkg/ansible/flags/flag.go
+++ b/pkg/ansible/flags/flag.go
@@ -28,11 +28,14 @@ type Flags struct {
 	ReconcilePeriod         time.Duration
 	WatchesFile             string
 	InjectOwnerRef          bool
+	EnableLeaderElection    bool
 	MaxConcurrentReconciles int
 	AnsibleVerbosity        int
 	AnsibleRolesPath        string
 	AnsibleCollectionsPath  string
 	MetricsAddress          string
+	LeaderElectionID        string
+	LeaderElectionNamespace string
 }
 
 const AnsibleRolesPathEnvVar = "ANSIBLE_ROLES_PATH"
@@ -81,5 +84,22 @@ func (f *Flags) AddTo(flagSet *pflag.FlagSet) {
 		":8080",
 		"The address the metric endpoint binds to",
 	)
-
+	flagSet.BoolVar(&f.EnableLeaderElection,
+		"enable-leader-election",
+		false,
+		"Enable leader election for controller manager. Enabling this will"+
+			" ensure there is only one active controller manager.",
+	)
+	flagSet.StringVar(&f.LeaderElectionID,
+		"leader-election-id",
+		"",
+		"Name of the configmap that is used for holding the leader lock.",
+	)
+	flagSet.StringVar(&f.LeaderElectionNamespace,
+		"leader-election-namespace",
+		"",
+		"Namespace in which to create the leader election configmap for"+
+			" holding the leader lock (required if running locally with leader"+
+			" election enabled).",
+	)
 }


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Ansible operator: add leader election flags, use controller-runtime leader election

**Motivation for the change:**
In general, the controller-runtime leader election method (lease-based) is preferable for most use cases. In the future, if there is a use case to support leader-for-life, we can add another flag to let operator developers choose their leader election mechanism.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
