### PR TITLE
website: fix old e2e file link

### DIFF
--- a/website/content/en/docs/contribution-guidelines/testing/travis-build.md
+++ b/website/content/en/docs/contribution-guidelines/testing/travis-build.md
@@ -67,7 +67,7 @@ The Go, Ansible, and Helm tests then differ in what tests they run.
 [k8s-script]: https://github.com/operator-framework/operator-sdk/blob/master/hack/ci/setup-k8s.sh
 [kind]: https://kind.sigs.k8s.io/
 [sanity]: https://github.com/operator-framework/operator-sdk/blob/master/hack/tests/sanity-check.sh
-[go-e2e]: https://github.com/operator-framework/operator-sdk/blob/master/test/e2e/e2e_suite.go
+[go-e2e]: https://github.com/operator-framework/operator-sdk/blob/master/test/e2e/e2e_suite_test.go
 [ansible-molecule]: https://github.com/operator-framework/operator-sdk/blob/master/hack/tests/e2e-ansible-molecule.sh
 [ansible-test]: https://github.com/operator-framework/operator-sdk/tree/master/test/ansible
 [helm-e2e]: https://github.com/operator-framework/operator-sdk/blob/master/hack/tests/e2e-helm.sh


### PR DESCRIPTION
**Description of the change:** fix broken e2e test link

**Motivation for the change:** broken link


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
