### PR TITLE
Removing stale sockets while running Ansible operators

### DIFF
--- a/changelog/fragments/socket-cleanup.yaml
+++ b/changelog/fragments/socket-cleanup.yaml
@@ -1,0 +1,9 @@
+entries:
+  - description: >
+      Removed stale unix sockets. This allows for smoother 
+      initialization during the start-up of an Ansible operator, 
+      as each operator will clean up its sockets during termination.
+
+    kind: "addition"
+
+    breaking: false

--- a/internal/ansible/runner/eventapi/eventapi.go
+++ b/internal/ansible/runner/eventapi/eventapi.go
@@ -18,16 +18,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/go-logr/logr"
 	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/go-logr/logr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // EventReceiver serves the event API

--- a/internal/ansible/runner/eventapi/eventapi.go
+++ b/internal/ansible/runner/eventapi/eventapi.go
@@ -18,17 +18,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/go-logr/logr"
 	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/go-logr/logr"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // EventReceiver serves the event API
@@ -100,6 +99,7 @@ func (e *EventReceiver) Close() {
 	if err := e.server.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
 		e.logger.Error(err, "Failed to close event receiver")
 	}
+	os.Remove(e.SocketPath)
 	close(e.Events)
 }
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Removed stale sockets during the closing of Ansible operators.

**Motivation for the change:**
Removing of unused/stale sockets allows for smoother initialization of the operator during start-up.

