### PR TITLE
ci: skip test jobs when just the template used as an example is changed

### DIFF
--- a/hack/ci/check-doc-only-update.sh
+++ b/hack/ci/check-doc-only-update.sh
@@ -12,6 +12,7 @@ fi
 declare -a DOC_PATTERNS
 DOC_PATTERNS=(
   "(\.md)"
+  "(\.go.tmpl)"
   "(\.MD)"
   "(\.png)"
   "(\.pdf)"


### PR DESCRIPTION
**Description of the change:**
ci: skip test jobs when just the template used as an example is changed

**Motivation for the change:**
We do not re-run all tests when the change is done for docs and in the template used by them only
