### PR TITLE
<run|cleanup> packagemanifests: remove `--olm-namespace`, change `--operator-namespace` to `--namespace`

### DIFF
--- a/changelog/fragments/run-packagemanifests-flags-2.yaml
+++ b/changelog/fragments/run-packagemanifests-flags-2.yaml
@@ -1,0 +1,15 @@
+entries:
+  - description: Removed the `--olm-namespace` flag from `run packagemanifests`.
+    kind: removal
+    breaking: true
+    migration:
+      header: Remove `--olm-namespace` from `run packagemanifests` invocations
+      body: >
+        OLM namespace is no longer required by this command.
+  - description: Changed the `--operator-namespace` flag to `--namespace` in `run packagemanifests`.
+    kind: change
+    breaking: true
+    migration:
+      header: Change the `run packagemanifests` flag `--operator-namespace` to `--namespace`
+      body: >
+        `--operator-namespace` is now `--namespace`.

--- a/test/e2e/e2e_suite.go
+++ b/test/e2e/e2e_suite.go
@@ -196,7 +196,7 @@ var _ = Describe("operator-sdk", func() {
 			Expect(err).NotTo(HaveOccurred())
 			runPkgManCmd := exec.Command(tc.BinaryName, "run", "packagemanifests",
 				"--install-mode", "AllNamespaces",
-				"--operator-namespace", tc.Kubectl.Namespace,
+				"--namespace", tc.Kubectl.Namespace,
 				"--version", operatorVersion,
 				"--timeout", "4m")
 			_, err = tc.Run(runPkgManCmd)
@@ -204,7 +204,7 @@ var _ = Describe("operator-sdk", func() {
 
 			By("destroying the deployed package manifests-formatted operator")
 			cleanupPkgManCmd := exec.Command(tc.BinaryName, "cleanup", "packagemanifests",
-				"--operator-namespace", tc.Kubectl.Namespace,
+				"--namespace", tc.Kubectl.Namespace,
 				"--version", operatorVersion,
 				"--timeout", "4m")
 			_, err = tc.Run(cleanupPkgManCmd)

--- a/test/integration/operator_olm_test.go
+++ b/test/integration/operator_olm_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	apimanifests "github.com/operator-framework/api/pkg/manifests"
-	"github.com/operator-framework/operator-sdk/internal/olm"
 	operator "github.com/operator-framework/operator-sdk/internal/olm/operator"
 	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
 
@@ -99,7 +98,6 @@ func PackageManifestsAllNamespaces(t *testing.T) {
 		OperatorCmd: operator.OperatorCmd{
 			KubeconfigPath: kubeconfigPath,
 			Timeout:        defaultTimeout,
-			OLMNamespace:   olm.DefaultOLMNamespace,
 			InstallMode:    string(operatorsv1alpha1.InstallModeTypeAllNamespaces),
 		},
 		ManifestsDir: manifestsDir,
@@ -162,7 +160,6 @@ func PackageManifestsBasic(t *testing.T) {
 		OperatorCmd: operator.OperatorCmd{
 			KubeconfigPath: kubeconfigPath,
 			Timeout:        defaultTimeout,
-			OLMNamespace:   olm.DefaultOLMNamespace,
 		},
 		ManifestsDir: manifestsDir,
 		Version:      defaultOperatorVersion,
@@ -265,7 +262,6 @@ func PackageManifestsMultiplePackages(t *testing.T) {
 		OperatorCmd: operator.OperatorCmd{
 			KubeconfigPath: kubeconfigPath,
 			Timeout:        defaultTimeout,
-			OLMNamespace:   olm.DefaultOLMNamespace,
 		},
 		ManifestsDir: manifestsDir,
 		Version:      operatorVersion2,

--- a/website/content/en/docs/cli/operator-sdk_cleanup_packagemanifests.md
+++ b/website/content/en/docs/cli/operator-sdk_cleanup_packagemanifests.md
@@ -18,13 +18,12 @@ operator-sdk cleanup packagemanifests [flags]
 ### Options
 
 ```
-  -h, --help                        help for packagemanifests
-      --install-mode string         InstallMode to create OperatorGroup with. Format: InstallModeType[=ns1,ns2[, ...]]
-      --kubeconfig string           The file path to kubernetes configuration file. Defaults to location specified by $KUBECONFIG, or to default file rules if not set
-      --olm-namespace string        The namespace where OLM is installed (default "olm")
-      --operator-namespace string   The namespace where operator resources are created. It must already exist in the cluster
-      --timeout duration            Time to wait for the command to complete before failing (default 2m0s)
-      --version string              Packaged version of the operator to deploy
+  -h, --help                  help for packagemanifests
+      --install-mode string   InstallMode to create OperatorGroup with. Format: InstallModeType[=ns1,ns2[, ...]]
+      --kubeconfig string     The file path to kubernetes configuration file. Defaults to location specified by $KUBECONFIG, or to default file rules if not set
+      --namespace string      The namespace where operator resources are created. It must already exist in the cluster
+      --timeout duration      Time to wait for the command to complete before failing (default 2m0s)
+      --version string        Packaged version of the operator to deploy
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/cli/operator-sdk_run_packagemanifests.md
+++ b/website/content/en/docs/cli/operator-sdk_run_packagemanifests.md
@@ -17,13 +17,12 @@ operator-sdk run packagemanifests [flags]
 ### Options
 
 ```
-  -h, --help                        help for packagemanifests
-      --install-mode string         InstallMode to create OperatorGroup with. Format: InstallModeType[=ns1,ns2[, ...]]
-      --kubeconfig string           The file path to kubernetes configuration file. Defaults to location specified by $KUBECONFIG, or to default file rules if not set
-      --olm-namespace string        The namespace where OLM is installed (default "olm")
-      --operator-namespace string   The namespace where operator resources are created. It must already exist in the cluster
-      --timeout duration            Time to wait for the command to complete before failing (default 2m0s)
-      --version string              Packaged version of the operator to deploy
+  -h, --help                  help for packagemanifests
+      --install-mode string   InstallMode to create OperatorGroup with. Format: InstallModeType[=ns1,ns2[, ...]]
+      --kubeconfig string     The file path to kubernetes configuration file. Defaults to location specified by $KUBECONFIG, or to default file rules if not set
+      --namespace string      The namespace where operator resources are created. It must already exist in the cluster
+      --timeout duration      Time to wait for the command to complete before failing (default 2m0s)
+      --version string        Packaged version of the operator to deploy
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/olm-integration/quickstart-bundle.md
+++ b/website/content/en/docs/olm-integration/quickstart-bundle.md
@@ -30,8 +30,7 @@ Ensure OLM is enabled on your cluster before following this guide. [`operator-sd
 has several subcommands that can install, uninstall, and check the status of particular OLM versions in a cluster.
 
 **Note:** Certain cluster types may already have OLM enabled, but under a non-default (`"olm"`) namespace,
-which can be configured by setting `--olm-namespace=[non-default-olm-namespace]` for `operator-sdk olm` subcommands
-and `operator-sdk run packagemanifests`.
+which can be configured by setting `--olm-namespace=[non-default-olm-namespace]` for `operator-sdk olm` subcommands.
 
 You can check if OLM is already installed by running the following command,
 which will detect the installed OLM version automatically (0.15.1 in this example):

--- a/website/content/en/docs/olm-integration/testing-deployment.md
+++ b/website/content/en/docs/olm-integration/testing-deployment.md
@@ -22,9 +22,8 @@ Let's look at the anatomy of the `run packagemanifests` (which is the same for `
 
 - **kubeconfig-path**: the local path to a kubeconfig.
   - This uses well-defined default loading rules to load the config if empty.
-- **olm-namespace**: the namespace in which OLM is installed.
-- **operator-namespace**: the cluster namespace in which Operator resources are created.
-  - This namespace must already exist in the cluster or be defined in a manifest passed to **include-paths**.
+- **namespace**: the cluster namespace in which Operator resources are created.
+  - This namespace must already exist in the cluster.
 - **manifests-dir**: a directory containing the Operator's package manifests.
 - **version**: the version of the Operator to deploy. It must be a semantic version, ex. 0.0.1.
   - This version must match the version of the CSV manifest found in **manifests-dir**,
@@ -34,8 +33,7 @@ Let's look at the anatomy of the `run packagemanifests` (which is the same for `
   - The `InstallModeType` string passed must be marked as "supported" in the CSV being installed.
     The namespaces passed must exist or be created by passing a `Namespace` manifest to IncludePaths.
   - This option understands the following strings (assuming your CSV does as well):
-      - `OwnNamespace`: the Operator will watch its own namespace (from **operator-namespace** or the kubeconfig default).
-      This is the default.
+      - `OwnNamespace`: the Operator will watch its own namespace (from **namespace** or the kubeconfig default). This is the default.
       - `SingleNamespace="my-ns"`: the Operator will watch a namespace, not necessarily its own.
       - `AllNamespaces=""`: the Operator will watch all namespaces (cluster-scoped Operators).
 - **timeout**: a time string dictating the maximum time that `run` can run. The command will


### PR DESCRIPTION
**Description of the change:**
* internal/olm/operator: remove OLM namespace usage, OLM installation detection, create resources in provided operator namespace, and change operator namespace to namespace
* website: update docs


**Motivation for the change:** `<run|cleanup packagemanifests` flag `--olm-namespace` has been removed since it  is no longer used by the command, and `--operator-namespace` has been renamed to `--namespace`. OLM-adjacent resources (ex. registry deployment) are now created in the provided namespace, and OLM installation is no longer checked.

/cc @joelanford @jmrodri @rashmigottipati 


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
