### PR TITLE
MD5 out... in with SHA256

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,4 +17,9 @@ linters:
     - staticcheck
     - unused
     - gosimple
-  
+    - gosec
+issues:
+  exclude-rules:
+    - linters:
+      - gosec
+      text: "G110|G601|G404|G204|G306"

--- a/internal/olm/operator/internal/configmap.go
+++ b/internal/olm/operator/internal/configmap.go
@@ -120,7 +120,7 @@ func makeObjectFileName(b []byte, names ...string) string {
 	return fileName + "yaml"
 }
 
-// hashContents creates a base32-encoded md5 digest of b's bytes.
+// hashContents creates a sha256 digest of b's bytes.
 func hashContents(b []byte) string {
 	h := sha256.New()
 	_, _ = h.Write(b)

--- a/internal/olm/operator/internal/configmap.go
+++ b/internal/olm/operator/internal/configmap.go
@@ -16,7 +16,7 @@ package olm
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/base32"
 	"fmt"
 	"strings"
@@ -122,7 +122,7 @@ func makeObjectFileName(b []byte, names ...string) string {
 
 // hashContents creates a base32-encoded md5 digest of b's bytes.
 func hashContents(b []byte) string {
-	h := md5.New()
+	h := sha256.New()
 	_, _ = h.Write(b)
 	enc := base32.StdEncoding.WithPadding(base32.NoPadding)
 	return enc.EncodeToString(h.Sum(nil))


### PR DESCRIPTION
Signed-off-by: Ken Sipe <kensipe@gmail.com>


**Description of the change:**
Move away from MD5 which the linter is angry with...

```
internal/olm/operator/internal/configmap.go:19:2: G501: Blacklisted import `crypto/md5`: weak cryptographic primitive (gosec)
	"crypto/md5"
	^
internal/olm/operator/internal/configmap.go:125:7: G401: Use of weak cryptographic primitive (gosec)
	h := md5.New()
	     ^
```

**Motivation for the change:**
Making the linter happy

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
