### PR TITLE
fix ansible-operator link to CR sample

### DIFF
--- a/website/content/en/docs/building-operators/ansible/reference/retroactively-owned-resources.md
+++ b/website/content/en/docs/building-operators/ansible/reference/retroactively-owned-resources.md
@@ -66,7 +66,7 @@ resource is a cluster level resource.
 
 **NOTE**: The {group} can be found by splitting the `apiVersion`
 metadata of the CR, into `group` and `version`. As an example, 
-[this apiVersion field](https://github.com/operator-framework/operator-sdk-samples/blob/master/ansible/memcached-operator/deploy/crds/cache.example.com_v1alpha1_memcached_cr.yaml#L1)
+[this apiVersion field](https://github.com/operator-framework/operator-sdk-samples/blob/938fd148ba106ca9811925e4956d6bb70c36b29d/ansible/memcached-operator/config/samples/cache_v1alpha1_memcached.yaml#L1)
 gives us the group `cache.example.com`.
 
 **Example Annotation:**


### PR DESCRIPTION
**Description of the change:**
Fix ansible-operator link to CR sample	

**Motivation for the change:**
Broken links cause CI to always fail

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
