### PR TITLE
release.sh, website: update release script and docs

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -9,12 +9,15 @@ fi
 
 VER=$1
 
-if ! [[ "$VER" =~ ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
+NUMRE="0|[1-9][0-9]*"
+PRERE="\-(alpha|beta|rc)\.[1-9][0-9]*"
+
+if ! [[ "$VER" =~ ^v($NUMRE)\.($NUMRE)\.($NUMRE)($PRERE)?$ ]]; then
 	echo "malformed version: \"$VER\""
 	exit 1
 fi
 
-if git ls-files --others | grep -Ev 'build/operator-sdk-v.+'; then
+if git ls-files --others --exclude-standard | grep -Ev 'build/operator-sdk-v.+'; then
 	echo "directory has untracked files"
 	exit 1
 fi
@@ -51,3 +54,6 @@ git verify-tag --verbose "$VER"
 
 # Run the release builds.
 make release V=1
+
+# Verify the signatures
+for f in $(ls build/*.asc); do gpg --verify $f; done

--- a/website/content/en/docs/contribution-guidelines/release.md
+++ b/website/content/en/docs/contribution-guidelines/release.md
@@ -253,9 +253,6 @@ $ GEN_CHANGELOG_TAG=v1.3.0 make gen-changelog
 Commit the following changes:
 
 - `version/version.go`: update `Version` to `v1.3.0`.
-- `internal/scaffold/go_mod.go`, change the `require` line version for `github.com/operator-framework/operator-sdk` from `master` to `v1.3.0`.
-- `internal/scaffold/helm/go_mod.go`: same as for `internal/scaffold/go_mod.go`.
-- `internal/scaffold/ansible/go_mod.go`: same as for `internal/scaffold/go_mod.go`.
 - `website/content/en/docs/installation/install-operator-sdk.md`: update the linux and macOS URLs to point to the new release URLs.
 - `CHANGELOG.md`: commit changes (updated by changelog generation).
 - `website/content/en/docs/migration/v1.3.0.md`: commit changes (created by changelog generation).
@@ -301,10 +298,10 @@ To verify binaries and tags, see the [verification section](#verifying-a-release
 `ansible-operator` and `helm-operator` release binaries and signatures are similarly built for upload so `make run`
 can download them in their respective operator type projects. See [#3327](https://github.com/operator-framework/operator-sdk/issues/3327) for details.
 
-Push tag `v1.3.0` upstream:
+Push tag `v1.3.0` upstream, assuming `origin` is the name of the upstream remote:
 
 ```sh
-$ git push --tags
+$ git push origin v1.3.0
 ```
 
 Once this tag passes CI, go to step 3. For more info on tagging, see the [release tags section](#release-tags).
@@ -335,9 +332,6 @@ $ git push -f origin v1.3.x
 Check out a new branch from `master` or release branch and commit the following changes:
 
 - `version/version.go`: update `Version` to `v1.3.0+git`.
-- `internal/scaffold/go_mod.go`, change the `require` line version for `github.com/operator-framework/operator-sdk` from `v1.3.0` to `master`.
-- `internal/scaffold/helm/go_mod.go`: same as for `internal/scaffold/go_mod.go`.
-- `internal/scaffold/ansible/go_mod.go`: same as for `internal/scaffold/go_mod.go`.
 - **(Major and minor releases only)** `website/config.toml`: update `version_menu = "v1.3"` to `version_menu = "Releases"`.
 
 ---
@@ -369,7 +363,10 @@ The release process for the samples repo is simple:
     $ git checkout master && git pull
     $ export VER="v1.3.0"
     $ git tag --sign --message "Operator SDK Samples $VER" "$VER"
-    $ git push --tags
+    ```
+1. Push the tag to the remote, assuming `origin` is the name of the upstream remote:
+    ```sh
+    $ git push origin $VER
     ```
 
 ### (Post-release) Updating the release notes

--- a/website/content/en/docs/installation/install-operator-sdk.md
+++ b/website/content/en/docs/installation/install-operator-sdk.md
@@ -33,7 +33,7 @@ $ brew install operator-sdk
 
 ```sh
 # Set the release version variable
-$ RELEASE_VERSION=v0.19.0
+$ RELEASE_VERSION=v1.0.0-alpha.1
 # Linux
 $ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
 $ curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/ansible-operator-${RELEASE_VERSION}-x86_64-linux-gnu


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
- Update release.sh script to allow pre-releases, ignore `.gitignore`d files, and automatically verify binary signatures.
- Update release docs to remove file changes that are no longer relevant, and only push the one release tag
- Use `v1.0.0-alpha.1` in installation doc

**Motivation for the change:**
Closes #3576 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
