### PR TITLE
Clarify that a role, playbook is necessary for a running operator

### DIFF
--- a/internal/plugins/ansible/v1/api.go
+++ b/internal/plugins/ansible/v1/api.go
@@ -58,6 +58,8 @@ func (p *createAPIPlugin) UpdateContext(ctx *plugin.Context) {
     - optionally generates Ansible Role tree
     - optionally generates Ansible playbook
 
+    For the scaffolded operator to be runnable with no changes, specify either --generate-role or --generate-playbook.
+
 `
 	ctx.Examples = fmt.Sprintf(`# Create a new API, without Ansible roles or playbooks
   $ %s create api \


### PR DESCRIPTION
Scaffolded operators without a role or playbook need manual
intervention, which can be avoided by including one of the optional
flags.


