### PR TITLE
update scorecard docs to be consistent in command examples

### DIFF
--- a/website/content/en/docs/advanced-topics/scorecard/custom-tests.md
+++ b/website/content/en/docs/advanced-topics/scorecard/custom-tests.md
@@ -166,7 +166,7 @@ docker push <repository_name>/<username>/<image_name>:tag
 The `operator-sdk scorecard` command is used to execute the scorecard tests by specifying the location of test bundle in the command. The name or suite of the tests which are to be executed can be specified with the `--selector` flag. The command will create scorecard pods with the image specified in `config.yaml` for the respective test. For example, the `CustomTest1Name` test provides the following json output.
 
 ```console
-operator-sdk scorecard bundle/ --selector=suite=custom -o json --wait-time=32s --skip-cleanup=false
+operator-sdk scorecard <bundle_dir_or_image> --selector=suite=custom -o json --wait-time=32s --skip-cleanup=false
 {
   "metadata": {
     "creationTimestamp": null
@@ -209,13 +209,13 @@ to be outside its scope.  You can however implement whatever
 service accounts your tests require and then specify
 that service account from the command line using the service-account flag:
 ```
-operator-sdk scorecard --service-account=mycustomsa
+operator-sdk scorecard <bundle_dir_or_image> --service-account=mycustomsa
 ```
 
 Also, you can set up a non-default namespace that your tests
 will be executed within using the following namespace flag:
 ```
-operator-sdk scorecard --namespace=mycustomns
+operator-sdk scorecard <bundle_dir_or_image> --namespace=mycustomns
 ```
 
 If you do not specify either of these flags, the default namespace

--- a/website/content/en/docs/advanced-topics/scorecard/kuttl-tests.md
+++ b/website/content/en/docs/advanced-topics/scorecard/kuttl-tests.md
@@ -64,7 +64,7 @@ end user along with any other test results.
 With the above kuttl test configuration, you can execute that
 kuttl test using scorecard as follows:
 ```bash
-operator-sdk scorecard deploy/olm-catalog/memcached-operator --selector=suite=kuttlsuite 
+operator-sdk scorecard <bundle_dir_or_image> --selector=suite=kuttlsuite 
 ```
 
 ## Defining kuttl Specific Configuration Options
@@ -132,13 +132,13 @@ that holds the required RBAC permissions.
 
 You can specify a custom service account in scorecard as follows:
 ```
-operator-sdk scorecard --service-account=mycustomsa
+operator-sdk scorecard <bundle_dir_or_image> --service-account=mycustomsa
 ```
 
 Also, you can set up a non-default namespace that your tests
 will be executed within using the following namespace flag:
 ```
-operator-sdk scorecard --namespace=mycustomns
+operator-sdk scorecard <bundle_dir_or_image> --namespace=mycustomns
 ```
 
 If you do not specify either of these flags, the default namespace

--- a/website/content/en/docs/advanced-topics/scorecard/scorecard.md
+++ b/website/content/en/docs/advanced-topics/scorecard/scorecard.md
@@ -139,18 +139,18 @@ being aggregated by scorecard and written to stdout.
 To select a single test (`basic-check-spec-test`) you would enter the
 following:
 ```sh
-$ operator-sdk scorecard -o text --selector=test=basic-check-spec-test
+$ operator-sdk scorecard <bundle_dir_or_image> -o text --selector=test=basic-check-spec-test
 ```
 
 To select a suite of tests, olm in this case, you would specify
 a label that is used by all the OLM tests:
 ```sh
-$ operator-sdk scorecard -o text --selector=suite=olm
+$ operator-sdk scorecard <bundle_dir_or_image> -o text --selector=suite=olm
 ```
 
 To select multiple tests, you could specify them as follows:
 ```sh
-$ operator-sdk scorecard -o text --selector='test in (basic-check-spec-test,olm-bundle-validation-test)'
+$ operator-sdk scorecard <bundle_dir_or_image> -o text --selector='test in (basic-check-spec-test,olm-bundle-validation-test)'
 ```
 
 ## Built-in Tests


### PR DESCRIPTION


**Description of the change:**
this PR updates the scorecard website docs to have the same command format when 'operator-sdk scorecard' is referenced.

**Motivation for the change:**
make things more clearer to the reader as to the fact that a bundle is a positional argument in all 'operator-sdk scorecard' command examples.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
