### PR TITLE
*: consistently use *.sdk.operatorframework.io wherever we use domains

### DIFF
--- a/changelog/fragments/consistent-domain.yaml
+++ b/changelog/fragments/consistent-domain.yaml
@@ -1,0 +1,41 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Changed domain suffix used for plugins and CR annotations to
+      consistently use `.sdk.operatorframework.io`.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: true
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: Update references to legacy operator-sdk domain strings
+      body: |
+        Update various usages of domains in plugin keys and annotations:
+
+          * In Kubebuilder-style projects, change the `.operator-sdk.io` suffix to `.sdk.operatorframework.io` in the `PROJECT` file.
+
+          * In Ansible and Helm projects, change legacy annotation keys to new annotation keys in sample CR files in your repository.
+
+          * In live clusters containing CRs for Ansible and Helm-based operators:
+            1. Patch all existing CRs that use a legacy annotation to ADD the new equivalent annotations alongside the legacy annotations.
+            2. Upgrade the operator
+            3. Patch all existing CRs that used a legacy annotation to REMOVE the legacy annotations.
+
+        | Location         | Legacy                                      | New                                                     |
+        |------------------|---------------------------------------------|---------------------------------------------------------|
+        | `PROJECT` file   | `go.operator-sdk.io`                        | `go.sdk.operatorframework.io`                           |
+        | Custom resources | `ansible.operator-sdk/reconcile-period`     | `ansible.sdk.operatorframework.io/reconcile-period`     |
+        | Custom resources | `ansible.operator-sdk/max-runner-artifacts` | `ansible.sdk.operatorframework.io/max-runner-artifacts` |
+        | Custom resources | `ansible.operator-sdk/verbosity`            | `ansible.sdk.operatorframework.io/verbosity`            |
+        | Custom resources | `helm.operator-sdk/upgrade-force`           | `helm.sdk.operatorframework.io/upgrade-force`           |

--- a/internal/generate/testdata/non-standard-layout/PROJECT
+++ b/internal/generate/testdata/non-standard-layout/PROJECT
@@ -7,4 +7,4 @@ resources:
   version: v1alpha1
 version: 3-alpha
 plugins:
-  go.operator-sdk.io/v2-alpha: {}
+  go.sdk.operatorframework.io/v2-alpha: {}

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -16,4 +16,4 @@ package plugins
 
 // DefaultNameQualifier is the Operator SDK plugin name suffix. Appending
 // this suffix to a short name, ex. "go", makes it fully qualified.
-const DefaultNameQualifier = ".operator-sdk.io"
+const DefaultNameQualifier = ".sdk.operatorframework.io"

--- a/pkg/ansible/controller/reconcile.go
+++ b/pkg/ansible/controller/reconcile.go
@@ -45,9 +45,9 @@ import (
 
 const (
 	// ReconcilePeriodAnnotation - annotation used by a user to specify the reconciliation interval for the CR.
-	// To use create a CR with an annotation "ansible.operator-sdk/reconcile-period: 30s" or some other valid
+	// To use create a CR with an annotation "ansible.sdk.operatorframework.io/reconcile-period: 30s" or some other valid
 	// Duration. This will override the operators/or controllers reconcile period for that particular CR.
-	ReconcilePeriodAnnotation = "ansible.operator-sdk/reconcile-period"
+	ReconcilePeriodAnnotation = "ansible.sdk.operatorframework.io/reconcile-period"
 )
 
 // AnsibleOperatorReconciler - object to reconcile runner requests

--- a/pkg/ansible/runner/runner.go
+++ b/pkg/ansible/runner/runner.go
@@ -41,13 +41,13 @@ const (
 	// MaxRunnerArtifactsAnnotation - annotation used by a user to specify the max artifacts to keep
 	// in the runner directory. This will override the value provided by the watches file for a
 	// particular CR. Setting this to zero will cause all artifact directories to be kept.
-	// Example usage "ansible.operator-sdk/max-runner-artifacts: 100"
-	MaxRunnerArtifactsAnnotation = "ansible.operator-sdk/max-runner-artifacts"
+	// Example usage "ansible.sdk.operatorframework.io/max-runner-artifacts: 100"
+	MaxRunnerArtifactsAnnotation = "ansible.sdk.operatorframework.io/max-runner-artifacts"
 
 	// AnsibleVerbosityAnnotation - annotation used by a user to specify the verbosity given
 	// to the ansible-runner command. This will override the value for a particular CR.
-	// Example usage "ansible.operator-sdk/verbosity: 5"
-	AnsibleVerbosityAnnotation = "ansible.operator-sdk/verbosity"
+	// Example usage "ansible.sdk.operatorframework.io/verbosity: 5"
+	AnsibleVerbosityAnnotation = "ansible.sdk.operatorframework.io/verbosity"
 )
 
 // Runner - a runnable that should take the parameters and name and namespace

--- a/pkg/helm/controller/reconcile.go
+++ b/pkg/helm/controller/reconcile.go
@@ -327,7 +327,7 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 // returns the boolean representation of the annotation string
 // will return false if annotation is not set
 func hasHelmUpgradeForceAnnotation(o *unstructured.Unstructured) bool {
-	const helmUpgradeForceAnnotation = "helm.operator-sdk/upgrade-force"
+	const helmUpgradeForceAnnotation = "helm.sdk.operatorframework.io/upgrade-force"
 	force := o.GetAnnotations()[helmUpgradeForceAnnotation]
 	if force == "" {
 		return false

--- a/pkg/helm/controller/reconcile_test.go
+++ b/pkg/helm/controller/reconcile_test.go
@@ -30,42 +30,42 @@ func TestHasHelmUpgradeForceAnnotation(t *testing.T) {
 	}{
 		{
 			input: map[string]interface{}{
-				"helm.operator-sdk/upgrade-force": "True",
+				"helm.sdk.operatorframework.io/upgrade-force": "True",
 			},
 			expectedVal: true,
 			name:        "base case true",
 		},
 		{
 			input: map[string]interface{}{
-				"helm.operator-sdk/upgrade-force": "False",
+				"helm.sdk.operatorframework.io/upgrade-force": "False",
 			},
 			expectedVal: false,
 			name:        "base case false",
 		},
 		{
 			input: map[string]interface{}{
-				"helm.operator-sdk/upgrade-force": "1",
+				"helm.sdk.operatorframework.io/upgrade-force": "1",
 			},
 			expectedVal: true,
 			name:        "true as int",
 		},
 		{
 			input: map[string]interface{}{
-				"helm.operator-sdk/upgrade-force": "0",
+				"helm.sdk.operatorframework.io/upgrade-force": "0",
 			},
 			expectedVal: false,
 			name:        "false as int",
 		},
 		{
 			input: map[string]interface{}{
-				"helm.operator-sdk/wrong-annotation": "true",
+				"helm.sdk.operatorframework.io/wrong-annotation": "true",
 			},
 			expectedVal: false,
 			name:        "annotation not set",
 		},
 		{
 			input: map[string]interface{}{
-				"helm.operator-sdk/upgrade-force": "invalid",
+				"helm.sdk.operatorframework.io/upgrade-force": "invalid",
 			},
 			expectedVal: false,
 			name:        "invalid value",

--- a/test/ansible/deploy/crds/test.example.com_v1_inventorytest_cr.yaml
+++ b/test/ansible/deploy/crds/test.example.com_v1_inventorytest_cr.yaml
@@ -3,7 +3,7 @@ kind: InventoryTest
 metadata:
   name: example-inventorytest
   annotations:
-    "ansible.operator-sdk/verbosity": "3"
+    "ansible.sdk.operatorframework.io/verbosity": "3"
 spec:
   # Add fields here
   size: 3

--- a/test/ansible/deploy/crds/test.example.com_v1alpha1_inventorytest_cr.yaml
+++ b/test/ansible/deploy/crds/test.example.com_v1alpha1_inventorytest_cr.yaml
@@ -3,7 +3,7 @@ kind: InventoryTest
 metadata:
   name: example-inventory
   annotations:
-    "ansible.operator-sdk/verbosity": "0"
+    "ansible.sdk.operatorframework.io/verbosity": "0"
 spec:
   # Add fields here
   size: 3

--- a/test/e2e-helm/e2e_helm_suite_test.go
+++ b/test/e2e-helm/e2e_helm_suite_test.go
@@ -89,7 +89,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("initializing a Helm project")
 	err = tc.Init(
-		"--plugins", "helm.operator-sdk.io/v1",
+		"--plugins", "helm.sdk.operatorframework.io/v1",
 		"--project-version", "3-alpha",
 		"--domain", tc.Domain)
 	Expect(err).Should(Succeed())

--- a/website/content/en/docs/building-operators/ansible/development-tips.md
+++ b/website/content/en/docs/building-operators/ansible/development-tips.md
@@ -187,7 +187,7 @@ the below section for Ansible Operator specific annotations.
 #### Ansible Operator annotations
 This is the list of CR annotations which will modify the behavior of the operator:
 
-**ansible.operator-sdk/reconcile-period**: Specifies the maximum time before a reconciliation is triggered. Note that at scale, this can reduce performance, see [watches][watches] reference for more information. This value is parsed using the standard Golang package
+**ansible.sdk.operatorframework.io/reconcile-period**: Specifies the maximum time before a reconciliation is triggered. Note that at scale, this can reduce performance, see [watches][watches] reference for more information. This value is parsed using the standard Golang package
 [time][time_pkg]. Specifically [ParseDuration][time_parse_duration] is used
 which will apply the default suffix of `s` giving the value in seconds.
 
@@ -198,7 +198,7 @@ kind: "Foo"
 metadata:
   name: "example"
 annotations:
-  ansible.operator-sdk/reconcile-period: "30s"
+  ansible.sdk.operatorframework.io/reconcile-period: "30s"
 ```
 
 Note that a lower period will correct entropy more quickly, but reduce responsiveness to change 

--- a/website/content/en/docs/building-operators/ansible/quickstart.md
+++ b/website/content/en/docs/building-operators/ansible/quickstart.md
@@ -309,7 +309,7 @@ In the `deploy/operator.yaml`:
 
 Occasionally while developing additional debug in the Operator logs is nice to have.
 Using the memcached operator as an example, we can simply add the
-`"ansible.operator-sdk/verbosity"` annotation to the Custom
+`"ansible.sdk.operatorframework.io/verbosity"` annotation to the Custom
 Resource with the desired verbosity.
 
 ```yaml
@@ -318,7 +318,7 @@ kind: "Memcached"
 metadata:
   name: "example-memcached"
   annotations:
-    "ansible.operator-sdk/verbosity": "4"
+    "ansible.sdk.operatorframework.io/verbosity": "4"
 spec:
   size: 4
 ```

--- a/website/content/en/docs/building-operators/ansible/reference/advanced_options.md
+++ b/website/content/en/docs/building-operators/ansible/reference/advanced_options.md
@@ -107,7 +107,7 @@ command:
    be all uppercase and all periods (e.g. in the group name) are replaced with
    underscore.
 1. Operator **users, authors, and admins** can set the Ansible verbosity by
-   setting the `"ansible.operator-sdk/verbosity"` annotation on the Custom
+   setting the `"ansible.sdk.operatorframework.io/verbosity"` annotation on the Custom
    Resource.
 
 ### Examples
@@ -134,7 +134,7 @@ spec in our `deploy/operator.yaml` might look something like:
 ```
 
 Once the Operator is deployed, the only way to change the verbosity is via the
-`"ansible.operator-sdk/verbosity"` annotation. Continuing with our example, our
+`"ansible.sdk.operatorframework.io/verbosity"` annotation. Continuing with our example, our
 CR may look like:
 
 ```yaml
@@ -143,7 +143,7 @@ kind: "PostgreSQL"
 metadata:
   name: "example-db"
   annotations:
-    "ansible.operator-sdk/verbosity": "5"
+    "ansible.sdk.operatorframework.io/verbosity": "5"
 spec: {}
 ```
 

--- a/website/content/en/docs/building-operators/ansible/reference/watches.md
+++ b/website/content/en/docs/building-operators/ansible/reference/watches.md
@@ -98,11 +98,11 @@ Some features can be overridden per resource via an annotation on that CR. The o
 
 | Feature | Yaml Key | Description| Annotation for override | default | Documentation |
 |---------|----------|------------|-------------------------|---------|---------------|
-| Reconcile Period | `reconcilePeriod`  | time between reconcile runs for a particular CR  | ansible.operator-sdk/reconcile-period  | 1m | |
+| Reconcile Period | `reconcilePeriod`  | time between reconcile runs for a particular CR  | ansible.sdk.operatorframework.io/reconcile-period  | 1m | |
 | Manage Status | `manageStatus` | Allows the ansible operator to manage the conditions section of each resource's status section. | | true | |
 | Watching Dependent Resources | `watchDependentResources` | Allows the ansible operator to dynamically watch resources that are created by ansible | | true | [dependent watches](../dependent-watches) |
 | Watching Cluster-Scoped Resources | `watchClusterScopedResources` | Allows the ansible operator to watch cluster-scoped resources that are created by ansible | | false | |
-| Max Runner Artifacts | `maxRunnerArtifacts` | Manages the number of [artifact directories](https://ansible-runner.readthedocs.io/en/latest/intro.html#runner-artifacts-directory-hierarchy) that ansible runner will keep in the operator container for each individual resource. | ansible.operator-sdk/max-runner-artifacts | 20 | |
+| Max Runner Artifacts | `maxRunnerArtifacts` | Manages the number of [artifact directories](https://ansible-runner.readthedocs.io/en/latest/intro.html#runner-artifacts-directory-hierarchy) that ansible runner will keep in the operator container for each individual resource. | ansible.sdk.operatorframework.io/max-runner-artifacts | 20 | |
 | Finalizer | `finalizer`  | Sets a finalizer on the CR and maps a deletion event to a playbook or role | | | [finalizers](../finalizers)|
 | Selector | `selector`  | Identifies a set of objects based on their labels | | None Applied | [Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)|
 | Automatic Case Conversion | `snakeCaseParameters`  | Determines whether to convert the CR spec from camelCase to snake_case before passing the contents to Ansible as extra_vars| | true | |

--- a/website/content/en/docs/building-operators/helm/migration.md
+++ b/website/content/en/docs/building-operators/helm/migration.md
@@ -39,7 +39,7 @@ Let's create the same project but with the Helm plugin:
 ```sh
 $ mkdir nginx-operator
 $ cd nginx-operator
-$ operator-sdk init --plugins=helm.operator-sdk.io/v1 --domain=com --group=example --version=v1alpha1 --kind=Nginx
+$ operator-sdk init --plugins=helm.sdk.operatorframework.io/v1 --domain=com --group=example --version=v1alpha1 --kind=Nginx
 ```
 
 **Note** Ensure that you use the same values for the flags to recreate the same Helm Chart and API's. If you have

--- a/website/content/en/docs/building-operators/helm/quickstart.md
+++ b/website/content/en/docs/building-operators/helm/quickstart.md
@@ -13,7 +13,7 @@ Use the CLI to create a new Helm-based nginx-operator project:
 ```sh
 $ mkdir nginx-operator
 $ cd nginx-operator
-$ operator-sdk init --plugins=helm.operator-sdk.io/v1 --domain=com --group=example --version=v1alpha1 --kind=Nginx
+$ operator-sdk init --plugins=helm.sdk.operatorframework.io/v1 --domain=com --group=example --version=v1alpha1 --kind=Nginx
 ```
 
 This creates the nginx-operator project specifically for watching the
@@ -62,7 +62,7 @@ If a custom repository URL is specified by `--helm-chart-repo`, the only support
 
 If `--helm-chart-version` is not set, the SDK will fetch the latest available version of the helm chart. Otherwise, it will fetch the specified version. The option `--helm-chart-version` is not used when `--helm-chart` itself refers to a specific version, for example when it is a local path or a URL.
 
-**Note:** For more details and examples run `operator-sdk init --plugins=helm.operator-sdk.io/v1 --help`.
+**Note:** For more details and examples run `operator-sdk init --plugins=helm.sdk.operatorframework.io/v1 --help`.
 
 ### Operator scope
 

--- a/website/content/en/docs/building-operators/helm/reference/advanced_features.md
+++ b/website/content/en/docs/building-operators/helm/reference/advanced_features.md
@@ -110,7 +110,7 @@ helm-operator --max-concurrent-reconciles=10
 
 ## Use `helm upgrade --force` for deployment
 
-By adding the annotation `helm.operator-sdk/upgrade-force: "True"` to the deployed CR, the operator uses the `--force` flag of helm to replace the rendered resources. For more info see the [Helm Upgrade documentation](https://helm.sh/docs/helm/helm_upgrade/) and this [explanation](https://github.com/helm/helm/issues/7082#issuecomment-559558318) of `--force` behavior.
+By adding the annotation `helm.sdk.operatorframework.io/upgrade-force: "True"` to the deployed CR, the operator uses the `--force` flag of helm to replace the rendered resources. For more info see the [Helm Upgrade documentation](https://helm.sh/docs/helm/helm_upgrade/) and this [explanation](https://github.com/helm/helm/issues/7082#issuecomment-559558318) of `--force` behavior.
 
 **Example**
 
@@ -120,7 +120,7 @@ kind: Nginx
 metadata:
   name: nginx-sample
   annotations:
-    helm.operator-sdk/upgrade-force: "True"
+    helm.sdk.operatorframework.io/upgrade-force: "True"
 spec:
   replicaCount: 2
   service:

--- a/website/content/en/docs/building-operators/helm/reference/scaffolding.md
+++ b/website/content/en/docs/building-operators/helm/reference/scaffolding.md
@@ -5,7 +5,7 @@ weight: 20
 ---
 
 After creating a new operator project using
-`operator-sdk init --plugins=helm.operator-sdk.io/v1`, 
+`operator-sdk init --plugins=helm.sdk.operatorframework.io/v1`,
 the project directory has numerous generated folders and files.
 The following table describes a basic rundown of each generated file/directory.
 

--- a/website/content/en/docs/cli/operator-sdk_init.md
+++ b/website/content/en/docs/cli/operator-sdk_init.md
@@ -42,7 +42,7 @@ operator-sdk init [flags]
   -h, --help                     help for init
       --license string           license to use to boilerplate, may be one of 'apache2', 'none' (default "apache2")
       --owner string             owner to add to the copyright
-      --plugins strings          Name and optionally version of the plugin to initialize the project with. Available plugins: ("go.kubebuilder.io/v2", "helm.operator-sdk.io/v1")
+      --plugins strings          Name and optionally version of the plugin to initialize the project with. Available plugins: ("go.kubebuilder.io/v2", "helm.sdk.operatorframework.io/v1")
       --project-version string   project version, possible values: ("2", "3-alpha") (default "3-alpha")
       --repo string              name to use for go module (e.g., github.com/user/repo), defaults to the go package of the current working directory.
       --skip-go-version-check    if specified, skip checking the Go version


### PR DESCRIPTION
**Description of the change:**
Use a consistent domain suffix for all SDK features (plugin names, annotations, etc.)

**Motivation for the change:**
Consistency and to align with a domain we actually own.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
