### PR TITLE
Add back setting environment variable

### DIFF
--- a/changelog/fragments/ansible-operator-env.yaml
+++ b/changelog/fragments/ansible-operator-env.yaml
@@ -1,0 +1,9 @@
+entries:
+  - description: >
+      Fixed a bug that caused the Ansible operator not to set the environment
+      variables `ANSIBLE_ROLES_PATH` and `ANSIBLE_COLLECTIONS_PATH` based on  the
+      flags `--ansible-roles-path` and `--ansible-collections-path`
+
+    kind: bugfix
+
+    breaking: false

--- a/cmd/ansible-operator/main.go
+++ b/cmd/ansible-operator/main.go
@@ -123,6 +123,12 @@ func main() {
 		options.Namespace = metav1.NamespaceAll
 	}
 
+	err = setAnsibleEnvVars(f)
+	if err != nil {
+		log.Error(err, "Failed to set environment variable.")
+		os.Exit(1)
+	}
+
 	// Create a new manager to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, options)
 	if err != nil {
@@ -219,4 +225,24 @@ func getAnsibleDebugLog() bool {
 			envVar, val)
 	}
 	return val
+}
+
+// setAnsibleEnvVars will set environment variables based on CLI flags
+func setAnsibleEnvVars(f *flags.Flags) error {
+	if len(f.AnsibleRolesPath) > 0 {
+		if err := os.Setenv(flags.AnsibleRolesPathEnvVar, f.AnsibleRolesPath); err != nil {
+			return fmt.Errorf("failed to set environment variable %s: %v", flags.AnsibleRolesPathEnvVar, err)
+		}
+		log.Info("Set the environment variable", "envVar", flags.AnsibleRolesPathEnvVar,
+			"value", f.AnsibleRolesPath)
+	}
+
+	if len(f.AnsibleCollectionsPath) > 0 {
+		if err := os.Setenv(flags.AnsibleCollectionsPathEnvVar, f.AnsibleCollectionsPath); err != nil {
+			return fmt.Errorf("failed to set environment variable %s: %v", flags.AnsibleCollectionsPathEnvVar, err)
+		}
+		log.Info("Set the environment variable", "envVar", flags.AnsibleCollectionsPathEnvVar,
+			"value", f.AnsibleCollectionsPath)
+	}
+	return nil
 }


### PR DESCRIPTION
**Description of the change:**

The commit [`ed92d3668ca921270d01055d8d8e01f3fd5187d3`](https://github.com/operator-framework/operator-sdk/commit/ed92d3668ca921270d01055d8d8e01f3fd5187d3) removed the `setAnsibleEnvVars` function. However, that function is important to make sure the command line flags `ansible-roles-path` and `ansible-collections-path` work. These command line flags are set into environment variables that will be picked up later.

**Motivation for the change:**

This PR fixes an issue introduced by a previous PR.

Not sure we need a change log for this kind of fix, because it is fixing a bug that is not yet released.

