### PR TITLE
cleanup: plugins to respect the interface used

### DIFF
--- a/internal/plugins/ansible/v1/api.go
+++ b/internal/plugins/ansible/v1/api.go
@@ -103,22 +103,7 @@ func (p *createAPIPlugin) InjectConfig(c *config.Config) {
 }
 
 func (p *createAPIPlugin) Run() error {
-	if err := cmdutil.Run(p); err != nil {
-		return err
-	}
-
-	// Run SDK phase 2 plugins.
-	if err := p.runPhase2(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// SDK phase 2 plugins.
-func (p *createAPIPlugin) runPhase2() error {
-	gvk := p.createOptions.GVK
-	return manifests.RunCreateAPI(p.config, config.GVK{Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind})
+	return cmdutil.Run(p)
 }
 
 func (p *createAPIPlugin) Validate() error {
@@ -155,5 +140,7 @@ func (p *createAPIPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
 }
 
 func (p *createAPIPlugin) PostScaffold() error {
-	return nil
+	// SDK phase 2 plugins.
+	gvk := p.createOptions.GVK
+	return manifests.RunCreateAPI(p.config, config.GVK{Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind})
 }

--- a/internal/plugins/ansible/v1/init.go
+++ b/internal/plugins/ansible/v1/init.go
@@ -109,34 +109,7 @@ func (p *initPlugin) InjectConfig(c *config.Config) {
 }
 
 func (p *initPlugin) Run() error {
-	if err := cmdutil.Run(p); err != nil {
-		return err
-	}
-
-	// Run SDK phase 2 plugins.
-	if err := p.runPhase2(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// SDK phase 2 plugins.
-func (p *initPlugin) runPhase2() error {
-	if err := manifests.RunInit(p.config); err != nil {
-		return err
-	}
-	if err := scorecard.RunInit(p.config); err != nil {
-		return err
-	}
-
-	if p.doCreateAPI {
-		if err := p.apiPlugin.runPhase2(); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return cmdutil.Run(p)
 }
 
 func (p *initPlugin) Validate() error {
@@ -161,23 +134,22 @@ func (p *initPlugin) Validate() error {
 }
 
 func (p *initPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
-	var (
-		apiScaffolder scaffold.Scaffolder
-		err           error
-	)
-	if p.doCreateAPI {
-		apiScaffolder, err = p.apiPlugin.GetScaffolder()
-		if err != nil {
-			return nil, err
-		}
-	}
-	return scaffolds.NewInitScaffolder(p.config, apiScaffolder), nil
+	return scaffolds.NewInitScaffolder(p.config), nil
 }
 
 func (p *initPlugin) PostScaffold() error {
-	if !p.doCreateAPI {
-		fmt.Printf("Next: define a resource with:\n$ %s create api\n", p.commandName)
+
+	// SDK phase 2 plugins.
+	if err := manifests.RunInit(p.config); err != nil {
+		return err
+	}
+	if err := scorecard.RunInit(p.config); err != nil {
+		return err
 	}
 
+	if p.doCreateAPI {
+		return p.apiPlugin.Run()
+	}
+	fmt.Printf("Next: define a resource with:\n$ %s create api\n", p.commandName)
 	return nil
 }

--- a/internal/plugins/ansible/v1/scaffolds/init.go
+++ b/internal/plugins/ansible/v1/scaffolds/init.go
@@ -52,10 +52,9 @@ type initScaffolder struct {
 }
 
 // NewInitScaffolder returns a new Scaffolder for project initialization operations
-func NewInitScaffolder(config *config.Config, apiScaffolder scaffold.Scaffolder) scaffold.Scaffolder {
+func NewInitScaffolder(config *config.Config) scaffold.Scaffolder {
 	return &initScaffolder{
-		config:        config,
-		apiScaffolder: apiScaffolder,
+		config: config,
 	}
 }
 

--- a/internal/plugins/helm/v1/api.go
+++ b/internal/plugins/helm/v1/api.go
@@ -123,22 +123,7 @@ func (p *createAPIPlugin) InjectConfig(c *config.Config) {
 
 // Run will call the plugin actions according to the definitions done in RunOptions interface
 func (p *createAPIPlugin) Run() error {
-	if err := cmdutil.Run(p); err != nil {
-		return err
-	}
-
-	// Run SDK phase 2 plugins.
-	if err := p.runPhase2(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// SDK phase 2 plugins.
-func (p *createAPIPlugin) runPhase2() error {
-	gvk := p.createOptions.GVK
-	return manifests.RunCreateAPI(p.config, config.GVK{Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind})
+	return cmdutil.Run(p)
 }
 
 // Validate perform the required validations for this plugin
@@ -188,5 +173,7 @@ func (p *createAPIPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
 
 // PostScaffold runs all actions that should be executed after the default plugin scaffold
 func (p *createAPIPlugin) PostScaffold() error {
-	return nil
+	// SDK phase 2 plugins.
+	gvk := p.createOptions.GVK
+	return manifests.RunCreateAPI(p.config, config.GVK{Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind})
 }

--- a/internal/plugins/helm/v1/scaffolds/init.go
+++ b/internal/plugins/helm/v1/scaffolds/init.go
@@ -53,10 +53,9 @@ type initScaffolder struct {
 }
 
 // NewInitScaffolder returns a new Scaffolder for project initialization operations
-func NewInitScaffolder(config *config.Config, apiScaffolder scaffold.Scaffolder) scaffold.Scaffolder {
+func NewInitScaffolder(config *config.Config) scaffold.Scaffolder {
 	return &initScaffolder{
-		config:        config,
-		apiScaffolder: apiScaffolder,
+		config: config,
 	}
 }
 


### PR DESCRIPTION
**Description of the change:**
- Cleanup: In order to respect the [RunOptions Interface](https://github.com/operator-framework/operator-sdk/blob/master/internal/kubebuilder/cmdutil/cmdutil.go#L22-L30)

**Motivation for the change:**

We are using the [RunOptions Interface](https://github.com/operator-framework/operator-sdk/blob/master/internal/kubebuilder/cmdutil/cmdutil.go#L22-L30) when we call the run but we are not respecting it. Note that the SDK "phase 2 plugins" just can be executed after/post the Scaffold. So, shows not fit well sense we call than in the run [i.e](https://github.com/operator-framework/operator-sdk/pull/3658/files#diff-5a802f27735d640dd4fedeba21453d67L110-L113) or in the scaffold func besides it be working. 

Also, by following up the interface and its workflow makes in POV the code easier to understand and get maintained, clarifies what and when should get done, what is of the plugin domain and what should be done in its scaffold or to be done after the scaffold (PostScaffold). See that when we call the `return cmdutil.Run(p)` it will: 

```go
// Step 1: Validate input
Validate() error
// Step 2: Get and run the scaffold. E.g scaffold the init plugin 
GetScaffolder() (scaffold.Scaffolder, error) 
// Step 3: perform the actions that can only get done just after the scaffold.
// E.g call other plugins that can be executed just after the scaffold.
PostScaffold() error 
```

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
