### PR TITLE
doc: add envtest setup info  (0.19.x) 

### DIFF
--- a/website/content/en/docs/golang/project_migration_guide.md
+++ b/website/content/en/docs/golang/project_migration_guide.md
@@ -121,6 +121,12 @@ Refer to [`memcached_controller.go`][kb_memcached_controller] for the example im
 
 Run [`make manifests`][generate_crd] to generate CRD manifests. They would be generated inside the `config/crd/bases` folder.
 
+## Configuring your test environment
+
+Projects are scaffolded with unit tests that utilize the [envtest](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/envtest)
+library, which requires certain Kubernetes server binaries be present locally.
+Installation instructions can be found [here][env-test-setup].
+
 ## Operator Manifests
 
 ### Operator deployment manifests
@@ -171,3 +177,4 @@ The project can now be built and the operator can be deployed on cluster. For fu
 [kb_memcached_controller]: https://github.com/operator-framework/operator-sdk/blob/master/example/kb-memcached-operator/memcached_controller.go.tmpl
 [kb_quickstart]: /docs/golang/quickstart/
 [install_guide]: /docs/install-operator-sdk/
+[env-test-setup]: /docs/golang/references/env-test-setup

--- a/website/content/en/docs/golang/quickstart.md
+++ b/website/content/en/docs/golang/quickstart.md
@@ -288,6 +288,12 @@ Once this is done, there are two ways to run the operator:
 - As Go program outside a cluster
 - As a Deployment inside a Kubernetes cluster
 
+## Configuring your test environment
+
+Projects are scaffolded with unit tests that utilize the [envtest](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/envtest)
+library, which requires certain Kubernetes server binaries be present locally.
+Installation instructions can be found [here][env-test-setup].
+
 ### 1. Run locally outside the cluster
 
 To run the operator locally execute the following command:
@@ -494,3 +500,4 @@ Also see the [advanced topics][advanced_topics] doc for more use cases and under
 [status_subresource]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource
 [API-groups]:https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups
 [legacy_CLI]:/docs/cli
+[env-test-setup]: /docs/golang/references/env-test-setup

--- a/website/content/en/docs/golang/references/env-test-setup.md
+++ b/website/content/en/docs/golang/references/env-test-setup.md
@@ -1,0 +1,64 @@
+---
+title: EnvTest Setup
+linkTitle: EnvTest Setup
+weight: 50
+---
+
+## Overview 
+
+This document describes how to configure the environment for the [controller tests][controller-test] which uses [envtest][envtest] and is supported by the SDK. 
+
+## Installing prerequisites
+
+[Envtest][envtest] requires that `kubectl`, `api-server` and `etcd` be present locally. You can use this [script][script] to download these binaries into the `testbin/` directory. It may be convenient to add this script your Makefile as follows:
+
+```sh
+# Setup binaries required to run the tests
+# See that it expects the Kubernetes and ETCD version
+K8S_VERSION = v1.18.2
+ETCD_VERSION = v3.4.3
+testbin:
+	curl -sSLo setup_envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/scripts/setup_envtest_bins.sh 
+	chmod +x setup_envtest.sh
+	./setup_envtest.sh $(K8S_VERSION) $(ETCD_VERSION)
+```
+
+
+The above script sets these environment variables to specify where test binaries can be found. In case you would like to not use the script then, is possible to do the same configuration to inform the path of your binaries: 
+
+```shell
+$ export TEST_ASSET_KUBECTL=<kubectl-bin-path>
+$ export TEST_ASSET_KUBE_APISERVER=<api-server-bin-path>
+$ export TEST_ASSET_ETCD=<etcd-bin-path>
+``` 
+
+See that the environment variables also can be specified via your `controllers/suite_test.go` such as the following example. 
+
+```go 
+var _ = BeforeSuite(func(done Done) {
+	Expect(os.Setenv("TEST_ASSET_KUBE_APISERVER", "../../testbin/kube-apiserver")).To(Succeed())
+	Expect(os.Setenv("TEST_ASSET_ETCD", "../../testbin/etcd")).To(Succeed())
+	Expect(os.Setenv("TEST_ASSET_KUBECTL", "../../testbin/kubectl")).To(Succeed())
+
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	testenv = &envtest.Environment{}
+
+	var err error
+	cfg, err = testenv.Start()
+	Expect(err).NotTo(HaveOccurred())
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	Expect(testenv.Stop()).To(Succeed())
+
+	Expect(os.Unsetenv("TEST_ASSET_KUBE_APISERVER")).To(Succeed())
+	Expect(os.Unsetenv("TEST_ASSET_ETCD")).To(Succeed())
+	Expect(os.Unsetenv("TEST_ASSET_KUBECTL")).To(Succeed())
+
+})
+```
+[envtest]: https://godoc.org/sigs.k8s.io/controller-runtime/pkg/envtest
+[controller-test]: https://book.kubebuilder.io/reference/writing-tests.html
+[script]: https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/scripts/setup_envtest_bins.sh


### PR DESCRIPTION
**Description of the change:**
- Add steps to configure env test and allow users to follow up the common steps. (Applying to 0.19.x the same changes made in #3510)

**Motivation for the change:**
Without this info, users are unable to run `docker-build`. They will face an issue because is missing the binaries that are shipped with kb. Related to: https://github.com/operator-framework/operator-sdk/pull/3510 and to close the issue #3461

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
