### PR TITLE
doc: steps and info to setup envtest

### DIFF
--- a/website/content/en/docs/building-operators/golang/project_migration_guide.md
+++ b/website/content/en/docs/building-operators/golang/project_migration_guide.md
@@ -122,6 +122,16 @@ Refer to [`memcached_controller.go`][kb_memcached_controller] for the example im
 
 Run [`make manifests`][generate_crd] to generate CRD manifests. They would be generated inside the `config/crd/bases` folder.
 
+## Configuring your test environment
+
+Before you deploy your project see that the Makefile target `docker-build` will also calls the `test` one. So, run the following commands to setup the requirements for your envtest.
+
+```
+$ curl -sSLo setup_envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/scripts/setup_envtest_bins.sh 
+$ chmod +x setup_envtest.sh
+$ ./setup_envtest.sh v1.18.2 v3.4.3
+```
+
 ## Operator Manifests
 
 ### Operator deployment manifests
@@ -173,3 +183,4 @@ The project can now be built, and the operator can be deployed on-cluster. For f
 [kb_memcached_controller]: https://github.com/operator-framework/operator-sdk/blob/master/example/memcached-operator/memcached_controller.go.tmpl
 [kb_quickstart]: /docs/building-operators/golang/quickstart/
 [install_guide]: /docs/installation/install-operator-sdk/
+[env-test-setup]: /docs/building-operators/golang/references/env-test-setup

--- a/website/content/en/docs/building-operators/golang/project_migration_guide.md
+++ b/website/content/en/docs/building-operators/golang/project_migration_guide.md
@@ -124,13 +124,9 @@ Run [`make manifests`][generate_crd] to generate CRD manifests. They would be ge
 
 ## Configuring your test environment
 
-Before you deploy your project see that the Makefile target `docker-build` will also calls the `test` one. So, run the following commands to setup the requirements for your envtest.
-
-```
-$ curl -sSLo setup_envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/scripts/setup_envtest_bins.sh 
-$ chmod +x setup_envtest.sh
-$ ./setup_envtest.sh v1.18.2 v3.4.3
-```
+Projects are scaffolded with unit tests that utilize the [envtest](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/envtest)
+library, which requires certain Kubernetes server binaries be present locally.
+Installation instructions can be found [here][env-test-setup].
 
 ## Operator Manifests
 

--- a/website/content/en/docs/building-operators/golang/quickstart.md
+++ b/website/content/en/docs/building-operators/golang/quickstart.md
@@ -290,14 +290,11 @@ Once this is done, there are two ways to run the operator:
 
 ### Configuring your test environment
 
-Before you deploy your project see that the Makefile target `docker-build` will also calls the `test` one. So, run the following commands to setup the requirements for your envtest.
+## Configuring your test environment
 
-```
-$ curl -sSLo setup_envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/scripts/setup_envtest_bins.sh 
-$ chmod +x setup_envtest.sh
-$ ./setup_envtest.sh v1.18.2 v3.4.3
-```
-For further information and options see: [EnvTest Setup][env-test-setup]. 
+Projects are scaffolded with unit tests that utilize the [envtest](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/envtest)
+library, which requires certain Kubernetes server binaries be present locally.
+Installation instructions can be found [here][env-test-setup].
 
 ### 1. Run locally outside the cluster
 

--- a/website/content/en/docs/building-operators/golang/quickstart.md
+++ b/website/content/en/docs/building-operators/golang/quickstart.md
@@ -288,6 +288,17 @@ Once this is done, there are two ways to run the operator:
 - As Go program outside a cluster
 - As a Deployment inside a Kubernetes cluster
 
+### Configuring your test environment
+
+Before you deploy your project see that the Makefile target `docker-build` will also calls the `test` one. So, run the following commands to setup the requirements for your envtest.
+
+```
+$ curl -sSLo setup_envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/scripts/setup_envtest_bins.sh 
+$ chmod +x setup_envtest.sh
+$ ./setup_envtest.sh v1.18.2 v3.4.3
+```
+For further information and options see: [EnvTest Setup][env-test-setup]. 
+
 ### 1. Run locally outside the cluster
 
 To run the operator locally execute the following command:
@@ -493,3 +504,4 @@ Also see the [advanced topics][advanced_topics] doc for more use cases and under
 [status_subresource]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource
 [API-groups]:https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups
 [legacy_CLI]:https://v0-19-x.sdk.operatorframework.io/docs/cli/
+[env-test-setup]: /docs/building-operators/golang/references/env-test-setup

--- a/website/content/en/docs/building-operators/golang/quickstart.md
+++ b/website/content/en/docs/building-operators/golang/quickstart.md
@@ -288,8 +288,6 @@ Once this is done, there are two ways to run the operator:
 - As Go program outside a cluster
 - As a Deployment inside a Kubernetes cluster
 
-### Configuring your test environment
-
 ## Configuring your test environment
 
 Projects are scaffolded with unit tests that utilize the [envtest](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/envtest)

--- a/website/content/en/docs/building-operators/golang/references/env-test-setup.md
+++ b/website/content/en/docs/building-operators/golang/references/env-test-setup.md
@@ -10,7 +10,7 @@ This document describes how to configure the environment for the [controller tes
 
 ## Installing prerequisites
 
-[Envtest][envtest] requires that the `kubectl`, `api-server` and `etcd` be present locally. You can use this [script][script] to download these binaries into the `testbin/` directory. It may be convenient to add this script your Makefile as follows:
+[Envtest][envtest] requires that `kubectl`, `api-server` and `etcd` be present locally. You can use this [script][script] to download these binaries into the `testbin/` directory. It may be convenient to add this script your Makefile as follows:
 
 ```sh
 # Setup binaries required to run the tests
@@ -24,7 +24,7 @@ testbin:
 ```
 
 
-The above script sets these environment variables to specify where test binaries can be found:
+The above script sets these environment variables to specify where test binaries can be found. Then, see that if you would like to NOT use the script you can use the same configuration by informing the path of your binaries: 
 
 ```shell
 $ export TEST_ASSET_KUBECTL=<kubectl-bin-path>

--- a/website/content/en/docs/building-operators/golang/references/env-test-setup.md
+++ b/website/content/en/docs/building-operators/golang/references/env-test-setup.md
@@ -1,0 +1,62 @@
+---
+title: EnvTest Setup
+linkTitle: EnvTest Setup
+weight: 50
+---
+
+## Overview 
+
+This document describes how to configure the environment for the [controller tests][controller-test] supported by the SDK.
+
+## Configuring your test 
+
+The suite test requires specify the `kubectl`, `api-server` and `etcd` the k8s binaries which are used by it. You can use the following script as a helper which will create the `testbin/` directory with these binaries. Following an example by adding a new target in your Makefile. 
+
+```sh
+# Setup binaries required to run the tests
+# The script will create the testbin dir and add on it the required binaries
+# See that it expects the Kubernetes and ETCD version
+testsetup:
+	curl -sSLo setup_envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/scripts/setup_envtest_bins.sh 
+	chmod +x setup_envtest.sh
+	./setup_envtest.sh v1.18.2 v3.4.3
+```
+
+
+Also, note that the above script will use environment variables to specify the place where its binaries can be found:
+
+```shell
+  export TEST_ASSET_KUBECTL=<kubectl bin path>
+  export TEST_ASSET_KUBE_APISERVER=<api-server bin path>
+  export TEST_ASSET_ETCD=/<etd bin path>
+``` 
+
+See that the environment variables also can be specified via your `controllers/suite_test.go` such as the following example. 
+
+```go 
+var _ = BeforeSuite(func(done Done) {
+	Expect(os.Setenv("TEST_ASSET_KUBE_APISERVER", "../../testbin/kube-apiserver")).To(Succeed())
+	Expect(os.Setenv("TEST_ASSET_ETCD", "../../testbin/etcd")).To(Succeed())
+	Expect(os.Setenv("TEST_ASSET_KUBECTL", "../../testbin/kubectl")).To(Succeed())
+
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	testenv = &envtest.Environment{}
+
+	var err error
+	cfg, err = testenv.Start()
+	Expect(err).NotTo(HaveOccurred())
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	Expect(testenv.Stop()).To(Succeed())
+
+	Expect(os.Unsetenv("TEST_ASSET_KUBE_APISERVER")).To(Succeed())
+	Expect(os.Unsetenv("TEST_ASSET_ETCD")).To(Succeed())
+	Expect(os.Unsetenv("TEST_ASSET_KUBECTL")).To(Succeed())
+
+})
+```
+ 
+[controller-test]: https://book.kubebuilder.io/reference/writing-tests.html

--- a/website/content/en/docs/building-operators/golang/references/env-test-setup.md
+++ b/website/content/en/docs/building-operators/golang/references/env-test-setup.md
@@ -6,29 +6,30 @@ weight: 50
 
 ## Overview 
 
-This document describes how to configure the environment for the [controller tests][controller-test] supported by the SDK.
+This document describes how to configure the environment for the [controller tests][controller-test] which uses [envtest][envtest] and is supported by the SDK. 
 
-## Configuring your test 
+## Installing prerequisites
 
-The suite test requires specify the `kubectl`, `api-server` and `etcd` the k8s binaries which are used by it. You can use the following script as a helper which will create the `testbin/` directory with these binaries. Following an example by adding a new target in your Makefile. 
+[Envtest][envtest] requires that the `kubectl`, `api-server` and `etcd` be present locally. You can use this [script][script] to download these binaries into the `testbin/` directory. It may be convenient to add this script your Makefile as follows:
 
 ```sh
 # Setup binaries required to run the tests
-# The script will create the testbin dir and add on it the required binaries
 # See that it expects the Kubernetes and ETCD version
-testsetup:
+K8S_VERSION = v1.18.2
+ETCD_VERSION = v3.4.3
+testbin:
 	curl -sSLo setup_envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/scripts/setup_envtest_bins.sh 
 	chmod +x setup_envtest.sh
-	./setup_envtest.sh v1.18.2 v3.4.3
+	./setup_envtest.sh $(K8S_VERSION) $(ETCD_VERSION)
 ```
 
 
-Also, note that the above script will use environment variables to specify the place where its binaries can be found:
+The above script sets these environment variables to specify where test binaries can be found:
 
 ```shell
-  export TEST_ASSET_KUBECTL=<kubectl bin path>
-  export TEST_ASSET_KUBE_APISERVER=<api-server bin path>
-  export TEST_ASSET_ETCD=/<etd bin path>
+$ export TEST_ASSET_KUBECTL=<kubectl-bin-path>
+$ export TEST_ASSET_KUBE_APISERVER=<api-server-bin-path>
+$ export TEST_ASSET_ETCD=<etcd-bin-path>
 ``` 
 
 See that the environment variables also can be specified via your `controllers/suite_test.go` such as the following example. 
@@ -58,5 +59,6 @@ var _ = AfterSuite(func() {
 
 })
 ```
- 
+[envtest]: https://godoc.org/sigs.k8s.io/controller-runtime/pkg/envtest
 [controller-test]: https://book.kubebuilder.io/reference/writing-tests.html
+[script]: https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/scripts/setup_envtest_bins.sh

--- a/website/content/en/docs/building-operators/golang/references/env-test-setup.md
+++ b/website/content/en/docs/building-operators/golang/references/env-test-setup.md
@@ -24,7 +24,7 @@ testbin:
 ```
 
 
-The above script sets these environment variables to specify where test binaries can be found. Then, see that if you would like to NOT use the script you can use the same configuration by informing the path of your binaries: 
+The above script sets these environment variables to specify where test binaries can be found. In case you would like to not use the script then, is possible to do the same configuration to inform the path of your binaries: 
 
 ```shell
 $ export TEST_ASSET_KUBECTL=<kubectl-bin-path>


### PR DESCRIPTION
**Description of the change:**
- Add info in the quick start over how to setup the env test. Otherwise. it will fail when users run `docker-build`
- Add new doc with its options and more detailed information in the references. 

**Motivation for the change:**
- https://github.com/operator-framework/operator-sdk/issues/3461
