### PR TITLE
run bundle: create subscription for run bundle subcommand

### DIFF
--- a/internal/olm/operator/olm.go
+++ b/internal/olm/operator/olm.go
@@ -66,10 +66,10 @@ func withPackageChannel(pkgName string, channel apimanifests.PackageChannel) fun
 	}
 }
 
-// newSubscription creates a new Subscription for a CSV with a name derived
-// from csvName, the CSV's objectmeta.name, in namespace. opts will be applied
+// NewSubscription creates a new Subscription for a CSV with a name derived
+// from resourceName, the CSV's objectmeta.name, in namespace. opts will be applied
 // to the Subscription object.
-func newSubscription(csvName, namespace string,
+func NewSubscription(resourceName, namespace string,
 	opts ...func(*operatorsv1alpha1.Subscription)) *operatorsv1alpha1.Subscription {
 	sub := &operatorsv1alpha1.Subscription{
 		TypeMeta: metav1.TypeMeta{
@@ -77,7 +77,7 @@ func newSubscription(csvName, namespace string,
 			Kind:       operatorsv1alpha1.SubscriptionKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getSubscriptionName(csvName),
+			Name:      getSubscriptionName(resourceName),
 			Namespace: namespace,
 		},
 	}
@@ -92,10 +92,10 @@ func getCatalogSourceName(pkgName string) string {
 	return fmt.Sprintf("%s-ocs", name)
 }
 
-// newCatalogSource creates a new CatalogSource with a name derived from
-// pkgName, the package manifest's packageName, in namespace. opts will
+// NewCatalogSource creates a new CatalogSource with a name derived from
+// resourceName, the package manifest's packageName, in namespace. opts will
 // be applied to the CatalogSource object.
-func newCatalogSource(pkgName, namespace string,
+func NewCatalogSource(resourceName, namespace string,
 	opts ...func(*operatorsv1alpha1.CatalogSource)) *operatorsv1alpha1.CatalogSource {
 	cs := &operatorsv1alpha1.CatalogSource{
 		TypeMeta: metav1.TypeMeta{
@@ -103,11 +103,11 @@ func newCatalogSource(pkgName, namespace string,
 			Kind:       operatorsv1alpha1.CatalogSourceKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getCatalogSourceName(pkgName),
+			Name:      getCatalogSourceName(resourceName),
 			Namespace: namespace,
 		},
 		Spec: operatorsv1alpha1.CatalogSourceSpec{
-			DisplayName: pkgName,
+			DisplayName: resourceName,
 			Publisher:   "operator-sdk",
 		},
 	}

--- a/internal/olm/operator/packagemanifests_manager.go
+++ b/internal/olm/operator/packagemanifests_manager.go
@@ -110,7 +110,7 @@ func (m *packageManifestsManager) run(ctx context.Context) (err error) {
 	}
 
 	// New CatalogSource.
-	catsrc := newCatalogSource(pkgName, m.namespace)
+	catsrc := NewCatalogSource(pkgName, m.namespace)
 	log.Info("Creating catalog source")
 	if err = m.client.DoCreate(ctx, catsrc); err != nil {
 		return fmt.Errorf("error creating catalog source: %w", err)
@@ -129,7 +129,7 @@ func (m *packageManifestsManager) run(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	sub := newSubscription(csv.GetName(), m.namespace,
+	sub := NewSubscription(csv.GetName(), m.namespace,
 		withPackageChannel(pkgName, channel),
 		withCatalogSource(getCatalogSourceName(pkgName), m.namespace))
 	// New SDK-managed OperatorGroup.

--- a/internal/operator/internal/operator_installer_test.go
+++ b/internal/operator/internal/operator_installer_test.go
@@ -57,6 +57,7 @@ var _ = Describe("Operator Installer", func() {
 				Expect(sub.Name).Should(Equal(oi.CatalogSourceName + "-sub"))
 				Expect(sub.Namespace).Should(Equal(oi.cfg.Namespace))
 				Expect(sub.Spec.InstallPlanApproval).NotTo(BeNil())
+				Expect(sub.Spec.InstallPlanApproval).Should(Equal(v1alpha1.ApprovalManual))
 				Expect(sub.Spec.CatalogSource).Should(Equal(oi.CatalogSourceName))
 				Expect(sub.Spec.CatalogSourceNamespace).Should(Equal(oi.cfg.Namespace))
 				Expect(sub.Spec.Channel).Should(Equal(oi.Channel))

--- a/internal/operator/internal/operator_installer_test.go
+++ b/internal/operator/internal/operator_installer_test.go
@@ -1,0 +1,69 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+package internal
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-sdk/internal/operator"
+)
+
+func TestOperatorInstaller(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test OperatorInstaller Suite")
+}
+
+var _ = Describe("Operator Installer", func() {
+
+	Describe("creating subscription", func() {
+
+		Context("with valid values", func() {
+			var sub *v1alpha1.Subscription
+			config := &operator.Configuration{
+				Client:    fakeclient.NewFakeClient(),
+				Namespace: "test-default-namespace",
+			}
+
+			oi := &OperatorInstaller{
+				cfg:               config,
+				CatalogSourceName: "test-cs",
+				PackageName:       "test-package",
+				StartingCSV:       "test-csv",
+				Channel:           "test-default-channel",
+			}
+
+			BeforeEach(func() {
+				sub = oi.createSubscription()
+				Expect(sub).NotTo(BeNil())
+			})
+
+			It("should create subscription successfully", func() {
+				Expect(sub.Name).Should(Equal(oi.CatalogSourceName + "-sub"))
+				Expect(sub.Namespace).Should(Equal(oi.cfg.Namespace))
+				Expect(sub.Spec.InstallPlanApproval).NotTo(BeNil())
+				Expect(sub.Spec.CatalogSource).Should(Equal(oi.CatalogSourceName))
+				Expect(sub.Spec.CatalogSourceNamespace).Should(Equal(oi.cfg.Namespace))
+				Expect(sub.Spec.Channel).Should(Equal(oi.Channel))
+				Expect(sub.Spec.StartingCSV).Should(Equal(oi.StartingCSV))
+				Expect(sub.Spec.Package).Should(Equal(oi.PackageName))
+			})
+
+		})
+	})
+})


### PR DESCRIPTION
Description of the change:

- Add creation of subscription logic to OperatorInstaller 
- Set the subscription fields (catalog source name and namespace, channel, startingCSV, package name) 
- Set the install plan approval to manual
- Add a basic unit test to verify subscription creation using controller-runtime fake client 

Motivation for the change:

- Create subscription to expand OperatorInstaller method and as this is one of the prerequisites to generate a successful CSV
Link to enhancement proposal:
https://github.com/operator-framework/enhancements/blob/master/enhancements/run-bundle.md