### PR TITLE
internal/generate/clusterserviceversion: append non-empty permissions

### DIFF
--- a/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
@@ -120,7 +120,9 @@ func applyRoles(c *collector.Manifests, strategy *operatorsv1alpha1.StrategyDeta
 	// Apply relevant roles to each service account.
 	perms := []operatorsv1alpha1.StrategyDeploymentPermissions{}
 	for _, perm := range saToPermissions {
-		perms = append(perms, perm)
+		if len(perm.Rules) != 0 {
+			perms = append(perms, perm)
+		}
 	}
 	strategy.Permissions = perms
 }
@@ -162,7 +164,9 @@ func applyClusterRoles(c *collector.Manifests, strategy *operatorsv1alpha1.Strat
 	// Apply relevant roles to each service account.
 	perms := []operatorsv1alpha1.StrategyDeploymentPermissions{}
 	for _, perm := range saToPermissions {
-		perms = append(perms, perm)
+		if len(perm.Rules) != 0 {
+			perms = append(perms, perm)
+		}
 	}
 	strategy.ClusterPermissions = perms
 }


### PR DESCRIPTION
**Description of the change:** check if permission rules exist before appending

**Motivation for the change:** do not add empty permissions to CSV

/kind bug


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
