### PR TITLE
Bug 1856714: Adding checks for rescued tasks during reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 ### Additions
 
 - Add "panic" level for --zap-stacktrace-level (allows "debug", "info", "error", "panic"). ([#3040](https://github.com/operator-framework/operator-sdk/pull/3040))
-- The `operator-sdk` binary has a new CLI workflow and project layout for scaffolding Go operators that is aligned with Kubebuilder's CLI and project layout. See the new [Quickstart Guide](https://sdk.operatorframework.io/docs/golang/quickstart/) and the new [CLI reference](https://v0-19-x.sdk.operatorframework.io/docs/new-cli/) for more details. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
+- The `operator-sdk` binary has a new CLI workflow and project layout for scaffolding Go operators that is aligned with Kubebuilder's CLI and project layout. See the new [Quickstart Guide](https://sdk.operatorframework.io/docs/building-operators/golang/quickstart/) and the new [CLI reference](https://v0-19-x.sdk.operatorframework.io/docs/new-cli/) for more details. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
 - `bundle validate` can now use a containerd image ("none") tool to unpack images, removing the need for an external image tool like docker/podman. ([#3222](https://github.com/operator-framework/operator-sdk/pull/3222))
 - The SDK `scorecard` command adds a new test image, scorecard-test-kuttl, that allows end users to write and execute kuttl based tests. ([#3278](https://github.com/operator-framework/operator-sdk/pull/3278))
 - Add "--olm-namespace" flag to olm subcommands (install, uninstall) to allow users to specify the  namespace where olm is to be installed or uninstalled. ([#3300](https://github.com/operator-framework/operator-sdk/pull/3300))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 ### Additions
 
 - Add "panic" level for --zap-stacktrace-level (allows "debug", "info", "error", "panic"). ([#3040](https://github.com/operator-framework/operator-sdk/pull/3040))
-- The `operator-sdk` binary has a new CLI workflow and project layout for scaffolding Go operators that is aligned with Kubebuilder's CLI and project layout. See the new [Quickstart Guide](https://sdk.operatorframework.io/docs/building-operators/golang/quickstart/) and the new [CLI reference](https://v0-19-x.sdk.operatorframework.io/docs/new-cli/) for more details. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
+The `operator-sdk` binary has a new CLI workflow and project layout for scaffolding Go operators that is aligned with Kubebuilder's CLI and project layout. See the new [Quickstart Guide](https://sdk.operatorframework.io/docs/building-operators/golang/quickstart/) and the new [CLI reference](https://v0-19-x.sdk.operatorframework.io/docs/new-cli/) for more details. ([#3190](https://github.com/operator-framework/operator-sdk/pull/3190))
 - `bundle validate` can now use a containerd image ("none") tool to unpack images, removing the need for an external image tool like docker/podman. ([#3222](https://github.com/operator-framework/operator-sdk/pull/3222))
 - The SDK `scorecard` command adds a new test image, scorecard-test-kuttl, that allows end users to write and execute kuttl based tests. ([#3278](https://github.com/operator-framework/operator-sdk/pull/3278))
 - Add "--olm-namespace" flag to olm subcommands (install, uninstall) to allow users to specify the  namespace where olm is to be installed or uninstalled. ([#3300](https://github.com/operator-framework/operator-sdk/pull/3300))

--- a/changelog/fragments/00-template.yaml
+++ b/changelog/fragments/00-template.yaml
@@ -1,5 +1,3 @@
-# entries is a list of entries to include in
-# release notes and/or the migration guide
 entries:
   - description: >
       Description is the line that shows up in the CHANGELOG. This
@@ -7,30 +5,6 @@ entries:
       the YAML string '>' operator means you can write your entry
       multiple lines and it will still be parsed as a single line.
 
-    # kind is one of:
-    # - addition
-    # - change
-    # - deprecation
-    # - removal
-    # - bugfix
-    kind: ""
+    kind: "addition"
 
-    # Is this a breaking change?
     breaking: false
-
-    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
-    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
-    #
-    # The generator auto-detects the PR number from the commit
-    # message in which this file was originally added.
-    #
-    # What is the pull request number (without the "#")?
-    # pull_request_override: 0
-
-
-    # Migration can be defined to automatically add a section to
-    # the migration guide. This is required for breaking changes.
-    migration:
-      header: Header text for the migration section
-      body: >
-        Body of the migration section.

--- a/changelog/fragments/00-template.yaml
+++ b/changelog/fragments/00-template.yaml
@@ -1,3 +1,5 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
 entries:
   - description: >
       Description is the line that shows up in the CHANGELOG. This
@@ -5,6 +7,30 @@ entries:
       the YAML string '>' operator means you can write your entry
       multiple lines and it will still be parsed as a single line.
 
-    kind: "addition"
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: ""
 
+    # Is this a breaking change?
     breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: Header text for the migration section
+      body: >
+        Body of the migration section.

--- a/changelog/fragments/rescue-reconciliation.yaml
+++ b/changelog/fragments/rescue-reconciliation.yaml
@@ -1,8 +1,8 @@
 entries:
   - description: >
-      Added checks for rescued tasks during reconciliation
-      to avoid adding rescued tasks to the list of failures.
+      Stop reconciling tasks when the event raised is a rescue in Ansible-based Operators. 
+      More info: [Bugzilla 1856714](https://bugzilla.redhat.com/show_bug.cgi?id=1856714)
 
-    kind: "addition"
+    kind: "bugfix"
 
     breaking: false

--- a/changelog/fragments/rescue-reconciliation.yaml
+++ b/changelog/fragments/rescue-reconciliation.yaml
@@ -1,0 +1,8 @@
+entries:
+  - description: >
+      Added checks for rescued tasks during reconciliation
+      to avoid adding rescued tasks to the list of failures.
+
+    kind: "addition"
+
+    breaking: false

--- a/cmd/operator-sdk/main.go
+++ b/cmd/operator-sdk/main.go
@@ -46,7 +46,7 @@ func main() {
 		if operatorType == projutil.OperatorTypeGo {
 			depMsg := "Operator SDK has a new CLI and project layout that is aligned with Kubebuilder.\n" +
 				"See `operator-sdk init -h` and the following doc on how to scaffold a new project:\n" +
-				"https://sdk.operatorframework.io/docs/building-operators/golang/quickstart/\n" +
+				"https://v0-19-x.sdk.operatorframework.io/docs/golang/quickstart/\n" +
 				"To migrate existing projects to the new layout see:\n" +
 				"https://sdk.operatorframework.io/docs/golang/migration/project_migration_guide/\n"
 			projutil.PrintDeprecationWarning(depMsg)

--- a/cmd/operator-sdk/main.go
+++ b/cmd/operator-sdk/main.go
@@ -46,7 +46,7 @@ func main() {
 		if operatorType == projutil.OperatorTypeGo {
 			depMsg := "Operator SDK has a new CLI and project layout that is aligned with Kubebuilder.\n" +
 				"See `operator-sdk init -h` and the following doc on how to scaffold a new project:\n" +
-				"https://sdk.operatorframework.io/docs/golang/quickstart/\n" +
+				"https://sdk.operatorframework.io/docs/building-operators/golang/quickstart/\n" +
 				"To migrate existing projects to the new layout see:\n" +
 				"https://sdk.operatorframework.io/docs/golang/migration/project_migration_guide/\n"
 			projutil.PrintDeprecationWarning(depMsg)

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -13,7 +13,7 @@ trap_add 'rm -rf $TMPDIR' EXIT
 pip3 install --user pyasn1==0.4.7 pyasn1-modules==0.2.6 idna==2.8 ipaddress==1.0.22
 pip3 install --user molecule==3.0.2
 pip3 install --user ansible-lint yamllint
-pip3 install --user docker openshift jmespath
+pip3 install --user docker==4.2.2 openshift jmespath
 ansible-galaxy collection install community.kubernetes
 
 deploy_prereqs() {

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -315,7 +315,7 @@ func CheckGoModules() error {
 	}
 	if !goModOn {
 		return fmt.Errorf(`using go modules requires GO111MODULE="on", "auto", or unset.` +
-			` More info: https://sdk.operatorframework.io/docs/golang/quickstart/#a-note-on-dependency-management`)
+			` More info: https://sdk.operatorframework.io/docs/building-operators/golang/quickstart/`)
 	}
 	return nil
 }

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -315,7 +315,7 @@ func CheckGoModules() error {
 	}
 	if !goModOn {
 		return fmt.Errorf(`using go modules requires GO111MODULE="on", "auto", or unset.` +
-			` More info: https://sdk.operatorframework.io/docs/building-operators/golang/quickstart/`)
+			` More info: https://v0-19-x.sdk.operatorframework.io/docs/golang/quickstart/#a-note-on-dependency-management`)
 	}
 	return nil
 }

--- a/pkg/ansible/controller/reconcile.go
+++ b/pkg/ansible/controller/reconcile.go
@@ -186,7 +186,7 @@ func (r *AnsibleOperatorReconciler) Reconcile(request reconcile.Request) (reconc
 				return reconcile.Result{}, err
 			}
 		}
-		if event.Event == eventapi.EventRunnerOnFailed && !event.IgnoreError() {
+		if event.Event == eventapi.EventRunnerOnFailed && !event.IgnoreError() && !event.Rescued() {
 			failureMessages = append(failureMessages, event.GetFailedPlaybookMessage())
 		}
 	}

--- a/pkg/ansible/runner/eventapi/types.go
+++ b/pkg/ansible/runner/eventapi/types.go
@@ -122,3 +122,15 @@ func (je JobEvent) IgnoreError() bool {
 	}
 	return false
 }
+
+// Rescued - Detects whether or not a task was rescued
+func (je JobEvent) Rescued() bool {
+	if rescued, contains := je.EventData["rescued"]; contains {
+		for _, v := range rescued.(map[string]interface{}) {
+			if int(v.(float64)) == 1 {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Added a check to determine whether or not a task has been rescued.

**Motivation for the change:**
Avoid adding rescued tasks to the list of failures during reconciliation.
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1856714
Backporting the PR https://github.com/operator-framework/operator-sdk/pull/3650
