### PR TITLE
Remove unnecessary initialization for Makefile scaffolding

### DIFF
--- a/internal/plugins/ansible/v1/scaffolds/init.go
+++ b/internal/plugins/ansible/v1/scaffolds/init.go
@@ -18,6 +18,8 @@ limitations under the License.
 package scaffolds
 
 import (
+	"strings"
+
 	"sigs.k8s.io/kubebuilder/pkg/model"
 	"sigs.k8s.io/kubebuilder/pkg/model/config"
 	"sigs.k8s.io/kubebuilder/pkg/plugin/scaffold"
@@ -35,14 +37,18 @@ import (
 	ansibleroles "github.com/operator-framework/operator-sdk/internal/plugins/ansible/v1/scaffolds/internal/templates/roles"
 
 	"github.com/operator-framework/operator-sdk/internal/kubebuilder/machinery"
+	"github.com/operator-framework/operator-sdk/internal/version"
 )
 
 const (
+	imageName = "controller:latest"
+
 	// KustomizeVersion is the kubernetes-sigs/kustomize version to be used in the project
 	KustomizeVersion = "v3.5.4"
-
-	imageName = "controller:latest"
 )
+
+// AnsibleOperatorVersion is the version of the base image and operator binary used in the Makefile
+var AnsibleOperatorVersion = strings.TrimSuffix(version.Version, "+git")
 
 var _ scaffold.Scaffolder = &initScaffolder{}
 
@@ -79,8 +85,12 @@ func (s *initScaffolder) Scaffold() error {
 func (s *initScaffolder) scaffold() error {
 	return machinery.NewScaffold().Execute(
 		s.newUniverse(),
-		&templates.Dockerfile{},
+
+		&templates.Dockerfile{
+			AnsibleOperatorVersion: AnsibleOperatorVersion,
+		},
 		&templates.GitIgnore{},
+
 		&templates.RequirementsYml{},
 		&templates.Watches{},
 
@@ -103,7 +113,10 @@ func (s *initScaffolder) scaffold() error {
 		&kdefault.Kustomize{},
 		&kdefault.AuthProxyPatch{},
 
-		&templates.Makefile{},
+		&templates.Makefile{
+			AnsibleOperatorVersion: AnsibleOperatorVersion,
+			Image:                  imageName,
+		},
 		&ansibleroles.Placeholder{},
 		&playbooks.Placeholder{},
 

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/dockerfile.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/dockerfile.go
@@ -15,12 +15,9 @@
 package templates
 
 import (
-	"strings"
-
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 
 	"github.com/operator-framework/operator-sdk/internal/plugins/ansible/v1/constants"
-	"github.com/operator-framework/operator-sdk/internal/version"
 )
 
 var _ file.Template = &Dockerfile{}
@@ -28,7 +25,9 @@ var _ file.Template = &Dockerfile{}
 // Dockerfile scaffolds a Dockerfile for building a main
 type Dockerfile struct {
 	file.TemplateMixin
-	ImageTag string
+
+	// AnsibleOperatorVersion is the version of the base image and operator binary used in the project
+	AnsibleOperatorVersion string
 
 	RolesDir     string
 	PlaybooksDir string
@@ -43,11 +42,14 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 	f.TemplateBody = dockerfileTemplate
 	f.RolesDir = constants.RolesDir
 	f.PlaybooksDir = constants.PlaybooksDir
-	f.ImageTag = strings.TrimSuffix(version.Version, "+git")
+
+	if f.AnsibleOperatorVersion == "" {
+		panic("docker file scaffold: ansible-operator version must be set")
+	}
 	return nil
 }
 
-const dockerfileTemplate = `FROM quay.io/operator-framework/ansible-operator:{{.ImageTag}}
+const dockerfileTemplate = `FROM quay.io/operator-framework/ansible-operator:{{.AnsibleOperatorVersion}}
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
@@ -18,11 +18,11 @@ limitations under the License.
 package templates
 
 import (
-	"strings"
+	"errors"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 
-	"github.com/operator-framework/operator-sdk/internal/version"
+	"github.com/operator-framework/operator-sdk/internal/plugins/ansible/v1/scaffolds"
 )
 
 var _ file.Template = &Makefile{}
@@ -48,21 +48,14 @@ func (f *Makefile) SetTemplateDefaults() error {
 	}
 
 	f.TemplateBody = makefileTemplate
-
 	f.IfExistsAction = file.Error
-
+	f.KustomizeVersion = scaffolds.KustomizeVersion
 	if f.Image == "" {
-		f.Image = "controller:latest"
+		return errors.New("makefile scaffold: ansible-operator image must be set")
 	}
-
-	if f.KustomizeVersion == "" {
-		f.KustomizeVersion = "v3.5.4"
-	}
-
 	if f.AnsibleOperatorVersion == "" {
-		f.AnsibleOperatorVersion = strings.TrimSuffix(version.Version, "+git")
+		return errors.New("makefile scaffold: ansible-operator version must be set")
 	}
-
 	return nil
 }
 

--- a/internal/plugins/helm/v1/scaffolds/init.go
+++ b/internal/plugins/helm/v1/scaffolds/init.go
@@ -37,6 +37,7 @@ import (
 
 const (
 	// KustomizeVersion is the kubernetes-sigs/kustomize version to be used in the project
+	// TODO: consolidate this with Ansible
 	KustomizeVersion = "v3.5.4"
 
 	imageName = "controller:latest"
@@ -88,9 +89,9 @@ func (s *initScaffolder) scaffold() error {
 		},
 		&templates.GitIgnore{},
 		&templates.Makefile{
+			HelmOperatorVersion: HelmOperatorVersion,
 			Image:               imageName,
 			KustomizeVersion:    KustomizeVersion,
-			HelmOperatorVersion: HelmOperatorVersion,
 		},
 		&templates.Watches{},
 		&rbac.AuthProxyRole{},

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/dockerfile.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/dockerfile.go
@@ -15,6 +15,8 @@
 package templates
 
 import (
+	"errors"
+
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
 
@@ -35,7 +37,9 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 	}
 
 	f.TemplateBody = dockerfileTemplate
-
+	if f.HelmOperatorVersion == "" {
+		return errors.New("dockerfile scaffold: helm-operator version is not set")
+	}
 	return nil
 }
 

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/makefile.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/makefile.go
@@ -18,11 +18,9 @@ limitations under the License.
 package templates
 
 import (
-	"strings"
+	"errors"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-
-	"github.com/operator-framework/operator-sdk/internal/version"
 )
 
 var _ file.Template = &Makefile{}
@@ -52,17 +50,12 @@ func (f *Makefile) SetTemplateDefaults() error {
 	f.IfExistsAction = file.Error
 
 	if f.Image == "" {
-		f.Image = "controller:latest"
-	}
-
-	if f.KustomizeVersion == "" {
-		f.KustomizeVersion = "v3.5.4"
+		return errors.New("makefile scaffold: helm-operator image name is needed")
 	}
 
 	if f.HelmOperatorVersion == "" {
-		f.HelmOperatorVersion = strings.TrimSuffix(version.Version, "+git")
+		return errors.New("makefile scaffold: helm-operator version is not set")
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
**Description of the change:**

This tiny cleanup removes the Makefile level guessing of Kustomize version, image name etc. We have these values defined at the higher level. Leaving literal strings as guess values may bring inconsistency in future.

**Motivation for the change:**

The logic in makefile template code for assigning default values is
unnecessary. These values are supposed to be passed top-down rather than
having the template guess a default value which may conflict with the
top level settings.
