### PR TITLE
Adding checks for rescued tasks during reconciliation

### DIFF
--- a/internal/ansible/controller/reconcile.go
+++ b/internal/ansible/controller/reconcile.go
@@ -186,10 +186,7 @@ func (r *AnsibleOperatorReconciler) Reconcile(request reconcile.Request) (reconc
 				return reconcile.Result{}, err
 			}
 		}
-		if event.Rescued() {
-			return reconcileResult, nil
-		}
-		if event.Event == eventapi.EventRunnerOnFailed && !event.IgnoreError() {
+		if event.Event == eventapi.EventRunnerOnFailed && !event.IgnoreError() && !event.Rescued() {
 			failureMessages = append(failureMessages, event.GetFailedPlaybookMessage())
 		}
 	}

--- a/internal/ansible/controller/reconcile.go
+++ b/internal/ansible/controller/reconcile.go
@@ -186,6 +186,9 @@ func (r *AnsibleOperatorReconciler) Reconcile(request reconcile.Request) (reconc
 				return reconcile.Result{}, err
 			}
 		}
+		if event.Rescued() {
+			return reconcileResult, nil
+		}
 		if event.Event == eventapi.EventRunnerOnFailed && !event.IgnoreError() {
 			failureMessages = append(failureMessages, event.GetFailedPlaybookMessage())
 		}

--- a/internal/ansible/runner/eventapi/types.go
+++ b/internal/ansible/runner/eventapi/types.go
@@ -123,7 +123,7 @@ func (je JobEvent) IgnoreError() bool {
 	return false
 }
 
-// Rescued - Stops reconciliation when an event is rescued
+// Rescued - Detects whether or not a task was rescued
 func (je JobEvent) Rescued() bool {
 	if rescued, contains := je.EventData["rescued"]; contains {
 		for _, v := range rescued.(map[string]interface{}) {

--- a/internal/ansible/runner/eventapi/types.go
+++ b/internal/ansible/runner/eventapi/types.go
@@ -122,3 +122,15 @@ func (je JobEvent) IgnoreError() bool {
 	}
 	return false
 }
+
+// Rescued - Stops reconciliation when an event is rescued
+func (je JobEvent) Rescued() bool {
+	if rescued, contains := je.EventData["rescued"]; contains {
+		for _, v := range rescued.(map[string]interface{}) {
+			if int(v.(float64)) == 1 {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Added a check to determine whether or not a task has been rescued. 

**Motivation for the change:**
Avoid adding rescued tasks to the list of failures during reconciliation. 
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1856714
