### PR TITLE
use kuttl v0.5.2 as the base for scorecard-test-kuttl

### DIFF
--- a/images/scorecard-test-kuttl/Dockerfile
+++ b/images/scorecard-test-kuttl/Dockerfile
@@ -1,6 +1,6 @@
 # Base image
-FROM docker.io/kudobuilder/kuttl@sha256:c9c5edc27ba6e5e994ffd8cea03368c0d4e274f3c7a00f51c1e360feb573f24e
-#FROM kudobuilder/kuttl:latest
+#FROM docker.io/kudobuilder/kuttl@sha256:c9c5edc27ba6e5e994ffd8cea03368c0d4e274f3c7a00f51c1e360feb573f24e
+FROM kudobuilder/kuttl:v0.5.2
 
 ENV TESTKUTTL=/usr/local/bin/scorecard-test-kuttl \
     USER_UID=1001 \


### PR DESCRIPTION

**Description of the change:**

update the scorecard-test-kuttl image to be based off of the kuttl v0.5.2 version 

**Motivation for the change:**

this changes the scorecard-test-kuttl image from being based off of a SHA to the
semver tagged version of kuttl, this supports multi-arch images better.
**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
