### PR TITLE
cmd/operator-sdk/generate/packagemanifests: add `--from-version` flag

### DIFF
--- a/changelog/fragments/packagemanifests-from-version.yaml
+++ b/changelog/fragments/packagemanifests-from-version.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: >
+      Added the `--from-version` flag to `generate packagemanifests`.
+    kind: addition

--- a/cmd/operator-sdk/generate/internal/genutil.go
+++ b/cmd/operator-sdk/generate/internal/genutil.go
@@ -37,7 +37,7 @@ func ValidateVersion(version string) error {
 	// Ensures numerical values composing csvVersion don't contain leading 0's,
 	// ex. 01.01.01
 	if v.String() != version {
-		return fmt.Errorf("provided CSV version %s contains bad values (parses to %s)", version, v)
+		return fmt.Errorf("version %s contains bad values (parses to %s)", version, v)
 	}
 	return nil
 }

--- a/cmd/operator-sdk/generate/packagemanifests/cmd.go
+++ b/cmd/operator-sdk/generate/packagemanifests/cmd.go
@@ -76,10 +76,6 @@ func NewCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&c.kustomizeDir, "kustomize-dir", filepath.Join("config", "manifests"),
-		"Directory containing kustomize bases and a kustomization.yaml for operator-framework manifests")
-	cmd.Flags().BoolVar(&c.stdout, "stdout", false, "Write package to stdout")
-
 	c.addFlagsTo(cmd.Flags())
 
 	return cmd
@@ -88,9 +84,12 @@ func NewCmd() *cobra.Command {
 func (c *packagemanifestsCmd) addFlagsTo(fs *pflag.FlagSet) {
 	fs.StringVar(&c.operatorName, "operator-name", "", "Name of the packaged operator")
 	fs.StringVarP(&c.version, "version", "v", "", "Semantic version of the packaged operator")
+	fs.StringVar(&c.fromVersion, "from-version", "", "Semantic version of the operator being upgraded from")
 	fs.StringVar(&c.inputDir, "input-dir", "", "Directory to read existing package manifests from. "+
 		"This directory is the parent of individual versioned package directories, and different from --deploy-dir")
 	fs.StringVar(&c.outputDir, "output-dir", "", "Directory in which to write package manifests")
+	fs.StringVar(&c.kustomizeDir, "kustomize-dir", filepath.Join("config", "manifests"),
+		"Directory containing kustomize bases and a kustomization.yaml for operator-framework manifests")
 	fs.StringVar(&c.deployDir, "deploy-dir", "", "Root directory for operator manifests such as "+
 		"Deployments and RBAC, ex. 'deploy'. This directory is different from that passed to --input-dir")
 	fs.StringVar(&c.crdsDir, "crds-dir", "", "Root directory for CustomResoureDefinition manifests")
@@ -99,4 +98,5 @@ func (c *packagemanifestsCmd) addFlagsTo(fs *pflag.FlagSet) {
 		"as the package manifest file's default channel")
 	fs.BoolVar(&c.updateCRDs, "update-crds", true, "Update CustomResoureDefinition manifests in this package")
 	fs.BoolVarP(&c.quiet, "quiet", "q", false, "Run in quiet mode")
+	fs.BoolVar(&c.stdout, "stdout", false, "Write package to stdout")
 }

--- a/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
+++ b/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
@@ -106,7 +106,9 @@ func (c packagemanifestsCmd) validate() error {
 	}
 
 	if c.fromVersion != "" {
-		return errors.New("--from-version cannot be set for PROJECT-configured projects")
+		if err := genutil.ValidateVersion(c.fromVersion); err != nil {
+			return err
+		}
 	}
 
 	if c.inputDir == "" {
@@ -165,6 +167,7 @@ func (c packagemanifestsCmd) run(cfg *config.Config) error {
 		OperatorName: c.operatorName,
 		OperatorType: projutil.PluginKeyToOperatorType(cfg.Layout),
 		Version:      c.version,
+		FromVersion:  c.fromVersion,
 		Collector:    col,
 	}
 

--- a/website/content/en/docs/cli/operator-sdk_generate_packagemanifests.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_packagemanifests.md
@@ -66,6 +66,7 @@ operator-sdk generate packagemanifests [flags]
       --crds-dir string        Root directory for CustomResoureDefinition manifests
       --default-channel        Use the channel passed to --channel as the package manifest file's default channel
       --deploy-dir string      Root directory for operator manifests such as Deployments and RBAC, ex. 'deploy'. This directory is different from that passed to --input-dir
+      --from-version string    Semantic version of the operator being upgraded from
   -h, --help                   help for packagemanifests
       --input-dir string       Directory to read existing package manifests from. This directory is the parent of individual versioned package directories, and different from --deploy-dir
       --kustomize-dir string   Directory containing kustomize bases and a kustomization.yaml for operator-framework manifests (default "config/manifests")

--- a/website/content/en/docs/olm-integration/generation.md
+++ b/website/content/en/docs/olm-integration/generation.md
@@ -1,5 +1,5 @@
 ---
-title: Generating Manifests and Metadata 
+title: Generating Manifests and Metadata
 linkTitle: Generating Manifests and Metadata
 weight: 20
 ---
@@ -125,13 +125,16 @@ you should add the following to your `Makefile` to make development easier:
 
 ```make
 # Options for "packagemanifests".
+ifneq ($(origin FROM_VERSION), undefined)
+PKG_FROM_VERSION := --from-version=$(FROM_VERSION)
+endif
 ifneq ($(origin CHANNEL), undefined)
 PKG_CHANNELS := --channel=$(CHANNEL)
 endif
 ifeq ($(IS_CHANNEL_DEFAULT), 1)
 PKG_IS_DEFAULT_CHANNEL := --default-channel
 endif
-PKG_MAN_OPTS ?= $(PKG_CHANNELS) $(PKG_IS_DEFAULT_CHANNEL)
+PKG_MAN_OPTS ?= $(FROM_VERSION) $(PKG_CHANNELS) $(PKG_IS_DEFAULT_CHANNEL)
 
 # Generate package manifests.
 packagemanifests: manifests
@@ -187,11 +190,11 @@ $ make bundle CHANNELS=beta DEFAULT_CHANNEL=beta
 If using a package manifests format, run:
 
 ```console
-$ make packagemanifests CHANNEL=beta IS_CHANNEL_DEFAULT=1
+$ make packagemanifests FROM_VERSION=0.0.1 CHANNEL=beta IS_CHANNEL_DEFAULT=1
 ```
 
 Running the command for either format will persist user-defined fields, updates `spec.version`,
-and populates `spec.replaces` with the old CSV versions' name.
+and populates `spec.replaces` with the old CSV version's name.
 
 ## CSV fields
 


### PR DESCRIPTION
**Description of the change:** add `generate packagemanifests --from-version`.

**Motivation for the change:** I'm not sure why this wasn't included in the original command, since it is still required to populate a CSV's `spec.replaces`.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
