### PR TITLE
run packagemanifests: change default install mode to AllNamespaces

### DIFF
--- a/changelog/fragments/run-pkgman-allnamespaces.yaml
+++ b/changelog/fragments/run-pkgman-allnamespaces.yaml
@@ -1,0 +1,13 @@
+entries:
+  - description: Default install mode for `run packagemanifests` changed from `OwnNamespace` to `AllNamespaces`
+    kind: change
+    breaking: true
+    migration:
+      header: Default install mode for `run packagemanifests` changed from `OwnNamespace` to `AllNamespaces`
+      body: >
+        By default all operators are scaffolded to run at the cluster scope and watch
+        all namespaces.
+
+        However, if you are relying on the default behavior of the `run packagemanifests`
+        command to use the default `OwnNamespace` install mode, you must now specify it
+        explicitly with `--install-mode=OwnNamespace`.

--- a/hack/tests/integration.sh
+++ b/hack/tests/integration.sh
@@ -10,6 +10,18 @@ TMPDIR="$(mktemp -d -p /tmp memcached-operator-XXXX)"
 trap_add 'rm -rf $TMPDIR' EXIT
 pushd "$TMPDIR"
 
+###########################################################################
+### DO NOT UNCOMMENT THESE LINES UNLESS YOU KNOW WHAT YOU'RE DOING !!!! ###
+###                                                                     ###
+### They cause the integration image not to be loaded into kind in      ###
+### TravisCI.                                                           ###
+###                                                                     ###
+###########################################################################
+###
+###    #prepare_staging_dir $tmp_sdk_root
+###    #fetch_envtest_tools $tmp_sdk_root
+###
+###########################################################################
 setup_envs $tmp_sdk_root
 
 header_text "Initializing test project"

--- a/internal/olm/operator/operator_manager.go
+++ b/internal/olm/operator/operator_manager.go
@@ -93,7 +93,7 @@ func (c *OperatorCmd) AddToFlagSet(fs *pflag.FlagSet) {
 
 func (c *OperatorCmd) validate() error {
 	if c.InstallMode != "" {
-		if _, _, err := parseInstallModeKV(c.InstallMode); err != nil {
+		if _, _, err := parseInstallModeKV(c.InstallMode, c.Namespace); err != nil {
 			return err
 		}
 	}

--- a/internal/olm/operator/packagemanifests_manager.go
+++ b/internal/olm/operator/packagemanifests_manager.go
@@ -63,11 +63,11 @@ func (c *PackageManifestsCmd) newManager() (m *packageManifestsManager, err erro
 
 	// Handle installModes.
 	if c.InstallMode == "" {
-		// Default to OwnNamespace.
-		m.installMode = operatorsv1alpha1.InstallModeTypeOwnNamespace
-		m.targetNamespaces = []string{m.namespace}
+		// Default to AllNamespaces.
+		m.installMode = operatorsv1alpha1.InstallModeTypeAllNamespaces
+		m.targetNamespaces = []string{}
 	} else {
-		m.installMode, m.targetNamespaces, err = parseInstallModeKV(c.InstallMode)
+		m.installMode, m.targetNamespaces, err = parseInstallModeKV(c.InstallMode, m.namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/olm/operator/tenancy.go
+++ b/internal/olm/operator/tenancy.go
@@ -54,10 +54,13 @@ func installModeCompatible(csv *olmapiv1alpha1.ClusterServiceVersion, installMod
 
 // parseInstallModeKV parses an installMode string of the format
 // installModeFormat.
-func parseInstallModeKV(raw string) (olmapiv1alpha1.InstallModeType, []string, error) {
+func parseInstallModeKV(raw, operatorNs string) (olmapiv1alpha1.InstallModeType, []string, error) {
 	modeSplit := strings.Split(raw, "=")
 	if allNs := string(olmapiv1alpha1.InstallModeTypeAllNamespaces); raw == allNs || modeSplit[0] == allNs {
 		return olmapiv1alpha1.InstallModeTypeAllNamespaces, nil, nil
+	}
+	if ownNs := string(olmapiv1alpha1.InstallModeTypeOwnNamespace); raw == ownNs || modeSplit[0] == ownNs {
+		return olmapiv1alpha1.InstallModeTypeOwnNamespace, []string{operatorNs}, nil
 	}
 	if len(modeSplit) != 2 {
 		return "", nil, fmt.Errorf("installMode string %q is malformatted, must be: %s", raw, installModeFormat)

--- a/test/integration/operator_olm_test.go
+++ b/test/integration/operator_olm_test.go
@@ -55,11 +55,11 @@ func TestOLMIntegration(t *testing.T) {
 	}
 
 	t.Run("PackageManifestsBasic", PackageManifestsBasic)
-	t.Run("PackageManifestsAllNamespaces", PackageManifestsAllNamespaces)
+	t.Run("PackageManifestsOwnNamespace", PackageManifestsOwnNamespace)
 	t.Run("PackageManifestsMultiplePackages", PackageManifestsMultiplePackages)
 }
 
-func PackageManifestsAllNamespaces(t *testing.T) {
+func PackageManifestsOwnNamespace(t *testing.T) {
 
 	csvConfig := CSVTemplateConfig{
 		OperatorName:    defaultOperatorName,
@@ -77,10 +77,10 @@ func PackageManifestsAllNamespaces(t *testing.T) {
 			},
 		},
 		InstallModes: []operatorsv1alpha1.InstallMode{
-			{Type: operatorsv1alpha1.InstallModeTypeOwnNamespace, Supported: false},
+			{Type: operatorsv1alpha1.InstallModeTypeOwnNamespace, Supported: true},
 			{Type: operatorsv1alpha1.InstallModeTypeSingleNamespace, Supported: false},
 			{Type: operatorsv1alpha1.InstallModeTypeMultiNamespace, Supported: false},
-			{Type: operatorsv1alpha1.InstallModeTypeAllNamespaces, Supported: true},
+			{Type: operatorsv1alpha1.InstallModeTypeAllNamespaces, Supported: false},
 		},
 	}
 	tmp, cleanup := mkTempDirWithCleanup(t, "")
@@ -104,7 +104,7 @@ func PackageManifestsAllNamespaces(t *testing.T) {
 		OperatorCmd: operator.OperatorCmd{
 			KubeconfigPath: kubeconfigPath,
 			Timeout:        defaultTimeout,
-			InstallMode:    string(operatorsv1alpha1.InstallModeTypeAllNamespaces),
+			InstallMode:    string(operatorsv1alpha1.InstallModeTypeOwnNamespace),
 		},
 		ManifestsDir: manifestsDir,
 		Version:      defaultOperatorVersion,
@@ -138,10 +138,10 @@ func PackageManifestsBasic(t *testing.T) {
 			},
 		},
 		InstallModes: []operatorsv1alpha1.InstallMode{
-			{Type: operatorsv1alpha1.InstallModeTypeOwnNamespace, Supported: true},
+			{Type: operatorsv1alpha1.InstallModeTypeOwnNamespace, Supported: false},
 			{Type: operatorsv1alpha1.InstallModeTypeSingleNamespace, Supported: false},
 			{Type: operatorsv1alpha1.InstallModeTypeMultiNamespace, Supported: false},
-			{Type: operatorsv1alpha1.InstallModeTypeAllNamespaces, Supported: false},
+			{Type: operatorsv1alpha1.InstallModeTypeAllNamespaces, Supported: true},
 		},
 	}
 	tmp, cleanup := mkTempDirWithCleanup(t, "")
@@ -205,10 +205,10 @@ func PackageManifestsMultiplePackages(t *testing.T) {
 				},
 			},
 			InstallModes: []operatorsv1alpha1.InstallMode{
-				{Type: operatorsv1alpha1.InstallModeTypeOwnNamespace, Supported: true},
+				{Type: operatorsv1alpha1.InstallModeTypeOwnNamespace, Supported: false},
 				{Type: operatorsv1alpha1.InstallModeTypeSingleNamespace, Supported: false},
 				{Type: operatorsv1alpha1.InstallModeTypeMultiNamespace, Supported: false},
-				{Type: operatorsv1alpha1.InstallModeTypeAllNamespaces, Supported: false},
+				{Type: operatorsv1alpha1.InstallModeTypeAllNamespaces, Supported: true},
 			},
 		},
 		{
@@ -228,10 +228,10 @@ func PackageManifestsMultiplePackages(t *testing.T) {
 				},
 			},
 			InstallModes: []operatorsv1alpha1.InstallMode{
-				{Type: operatorsv1alpha1.InstallModeTypeOwnNamespace, Supported: true},
+				{Type: operatorsv1alpha1.InstallModeTypeOwnNamespace, Supported: false},
 				{Type: operatorsv1alpha1.InstallModeTypeSingleNamespace, Supported: false},
 				{Type: operatorsv1alpha1.InstallModeTypeMultiNamespace, Supported: false},
-				{Type: operatorsv1alpha1.InstallModeTypeAllNamespaces, Supported: false},
+				{Type: operatorsv1alpha1.InstallModeTypeAllNamespaces, Supported: true},
 			},
 		},
 	}

--- a/website/content/en/docs/olm-integration/testing-deployment.md
+++ b/website/content/en/docs/olm-integration/testing-deployment.md
@@ -33,9 +33,9 @@ Let's look at the anatomy of the `run packagemanifests` (which is the same for `
   - The `InstallModeType` string passed must be marked as "supported" in the CSV being installed.
     The namespaces passed must exist or be created by passing a `Namespace` manifest to IncludePaths.
   - This option understands the following strings (assuming your CSV does as well):
-      - `OwnNamespace`: the Operator will watch its own namespace (from **namespace** or the kubeconfig default). This is the default.
+      - `AllNamespaces`: the Operator will watch all namespaces (cluster-scoped Operators). This is the default.
+      - `OwnNamespace`: the Operator will watch its own namespace (from **namespace** or the kubeconfig default).
       - `SingleNamespace="my-ns"`: the Operator will watch a namespace, not necessarily its own.
-      - `AllNamespaces=""`: the Operator will watch all namespaces (cluster-scoped Operators).
 - **timeout**: a time string dictating the maximum time that `run` can run. The command will
   return an error if the timeout is exceeded.
 


### PR DESCRIPTION
**Description of the change:**
The default install mode for the `run packagemanifests` command changed from `OwnNamespace` to `AllNamespaces`

**Motivation for the change:**
In 1.0, operators are scaffolded to have cluster-scoped permissions and watch all namespaces, so it makes sense to align `run packagemanifests` with this default.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
