### PR TITLE
internal/plugins/ansible: manager scaffolding updates for --metrics-addr and envvars

### DIFF
--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/config/kdefault/auth_proxy_patch.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/config/kdefault/auth_proxy_patch.go
@@ -65,4 +65,9 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+      - name: manager
+        args:
+        - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election"
+        - "--leader-election-id={{ .ProjectName }}"
 `

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/config/kdefault/auth_proxy_patch.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/config/kdefault/auth_proxy_patch.go
@@ -29,6 +29,7 @@ var _ file.Template = &AuthProxyPatch{}
 // prometheus metrics for manager Pod.
 type AuthProxyPatch struct {
 	file.TemplateMixin
+	file.ProjectNameMixin
 }
 
 // SetTemplateDefaults implements input.Template

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/config/manager/manager.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/config/manager/manager.go
@@ -74,14 +74,6 @@ spec:
           args:
             - "--enable-leader-election"
             - "--leader-election-id={{ .ProjectName }}"
-            - "--metrics-addr=127.0.0.1:8080"
           image: {{ .Image }}
-          env:
-            - name: WATCH_NAMESPACE
-              value: ""
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
       terminationGracePeriodSeconds: 10
 `


### PR DESCRIPTION
**Description of the change:**
- Remove scaffolding of POD_NAME and WATCH_NAMESPACE
- Use default --metrics-addr flag when auth proxy is not in use


**Motivation for the change:**
Closes #3567 and #3569 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
