### PR TITLE
fix broken link in ansible quickstart docs

### DIFF
--- a/website/content/en/docs/building-operators/ansible/quickstart.md
+++ b/website/content/en/docs/building-operators/ansible/quickstart.md
@@ -86,6 +86,7 @@ make undeploy
 Read the [tutorial][tutorial] for an in-depth walkthough of building a Ansible operator.
 
 [operator_install]: /docs/installation/install-operator-sdk
+[ansible-operator-install]: /docs/building-operators/ansible/installation
 [layout-doc]:../reference/scaffolding
 [tutorial]: /docs/building-operators/ansible/tutorial/
 [ansible-link]: https://www.ansible.com/ 


### PR DESCRIPTION
**Description of the change:**
Add a target for the markdown link in the ansible quickstart guide.

**Motivation for the change:**
Links that work are cool.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
