### PR TITLE
website/content/en/docs/: fix links pointing to master docs site

### DIFF
--- a/website/content/en/docs/building-operators/ansible/tutorial.md
+++ b/website/content/en/docs/building-operators/ansible/tutorial.md
@@ -229,4 +229,4 @@ OLM will manage creation of most if not all resources required to run your opera
 [layout-doc]:../reference/scaffolding
 [docker-tool]:https://docs.docker.com/install/
 [kubectl-tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
-[quickstart-bundle]:https://master.sdk.operatorframework.io/docs/olm-integration/quickstart-bundle/
+[quickstart-bundle]: /docs/olm-integration/quickstart-bundle/

--- a/website/content/en/docs/upgrading-sdk-version/v0.19.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v0.19.0.md
@@ -22,8 +22,8 @@ _See [#3265](https://github.com/operator-framework/operator-sdk/pull/3265) for m
 
 ## Migrating Go projects to the new Kubebuilder aligned project layout
 
-See the [migration guide](https://master.sdk.operatorframework.io/docs/building-operators/golang/project_migration_guide/)
-that walks through an example of how to migrate a Go based operator project from the old layout to the new layout.
+See the [migration guide][migration-guide] that walks through an example of how
+to migrate a Go based operator project from the old layout to the new layout.
 
 _See [#3190](https://github.com/operator-framework/operator-sdk/pull/3190) for more details._
 
@@ -46,3 +46,5 @@ However, any script or code that is depending on this condition reason must be u
 to use `UpgradeError` instead of `UpdateError`.
 
 _See [#3269](https://github.com/operator-framework/operator-sdk/pull/3269) for more details._
+
+[migration-guide]: /docs/golang/project_migration_guide

--- a/website/content/en/docs/upgrading-sdk-version/v0.19.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v0.19.0.md
@@ -47,4 +47,4 @@ to use `UpgradeError` instead of `UpdateError`.
 
 _See [#3269](https://github.com/operator-framework/operator-sdk/pull/3269) for more details._
 
-[migration-guide]: /docs/golang/project_migration_guide
+[migration-guide]: /docs/building-operators/golang/project_migration_guide/

--- a/website/content/en/docs/upgrading-sdk-version/v1.0.0-alpha.1.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.0.0-alpha.1.md
@@ -9,9 +9,9 @@ To migrate your project, follow the migration guides to convert your projects to
 Kubebuilder-style layout.
 
 <!-- TODO(joelanford) Change these links to use `sdk.operatorframework.io` once 1.0.0 is released -->
-- [Go](https://master.sdk.operatorframework.io/docs/building-operators/golang/project_migration_guide/)
+- [Go](/docs/building-operators/golang/project_migration_guide/)
 - [Ansible](https://github.com/operator-framework/operator-sdk/pull/3571) (PR in progress)
-- [Helm](https://master.sdk.operatorframework.io/docs/building-operators/helm/migration/)
+- [Helm](/docs/building-operators/helm/migration/)
 
 The following subcommands were removed:
 
@@ -182,7 +182,7 @@ _See [#3468](https://github.com/operator-framework/operator-sdk/pull/3468) for m
 
 ## Update your scorecard config file to the new format
 
-See the updated scorecard [config documentation](https://sdk.operatorframework.io/docs/scorecard/scorecard/#config-file)
+See the updated scorecard [config documentation](/docs/scorecard/scorecard/#config-file)
 for details.
 
 _See [#3434](https://github.com/operator-framework/operator-sdk/pull/3434) and
@@ -193,7 +193,7 @@ _See [#3434](https://github.com/operator-framework/operator-sdk/pull/3434) and
 If you have been using `operator-sdk alpha scorecard`, update to use `operator-sdk scorecard`.
 <!-- TODO(joelanford): update this link to sdk.operatorframework.io when 1.0.0 is released -->
 If you have been using `operator-sdk scorecard`, migrate to the new scorecard. See the new
-[scorecard documentation](https://master.sdk.operatorframework.io/docs/advanced-topics/scorecard/scorecard/).
+[scorecard documentation](/docs/advanced-topics/scorecard/scorecard/).
 
 _See [#3444](https://github.com/operator-framework/operator-sdk/pull/3444) for more details._
 
@@ -202,8 +202,8 @@ _See [#3444](https://github.com/operator-framework/operator-sdk/pull/3444) for m
 Update any scripts interpretting the scorecard output to
 understand the `v1alpha3.TestList` format.
 
-See the [`json`](https://master.sdk.operatorframework.io/docs/advanced-topics/scorecard/scorecard/#json-format) and
-[`text`](https://master.sdk.operatorframework.io/docs/advanced-topics/scorecard/scorecard/#text-format) format
+See the [`json`](/docs/advanced-topics/scorecard/scorecard/#json-format) and
+[`text`](/docs/advanced-topics/scorecard/scorecard/#text-format) format
 descriptions for details.
 
 _See [#3427](https://github.com/operator-framework/operator-sdk/pull/3427) for more details._

--- a/website/content/en/docs/upgrading-sdk-version/v1.0.0-alpha.1.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.0.0-alpha.1.md
@@ -182,7 +182,7 @@ _See [#3468](https://github.com/operator-framework/operator-sdk/pull/3468) for m
 
 ## Update your scorecard config file to the new format
 
-See the updated scorecard [config documentation](/docs/scorecard/scorecard/#config-file)
+See the updated scorecard [config documentation](/docs/advanced-topics/scorecard/scorecard/#config-file)
 for details.
 
 _See [#3434](https://github.com/operator-framework/operator-sdk/pull/3434) and


### PR DESCRIPTION
**Description of the change:**
Fixup links that were pointing to `master.sdk.operatorframework.io`

**Motivation for the change:**
No links should point to master in our docs.


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
