### PR TITLE
Meta ansible operator meta

### DIFF
--- a/changelog/fragments/rename-meta-ansible-operator-meta.yaml
+++ b/changelog/fragments/rename-meta-ansible-operator-meta.yaml
@@ -1,0 +1,27 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      The `meta` variable passed to Ansible playbooks and roles
+      has been renamed to `ansible_operator_meta`.
+    kind: "change"
+    breaking: true
+    migration:
+      header: Ansible Operator `meta` variable renamed to `ansible_operator_meta`
+      body: |
+        All existing references to the `meta` variable in your Ansible content will
+        no longer work. Instead, your Ansible content should reference the
+        `ansible_operator_meta` variable.
+
+        Alternatively, you can use the `vars` keyword in your `watches.yaml` in order
+        to map the new `ansible_operator_meta` variable to `meta`. Below is a sample
+        `watches.yaml` that has made this change:
+
+        ```yaml
+            - version: v1alpha1
+              group: test.example.com
+              kind: Example
+              role: test
+              vars:
+                meta: '{{ ansible_operator_meta }}'
+        ```

--- a/internal/ansible/runner/runner.go
+++ b/internal/ansible/runner/runner.go
@@ -286,7 +286,7 @@ func (r *runner) isFinalizerRun(u *unstructured.Unstructured) bool {
 
 // makeParameters - creates the extravars parameters for ansible
 // The resulting structure in json is:
-// { "meta": {
+// { "ansible_operator_meta": {
 //      "name": <object_name>,
 //      "namespace": <object_namespace>,
 //   },
@@ -319,7 +319,7 @@ func (r *runner) makeParameters(u *unstructured.Unstructured) map[string]interfa
 		}
 	}
 
-	parameters["meta"] = map[string]string{"namespace": u.GetNamespace(), "name": u.GetName()}
+	parameters["ansible_operator_meta"] = map[string]string{"namespace": u.GetNamespace(), "name": u.GetName()}
 
 	objKey := escapeAnsibleKey(fmt.Sprintf("_%v_%v", r.GVK.Group, strings.ToLower(r.GVK.Kind)))
 	parameters[objKey] = u.Object

--- a/test/ansible-memcached/tasks.yml
+++ b/test/ansible-memcached/tasks.yml
@@ -5,8 +5,8 @@
       kind: Deployment
       apiVersion: apps/v1
       metadata:
-        name: '{{ meta.name }}-memcached'
-        namespace: '{{ meta.namespace }}'
+        name: '{{ ansible_operator_meta.name }}-memcached'
+        namespace: '{{ ansible_operator_meta.namespace }}'
         labels:
           app: memcached
       spec:
@@ -39,8 +39,8 @@
 - operator_sdk.util.k8s_status:
     api_version: ansible.example.com/v1alpha1
     kind: Memcached
-    name: "{{ meta.name }}"
-    namespace: "{{ meta.namespace }}"
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
     status:
       test: "hello world"
 
@@ -50,7 +50,7 @@
       apiVersion: v1
       metadata:
         name: test-secret
-        namespace: "{{ meta.namespace }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
       data:
         test: aGVsbG8K
 - name: Get cluster api_groups
@@ -73,7 +73,7 @@
       apiVersion: v1
       metadata:
         name: test-blacklist-watches
-        namespace: "{{ meta.namespace }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
       data:
         arbitrary: afdasdfsajsafj
     state: present

--- a/test/ansible/watches.yaml
+++ b/test/ansible/watches.yaml
@@ -3,22 +3,30 @@
   group: test.example.com
   kind: InventoryTest
   playbook: playbooks/inventory.yml
+  vars:
+    meta: '{{ ansible_operator_meta }}'
 
 - version: v1alpha1
   group: test.example.com
   kind: CollectionTest
   role: operator_sdk.test_fixtures.dummy
+  vars:
+    meta: '{{ ansible_operator_meta }}'
 
 - version: v1alpha1
   group: test.example.com
   kind: SubresourcesTest
   playbook: playbooks/subresources.yml
+  vars:
+    meta: '{{ ansible_operator_meta }}'
 
 - version: v1
   group: ""
   kind: Secret
   playbook: playbooks/secret.yml
   manageStatus: false
+  vars:
+    meta: '{{ ansible_operator_meta }}'
 
 - version: v1alpha1
   group: test.example.com
@@ -27,9 +35,13 @@
   selector:
     matchExpressions:
      - {key: testLabel, operator: Exists, values: []}
+  vars:
+    meta: '{{ ansible_operator_meta }}'
 
 - version: v1alpha1
   group: test.example.com
   kind: CaseTest
   playbook: playbooks/case.yml
   snakeCaseParameters: false
+  vars:
+    meta: '{{ ansible_operator_meta }}'

--- a/website/content/en/docs/building-operators/ansible/development-tips.md
+++ b/website/content/en/docs/building-operators/ansible/development-tips.md
@@ -409,8 +409,8 @@ used as shown:
 - operator_sdk.util.k8s_status:
     api_version: app.example.com/v1
     kind: Foo
-    name: "{{ meta.name }}"
-    namespace: "{{ meta.namespace }}"
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
     status:
       foo: bar
 ```
@@ -480,7 +480,7 @@ The structure passed to Ansible as extra vars is:
 
 
 ```json
-{ "meta": {
+{ "ansible_operator_meta": {
         "name": "<cr-name>",
         "namespace": "<cr-namespace>",
   },
@@ -500,7 +500,7 @@ operator. The `meta` fields can be accesses via dot notation in Ansible as so:
 ```yaml
 ---
 - debug:
-    msg: "name: {{ meta.name }}, {{ meta.namespace }}"
+    msg: "name: {{ ansible_operator_meta.name }}, {{ ansible_operator_meta.namespace }}"
 ```
 
 [k8s_ansible_module]:https://docs.ansible.com/ansible/2.6/modules/k8s_module.html

--- a/website/content/en/docs/building-operators/ansible/quickstart.md
+++ b/website/content/en/docs/building-operators/ansible/quickstart.md
@@ -122,8 +122,8 @@ Modify `roles/memcached/tasks/main.yml` to look like the following:
       kind: Deployment
       apiVersion: apps/v1
       metadata:
-        name: '{{ meta.name }}-memcached'
-        namespace: '{{ meta.namespace }}'
+        name: '{{ ansible_operator_meta.name }}-memcached'
+        namespace: '{{ ansible_operator_meta.namespace }}'
       spec:
         replicas: "{{size}}"
         selector:

--- a/website/content/en/docs/building-operators/ansible/reference/apb-migration-guide.md
+++ b/website/content/en/docs/building-operators/ansible/reference/apb-migration-guide.md
@@ -123,11 +123,11 @@ Ansible Operator does not respect the Service Bundle contract that exists betwee
 - `cluster`: Operators ideally work on both Kubernetes and OpenShift, so any uses of openshift-specific resources should handle errors and fallback
 - `_apb_plan_id`: Operators have no concept of a plan
 - `_apb_service_class_id`: This concept is replaced by the group/version/kind specified in your CRD
-- `_apb_service_instance_id`: This concept is replaced by `meta.name`, the name of the Custom Resource created by the user requesting the action.
+- `_apb_service_instance_id`: This concept is replaced by `ansible_operator_meta.name`, the name of the Custom Resource created by the user requesting the action.
 - `_apb_last_requesting_user`: There is no analogue to this.
 - `_apb_provision_creds`: There is no analogue to this.
-- `_apb_service_binding_id`: This concept is replaced by the `meta.name` of a `<kind>Binding` resource
-- `namespace`: This is accessible via the `meta.namespace` variable
+- `_apb_service_binding_id`: This concept is replaced by the `ansible_operator_meta.name` of a `<kind>Binding` resource
+- `namespace`: This is accessible via the `ansible_operator_meta.namespace` variable
 
 Instead, the Ansible Operator will pass in a field called `meta`, which contains the `name` and `namespace` of the Custom Resource that the user created.
 
@@ -164,8 +164,8 @@ would become:
       apiVersion: v1
       kind: Secret
       metadata:
-        name: '{{ meta.name }}-credentials'
-        namespace: '{{ meta.namespace }}'
+        name: '{{ ansible_operator_meta.name }}-credentials'
+        namespace: '{{ ansible_operator_meta.namespace }}'
       data:
         DB_TYPE: "{{ 'postgres' | b64encode }}"
         DB_HOST: "{{ app_name | b64encode }}"
@@ -178,10 +178,10 @@ would become:
   operator_sdk.util.k8s_status:
     api_version: apps.example.com/v1alpha1
     kind: PostgreSQL
-    name: '{{ meta.name }}'
-    namespace: '{{ meta.namespace }}'
+    name: '{{ ansible_operator_meta.name }}'
+    namespace: '{{ ansible_operator_meta.namespace }}'
     status:
-      bind_credentials_secret: '{{ meta.name }}-credentials'
+      bind_credentials_secret: '{{ ansible_operator_meta.name }}-credentials'
 ```
 
 ### ansible_kubernetes_modules

--- a/website/content/en/docs/building-operators/ansible/testing-guide.md
+++ b/website/content/en/docs/building-operators/ansible/testing-guide.md
@@ -205,7 +205,7 @@ We'll be adding the task to `roles/example/tasks/main.yml`, which should now loo
       kind: ConfigMap
       metadata:
         name: 'test-data'
-        namespace: '{{ meta.namespace }}'
+        namespace: '{{ ansible_operator_meta.namespace }}'
       data:
         hello: world
 ```


### PR DESCRIPTION
**Description of the change:**
Rename the `meta` variable that is passed to the Ansible Operator to `ansible_operator_meta`

Closes #2692

**Motivation for the change:**
This brings it in line with the typical naming scheme for implicit facts passed to roles/playbooks.


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
