### PR TITLE
pkg/ansible/run.go: add back setting environment variables (v0.19.x)

### DIFF
--- a/changelog/fragments/ansible-operator-env.yaml
+++ b/changelog/fragments/ansible-operator-env.yaml
@@ -1,0 +1,9 @@
+entries:
+  - description: >
+      Fixed a bug that caused the Ansible operator not to set the environment
+      variables `ANSIBLE_ROLES_PATH` and `ANSIBLE_COLLECTIONS_PATH` based on  the
+      flags `--ansible-roles-path` and `--ansible-collections-path`
+
+    kind: bugfix
+
+    breaking: false

--- a/pkg/ansible/run.go
+++ b/pkg/ansible/run.go
@@ -113,6 +113,12 @@ func Run(flags *aoflags.AnsibleOperatorFlags) error {
 		options.Namespace = metav1.NamespaceAll
 	}
 
+	err = setAnsibleEnvVars(flags)
+	if err != nil {
+		log.Error(err, "Failed to set environment variable.")
+		return err
+	}
+
 	// Create a new manager to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, options)
 	if err != nil {
@@ -290,4 +296,24 @@ func getAnsibleDebugLog() bool {
 			envVar, val)
 	}
 	return val
+}
+
+// setAnsibleEnvVars will set environment variables based on CLI flags
+func setAnsibleEnvVars(f *aoflags.AnsibleOperatorFlags) error {
+	if len(f.AnsibleRolesPath) > 0 {
+		if err := os.Setenv(aoflags.AnsibleRolesPathEnvVar, f.AnsibleRolesPath); err != nil {
+			return fmt.Errorf("failed to set environment variable %s: %v", aoflags.AnsibleRolesPathEnvVar, err)
+		}
+		log.Info("Set the environment variable", "envVar", aoflags.AnsibleRolesPathEnvVar,
+			"value", f.AnsibleRolesPath)
+	}
+
+	if len(f.AnsibleCollectionsPath) > 0 {
+		if err := os.Setenv(aoflags.AnsibleCollectionsPathEnvVar, f.AnsibleCollectionsPath); err != nil {
+			return fmt.Errorf("failed to set environment variable %s: %v", aoflags.AnsibleCollectionsPathEnvVar, err)
+		}
+		log.Info("Set the environment variable", "envVar", aoflags.AnsibleCollectionsPathEnvVar,
+			"value", f.AnsibleCollectionsPath)
+	}
+	return nil
 }


### PR DESCRIPTION
**Description of the change:**
Backport of #3549 

**Motivation for the change:**
Fix bugs

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
