### PR TITLE
Fix flag name in error message for generate packagemanifests

### DIFF
--- a/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
+++ b/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
@@ -121,7 +121,7 @@ func (c packagemanifestsCmd) validate() error {
 			return errors.New("--deploy-dir must be set if not reading from stdin")
 		}
 		if c.crdsDir == "" {
-			return errors.New("--crd-dir must be set if not reading from stdin")
+			return errors.New("--crds-dir must be set if not reading from stdin")
 		}
 	}
 


### PR DESCRIPTION
**Description of the change:**
change an error message so the suggested flag matches the actual flag for the command

**Motivation for the change:**
It's helpful if the suggested flag is the actual flag of the command
