### PR TITLE
internal/plugins/manifests: inject operator image using `IMG=<tag>`

### DIFF
--- a/changelog/fragments/inject-operator-image-olm.yaml
+++ b/changelog/fragments/inject-operator-image-olm.yaml
@@ -1,0 +1,17 @@
+entries:
+  - description: >
+      Added `IMG` argument to `bundle` make rule that accepts an operator image tag. This tag will be inserted
+      into the manager's deployment manifest when `make bundle IMG=<tag>` is run.
+    kind: change
+    breaking: true
+    migration:
+      header: Update your Makefile's `bundle` recipe to inject an operator image tag.
+      body: >
+        Make the following update to your Makefile's `bundle` recipe, which will allow you to set `make bundle IMG=<tag>`:
+
+        ```make
+        bundle: ...
+          operator-sdk generate kustomize manifests -q
+          cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG) # Add this line
+          ...
+        ```

--- a/internal/plugins/manifests/init.go
+++ b/internal/plugins/manifests/init.go
@@ -81,6 +81,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # Generate bundle manifests and metadata, then validate generated files.
 bundle: manifests
 	operator-sdk generate kustomize manifests -q
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle
 `
@@ -89,6 +90,7 @@ bundle: manifests
 # Generate bundle manifests and metadata, then validate generated files.
 bundle: kustomize
 	operator-sdk generate kustomize manifests -q
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle
 `

--- a/test/e2e-helm/e2e_helm_olm_test.go
+++ b/test/e2e-helm/e2e_helm_olm_test.go
@@ -15,7 +15,6 @@
 package e2e_helm_test
 
 import (
-	"fmt"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -50,12 +49,7 @@ var _ = Describe("Integrating Helm Projects with OLM", func() {
 
 		It("should generate and run a valid OLM bundle and packagemanifests", func() {
 			By("building the bundle")
-			err := tc.Make("bundle")
-			Expect(err).NotTo(HaveOccurred())
-
-			By("validating the bundle")
-			bundleValidateCmd := exec.Command(tc.BinaryName, "bundle", "validate", "bundle")
-			_, err = tc.Run(bundleValidateCmd)
+			err := tc.Make("bundle", "IMG="+tc.ImageName)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("building the operator bundle image")
@@ -77,17 +71,7 @@ var _ = Describe("Integrating Helm Projects with OLM", func() {
 			Expect(err).Should(Succeed())
 
 			By("generating the operator package manifests")
-			err = tc.Make("packagemanifests")
-			Expect(err).NotTo(HaveOccurred())
-
-			By("updating clusterserviceversion with the manager image")
-			testutils.ReplaceInFile(
-				filepath.Join(tc.Dir, "packagemanifests", operatorVersion,
-					fmt.Sprintf("e2e-%s.clusterserviceversion.yaml", tc.TestSuffix)),
-				"controller:latest", tc.ImageName)
-
-			By("installing crds to run packagemanifests")
-			err = tc.Make("install")
+			err = tc.Make("packagemanifests", "IMG="+tc.ImageName)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("running the package")

--- a/test/e2e/e2e_suite.go
+++ b/test/e2e/e2e_suite.go
@@ -176,7 +176,7 @@ var _ = Describe("operator-sdk", func() {
 			// Turn off interactive prompts for all generation tasks.
 			replace := "operator-sdk generate kustomize manifests"
 			testutils.ReplaceInFile(filepath.Join(tc.Dir, "Makefile"), replace, replace+" --interactive=false")
-			err = tc.Make("bundle")
+			err = tc.Make("bundle", "IMG="+tc.ImageName)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("building the operator bundle image")

--- a/test/internal/utils.go
+++ b/test/internal/utils.go
@@ -40,8 +40,9 @@ endif
 PKG_MAN_OPTS ?= $(PKG_CHANNELS) $(PKG_IS_DEFAULT_CHANNEL)
 
 # Generate package manifests.
-packagemanifests: kustomize 
+packagemanifests: kustomize
 	operator-sdk generate kustomize manifests -q --interactive=false
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate packagemanifests -q --version $(VERSION) $(PKG_MAN_OPTS)
 `
 

--- a/website/content/en/docs/olm-integration/generation.md
+++ b/website/content/en/docs/olm-integration/generation.md
@@ -67,7 +67,7 @@ The following resource kinds are typically included in a CSV, which are addresse
 
 You've recently run `operator-sdk init` and created your APIs with `operator-sdk create api`. Now you'd like to
 package your Operator for deployment by OLM. Your Operator is at version `v0.0.1`; the `Makefile` variable `VERSION`
-should be set to `0.0.1`.
+should be set to `0.0.1`. You've also built your operator image, `quay.io/<user>/memcached-operator:v0.0.1`.
 
 ### Bundle format
 
@@ -141,6 +141,7 @@ PKG_MAN_OPTS ?= $(FROM_VERSION) $(PKG_CHANNELS) $(PKG_IS_DEFAULT_CHANNEL)
 # Generate package manifests.
 packagemanifests: kustomize manifests
   operator-sdk generate kustomize manifests -q
+  cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
   $(KUSTOMIZE) build config/manifests | operator-sdk generate packagemanifests -q --version $(VERSION) $(PKG_MAN_OPTS)
 ```
 
@@ -162,13 +163,14 @@ PKG_MAN_OPTS ?= $(FROM_VERSION) $(PKG_CHANNELS) $(PKG_IS_DEFAULT_CHANNEL)
 # Generate package manifests.
 packagemanifests: kustomize
   operator-sdk generate kustomize manifests -q
+  cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
   $(KUSTOMIZE) build config/manifests | operator-sdk generate packagemanifests -q --version $(VERSION) $(PKG_MAN_OPTS)
 ```
 
 By default `make packagemanifests` will generate a CSV, a package manifest file, and copy CRDs in the package manifests format:
 
 ```console
-$ make packagemanifests
+$ make packagemanifests IMG=quay.io/<user>/memcached-operator:v0.0.1
 $ tree ./packagemanifests
 ./packagemanifests
 ├── 0.0.1
@@ -185,13 +187,13 @@ and added a port to your manager Deployment in `config/manager/manager.yaml`.
 If using a bundle format, the current version of your CSV can be updated by running:
 
 ```console
-$ make bundle
+$ make bundle IMG=quay.io/<user>/memcached-operator:v0.0.1
 ```
 
 If using a package manifests format, run:
 
 ```console
-$ make packagemanifests
+$ make packagemanifests IMG=quay.io/<user>/memcached-operator:v0.0.1
 ```
 
 Running the command for either format will append your new CRD to `spec.customresourcedefinitions.owned`,
@@ -201,19 +203,20 @@ fields like `spec.maintainers`.
 
 ## Upgrade your Operator
 
-Let's say you're upgrading your Operator to version `v0.0.2`, and you've already updated the `VERSION` variable
-in your `Makefile` to `0.0.2`. You also want to add a new channel `beta`, and use it as the default channel.
+Let's say you're upgrading your Operator to version `v0.0.2`, you've already updated the `VERSION` variable
+in your `Makefile` to `0.0.2`, and built a new operator image `quay.io/<user>/memcached-operator:v0.0.2`.
+You also want to add a new channel `beta`, and use it as the default channel.
 
 If using a bundle format, a new version of your CSV can be created by running:
 
 ```console
-$ make bundle CHANNELS=beta DEFAULT_CHANNEL=beta
+$ make bundle CHANNELS=beta DEFAULT_CHANNEL=beta IMG=quay.io/<user>/memcached-operator:v0.0.2
 ```
 
 If using a package manifests format, run:
 
 ```console
-$ make packagemanifests FROM_VERSION=0.0.1 CHANNEL=beta IS_CHANNEL_DEFAULT=1
+$ make packagemanifests FROM_VERSION=0.0.1 CHANNEL=beta IS_CHANNEL_DEFAULT=1 IMG=quay.io/<user>/memcached-operator:v0.0.2
 ```
 
 Running the command for either format will persist user-defined fields, updates `spec.version`,


### PR DESCRIPTION
**Description of the change:**
* internal/plugins/manifests: add `IMG` variable injection to `bundle` recipe
* test/: update tests to use `IMG=<test image tag>`
* website/: update OLM integration docs with this change

**Motivation for the change:** This PR adds `cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)` to the manifests phase 2 plugin's Makefile modifier, such that a user can specify operator image using `make bundle IMG=<tag>`. Our e2e tests were passing because `make deploy IMG=<tag>` was run beforehand; in a newly scaffolded project that only uses bundles/package manifests, that will likely not be the case.

/cc @joelanford @camilamacedo86 @asmacdo @fabianvf 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
