### PR TITLE
internal/plugins/{ansible,helm}: run `CreateAPI` phase 2 plugins in `Init`

### DIFF
--- a/internal/plugins/ansible/v1/init.go
+++ b/internal/plugins/ansible/v1/init.go
@@ -36,7 +36,8 @@ type initPlugin struct {
 	config    *config.Config
 	apiPlugin createAPIPlugin
 
-	doAPIScaffold bool
+	// If true, run the `create api` plugin.
+	doCreateAPI bool
 
 	// For help text.
 	commandName string
@@ -128,6 +129,13 @@ func (p *initPlugin) runPhase2() error {
 	if err := scorecard.RunInit(p.config); err != nil {
 		return err
 	}
+
+	if p.doCreateAPI {
+		if err := p.apiPlugin.runPhase2(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -146,7 +154,7 @@ func (p *initPlugin) Validate() error {
 
 	defaultOpts := scaffolds.CreateOptions{CRDVersion: "v1"}
 	if !p.apiPlugin.createOptions.GVK.Empty() || p.apiPlugin.createOptions != defaultOpts {
-		p.doAPIScaffold = true
+		p.doCreateAPI = true
 		return p.apiPlugin.Validate()
 	}
 	return nil
@@ -157,7 +165,7 @@ func (p *initPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
 		apiScaffolder scaffold.Scaffolder
 		err           error
 	)
-	if p.doAPIScaffold {
+	if p.doCreateAPI {
 		apiScaffolder, err = p.apiPlugin.GetScaffolder()
 		if err != nil {
 			return nil, err
@@ -167,7 +175,7 @@ func (p *initPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
 }
 
 func (p *initPlugin) PostScaffold() error {
-	if !p.doAPIScaffold {
+	if !p.doCreateAPI {
 		fmt.Printf("Next: define a resource with:\n$ %s create api\n", p.commandName)
 	}
 


### PR DESCRIPTION
**Description of the change:** call the `createAPIPlugin.runPhase2()` on `Init.Run()` if API flags are set on `init`.

**Motivation for the change:** Currently if you run
```sh
$ operator-sdk init --plugins {ansible,helm} --group cache --version v1 --kind Memcached
```
You do not get the same behavior (no `config/samples/kustomization.yaml` is written) as running
```sh
$ operator-sdk init --plugins {ansible,helm}
$ operator-sdk create api --group cache --version v1 --kind Memcached
```

The changes in this PR replicate `create api` behavior in `init` when GVK flags are set exactly without actually running the `CreateAPI` plugin directly, as to keep changes minimally. However I do want to rethink separation of plugins going forward to avoid issues like this.

/cc @joelanford @camilamacedo86 @fabianvf @asmacdo 

/kind bug

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
