### PR TITLE
test,website: use --plugins=helm when referencing the plugin name

### DIFF
--- a/test/e2e-helm/e2e_helm_suite_test.go
+++ b/test/e2e-helm/e2e_helm_suite_test.go
@@ -89,7 +89,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("initializing a Helm project")
 	err = tc.Init(
-		"--plugins", "helm.sdk.operatorframework.io/v1",
+		"--plugins", "helm",
 		"--project-version", "3-alpha",
 		"--domain", tc.Domain)
 	Expect(err).Should(Succeed())

--- a/website/content/en/docs/building-operators/helm/migration.md
+++ b/website/content/en/docs/building-operators/helm/migration.md
@@ -39,7 +39,7 @@ Let's create the same project but with the Helm plugin:
 ```sh
 $ mkdir nginx-operator
 $ cd nginx-operator
-$ operator-sdk init --plugins=helm.sdk.operatorframework.io/v1 --domain=com --group=example --version=v1alpha1 --kind=Nginx
+$ operator-sdk init --plugins=helm --domain=com --group=example --version=v1alpha1 --kind=Nginx
 ```
 
 **Note** Ensure that you use the same values for the flags to recreate the same Helm Chart and API's. If you have

--- a/website/content/en/docs/building-operators/helm/quickstart.md
+++ b/website/content/en/docs/building-operators/helm/quickstart.md
@@ -13,7 +13,7 @@ Use the CLI to create a new Helm-based nginx-operator project:
 ```sh
 $ mkdir nginx-operator
 $ cd nginx-operator
-$ operator-sdk init --plugins=helm.sdk.operatorframework.io/v1 --domain=com --group=example --version=v1alpha1 --kind=Nginx
+$ operator-sdk init --plugins=helm --domain=com --group=example --version=v1alpha1 --kind=Nginx
 ```
 
 This creates the nginx-operator project specifically for watching the
@@ -62,7 +62,7 @@ If a custom repository URL is specified by `--helm-chart-repo`, the only support
 
 If `--helm-chart-version` is not set, the SDK will fetch the latest available version of the helm chart. Otherwise, it will fetch the specified version. The option `--helm-chart-version` is not used when `--helm-chart` itself refers to a specific version, for example when it is a local path or a URL.
 
-**Note:** For more details and examples run `operator-sdk init --plugins=helm.sdk.operatorframework.io/v1 --help`.
+**Note:** For more details and examples run `operator-sdk init --plugins=helm --help`.
 
 ### Operator scope
 

--- a/website/content/en/docs/building-operators/helm/reference/scaffolding.md
+++ b/website/content/en/docs/building-operators/helm/reference/scaffolding.md
@@ -5,7 +5,7 @@ weight: 20
 ---
 
 After creating a new operator project using
-`operator-sdk init --plugins=helm.sdk.operatorframework.io/v1`,
+`operator-sdk init --plugins=helm`,
 the project directory has numerous generated folders and files.
 The following table describes a basic rundown of each generated file/directory.
 


### PR DESCRIPTION
**Description of the change:**
Update documentations and tests to use `--plugins=helm` short name for plugin

**Motivation for the change:**
It's a lot easier to type :)


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
