### PR TITLE
Update `Advanced Topics` conditions with operator-framework/operator-lib

### DIFF
--- a/website/content/en/docs/building-operators/golang/advanced-topics.md
+++ b/website/content/en/docs/building-operators/golang/advanced-topics.md
@@ -19,7 +19,7 @@ To use conditions in your custom resource, add a Conditions field to the Status 
 
 ```Go
 import (
-    "github.com/operator-framework/operator-sdk/pkg/status"
+    "github.com/operator-framework/operator-lib/status"
 )
 
 type MyAppStatus struct {

--- a/website/content/en/docs/building-operators/golang/advanced-topics.md
+++ b/website/content/en/docs/building-operators/golang/advanced-topics.md
@@ -247,7 +247,7 @@ A call to `leader.Become()` will block the operator as it retries until it can b
 ```Go
 import (
     ...
-    "github.com/operator-framework/operator-sdk/pkg/leader"
+    "github.com/operator-framework/operator-lib/leader"
 )
 
 func main() {


### PR DESCRIPTION
Hello,

This PR Closes #3647

**Description of the change:**

It changes the documentation to point to the new status location that is now `operator-framework/operator-lib`

**Motivation for the change:**

see #3647. I've faced the same issue and it does not work with v1+ of operator-sdk.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:

- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
