### PR TITLE
internal/plugins: scaffold a vanilla `go.kubebuilder.io/v2` project when `--project-version=2`

### DIFF
--- a/changelog/fragments/3-alpha-config.yaml
+++ b/changelog/fragments/3-alpha-config.yaml
@@ -1,0 +1,12 @@
+entries:
+  - description: >
+      Changed the go.sdk.operatorframework.io plugin to only write a `plugins` PROJECT field if the
+      project version is 3-alpha or above, as this field was introduced in this project version.
+    kind: change
+    breaking: false
+    migration:
+      header: Remove the `plugins` field from Go project's PROJECT file if it has `version: "2"`
+      body: >
+        The SDK's default Go plugin no longer write a `plugins` PROJECT field if the
+        project version is "2", as this field was introduced in project version "3-alpha",
+        so remove this field and any data within it.

--- a/changelog/fragments/3-alpha-config.yaml
+++ b/changelog/fragments/3-alpha-config.yaml
@@ -1,12 +1,21 @@
 entries:
   - description: >
-      Changed the go.sdk.operatorframework.io plugin to only write a `plugins` PROJECT field if the
-      project version is 3-alpha or above, as this field was introduced in this project version.
+      Changed the `go.sdk.operatorframework.io` plugin to only write a `plugins` PROJECT field and
+      run the OLM integration and scorecard plugins if the project version is "3-alpha" or above.
     kind: change
-    breaking: false
+    breaking: true
     migration:
-      header: Remove the `plugins` field from Go project's PROJECT file if it has `version: "2"`
+      header: Upgrade your project from version "2" to "3-alpha"
       body: >
-        The SDK's default Go plugin no longer write a `plugins` PROJECT field if the
-        project version is "2", as this field was introduced in project version "3-alpha",
-        so remove this field and any data within it.
+        The SDK's default Go plugin no longer supports OLM- or scorecard-related project files
+        nor writes a `plugins` PROJECT field for projects scaffolded previously with
+        `operator-sdk init --project-version=2`, Please migrate to project version "3-alpha"
+        for support of these features by adding the following to your `PROJECT` file:
+
+        ```yaml
+        version: "3-alpha" # Updated from "2"
+        projectName: <output of $(basename $(pwd))>
+        layout: go.kubebuilder.io/v2
+        plugins:
+          go.sdk.operatorframework.io/v2-alpha: {}
+        ```

--- a/internal/plugins/golang/v2/api.go
+++ b/internal/plugins/golang/v2/api.go
@@ -48,14 +48,13 @@ func (p *createAPIPlugin) Run() error {
 		return err
 	}
 
-	// Emulate plugins phase 2 behavior by checking the config for this plugin's
-	// config object.
+	// Emulate plugins phase 2 behavior by checking the config for this plugin's config object.
 	if !hasPluginConfig(p.config) {
 		return nil
 	}
 
-	// Find the new resource. Here we shouldn't worry about checking if one was found, since downstream
-	// plugins will do so.
+	// Find the new resource. Here we shouldn't worry about checking if one was found,
+	// since downstream plugins will do so.
 	var newResource config.GVK
 	for _, r := range p.config.Resources {
 		if _, hasResource := oldResources[r]; !hasResource {

--- a/internal/plugins/golang/v2/config.go
+++ b/internal/plugins/golang/v2/config.go
@@ -21,7 +21,7 @@ type Config struct{}
 
 // hasPluginConfig returns true if cfg.Plugins contains an exact match for this plugin's key.
 func hasPluginConfig(cfg *config.Config) bool {
-	if len(cfg.Plugins) == 0 {
+	if !cfg.IsV3() || len(cfg.Plugins) == 0 {
 		return false
 	}
 	_, hasKey := cfg.Plugins[pluginConfigKey]

--- a/internal/plugins/golang/v2/init.go
+++ b/internal/plugins/golang/v2/init.go
@@ -51,10 +51,12 @@ func (p *initPlugin) Run() error {
 		return err
 	}
 
-	// Update plugin config section with this plugin's configuration.
-	cfg := Config{}
-	if err := p.config.EncodePluginConfig(pluginConfigKey, cfg); err != nil {
-		return fmt.Errorf("error writing plugin config for %s: %v", pluginConfigKey, err)
+	// Update plugin config section with this plugin's configuration for v3 projects.
+	if p.config.IsV3() {
+		cfg := Config{}
+		if err := p.config.EncodePluginConfig(pluginConfigKey, cfg); err != nil {
+			return fmt.Errorf("error writing plugin config for %s: %v", pluginConfigKey, err)
+		}
 	}
 
 	return nil

--- a/internal/plugins/manifests/api.go
+++ b/internal/plugins/manifests/api.go
@@ -27,6 +27,10 @@ import (
 
 // RunCreateAPI runs the manifests SDK phase 2 plugin.
 func RunCreateAPI(cfg *config.Config, gvk config.GVK) error {
+	// Only run these if project version is v3.
+	if !cfg.IsV3() {
+		return nil
+	}
 
 	if err := newAPIScaffolder(cfg, gvk).scaffold(); err != nil {
 		return err

--- a/internal/plugins/manifests/init.go
+++ b/internal/plugins/manifests/init.go
@@ -78,12 +78,11 @@ ifneq ($(origin DEFAULT_CHANNEL), undefined)
 BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
-
-.PHONY: bundle
 `
 
 	makefileBundleFragmentGo = `
 # Generate bundle manifests and metadata, then validate generated files.
+.PHONY: bundle
 bundle: manifests
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
@@ -93,6 +92,7 @@ bundle: manifests
 
 	makefileBundleFragmentNonGo = `
 # Generate bundle manifests and metadata, then validate generated files.
+.PHONY: bundle
 bundle: kustomize
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
@@ -102,6 +102,7 @@ bundle: kustomize
 
 	makefileBundleBuildFragment = `
 # Build the bundle image.
+.PHONY: bundle-build
 bundle-build:
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 `

--- a/internal/plugins/manifests/init.go
+++ b/internal/plugins/manifests/init.go
@@ -26,6 +26,11 @@ import (
 
 // RunInit modifies the project scaffolded by kubebuilder's Init plugin.
 func RunInit(cfg *config.Config) error {
+	// Only run these if project version is v3.
+	if !cfg.IsV3() {
+		return nil
+	}
+
 	// Update the scaffolded Makefile with operator-sdk recipes.
 	if err := initUpdateMakefile(cfg, "Makefile"); err != nil {
 		return fmt.Errorf("error updating Makefile: %v", err)

--- a/internal/plugins/scorecard/init.go
+++ b/internal/plugins/scorecard/init.go
@@ -69,7 +69,12 @@ const (
 var defaultDir = filepath.Join("config", "scorecard")
 
 // RunInit scaffolds kustomize files for kustomizing a scorecard componentconfig.
-func RunInit(*config.Config) error {
+func RunInit(cfg *config.Config) error {
+	// Only run these if project version is v3.
+	if !cfg.IsV3() {
+		return nil
+	}
+
 	return generate(defaultTestImageTag, defaultDir)
 }
 

--- a/website/content/en/docs/olm-integration/quickstart-bundle.md
+++ b/website/content/en/docs/olm-integration/quickstart-bundle.md
@@ -16,6 +16,10 @@ explanations of certain steps for brevity. The following documents contain more 
 If you are working with package manifests, see the [package manifests quickstart][quickstart-package-manifests]
 once you have completed the *Setup* section below.
 
+**Important:** this guide assumes your project was scaffolded with `operator-sdk init --project-version=3-alpha`.
+These features are unavailable to projects of version `2` or less; this information can be found by inspecting
+your `PROJECT` file's `version` value.
+
 ## Setup
 
 Let's first walk through creating an Operator for `memcached`, a distributed key-value store.

--- a/website/content/en/docs/olm-integration/quickstart-package-manifests.md
+++ b/website/content/en/docs/olm-integration/quickstart-package-manifests.md
@@ -7,6 +7,10 @@ weight: 2
 This guide assumes you have followed the introduction and *Setup* section of the [bundle quickstart][quickstart-bundle],
 and have added the `packagemanifests` target to your `Makefile` as described [here][doc-olm-generate].
 
+**Important:** this guide assumes your project was scaffolded with `operator-sdk init --project-version=3-alpha`.
+These features are unavailable to projects of version `2` or less; this information can be found by inspecting
+your `PROJECT` file's `version` value.
+
 ## Creating package manifests
 
 We will now create a package manifests format by running `make packagemanifests` in the root of the memcached-operator project:


### PR DESCRIPTION
**Description of the change:** only run phase 2 plugins for project versions >= 3-alpha.

**Motivation for the change:** The SDK should be scaffolding the vanilla `go.kubebuilder.io/v2` plugin if `--project-version 2` is set, since the `go.sdk.operatorframework.io` phase 2 plugin requires a 3-alpha project.

Holding for discussion

/hold

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
