### PR TITLE
fix: generate required bin in the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ x_base_steps:
       - source hack/ci/check-doc-only-update.sh
       - travis_retry make tidy
     install:
-      - make install
       - make setup-k8s
       - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
     after_success:
@@ -124,6 +123,9 @@ jobs:
         - pip3 install --upgrade setuptools pip
         - pip install --user ansible
       script:
+        # todo: move the `make install` to the shell when the tests be migrated to go and centralized
+        # note that it allows us run the tests locally easily
+        - make install
         - make test-e2e-ansible
         - make test-e2e-ansible-molecule
 
@@ -131,6 +133,9 @@ jobs:
     - <<: *test
       name: Subcommands and Integration on Kubernetes
       script:
+      # todo: move the `make install` to the shell when the tests be migrated to go and centralized
+      # note that it allows us run the tests locally easily
+      - make install
       - make test-subcommand
       - make test-integration
 

--- a/hack/tests/e2e-go.sh
+++ b/hack/tests/e2e-go.sh
@@ -7,6 +7,9 @@ set -o pipefail
 source ./hack/lib/test_lib.sh
 source ./hack/lib/image_lib.sh
 
+# install sdk binaries
+make install
+
 test_dir=./test
 tests=$test_dir/e2e
 

--- a/hack/tests/e2e-helm.sh
+++ b/hack/tests/e2e-helm.sh
@@ -5,6 +5,9 @@ set -eux
 source hack/lib/test_lib.sh
 source hack/lib/image_lib.sh
 
+# install sdk binaries
+make install
+
 DEST_IMAGE="quay.io/example/nginx-operator:v0.0.2"
 TMPDIR="$(mktemp -d)"
 pushd $TMPDIR


### PR DESCRIPTION
**Description**
- Add command to build sdk to allow the go-tests using a binary generated with the code changes made

PS.: By testing it locally I notice that the changes made for the sdk tool were was not reflecting in the tests when they were executed by the command line since it was not getting a binary generated with the code changes.  