### PR TITLE
internal/plugins/helm: initialize manager role; other minor flag usage fixes

### DIFF
--- a/internal/plugins/helm/v1/api.go
+++ b/internal/plugins/helm/v1/api.go
@@ -105,15 +105,15 @@ func (p *createAPIPlugin) BindFlags(fs *pflag.FlagSet) {
 	p.createOptions = chartutil.CreateOptions{}
 	fs.SortFlags = false
 
-	fs.StringVar(&p.createOptions.GVK.Group, groupFlag, "", "resource Group")
-	fs.StringVar(&p.createOptions.GVK.Version, versionFlag, "", "resource Version")
-	fs.StringVar(&p.createOptions.GVK.Kind, kindFlag, "", "resource Kind")
+	fs.StringVar(&p.createOptions.GVK.Group, groupFlag, "", "resource group")
+	fs.StringVar(&p.createOptions.GVK.Version, versionFlag, "", "resource version")
+	fs.StringVar(&p.createOptions.GVK.Kind, kindFlag, "", "resource kind")
 
 	fs.StringVar(&p.createOptions.Chart, helmChartFlag, "", "helm chart")
 	fs.StringVar(&p.createOptions.Repo, helmChartRepoFlag, "", "helm chart repository")
-	fs.StringVar(&p.createOptions.Version, helmChartVersionFlag, "", "helm chart versionFlag (default: latest)")
+	fs.StringVar(&p.createOptions.Version, helmChartVersionFlag, "", "helm chart version (default: latest)")
 
-	fs.StringVar(&p.createOptions.CRDVersion, crdVersionFlag, crdVersionV1, "crd versionFlag to generate")
+	fs.StringVar(&p.createOptions.CRDVersion, crdVersionFlag, crdVersionV1, "crd version to generate")
 }
 
 // InjectConfig will inject the PROJECT file/config in the plugin

--- a/internal/plugins/helm/v1/scaffolds/api.go
+++ b/internal/plugins/helm/v1/scaffolds/api.go
@@ -107,8 +107,7 @@ func (s *apiScaffolder) scaffold() error {
 
 	if err := machinery.NewScaffold().Execute(
 		s.newUniverse(res),
-		&templates.Role{},
-		&templates.RoleUpdater{Chart: chrt},
+		&templates.ManagerRoleUpdater{Chart: chrt},
 	); err != nil {
 		return fmt.Errorf("error scaffolding role: %v", err)
 	}

--- a/internal/plugins/helm/v1/scaffolds/init.go
+++ b/internal/plugins/helm/v1/scaffolds/init.go
@@ -97,6 +97,7 @@ func (s *initScaffolder) scaffold() error {
 			HelmOperatorVersion: HelmOperatorVersion,
 		},
 		&templates.Kustomize{},
+		&templates.ManagerRole{},
 		&templates.ManagerRoleBinding{},
 		&templates.LeaderElectionRole{},
 		&templates.LeaderElectionRoleBinding{},

--- a/internal/plugins/helm/v1/scaffolds/templates/role.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/role.go
@@ -36,17 +36,17 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-var _ file.Template = &Role{}
+var _ file.Template = &ManagerRole{}
 
 var defaultRoleFile = filepath.Join("config", "rbac", "role.yaml")
 
-// Role scaffolds the role.yaml file
-type Role struct {
+// ManagerRole scaffolds the role.yaml file
+type ManagerRole struct {
 	file.TemplateMixin
 }
 
 // SetTemplateDefaults implements input.Template
-func (f *Role) SetTemplateDefaults() error {
+func (f *ManagerRole) SetTemplateDefaults() error {
 	if f.Path == "" {
 		f.Path = defaultRoleFile
 	}
@@ -57,9 +57,9 @@ func (f *Role) SetTemplateDefaults() error {
 	return nil
 }
 
-var _ file.Inserter = &RoleUpdater{}
+var _ file.Inserter = &ManagerRoleUpdater{}
 
-type RoleUpdater struct {
+type ManagerRoleUpdater struct {
 	file.TemplateMixin
 	file.ResourceMixin
 
@@ -68,11 +68,11 @@ type RoleUpdater struct {
 	CustomRules      []rbacv1.PolicyRule
 }
 
-func (*RoleUpdater) GetPath() string {
+func (*ManagerRoleUpdater) GetPath() string {
 	return defaultRoleFile
 }
 
-func (*RoleUpdater) GetIfExistsAction() file.IfExistsAction {
+func (*ManagerRoleUpdater) GetIfExistsAction() file.IfExistsAction {
 	return file.Overwrite
 }
 
@@ -80,13 +80,13 @@ const (
 	rulesMarker = "rules"
 )
 
-func (f *RoleUpdater) GetMarkers() []file.Marker {
+func (f *ManagerRoleUpdater) GetMarkers() []file.Marker {
 	return []file.Marker{
 		file.NewMarkerFor(defaultRoleFile, rulesMarker),
 	}
 }
 
-func (f *RoleUpdater) GetCodeFragments() file.CodeFragmentsMap {
+func (f *ManagerRoleUpdater) GetCodeFragments() file.CodeFragmentsMap {
 	fragments := make(file.CodeFragmentsMap, 1)
 
 	// If resource is not being provided we are creating the file, not updating it
@@ -247,7 +247,7 @@ type roleDiscoveryInterface interface {
 // renders a release manifest using the chart's default values and uses the Kubernetes
 // discovery API to lookup each resource in the resulting manifest.
 // The role scaffold will have IsClusterScoped=true if the chart lists cluster scoped resources
-func (f *RoleUpdater) updateForChart(dc roleDiscoveryInterface) {
+func (f *ManagerRoleUpdater) updateForChart(dc roleDiscoveryInterface) {
 	log.Info("Generating RBAC rules")
 
 	clusterResourceRules, namespacedResourceRules, err := generateRoleRules(dc, f.Chart)

--- a/internal/plugins/helm/v1/scaffolds/templates/role_test.go
+++ b/internal/plugins/helm/v1/scaffolds/templates/role_test.go
@@ -66,14 +66,14 @@ func TestGenerateRoleScaffold(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s with valid discovery client", tc.name), func(t *testing.T) {
-			f := RoleUpdater{Chart: tc.chart}
+			f := ManagerRoleUpdater{Chart: tc.chart}
 			f.updateForChart(validDiscoveryClient)
 			assert.Equal(t, tc.expectSkipDefaultRules, f.SkipDefaultRules)
 			assert.Equal(t, tc.expectLenCustomRules, len(f.CustomRules))
 		})
 
 		t.Run(fmt.Sprintf("%s with broken discovery client", tc.name), func(t *testing.T) {
-			f := RoleUpdater{Chart: tc.chart}
+			f := ManagerRoleUpdater{Chart: tc.chart}
 			f.updateForChart(brokenDiscoveryClient)
 			assert.Equal(t, false, f.SkipDefaultRules)
 			assert.Equal(t, 0, len(f.CustomRules))


### PR DESCRIPTION
**Description of the change:**
In the helm project scaffolding, move initial generation of `config/rbac/role.yaml` to the `init` plugin.

**Motivation for the change:**
A project without an API should still have a valid base role.
