### PR TITLE
generate: remove `--operator-name`

### DIFF
--- a/changelog/fragments/operator-name-config.yaml
+++ b/changelog/fragments/operator-name-config.yaml
@@ -1,0 +1,14 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Remove `--operator-name` from `generate` subcommands in favor of using `project-name`
+      from the PROJECT config file (v3-alpha+).
+    kind: removal
+    breaking: true
+    migration:
+      header: Remove `--operator-name` from scripts
+      body: >
+        The `--operator-name` flag has been removed from `generate bundle` and `generate packagemanifests`
+        subcommands. Remove this flag from your scripts, and make sure the `project-name` key is set in
+        your PROJECT file. If this key is not set, the current working directory's base name will be used.

--- a/internal/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/internal/cmd/operator-sdk/generate/bundle/bundle.go
@@ -105,14 +105,11 @@ https://github.com/operator-framework/operator-registry/#manifest-format
 const defaultRootDir = "bundle"
 
 // setDefaults sets defaults useful to all modes of this subcommand.
-func (c *bundleCmd) setDefaults(cfg *config.Config) error {
-	if c.operatorName == "" {
-		projectName, err := genutil.GetOperatorName(cfg)
-		if err != nil {
-			return err
-		}
-		c.operatorName = projectName
+func (c *bundleCmd) setDefaults(cfg *config.Config) (err error) {
+	if c.projectName, err = genutil.GetOperatorName(cfg); err != nil {
+		return err
 	}
+
 	// A default channel can be inferred if there is only one channel. Don't infer
 	// default otherwise; the user must set this value.
 	if c.defaultChannel == "" && strings.Count(c.channels, ",") == 0 {
@@ -184,7 +181,7 @@ func (c bundleCmd) runManifests(cfg *config.Config) (err error) {
 	}
 
 	csvGen := gencsv.Generator{
-		OperatorName: c.operatorName,
+		OperatorName: c.projectName,
 		OperatorType: projutil.PluginKeyToOperatorType(cfg.Layout),
 		Version:      c.version,
 		Collector:    col,
@@ -293,7 +290,7 @@ func (c bundleCmd) runMetadata(cfg *config.Config) error {
 func (c bundleCmd) generateMetadata(cfg *config.Config, manifestsDir, outputDir string) error {
 
 	metadataExists := isMetatdataExist(outputDir, manifestsDir)
-	err := bundle.GenerateFunc(manifestsDir, outputDir, c.operatorName, c.channels, c.defaultChannel, c.overwrite)
+	err := bundle.GenerateFunc(manifestsDir, outputDir, c.projectName, c.channels, c.defaultChannel, c.overwrite)
 	if err != nil {
 		return fmt.Errorf("error generating bundle metadata: %v", err)
 	}

--- a/internal/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/generate/bundle/cmd.go
@@ -32,7 +32,7 @@ type bundleCmd struct {
 	metadata  bool
 
 	// Common options.
-	operatorName string
+	projectName  string
 	version      string
 	inputDir     string
 	outputDir    string
@@ -119,7 +119,6 @@ func (c *bundleCmd) addFlagsTo(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.manifests, "manifests", false, "Generate bundle manifests")
 	fs.BoolVar(&c.metadata, "metadata", false, "Generate bundle metadata and Dockerfile")
 
-	fs.StringVar(&c.operatorName, "operator-name", "", "Name of the bundle's operator")
 	fs.StringVarP(&c.version, "version", "v", "", "Semantic version of the operator in the generated bundle. "+
 		"Only set if creating a new bundle or upgrading your operator")
 	fs.StringVar(&c.inputDir, "input-dir", "", "Directory to read an existing bundle from. "+

--- a/internal/cmd/operator-sdk/generate/kustomize/manifests.go
+++ b/internal/cmd/operator-sdk/generate/kustomize/manifests.go
@@ -60,11 +60,11 @@ const examples = `
 
 //nolint:maligned
 type manifestsCmd struct {
-	operatorName string
-	inputDir     string
-	outputDir    string
-	apisDir      string
-	quiet        bool
+	projectName string
+	inputDir    string
+	outputDir   string
+	apisDir     string
+	quiet       bool
 
 	// Interactive options.
 	interactiveLevel projutil.InteractiveLevel
@@ -118,7 +118,6 @@ func newManifestsCmd() *cobra.Command {
 }
 
 func (c *manifestsCmd) addFlagsTo(fs *pflag.FlagSet) {
-	fs.StringVar(&c.operatorName, "operator-name", "", "Name of the operator")
 	fs.StringVar(&c.inputDir, "input-dir", "", "Directory containing existing kustomize files")
 	fs.StringVar(&c.outputDir, "output-dir", "", "Directory to write kustomize files")
 	fs.StringVar(&c.apisDir, "apis-dir", "", "Root directory for API type defintions")
@@ -131,13 +130,9 @@ func (c *manifestsCmd) addFlagsTo(fs *pflag.FlagSet) {
 var defaultDir = filepath.Join("config", "manifests")
 
 // setDefaults sets command defaults.
-func (c *manifestsCmd) setDefaults(cfg *config.Config) error {
-	if c.operatorName == "" {
-		projectName, err := genutil.GetOperatorName(cfg)
-		if err != nil {
-			return err
-		}
-		c.operatorName = projectName
+func (c *manifestsCmd) setDefaults(cfg *config.Config) (err error) {
+	if c.projectName, err = genutil.GetOperatorName(cfg); err != nil {
+		return err
 	}
 
 	if c.inputDir == "" {
@@ -172,7 +167,7 @@ func (c manifestsCmd) run(cfg *config.Config) error {
 	}
 
 	csvGen := gencsv.Generator{
-		OperatorName: c.operatorName,
+		OperatorName: c.projectName,
 		OperatorType: projutil.PluginKeyToOperatorType(cfg.Layout),
 	}
 	opts := []gencsv.Option{

--- a/internal/cmd/operator-sdk/generate/packagemanifests/cmd.go
+++ b/internal/cmd/operator-sdk/generate/packagemanifests/cmd.go
@@ -28,7 +28,7 @@ import (
 //nolint:maligned
 type packagemanifestsCmd struct {
 	// Common options.
-	operatorName string
+	projectName  string
 	version      string
 	fromVersion  string
 	inputDir     string
@@ -84,7 +84,6 @@ func NewCmd() *cobra.Command {
 }
 
 func (c *packagemanifestsCmd) addFlagsTo(fs *pflag.FlagSet) {
-	fs.StringVar(&c.operatorName, "operator-name", "", "Name of the packaged operator")
 	fs.StringVarP(&c.version, "version", "v", "", "Semantic version of the packaged operator")
 	fs.StringVar(&c.fromVersion, "from-version", "", "Semantic version of the operator being upgraded from")
 	fs.StringVar(&c.inputDir, "input-dir", "", "Directory to read existing package manifests from. "+

--- a/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
+++ b/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
@@ -79,13 +79,9 @@ https://github.com/operator-framework/operator-registry/#manifest-format
 const defaultRootDir = "packagemanifests"
 
 // setDefaults sets command defaults.
-func (c *packagemanifestsCmd) setDefaults(cfg *config.Config) error {
-	if c.operatorName == "" {
-		projectName, err := genutil.GetOperatorName(cfg)
-		if err != nil {
-			return err
-		}
-		c.operatorName = projectName
+func (c *packagemanifestsCmd) setDefaults(cfg *config.Config) (err error) {
+	if c.projectName, err = genutil.GetOperatorName(cfg); err != nil {
+		return err
 	}
 
 	if c.inputDir == "" {
@@ -169,7 +165,7 @@ func (c packagemanifestsCmd) run(cfg *config.Config) error {
 	}
 
 	csvGen := gencsv.Generator{
-		OperatorName: c.operatorName,
+		OperatorName: c.projectName,
 		OperatorType: projutil.PluginKeyToOperatorType(cfg.Layout),
 		Version:      c.version,
 		FromVersion:  c.fromVersion,
@@ -221,7 +217,7 @@ func (c packagemanifestsCmd) run(cfg *config.Config) error {
 
 func (c packagemanifestsCmd) generatePackageManifest() error {
 	pkgGen := genpkg.Generator{
-		OperatorName:     c.operatorName,
+		OperatorName:     c.projectName,
 		Version:          c.version,
 		ChannelName:      c.channelName,
 		IsDefaultChannel: c.isDefaultChannel,

--- a/internal/generate/packagemanifest/packagemanifest.go
+++ b/internal/generate/packagemanifest/packagemanifest.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	apimanifests "github.com/operator-framework/api/pkg/manifests"
 	"github.com/operator-framework/api/pkg/validation"
@@ -173,7 +172,7 @@ func (g Generator) makeBaseGetter(inputDir string) func() (*apimanifests.Package
 
 // makePkgManFileName will return the file name of a PackageManifest.
 func makePkgManFileName(operatorName string) string {
-	return strings.ToLower(operatorName) + packageManifestFileExt
+	return operatorName + packageManifestFileExt
 }
 
 // sortChannelsByName sorts pkg.Channels by each element's name.

--- a/website/content/en/docs/cli/operator-sdk_generate_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_bundle.md
@@ -88,7 +88,6 @@ operator-sdk generate bundle [flags]
       --kustomize-dir string     Directory containing kustomize bases and a kustomization.yaml for operator-framework manifests (default "config/manifests")
       --manifests                Generate bundle manifests
       --metadata                 Generate bundle metadata and Dockerfile
-      --operator-name string     Name of the bundle's operator
       --output-dir string        Directory to write the bundle to
       --overwrite                Overwrite the bundle's metadata and Dockerfile if they exist (default true)
   -q, --quiet                    Run in quiet mode

--- a/website/content/en/docs/cli/operator-sdk_generate_kustomize_manifests.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_kustomize_manifests.md
@@ -47,13 +47,12 @@ operator-sdk generate kustomize manifests [flags]
 ### Options
 
 ```
-      --apis-dir string        Root directory for API type defintions
-  -h, --help                   help for manifests
-      --input-dir string       Directory containing existing kustomize files
-      --interactive            When set or no kustomize base exists, an interactive command prompt will be presented to accept non-inferrable metadata
-      --operator-name string   Name of the operator
-      --output-dir string      Directory to write kustomize files
-  -q, --quiet                  Run in quiet mode
+      --apis-dir string     Root directory for API type defintions
+  -h, --help                help for manifests
+      --input-dir string    Directory containing existing kustomize files
+      --interactive         When set or no kustomize base exists, an interactive command prompt will be presented to accept non-inferrable metadata
+      --output-dir string   Directory to write kustomize files
+  -q, --quiet               Run in quiet mode
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/cli/operator-sdk_generate_packagemanifests.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_packagemanifests.md
@@ -70,7 +70,6 @@ operator-sdk generate packagemanifests [flags]
   -h, --help                   help for packagemanifests
       --input-dir string       Directory to read existing package manifests from. This directory is the parent of individual versioned package directories, and different from --deploy-dir
       --kustomize-dir string   Directory containing kustomize bases and a kustomization.yaml for operator-framework manifests (default "config/manifests")
-      --operator-name string   Name of the packaged operator
       --output-dir string      Directory in which to write package manifests
   -q, --quiet                  Run in quiet mode
       --stdout                 Write package to stdout

--- a/website/content/en/docs/olm-integration/generation.md
+++ b/website/content/en/docs/olm-integration/generation.md
@@ -25,7 +25,7 @@ However the package manifests format is still supported by operator-framework to
 ### Kustomize files
 
 `operator-sdk generate kustomize manifests` generates a CSV kustomize base
-`config/manifests/bases/<operator-name>.clusterserviceversion.yaml` and a `config/manifests/bases/kustomization.yaml`
+`config/manifests/bases/<project-name>.clusterserviceversion.yaml` and a `config/manifests/bases/kustomization.yaml`
 by default. These files are required as `kustomize build` input in downstream commands.
 
 By default, the command starts an interactive prompt if a CSV base in `config/manifests/bases` is not present
@@ -160,7 +160,7 @@ endif
 PKG_MAN_OPTS ?= $(FROM_VERSION) $(PKG_CHANNELS) $(PKG_IS_DEFAULT_CHANNEL)
 
 # Generate package manifests.
-packagemanifests: kustomize 
+packagemanifests: kustomize
   operator-sdk generate kustomize manifests -q
   $(KUSTOMIZE) build config/manifests | operator-sdk generate packagemanifests -q --version $(VERSION) $(PKG_MAN_OPTS)
 ```
@@ -228,7 +228,7 @@ Below are two lists of fields: the first is a list of all fields the SDK and OLM
 These markers are not available to Ansible or Helm project types.
 
 Required:
-- `metadata.name`: a *unique* name for this CSV of the format `<operator-name>.vX.Y.Z`, ex. `app-operator.v0.0.1`.
+- `metadata.name`: a *unique* name for this CSV of the format `<project-name>.vX.Y.Z`, ex. `app-operator.v0.0.1`.
 - `spec.version`: semantic version of the Operator, ex. `0.0.1`.
 - `spec.installModes`: what mode of [installation namespacing][install-modes] OLM should use.
 Currently all but `MultiNamespace` are supported by SDK Operators.

--- a/website/content/en/docs/olm-integration/quickstart-package-manifests.md
+++ b/website/content/en/docs/olm-integration/quickstart-package-manifests.md
@@ -19,7 +19,7 @@ kustomize build config/manifests | operator-sdk generate packagemanifests -q --v
 ```
 
 A versioned manifests directory `packagemanifests/0.0.1` containing a CSV and all CRDs in `config/crds` and a
-package manifest YAML file `packagemanifests/<operator-name>.package.yaml` have been created in the Operator project.
+package manifest YAML file `packagemanifests/<project-name>.package.yaml` have been created in the Operator project.
 
 ## Deploying an Operator with OLM
 


### PR DESCRIPTION
**Description of the change:** remove `--operator-name` flag

**Motivation for the change:** `projectName` is now universal for plugins, so should be used instead of a flag value.

/cc @joelanford @camilamacedo86 @hasbro17 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
