### PR TITLE
internal/scorecard: fix cleanup skip on timeout bug

### DIFF
--- a/changelog/fragments/no-pod-left-behind.yaml
+++ b/changelog/fragments/no-pod-left-behind.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      The `scorecard` subcommand now removes existing pods if the `--wait-time` deadline is exceeded
+      and `--skip-cleanup=false` (the default). Fixes [#3419](https://github.com/operator-framework/operator-sdk/issues/3419).
+    kind: bugfix

--- a/internal/scorecard/testpod.go
+++ b/internal/scorecard/testpod.go
@@ -132,9 +132,6 @@ func getPodLog(ctx context.Context, client kubernetes.Interface, pod *v1.Pod) ([
 
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, podLogs)
-	if err != nil {
-		return nil, err
-	}
 	return buf.Bytes(), err
 }
 
@@ -145,7 +142,7 @@ func (r PodTestRunner) deletePods(ctx context.Context, configMapName string) err
 	lo := metav1.ListOptions{LabelSelector: selector}
 	err := r.Client.CoreV1().Pods(r.Namespace).DeleteCollection(ctx, do, lo)
 	if err != nil {
-		return fmt.Errorf("error deleting pods selector %s %w", selector, err)
+		return fmt.Errorf("error deleting pods (label selector %q): %w", selector, err)
 	}
 	return nil
 }


### PR DESCRIPTION
**Description of the change:** check timeout error in scorecard before cleaning up, and use a separate timeout for cleanup

**Motivation for the change:** fixes #3419 

/cc @jmccormick2001 

/kind bug

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
