### PR TITLE
scorecard - lookup namespace from kubeconfig

### DIFF
--- a/changelog/fragments/scorecard-default-ns.yaml
+++ b/changelog/fragments/scorecard-default-ns.yaml
@@ -1,0 +1,12 @@
+entries:
+  - description: >
+      Changes the scorecard command to look for a namespace in the
+      kubeconfig instead of defaulting to 'default' when the 
+      namespace is not defined on the command line flag.  If a namespace
+      can not be found in the kubeconfig file, then 'default' is used.
+
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false
+

--- a/cmd/operator-sdk/scorecard/cmd.go
+++ b/cmd/operator-sdk/scorecard/cmd.go
@@ -71,7 +71,7 @@ If the argument holds an image tag, it must be present remotely.`,
 	scorecardCmd.Flags().StringVar(&c.kubeconfig, "kubeconfig", "", "kubeconfig path")
 	scorecardCmd.Flags().StringVarP(&c.selector, "selector", "l", "", "label selector to determine which tests are run")
 	scorecardCmd.Flags().StringVarP(&c.config, "config", "c", "", "path to scorecard config file")
-	scorecardCmd.Flags().StringVarP(&c.namespace, "namespace", "n", "default", "namespace to run the test images in")
+	scorecardCmd.Flags().StringVarP(&c.namespace, "namespace", "n", "", "namespace to run the test images in")
 	scorecardCmd.Flags().StringVarP(&c.outputFormat, "output", "o", "text",
 		"Output format for results. Valid values: text, json")
 	scorecardCmd.Flags().StringVarP(&c.serviceAccount, "service-account", "s", "default",
@@ -150,7 +150,7 @@ func (c *scorecardCmd) run() (err error) {
 	} else {
 		runner := scorecard.PodTestRunner{
 			ServiceAccount: c.serviceAccount,
-			Namespace:      c.namespace,
+			Namespace:      scorecard.GetKubeNamespace(c.kubeconfig, c.namespace),
 			BundlePath:     c.bundle,
 			BundleMetadata: metadata,
 		}

--- a/cmd/operator-sdk/scorecard/cmd_test.go
+++ b/cmd/operator-sdk/scorecard/cmd_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Running the scorecard command", func() {
 			flag = cmd.Flags().Lookup("namespace")
 			Expect(flag).NotTo(BeNil())
 			Expect(flag.Shorthand).To(Equal("n"))
-			Expect(flag.DefValue).To(Equal("default"))
+			Expect(flag.DefValue).To(Equal(""))
 
 			flag = cmd.Flags().Lookup("output")
 			Expect(flag).NotTo(BeNil())

--- a/internal/scorecard/kubeclient.go
+++ b/internal/scorecard/kubeclient.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 	cruntime "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
@@ -46,4 +47,36 @@ func GetKubeClient(kubeconfig string) (client kubernetes.Interface, err error) {
 	}
 
 	return clientset, err
+}
+
+// GetKubeNamespace returns the kubernetes namespace to use
+// for scorecard pod creation
+// the order of how the namespace is determined is as follows:
+// - a namespace command line argument
+// - a namespace determined from the kubeconfig file
+// - the kubeconfig file is determined in the following order:
+//   - from the kubeconfig flag if set
+//   - from the KUBECONFIG env var if set
+//   - from the $HOME/.kube/config path if exists
+//   - returns 'default' as the namespace if not set in the kubeconfig
+func GetKubeNamespace(kubeconfigPath, namespace string) string {
+
+	if namespace != "" {
+		return namespace
+	}
+
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+
+	if kubeconfigPath != "" {
+		rules.ExplicitPath = kubeconfigPath
+	}
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{})
+
+	ns, _, err := kubeConfig.Namespace()
+	if err != nil {
+		return "default"
+	}
+	return ns
+
 }

--- a/internal/scorecard/kubeclient_test.go
+++ b/internal/scorecard/kubeclient_test.go
@@ -1,0 +1,128 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorecard
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+)
+
+func TestGetKubeNamespace(t *testing.T) {
+
+	// create temp kubeconfig file
+	file, err := ioutil.TempFile("/tmp", "")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer os.Remove(file.Name())
+
+	data := []byte(testKubeconfig)
+	err = ioutil.WriteFile(file.Name(), data, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cases := []struct {
+		kubeconfigPath string
+		namespace      string
+		expectedValue  string
+	}{
+		{"", "userspecified", "userspecified"},
+		{"/tmp/doesnotexist", "", "default"},
+		{file.Name(), "", "goo"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.kubeconfigPath, func(t *testing.T) {
+
+			oNamespace := GetKubeNamespace(c.kubeconfigPath, c.namespace)
+			if oNamespace != c.expectedValue {
+				t.Errorf("Wanted namespace %s, got: %s", c.expectedValue, oNamespace)
+			}
+		})
+
+	}
+}
+
+func TestGetKubeNamespaceEnvVar(t *testing.T) {
+
+	// create temp kubeconfig file
+	file, err := ioutil.TempFile("/tmp", "")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer os.Remove(file.Name())
+
+	data := []byte(testKubeconfig)
+	err = ioutil.WriteFile(file.Name(), data, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// set KUBECONFIG env var
+	err = os.Setenv("KUBECONFIG", file.Name())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cases := []struct {
+		kubeconfigPath string
+		namespace      string
+		expectedValue  string
+	}{
+		{"", "", "goo"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.kubeconfigPath, func(t *testing.T) {
+			oNamespace := GetKubeNamespace(c.kubeconfigPath, c.namespace)
+			if oNamespace != c.expectedValue {
+				t.Errorf("Wanted namespace %s, got: %s", c.expectedValue, oNamespace)
+			}
+		})
+
+	}
+}
+
+const testKubeconfig = `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://192.168.0.130:6443
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    namespace: foo
+    user: kubernetes-admin
+  name: dev
+- context:
+    cluster: kubernetes
+    user: kubernetes-admin
+  name: kubernetes-admin@kubernetes
+- context:
+    cluster: kubernetes
+    namespace: goo
+    user: kubernetes-admin
+  name: prod
+current-context: prod
+kind: Config
+preferences: {}
+users:
+- name: kubernetes-admin
+  user:
+`

--- a/website/content/en/docs/cli/operator-sdk_scorecard.md
+++ b/website/content/en/docs/cli/operator-sdk_scorecard.md
@@ -22,7 +22,7 @@ operator-sdk scorecard [flags]
   -h, --help                     help for scorecard
       --kubeconfig string        kubeconfig path
   -L, --list                     Option to enable listing which tests are run
-  -n, --namespace string         namespace to run the test images in (default "default")
+  -n, --namespace string         namespace to run the test images in
   -o, --output string            Output format for results. Valid values: text, json (default "text")
   -l, --selector string          label selector to determine which tests are run
   -s, --service-account string   Service account to use for tests (default "default")


### PR DESCRIPTION

**Description of the change:**

add logic in scorecard command to lookup the namespace, if not set on the command line, from the 
kubeconfig

**Motivation for the change:**

Closes #3422 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
