### PR TITLE
Ansible/Helm: use structured logging for version info

### DIFF
--- a/changelog/fragments/ansible-helm-log-fmt.yaml
+++ b/changelog/fragments/ansible-helm-log-fmt.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      Use structure logging in Helm and Ansible operator base images
+      when printing version information.
+    kind: "change"
+    breaking: false

--- a/cmd/ansible-operator/main.go
+++ b/cmd/ansible-operator/main.go
@@ -50,9 +50,11 @@ var (
 )
 
 func printVersion() {
-	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
+	log.Info("version",
+		"Go Version", runtime.Version(),
+		"GOOS", runtime.GOOS,
+		"GOARCH", runtime.GOARCH,
+		"ansible-operator", sdkVersion.Version)
 }
 
 func main() {

--- a/cmd/ansible-operator/main.go
+++ b/cmd/ansible-operator/main.go
@@ -50,7 +50,7 @@ var (
 )
 
 func printVersion() {
-	log.Info("version",
+	log.Info("Version",
 		"Go Version", runtime.Version(),
 		"GOOS", runtime.GOOS,
 		"GOARCH", runtime.GOARCH,

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -42,9 +42,11 @@ import (
 var log = logf.Log.WithName("cmd")
 
 func printVersion() {
-	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
+	log.Info("version",
+		"Go Version", runtime.Version(),
+		"GOOS", runtime.GOOS,
+		"GOARCH", runtime.GOARCH,
+		"helm-operator", sdkVersion.Version)
 }
 
 func main() {

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -42,7 +42,7 @@ import (
 var log = logf.Log.WithName("cmd")
 
 func printVersion() {
-	log.Info("version",
+	log.Info("Version",
 		"Go Version", runtime.Version(),
 		"GOOS", runtime.GOOS,
 		"GOARCH", runtime.GOARCH,


### PR DESCRIPTION
**Description of the change:**
Use structured logging for version information for Ansible and Helm operators

**Motivation for the change:**
Closes #2843

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
