### PR TITLE
bump kuttl base image version

### DIFF
--- a/changelog/fragments/scorecard-kuttl-image-bump.yaml
+++ b/changelog/fragments/scorecard-kuttl-image-bump.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: Updated scorecard-test-kuttl image to kuttl v0.5.2
+    kind: change
+    breaking: false

--- a/images/scorecard-test-kuttl/Dockerfile
+++ b/images/scorecard-test-kuttl/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM docker.io/kudobuilder/kuttl@sha256:d23368441f313107954e80a3a5f2884f374bd5a4746193e304c7733f98d6915e
+FROM docker.io/kudobuilder/kuttl@sha256:c9c5edc27ba6e5e994ffd8cea03368c0d4e274f3c7a00f51c1e360feb573f24e
 #FROM kudobuilder/kuttl:latest
 
 ENV TESTKUTTL=/usr/local/bin/scorecard-test-kuttl \


### PR DESCRIPTION

**Description of the change:**
this PR bumps the kuttl base image version to v0.5.2 that is used by the
scorecard-test-kuttl  image

**Motivation for the change:**
this version has bug fixes and features we might make use of.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
