### PR TITLE
internal/olm/operator: handle conflicting OperatorGroups

### DIFF
--- a/changelog/fragments/operatorgroup-conflict.yaml
+++ b/changelog/fragments/operatorgroup-conflict.yaml
@@ -1,0 +1,7 @@
+entries:
+  - description: >
+      Prevent `run packagemanifests` from creating an OperatorGroup if one already exists in a namespace,
+      and use that OperatorGroup if its target namespaces exactly match those passed in `--install-mode`.
+      See [#3681](https://github.com/operator-framework/operator-sdk/issues/3681).
+    kind: bugfix
+    breaking: false

--- a/internal/olm/operator/operator_suite_test.go
+++ b/internal/olm/operator/operator_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package olm
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestOperator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator Suite")
+}

--- a/internal/olm/operator/tenancy.go
+++ b/internal/olm/operator/tenancy.go
@@ -15,30 +15,39 @@
 package olm
 
 import (
+	"context"
 	"fmt"
+	"reflect"
+	"sort"
 	"strings"
 
-	olmapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	olmclient "github.com/operator-framework/operator-sdk/internal/olm/client"
+	"github.com/operator-framework/operator-sdk/internal/operator"
 )
 
 // Mapping of installMode string values to types, for validation.
-var installModeStrings = map[string]olmapiv1alpha1.InstallModeType{
-	string(olmapiv1alpha1.InstallModeTypeOwnNamespace):    olmapiv1alpha1.InstallModeTypeOwnNamespace,
-	string(olmapiv1alpha1.InstallModeTypeSingleNamespace): olmapiv1alpha1.InstallModeTypeSingleNamespace,
-	string(olmapiv1alpha1.InstallModeTypeMultiNamespace):  olmapiv1alpha1.InstallModeTypeMultiNamespace,
-	string(olmapiv1alpha1.InstallModeTypeAllNamespaces):   olmapiv1alpha1.InstallModeTypeAllNamespaces,
+var installModeStrings = map[string]operatorsv1alpha1.InstallModeType{
+	string(operatorsv1alpha1.InstallModeTypeOwnNamespace):    operatorsv1alpha1.InstallModeTypeOwnNamespace,
+	string(operatorsv1alpha1.InstallModeTypeSingleNamespace): operatorsv1alpha1.InstallModeTypeSingleNamespace,
+	string(operatorsv1alpha1.InstallModeTypeMultiNamespace):  operatorsv1alpha1.InstallModeTypeMultiNamespace,
+	string(operatorsv1alpha1.InstallModeTypeAllNamespaces):   operatorsv1alpha1.InstallModeTypeAllNamespaces,
 }
 
 // installModeCompatible ensures installMode is compatible with the namespaces
 // and CSV's installModes being used.
-func installModeCompatible(csv *olmapiv1alpha1.ClusterServiceVersion, installMode olmapiv1alpha1.InstallModeType,
+func installModeCompatible(csv *operatorsv1alpha1.ClusterServiceVersion, installMode operatorsv1alpha1.InstallModeType,
 	operatorNamespace string, targetNamespaces []string) error {
 
 	err := validateInstallModeForNamespaces(installMode, targetNamespaces)
 	if err != nil {
 		return err
 	}
-	if installMode == olmapiv1alpha1.InstallModeTypeOwnNamespace {
+	if installMode == operatorsv1alpha1.InstallModeTypeOwnNamespace {
 		if ns := targetNamespaces[0]; ns != operatorNamespace {
 			return fmt.Errorf("installMode %s namespace %q must match namespace %q",
 				installMode, ns, operatorNamespace)
@@ -54,13 +63,13 @@ func installModeCompatible(csv *olmapiv1alpha1.ClusterServiceVersion, installMod
 
 // parseInstallModeKV parses an installMode string of the format
 // installModeFormat.
-func parseInstallModeKV(raw, operatorNs string) (olmapiv1alpha1.InstallModeType, []string, error) {
+func parseInstallModeKV(raw, operatorNs string) (operatorsv1alpha1.InstallModeType, []string, error) {
 	modeSplit := strings.Split(raw, "=")
-	if allNs := string(olmapiv1alpha1.InstallModeTypeAllNamespaces); raw == allNs || modeSplit[0] == allNs {
-		return olmapiv1alpha1.InstallModeTypeAllNamespaces, nil, nil
+	if allNs := string(operatorsv1alpha1.InstallModeTypeAllNamespaces); raw == allNs || modeSplit[0] == allNs {
+		return operatorsv1alpha1.InstallModeTypeAllNamespaces, nil, nil
 	}
-	if ownNs := string(olmapiv1alpha1.InstallModeTypeOwnNamespace); raw == ownNs || modeSplit[0] == ownNs {
-		return olmapiv1alpha1.InstallModeTypeOwnNamespace, []string{operatorNs}, nil
+	if ownNs := string(operatorsv1alpha1.InstallModeTypeOwnNamespace); raw == ownNs || modeSplit[0] == ownNs {
+		return operatorsv1alpha1.InstallModeTypeOwnNamespace, []string{operatorNs}, nil
 	}
 	if len(modeSplit) != 2 {
 		return "", nil, fmt.Errorf("installMode string %q is malformatted, must be: %s", raw, installModeFormat)
@@ -76,19 +85,19 @@ func parseInstallModeKV(raw, operatorNs string) (olmapiv1alpha1.InstallModeType,
 }
 
 // validateInstallModeForNamespaces ensures namespaces are valid given mode.
-func validateInstallModeForNamespaces(mode olmapiv1alpha1.InstallModeType, namespaces []string) error {
+func validateInstallModeForNamespaces(mode operatorsv1alpha1.InstallModeType, namespaces []string) error {
 	switch mode {
-	case olmapiv1alpha1.InstallModeTypeOwnNamespace, olmapiv1alpha1.InstallModeTypeSingleNamespace:
+	case operatorsv1alpha1.InstallModeTypeOwnNamespace, operatorsv1alpha1.InstallModeTypeSingleNamespace:
 		if len(namespaces) != 1 || namespaces[0] == "" {
 			return fmt.Errorf("installMode %s must be passed with exactly one non-empty namespace, have: %+q",
 				mode, namespaces)
 		}
-	case olmapiv1alpha1.InstallModeTypeMultiNamespace:
+	case operatorsv1alpha1.InstallModeTypeMultiNamespace:
 		if len(namespaces) < 2 {
 			return fmt.Errorf("installMode %s must be passed with more than one non-empty namespaces, have: %+q",
 				mode, namespaces)
 		}
-	case olmapiv1alpha1.InstallModeTypeAllNamespaces:
+	case operatorsv1alpha1.InstallModeTypeAllNamespaces:
 		if len(namespaces) != 0 && namespaces[0] != "" {
 			return fmt.Errorf("installMode %s must be passed with no namespaces, have: %+q",
 				mode, namespaces)
@@ -97,4 +106,59 @@ func validateInstallModeForNamespaces(mode olmapiv1alpha1.InstallModeType, names
 		return fmt.Errorf("installMode %q is not a valid installMode type", mode)
 	}
 	return nil
+}
+
+// createOperatorGroup creates an OperatorGroup using pkgName if an OperatorGroup does not exist.
+// If one exists in the desired namespace and it's target namespaces do not match the desired set,
+// createOperatorGroup will return an error.
+func (m *packageManifestsManager) createOperatorGroup(ctx context.Context, pkgName string) error {
+	// Check OperatorGroup existence, since we cannot create a second OperatorGroup in namespace.
+	og, ogFound, err := getOperatorGroup(ctx, m.client, m.namespace)
+	if err != nil {
+		return err
+	}
+	if ogFound {
+		// Simple check for OperatorGroup compatibility: if namespaces are not an exact match,
+		// the user must manage the resource themselves.
+		sort.Strings(og.Status.Namespaces)
+		sort.Strings(m.targetNamespaces)
+		if !reflect.DeepEqual(og.Status.Namespaces, m.targetNamespaces) {
+			msg := fmt.Sprintf("namespaces %+q do not match desired namespaces %+q", og.Status.Namespaces, m.targetNamespaces)
+			if og.GetName() == operator.SDKOperatorGroupName {
+				return fmt.Errorf("existing SDK-managed operator group's %s, "+
+					"please clean up existing operators `operator-sdk cleanup` before running package %q", msg, pkgName)
+			}
+			return fmt.Errorf("existing operator group %q's %s, "+
+				"please ensure it has the exact namespace set before running package %q", og.GetName(), msg, pkgName)
+		}
+		log.Infof("  Using existing operator group %q", og.GetName())
+	} else {
+		// New SDK-managed OperatorGroup.
+		og = newSDKOperatorGroup(m.namespace, withTargetNamespaces(m.targetNamespaces...))
+		if err = m.client.DoCreate(ctx, og); err != nil {
+			return fmt.Errorf("error creating operator resources: %w", err)
+		}
+	}
+	return nil
+}
+
+// getOperatorGroup returns true if an operator group in namespace was found and that operator group.
+// If more than one operator group exists in namespace, this function will return an error
+// since CSVs in namespace will have an error status in that case.
+func getOperatorGroup(ctx context.Context, c *olmclient.Client, namespace string) (*operatorsv1.OperatorGroup, bool, error) {
+	ogList := &operatorsv1.OperatorGroupList{}
+	if err := c.KubeClient.List(ctx, ogList, client.InNamespace(namespace)); err != nil {
+		return nil, false, err
+	}
+	if len(ogList.Items) == 0 {
+		return nil, false, nil
+	}
+	if len(ogList.Items) != 1 {
+		var names []string
+		for _, og := range ogList.Items {
+			names = append(names, og.GetName())
+		}
+		return nil, true, fmt.Errorf("more than one operator group in namespace %s: %+q", namespace, names)
+	}
+	return &ogList.Items[0], true, nil
 }

--- a/internal/olm/operator/tenancy_test.go
+++ b/internal/olm/operator/tenancy_test.go
@@ -1,0 +1,118 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package olm
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	olmclient "github.com/operator-framework/operator-sdk/internal/olm/client"
+	"github.com/operator-framework/operator-sdk/internal/operator"
+)
+
+var _ = Describe("Tenancy", func() {
+	Describe("createOperatorGroup", func() {
+		var (
+			m   *packageManifestsManager
+			ctx context.Context
+			err error
+
+			packageName             = "test-operator"
+			namespace               = "default"
+			nonSDKOperatorGroupName = "my-og"
+		)
+
+		BeforeEach(func() {
+			m = &packageManifestsManager{
+				operatorManager: &operatorManager{
+					namespace: namespace,
+					client:    &olmclient.Client{KubeClient: fake.NewFakeClient()},
+				},
+			}
+			ctx = context.TODO()
+		})
+
+		Context("with no existing OperatorGroup", func() {
+			It("creates one successfully", func() {
+				err = m.createOperatorGroup(ctx, packageName)
+				Expect(err).To(BeNil())
+				og, ogExists, err := getOperatorGroup(ctx, m.client, m.namespace)
+				Expect(err).To(BeNil())
+				Expect(ogExists).To(BeTrue())
+				Expect(og.GetName()).To(Equal(operator.SDKOperatorGroupName))
+			})
+		})
+
+		Context("with an existing, valid OperatorGroup", func() {
+			It("returns no error and the existing SDK OperatorGroup is unchanged", func() {
+				existingOG := createOperatorGroupHelper(ctx, m.client.KubeClient, operator.SDKOperatorGroupName, namespace)
+				err = m.createOperatorGroup(ctx, packageName)
+				Expect(err).To(BeNil())
+				og, ogExists, err := getOperatorGroup(ctx, m.client, m.namespace)
+				Expect(err).To(BeNil())
+				Expect(ogExists).To(BeTrue())
+				Expect(og.GetName()).To(Equal(existingOG.GetName()))
+			})
+			It("returns no error and the existing non-SDK OperatorGroup is unchanged", func() {
+				existingOG := createOperatorGroupHelper(ctx, m.client.KubeClient, nonSDKOperatorGroupName, namespace)
+				err = m.createOperatorGroup(ctx, packageName)
+				Expect(err).To(BeNil())
+				og, ogExists, err := getOperatorGroup(ctx, m.client, m.namespace)
+				Expect(err).To(BeNil())
+				Expect(ogExists).To(BeTrue())
+				Expect(og.GetName()).To(Equal(existingOG.GetName()))
+			})
+			It("returns no error and the existing OperatorGroup in another namespace is unchanged", func() {
+				otherNS := "my-ns"
+				existingOG := createOperatorGroupHelper(ctx, m.client.KubeClient, operator.SDKOperatorGroupName, otherNS)
+				err = m.createOperatorGroup(ctx, packageName)
+				Expect(err).To(BeNil())
+				og, ogExists, err := getOperatorGroup(ctx, m.client, m.namespace)
+				Expect(err).To(BeNil())
+				Expect(ogExists).To(BeTrue())
+				Expect(og.GetName()).To(Equal(existingOG.GetName()))
+				Expect(og.GetNamespace()).NotTo(Equal(existingOG.GetNamespace()))
+			})
+		})
+
+		Context("with an existing, invalid OperatorGroup", func() {
+			It("returns an error for an SDK OperatorGroup", func() {
+				_ = createOperatorGroupHelper(ctx, m.client.KubeClient, operator.SDKOperatorGroupName, namespace, "foo")
+				err = m.createOperatorGroup(ctx, packageName)
+				Expect(err.Error()).To(ContainSubstring(`existing SDK-managed operator group's namespaces ["foo"] do not match desired namespaces []`))
+			})
+			It("returns an error for a non-SDK OperatorGroup", func() {
+				_ = createOperatorGroupHelper(ctx, m.client.KubeClient, nonSDKOperatorGroupName, namespace, "foo")
+				err = m.createOperatorGroup(ctx, packageName)
+				Expect(err.Error()).To(ContainSubstring(`existing operator group "my-og"'s namespaces ["foo"] do not match desired namespaces []`))
+			})
+		})
+	})
+
+})
+
+func createOperatorGroupHelper(ctx context.Context, c client.Client, name, namespace string, targetNamespaces ...string) (og operatorsv1.OperatorGroup) {
+	og.SetGroupVersionKind(operatorsv1.SchemeGroupVersion.WithKind("OperatorGroup"))
+	og.SetName(name)
+	og.SetNamespace(namespace)
+	og.Status.Namespaces = targetNamespaces
+	ExpectWithOffset(1, c.Create(ctx, &og)).Should(Succeed())
+	return
+}


### PR DESCRIPTION
**Description of the change:** This PR prevents `run packagemanifests` from creating an OperatorGroup in a namespace if one already exists. If one does exist and its target namespaces match exactly those provided by the user, it will use the existing one; if those namespaces do not match, it will return an error with instructions on how to handle the namespace conflict.

* internal/olm/operator: wrap OperatorGroup creation in a method that handles conflict cases, and add unit tests

**Motivation for the change:** See #3681.

/cc @joelanford @jmrodri @rashmigottipati 

/kind bug

Closes #3681

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
