### PR TITLE
Cleanup CMD tests 

### DIFF
--- a/internal/cmd/operator-sdk/bundle/bundle_suite_test.go
+++ b/internal/cmd/operator-sdk/bundle/bundle_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bundle
+package bundle_test
 
 import (
 	"testing"
@@ -23,5 +23,5 @@ import (
 
 func TestBundle(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Bundle Suite")
+	RunSpecs(t, "Bundle Cmd Suite")
 }

--- a/internal/cmd/operator-sdk/completion/completion_suite_test.go
+++ b/internal/cmd/operator-sdk/completion/completion_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package completion
+package completion_test
 
 import (
 	"testing"

--- a/internal/cmd/operator-sdk/olm/olm_suite_test.go
+++ b/internal/cmd/operator-sdk/olm/olm_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package olm
+package olm_test
 
 import (
 	"testing"
@@ -23,5 +23,5 @@ import (
 
 func TestOlm(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Olm Suite")
+	RunSpecs(t, "Olm Cmd Suite")
 }

--- a/internal/cmd/operator-sdk/run/packagemanifests/packagemanifests_suite_test.go
+++ b/internal/cmd/operator-sdk/run/packagemanifests/packagemanifests_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package packagemanifests
+package packagemanifests_test
 
 import (
 	"testing"
@@ -23,5 +23,5 @@ import (
 
 func TestRun(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Packagemanifests Suite")
+	RunSpecs(t, "Packagemanifests Cmd Suite")
 }

--- a/internal/cmd/operator-sdk/run/run_suite_test.go
+++ b/internal/cmd/operator-sdk/run/run_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package run
+package run_test
 
 import (
 	"testing"
@@ -23,5 +23,5 @@ import (
 
 func TestRun(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Run Suite")
+	RunSpecs(t, "Run Cmd Suite")
 }

--- a/internal/cmd/operator-sdk/scorecard/scorecard_suite_test.go
+++ b/internal/cmd/operator-sdk/scorecard/scorecard_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package scorecard
+package scorecard_test
 
 import (
 	"testing"
@@ -23,5 +23,5 @@ import (
 
 func TestScorecard(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Scorecard Suite")
+	RunSpecs(t, "Scorecard Cmd Suite")
 }

--- a/internal/cmd/operator-sdk/version/version_suite_test.go
+++ b/internal/cmd/operator-sdk/version/version_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package version
+package version_test
 
 import (
 	"testing"
@@ -23,5 +23,5 @@ import (
 
 func TestVersion(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Version Suite")
+	RunSpecs(t, "Version Cmd Suite")
 }

--- a/internal/scorecard/scorecard_suite_test.go
+++ b/internal/scorecard/scorecard_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package scorecard
+package scorecard_test
 
 import (
 	"testing"


### PR DESCRIPTION
**Description of the change:**
- Update the go e2e test to have the suffix _test which has special meaning for the Go compiler.
- Rename test suites created for cmd. Otherwise, when it fails we are unable to know if is for example `Scorecard Suite` from cmd or from the internals one.   


**Motivation for the change:**
Know what is the suite of test that fails and avoid duplications in the names. 
