### PR TITLE
fix: broken link to the migration guide (0.19.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Additions
 
 - Add "panic" level for --zap-stacktrace-level (allows "debug", "info", "error", "panic"). ([#3040](https://github.com/operator-framework/operator-sdk/pull/3040))
-- The `operator-sdk` binary has a new CLI workflow and project layout for scaffolding Go operators that is aligned with Kubebuilder's CLI and project layout. See the new [Quickstart Guide](https://master.sdk.operatorframework.io/docs/golang/quickstart) and the new [CLI reference](https://master.sdk.operatorframework.io/docs/new-cli) for more details. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
+- The `operator-sdk` binary has a new CLI workflow and project layout for scaffolding Go operators that is aligned with Kubebuilder's CLI and project layout. See the new [Quickstart Guide](https://sdk.operatorframework.io/docs/golang/quickstart/) and the new [CLI reference](https://v0-19-x.sdk.operatorframework.io/docs/new-cli/) for more details. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
 - `bundle validate` can now use a containerd image ("none") tool to unpack images, removing the need for an external image tool like docker/podman. ([#3222](https://github.com/operator-framework/operator-sdk/pull/3222))
 - The SDK `scorecard` command adds a new test image, scorecard-test-kuttl, that allows end users to write and execute kuttl based tests. ([#3278](https://github.com/operator-framework/operator-sdk/pull/3278))
 - Add "--olm-namespace" flag to olm subcommands (install, uninstall) to allow users to specify the  namespace where olm is to be installed or uninstalled. ([#3300](https://github.com/operator-framework/operator-sdk/pull/3300))
@@ -29,11 +29,11 @@
 
 ### Removals
 
-- The `operator-sdk new` command no longer supports scaffolding new Go projects with the `--type=Go` flag.  To scaffold new projects, users are expected to use `operator-sdk init` as part of the  [new CLI](https://master.sdk.operatorframework.io/docs/new-cli) for Go operators. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
+- The `operator-sdk new` command no longer supports scaffolding new Go projects with the `--type=Go` flag.  To scaffold new projects, users are expected to use `operator-sdk init` as part of the  [new CLI](https://v0-19-x.sdk.operatorframework.io/docs/new-cli/) for Go operators. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
 
 ### Deprecations
 
-- With the introduction of the new [Kubebuilder aligned CLI](https://master.sdk.operatorframework.io/docs/new-cli)  and project layout for Go operators, the [old CLI](https://sdk.operatorframework.io/docs/cli)  will still continue to work for Go projects scaffolded in the old layout with `operator-sdk new`. However the old CLI is now deprecated and will be removed in a future release. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
+- With the introduction of the new [Kubebuilder aligned CLI](https://v0-19-x.sdk.operatorframework.io/docs/new-cli/)  and project layout for Go operators, the [old CLI](https://sdk.operatorframework.io/docs/cli)  will still continue to work for Go projects scaffolded in the old layout with `operator-sdk new`. However the old CLI is now deprecated and will be removed in a future release. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
 - The migrate sub-command is deprecated. ([#3319](https://github.com/operator-framework/operator-sdk/pull/3319))
 - Deprecate 'operator-sdk add crd'. Use 'operator-sdk add api' instead. ([#3180](https://github.com/operator-framework/operator-sdk/pull/3180))
 - `bundle create` is deprecated in favor of a combination of `generate bundle` and `docker build -f bundle.Dockerfile ...`. ([#3323](https://github.com/operator-framework/operator-sdk/pull/3323))

--- a/website/content/en/docs/migration/v0.19.0.md
+++ b/website/content/en/docs/migration/v0.19.0.md
@@ -22,7 +22,7 @@ _See [#3265](https://github.com/operator-framework/operator-sdk/pull/3265) for m
 
 ## Migrating Go projects to the new Kubebuilder aligned project layout
 
-See the [migration guide](https://master.sdk.operatorframework.io/docs/golang/project_migration_guide/)
+See the [migration guide][migration-guide]
 that walks through an example of how to migrate a Go based operator project from the old layout to the new layout.
 
 _See [#3190](https://github.com/operator-framework/operator-sdk/pull/3190) for more details._
@@ -46,3 +46,5 @@ However, any script or code that is depending on this condition reason must be u
 to use `UpgradeError` instead of `UpdateError`.
 
 _See [#3269](https://github.com/operator-framework/operator-sdk/pull/3269) for more details._
+
+[migration-guide]: docs/golang/project_migration_guide


### PR DESCRIPTION
Closes: https://github.com/operator-framework/operator-sdk/issues/3512