### PR TITLE
doc: add missing prerequisite for Ansible plugin

### DIFF
--- a/website/content/en/docs/building-operators/ansible/installation.md
+++ b/website/content/en/docs/building-operators/ansible/installation.md
@@ -11,6 +11,7 @@ Follow the steps in the [installation guide][install-guide] to learn how to inst
 - [ansible][ansible-tool] version v2.9.0+
 - [ansible-runner][ansible-runner-tool] version v1.1.0+
 - [ansible-runner-http][ansible-runner-http-plugin] version v1.0.0+
+- [openshift][openshift-module] version v0.11.2+
 
 **Note**: This guide uses [minikube][minikube-tool] version v0.25.0+ as the
 local Kubernetes cluster and [quay.io][quay-link] for the public registry.
@@ -22,3 +23,4 @@ local Kubernetes cluster and [quay.io][quay-link] for the public registry.
 [install-guide]: /docs/installation/install-operator-sdk
 [minikube-tool]:https://github.com/kubernetes/minikube#installation
 [quay-link]:https://quay.io
+[openshift-module]:https://pypi.org/project/openshift/


### PR DESCRIPTION
this includes openshift python's module as a prerequisite for Ansible Operator SDK.

Fixes #3753