### PR TITLE
Add Ansible metrics address flag

### DIFF
--- a/changelog/fragments/ansible-metrics-addr.yml
+++ b/changelog/fragments/ansible-metrics-addr.yml
@@ -1,0 +1,15 @@
+entries:
+    - description: >
+        Added `--metrics-addr` flag to ansible operator to make it configurable, and
+        changed the default from `:8383` to `:8080`
+  
+      kind: "change"
+  
+      # Is this a breaking change?
+      breaking: true
+  
+      migration:
+        header: Default ansible operator metrics port changed
+        body: >
+          To continue using port 8383, specify `--metrics-addr=:8383` when you start the operator.
+  

--- a/cmd/ansible-operator/main.go
+++ b/cmd/ansible-operator/main.go
@@ -48,7 +48,6 @@ import (
 var (
 	metricsHost           = "0.0.0.0"
 	log                   = logf.Log.WithName("cmd")
-	metricsPort     int32 = 8383
 	healthProbePort int32 = 6789
 )
 
@@ -76,7 +75,7 @@ func main() {
 	// TODO: probably should expose the host & port as an environment variables
 	options := manager.Options{
 		HealthProbeBindAddress: fmt.Sprintf("%s:%d", metricsHost, healthProbePort),
-		MetricsBindAddress:     fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		MetricsBindAddress:     f.MetricsAddress,
 		NewClient: func(cache cache.Cache, config *rest.Config, options client.Options) (client.Client, error) {
 			c, err := client.New(config, options)
 			if err != nil {

--- a/pkg/ansible/flags/flag.go
+++ b/pkg/ansible/flags/flag.go
@@ -32,6 +32,7 @@ type Flags struct {
 	AnsibleVerbosity        int
 	AnsibleRolesPath        string
 	AnsibleCollectionsPath  string
+	MetricsAddress          string
 }
 
 const AnsibleRolesPathEnvVar = "ANSIBLE_ROLES_PATH"
@@ -75,4 +76,10 @@ func (f *Flags) AddTo(flagSet *pflag.FlagSet) {
 		"",
 		"Path to installed Ansible Collections. If set, collections should be located in {{value}}/ansible_collections/. If unset, collections are assumed to be in ~/.ansible/collections or /usr/share/ansible/collections.",
 	)
+	flagSet.StringVar(&f.MetricsAddress,
+		"metrics-addr",
+		":8080",
+		"The address the metric endpoint binds to",
+	)
+
 }


### PR DESCRIPTION
Description of the change:

Add --metrics-addr flag for Ansible operator, and change to the port to 8080.

Closes partially: #3358 