### PR TITLE
fix: reword changelog fragment for renaming flag

### DIFF
--- a/changelog/fragments/modify-ansible-flags.yaml
+++ b/changelog/fragments/modify-ansible-flags.yaml
@@ -1,6 +1,5 @@
 entries:
   - description: >
-      Add "--max-concurrent-reconciles" flag and "MAX_CONCURRENT_RECONCILES_<Kind>_<Group>" global variable
-      to ansible binary. Also add deprecate message for "--max-workers" flag and "WORKERS_<Kind>_<Group>" 
-      global variable.
+      Rename "--max-workers" flag to "--max-concurrent-reconciles", and add "MAX_CONCURRENT_RECONCILES_<Kind>_<Group>" global variable
+      to ansible binary. Also include deprecation message for "--max-workers" flag and "WORKERS_<Kind>_<Group>" global variable.
     kind: "addition"


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Reword changelog fragment for removing --max-workers flag in ansible.

**Motivation for the change:**
Follow up from #3456 


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
