### PR TITLE
fix: (ansible) - kustomize target is missing realpath

### DIFF
--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
@@ -115,7 +115,7 @@ ifeq (, $(shell which kustomize 2>/dev/null))
 	mkdir -p bin ;\
 	curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/{{ .KustomizeVersion }}/kustomize_{{ .KustomizeVersion }}_$(OS)_$(ARCH).tar.gz | tar xzf - -C bin/ ;\
 	}
-KUSTOMIZE=./bin/kustomize
+KUSTOMIZE=$(realpath ./bin/kustomize)
 else
 KUSTOMIZE=$(shell which kustomize)
 endif


### PR DESCRIPTION
**Description of the change:**
The kustomize target in the Makefile scaffolded by ansible plugin is missing use the realpath

**Motivation for the change:**
To allow the test work without pre-install it. (PS. The need to use the real path was identified when we were porting the helm tests to go and we remove its setup from the script. we were looking for to test the makefile target in the tests as well )

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
