### PR TITLE
Adding unconvert to Linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,4 +17,4 @@ linters:
     - staticcheck
     - unused
     - gosimple
-  
+    - unconvert

--- a/images/scorecard-test-kuttl/cmd/test-kuttl/main.go
+++ b/images/scorecard-test-kuttl/cmd/test-kuttl/main.go
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	var jsonReport Testsuites
-	err = json.Unmarshal([]byte(byteValue), &jsonReport)
+	err = json.Unmarshal(byteValue, &jsonReport)
 	if err != nil {
 		printErrorStatus(fmt.Errorf("could not unmarshal kuttl report %v", err))
 		return

--- a/internal/ansible/proxy/kubeconfig/kubeconfig.go
+++ b/internal/ansible/proxy/kubeconfig/kubeconfig.go
@@ -79,7 +79,7 @@ func Create(ownerRef metav1.OwnerReference, proxyURL string, namespace string) (
 	if err != nil {
 		return nil, err
 	}
-	username := base64.URLEncoding.EncodeToString([]byte(ownerRefJSON))
+	username := base64.URLEncoding.EncodeToString(ownerRefJSON)
 	parsedURL.User = url.User(username)
 	v := values{
 		Username:  username,

--- a/internal/cmd/operator-sdk/scorecard/cmd.go
+++ b/internal/cmd/operator-sdk/scorecard/cmd.go
@@ -81,7 +81,7 @@ If the argument holds an image tag, it must be present remotely.`,
 		"Option to enable listing which tests are run")
 	scorecardCmd.Flags().BoolVarP(&c.skipCleanup, "skip-cleanup", "x", false,
 		"Disable resource cleanup after tests are run")
-	scorecardCmd.Flags().DurationVarP(&c.waitTime, "wait-time", "w", time.Duration(30*time.Second),
+	scorecardCmd.Flags().DurationVarP(&c.waitTime, "wait-time", "w", 30*time.Second,
 		"seconds to wait for tests to complete. Example: 35s")
 
 	return scorecardCmd

--- a/internal/olm/operator/internal/registry_pod.go
+++ b/internal/olm/operator/internal/registry_pod.go
@@ -179,8 +179,7 @@ func (rp *RegistryPod) VerifyPodRunning(ctx context.Context) error {
 // checkPodStatus polls and verifies that the pod status is running
 func (rp *RegistryPod) checkPodStatus(ctx context.Context, podCheck wait.ConditionFunc) error {
 	// poll every 200 ms until podCheck is true or context is done
-	err := wait.PollImmediateUntil(time.Duration(200*time.Millisecond),
-		podCheck, ctx.Done())
+	err := wait.PollImmediateUntil(200*time.Millisecond, podCheck, ctx.Done())
 	if err != nil {
 		return fmt.Errorf("error waiting for registry pod %s to run: %v", rp.pod.Name, err)
 	}

--- a/internal/registry/validate.go
+++ b/internal/registry/validate.go
@@ -176,7 +176,7 @@ func writeAnnotationFile(filename string, annotation *registrybundle.AnnotationM
 		mode = info.Mode()
 	}
 
-	err = ioutil.WriteFile(filename, []byte(file), mode)
+	err = ioutil.WriteFile(filename, file, mode)
 	if err != nil {
 		return fmt.Errorf("error writing modified contents to annotations file, %v", err)
 	}


### PR DESCRIPTION
Signed-off-by: Ken Sipe <kensipe@gmail.com>


**Description of the change:**

Adding unconvert to Linter with Fixes.  This is simply unnecessary conversions in code.

**Motivation for the change:**

💪 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
