### PR TITLE
Fix  G306: Expect WriteFile permissions to be 0600 or less

### DIFF
--- a/hack/generate/changelog/util/changelog.go
+++ b/hack/generate/changelog/util/changelog.go
@@ -84,12 +84,12 @@ func (c *Changelog) WriteFile(path string) error {
 		return err
 	}
 	if errors.Is(err, os.ErrNotExist) || len(existingFile) == 0 {
-		return ioutil.WriteFile(path, data, 0644)
+		return ioutil.WriteFile(path, data, 0600)
 	}
 
 	data = append(data, '\n')
 	data = append(data, existingFile...)
-	return ioutil.WriteFile(path, data, 0644)
+	return ioutil.WriteFile(path, data, 0600)
 }
 
 func ChangelogFromEntries(version semver.Version, entries []FragmentEntry) Changelog {

--- a/hack/generate/changelog/util/changelog_test.go
+++ b/hack/generate/changelog/util/changelog_test.go
@@ -441,7 +441,7 @@ func TestChangelog_WriteFile(t *testing.T) {
 			defer assert.NoError(t, os.Remove(tmpFile.Name()))
 
 			if tc.existingFile || len(tc.existingFileContents) > 0 {
-				assert.NoError(t, ioutil.WriteFile(tmpFile.Name(), []byte(tc.existingFileContents), 0644))
+				assert.NoError(t, ioutil.WriteFile(tmpFile.Name(), []byte(tc.existingFileContents), 0600))
 			}
 
 			assert.NoError(t, tc.changelog.WriteFile(tmpFile.Name()))

--- a/hack/generate/changelog/util/migration_guide.go
+++ b/hack/generate/changelog/util/migration_guide.go
@@ -51,7 +51,7 @@ func (mg *MigrationGuide) WriteFile(path string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, data, 0644)
+	return ioutil.WriteFile(path, data, 0600)
 }
 
 func MigrationGuideFromEntries(version semver.Version, entries []FragmentEntry) MigrationGuide {

--- a/internal/ansible/runner/internal/inputdir/inputdir.go
+++ b/internal/ansible/runner/internal/inputdir/inputdir.go
@@ -55,7 +55,7 @@ func (i *InputDir) makeDirs() error {
 // addFile adds a file to the given relative path within the input directory.
 func (i *InputDir) addFile(path string, content []byte) error {
 	fullPath := filepath.Join(i.Path, path)
-	err := ioutil.WriteFile(fullPath, content, 0644)
+	err := ioutil.WriteFile(fullPath, content, 0600)
 	if err != nil {
 		log.Error(err, "Unable to write file", "Path", fullPath)
 	}

--- a/internal/kubebuilder/filesystem/filesystem.go
+++ b/internal/kubebuilder/filesystem/filesystem.go
@@ -28,7 +28,7 @@ const (
 	createOrUpdate = os.O_WRONLY | os.O_CREATE | os.O_TRUNC
 
 	defaultDirectoryPermission os.FileMode = 0755
-	defaultFilePermission      os.FileMode = 0644
+	defaultFilePermission      os.FileMode = 0600
 )
 
 // FileSystem is an IO wrapper to create files

--- a/internal/plugins/manifests/init.go
+++ b/internal/plugins/manifests/init.go
@@ -56,7 +56,7 @@ func initUpdateMakefile(cfg *config.Config, filePath string) error {
 
 	makefileBytes = append(makefileBytes, []byte(makefileBundleBuildFragment)...)
 
-	return ioutil.WriteFile(filePath, makefileBytes, 0644)
+	return ioutil.WriteFile(filePath, makefileBytes, 0600)
 }
 
 // Makefile fragments to add to the base Makefile.

--- a/internal/scorecard/kubeclient_test.go
+++ b/internal/scorecard/kubeclient_test.go
@@ -31,7 +31,7 @@ func TestGetKubeNamespace(t *testing.T) {
 	defer os.Remove(file.Name())
 
 	data := []byte(testKubeconfig)
-	err = ioutil.WriteFile(file.Name(), data, 0644)
+	err = ioutil.WriteFile(file.Name(), data, 0600)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestGetKubeNamespaceEnvVar(t *testing.T) {
 	defer os.Remove(file.Name())
 
 	data := []byte(testKubeconfig)
-	err = ioutil.WriteFile(file.Name(), data, 0644)
+	err = ioutil.WriteFile(file.Name(), data, 0600)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -28,7 +28,7 @@ import (
 const (
 	// Useful file modes.
 	DirMode      = 0755
-	FileMode     = 0644
+	FileMode     = 0600
 	ExecFileMode = 0755
 )
 

--- a/test/integration/integration_helpers.go
+++ b/test/integration/integration_helpers.go
@@ -252,7 +252,7 @@ func writeManifest(path string, o interface{}) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, b, 0644)
+	return ioutil.WriteFile(path, b, 0600)
 }
 
 func execTemplateOnFile(path, tmplStr string, o interface{}) error {

--- a/test/internal/utils.go
+++ b/test/internal/utils.go
@@ -87,7 +87,7 @@ func (tc TestContext) AddPackagemanifestsTarget() error {
 	}
 
 	makefileBytes = append([]byte(makefilePackagemanifests), makefileBytes...)
-	err = ioutil.WriteFile(filepath.Join(tc.Dir, "Makefile"), makefileBytes, 0644)
+	err = ioutil.WriteFile(filepath.Join(tc.Dir, "Makefile"), makefileBytes, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Ken Sipe <kensipe@gmail.com>


**Description of the change:**
Gosec says NO to 0666 or 0644. 

**Motivation for the change:**
happy linter

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
