### PR TITLE
test/integration: use default service account for CSV perms

### DIFF
--- a/test/integration/integration_helpers.go
+++ b/test/integration/integration_helpers.go
@@ -58,6 +58,9 @@ type CSVTemplateConfig struct {
 	IsBundle bool
 }
 
+// TODO(estroz): devise a way for "make bundle" to be called, then update the generated bundle with correct
+// install modes within integration tests themselves.
+
 const csvTmpl = `apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
@@ -104,7 +107,7 @@ spec:
           - patch
           - update
         {{- end}}
-        serviceAccountName: {{ .OperatorName }}-manager-role
+        serviceAccountName: default
       - rules:
         - apiGroups:
           - authentication.k8s.io
@@ -118,13 +121,7 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: {{ .OperatorName }}-proxy-role
-      - rules:
-        - nonResourceURLs:
-          - /metrics
-          verbs:
-          - get
-        serviceAccountName: {{ .OperatorName }}-metrics-reader
+        serviceAccountName: default
       deployments:
       - name: {{ .OperatorName }}-controller-manager
         spec:
@@ -186,7 +183,7 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: {{ .OperatorName }}-leader-election-role
+        serviceAccountName: default
     strategy: deployment
   installModes:
 {{- range $i, $mode := .InstallModes }}


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:** use default service account for CSV perms in integration tests

**Motivation for the change:** follow up from #3610. Relates to #663.

/cc @joelanford 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
