### PR TITLE
internal/plugins/helm/v1/scaffolds/templates/role.go: remove metrics rules

### DIFF
--- a/internal/plugins/helm/v1/scaffolds/templates/role.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/role.go
@@ -133,34 +133,6 @@ rules:
   {{- end }}
   {{- end }}
 {{- end }}
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - "get"
-  - "create"
-- apiGroups:
-  - apps
-  resources:
-  - deployments/finalizers
-  resourceNames:
-  - ""
-  verbs:
-  - "update"
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  - deployments
-  verbs:
-  - get
 `
 
 // roleDiscoveryInterface is an interface that contains just the discovery


### PR DESCRIPTION
**Description of the change:**
Remove operator RBAC rules that give it permission to manage services and service monitors.

**Motivation for the change:**
Now that the helm-operator no longer creates its own metrics service and service monitor, it doesn't need permissions to do these things.