### PR TITLE
feat: allow operator-sdk cleanup works by reading projectName from the file (no breaking change)

### DIFF
--- a/changelog/fragments/clean-usingconfig.yaml
+++ b/changelog/fragments/clean-usingconfig.yaml
@@ -1,0 +1,17 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      The package name argument in the `operator-sdk cleanup` command is now optional. If the argument is not provided,
+      SDK will use the `projectName` value from the `PROJECT` file as the package name.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false

--- a/test/e2e-ansible/e2e_ansible_olm_test.go
+++ b/test/e2e-ansible/e2e_ansible_olm_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Integrating ansible Projects with OLM", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("destroying the deployed package manifests-formatted operator")
-			cleanupPkgManCmd := exec.Command(tc.BinaryName, "cleanup", tc.ProjectName,
+			cleanupPkgManCmd := exec.Command(tc.BinaryName, "cleanup",
 				"--timeout", "4m")
 			_, err = tc.Run(cleanupPkgManCmd)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e-go/e2e_go_olm_test.go
+++ b/test/e2e-go/e2e_go_olm_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Integrating Go Projects with OLM", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("destroying the deployed package manifests-formatted operator")
-			cleanupPkgManCmd := exec.Command(tc.BinaryName, "cleanup", tc.ProjectName,
+			cleanupPkgManCmd := exec.Command(tc.BinaryName, "cleanup",
 				"--timeout", "4m")
 			_, err = tc.Run(cleanupPkgManCmd)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e-helm/e2e_helm_olm_test.go
+++ b/test/e2e-helm/e2e_helm_olm_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Integrating Helm Projects with OLM", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("destroying the deployed package manifests-formatted operator")
-			cleanupPkgManCmd := exec.Command(tc.BinaryName, "cleanup", tc.ProjectName,
+			cleanupPkgManCmd := exec.Command(tc.BinaryName, "cleanup",
 				"--timeout", "4m")
 			_, err = tc.Run(cleanupPkgManCmd)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
**Description of the change:**
Make the command be simpler to be used since we do not need to inform info that we have already. 

**Motivation for the change:**

Currently, we need to tell the users to look in tthe PROJECT file, get the project name and inform here which in POV is not good UX at all since we have this value. 

The scenario `If we want to allow this command to be run outside of a project` is not the target since 80% of the cases users will like to check their projects running with locally and it still possible. The change here it does not prevent or limit this action just bring a better UX for the common case.

**See that pkgName is not used by default to run the pkgManifest whcih make confuse requires it to cleanup.**

Closes: #https://github.com/operator-framework/operator-sdk/issues/3706


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
