### PR TITLE
[olm] Remove olm-namespace flag from install sub-command

### DIFF
--- a/changelog/fragments/remove-olm-namespace-flag.yaml
+++ b/changelog/fragments/remove-olm-namespace-flag.yaml
@@ -1,0 +1,11 @@
+entries:
+  - description: Removed `olm-namespace` flag from `operator-sdk olm install` command
+    kind: removal
+    breaking: true
+    migration:
+      header: Remove `olm-namespace` flag from `operator-sdk olm install` command
+      body: |
+        The `olm-namespace` flag has been removed from `operator-sdk olm install`
+        command, as the olm manifests published in github have a hardcoded
+        namespace value. Hence, the olm operators can only be installed in `olm`
+        namespace using this command.

--- a/internal/cmd/operator-sdk/olm/install.go
+++ b/internal/cmd/operator-sdk/olm/install.go
@@ -35,8 +35,6 @@ func newInstallCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&mgr.Version, "version", olm.DefaultVersion, "version of OLM resources to install")
-	cmd.Flags().StringVar(&mgr.OLMNamespace, "olm-namespace", olm.DefaultOLMNamespace,
-		"namespace where OLM is to be installed.")
 	mgr.AddToFlagSet(cmd.Flags())
 	return cmd
 }

--- a/internal/cmd/operator-sdk/olm/install_test.go
+++ b/internal/cmd/operator-sdk/olm/install_test.go
@@ -32,11 +32,6 @@ var _ = Describe("Running an olm install command", func() {
 			Expect(flag).NotTo(BeNil())
 			Expect(flag.DefValue).To(Equal(olm.DefaultVersion))
 			Expect(flag.Usage).NotTo(BeNil())
-
-			flag = cmd.Flags().Lookup("olm-namespace")
-			Expect(flag).NotTo(BeNil())
-			Expect(flag.DefValue).To(Equal(olm.DefaultOLMNamespace))
-			Expect(flag.Usage).NotTo(BeNil())
 		})
 	})
 })

--- a/website/content/en/docs/cli/operator-sdk_olm_install.md
+++ b/website/content/en/docs/cli/operator-sdk_olm_install.md
@@ -16,10 +16,9 @@ operator-sdk olm install [flags]
 ### Options
 
 ```
-  -h, --help                   help for install
-      --olm-namespace string   namespace where OLM is to be installed. (default "olm")
-      --timeout duration       time to wait for the command to complete before failing (default 2m0s)
-      --version string         version of OLM resources to install (default "latest")
+  -h, --help               help for install
+      --timeout duration   time to wait for the command to complete before failing (default 2m0s)
+      --version string     version of OLM resources to install (default "latest")
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/olm-integration/quickstart-bundle.md
+++ b/website/content/en/docs/olm-integration/quickstart-bundle.md
@@ -30,7 +30,7 @@ Ensure OLM is enabled on your cluster before following this guide. [`operator-sd
 has several subcommands that can install, uninstall, and check the status of particular OLM versions in a cluster.
 
 **Note:** Certain cluster types may already have OLM enabled, but under a non-default (`"olm"`) namespace,
-which can be configured by setting `--olm-namespace=[non-default-olm-namespace]` for `operator-sdk olm` subcommands.
+which can be configured by setting `--olm-namespace=[non-default-olm-namespace]` for `operator-sdk olm status|uninstall` subcommands.
 
 You can check if OLM is already installed by running the following command,
 which will detect the installed OLM version automatically (0.15.1 in this example):


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Remove 'olm-namespace' flag from 'operator-sdk olm install' command.

**Motivation for the change:**
The olm manifests published in github have a hardcoded
namespace value. Hence, the olm operators can only be installed in `olm`
namespace using `operator-sdk olm install` command.


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
