### PR TITLE
update go tutorial docs to reflect call to NewManager func

### DIFF
--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -39,18 +39,18 @@ See the [Kubebuilder entrypoint doc][kubebuilder_entrypoint_doc] for more detail
 
 The Manager can restrict the namespace that all controllers will watch for resources:
 ```Go
-mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})
+mgr, err := ctrl.NewManager(cfg, manager.Options{Namespace: namespace})
 ```
 By default this will be the namespace that the operator is running in. To watch all namespaces leave the namespace option empty:
 ```Go
-mgr, err := manager.New(cfg, manager.Options{Namespace: ""})
+mgr, err := ctrl.NewManager(cfg, manager.Options{Namespace: ""})
 ```
 
 It is also possible to use the [MultiNamespacedCacheBuilder][multi-namespaced-cache-builder] to watch a specific set of namespaces:
 ```Go
 var namespaces []string // List of Namespaces
 // Create a new Cmd to provide shared dependencies and start components
-mgr, err := manager.New(cfg, manager.Options{
+mgr, err := ctrl.NewManager(cfg, manager.Options{
    NewCache: cache.MultiNamespacedCacheBuilder(namespaces),
 })
 ```


### PR DESCRIPTION
Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

**Description of the change:**

With v1.0, the scaffolding creates a manager with some default options using `"sigs.k8s.io/controller-runtime".NewManager()` (changed from `"sigs.k8s.io/controller-runtime/pkg/manager".New()`) This seems to be accounted for in other places in the docs.

**Motivation for the change:**

Thought it might help with consistency across the documentation. Not sure if the Tutorial in its current form was going to stick around but figured I'd send this PR either way and we just close if it not.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
