### PR TITLE
website: Fix link to the pull requests that implements support for configuring a liveness probe for an Ansible operator.

### DIFF
--- a/website/content/en/docs/migration/v0.18.0.md
+++ b/website/content/en/docs/migration/v0.18.0.md
@@ -33,7 +33,7 @@ Existing operators will have a healthz endpoint without intervention, but to tak
     periodSeconds: 3
 ```
 
-_See [#2761](https://github.com/operator-framework/operator-sdk/pull/2761) for more details._
+_See [#2936](https://github.com/operator-framework/operator-sdk/pull/2936) for more details._
 
 ## Remove the file `/bin/ao-logs` for Ansible based-operators
 
@@ -93,7 +93,7 @@ update many of their client-go function calls, which
 have signature changes related to passing contexts
 and options.
 
-Users can use http://sigs.k8s.io/clientgofix to 
+Users can use http://sigs.k8s.io/clientgofix to
 rewrite method invocations to the new signatures.
 
 _See [#2918](https://github.com/operator-framework/operator-sdk/pull/2918) for more details._


### PR DESCRIPTION
Fix link to that points to the work that implements liveness probe handling for Ansible-based operators that was done during the 0.18 release.

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
