### PR TITLE
Scorecard push custom and kuttl multiarch images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,7 @@ ANSIBLE_ARCHES:="amd64" "ppc64le" "arm64"
 HELM_ARCHES:="amd64" "ppc64le" "arm64"
 SCORECARD_TEST_ARCHES:="amd64" "ppc64le" "arm64"
 SCORECARD_TEST_KUTTL_ARCHES:="amd64" "ppc64le" "arm64"
-# the custom scorecard test image is a scorecard example only and
-# is not pushed to an official registry
+# the custom scorecard test image is a scorecard example only
 CUSTOM_SCORECARD_TESTS_ARCHES:="amd64" "ppc64le" "arm64"
 
 export CGO_ENABLED:=0
@@ -185,7 +184,7 @@ image: image-build image-push ## Build and push all images
 
 image-build: image-build-ansible image-build-helm image-build-scorecard-test image-build-scorecard-test-kuttl image-build-custom-scorecard-tests ## Build all images
 
-image-push: image-push-ansible image-push-helm image-push-scorecard-test ## Push all images
+image-push: image-push-ansible image-push-helm image-push-scorecard-test image-build-scorecard-test-kuttl image-push-custom-scorecard-tests ## Push all images
 
 # Ansible operator image scaffold/build/push.
 .PHONY: image-scaffold-ansible image-build-ansible image-push-ansible image-push-ansible-multiarch
@@ -228,6 +227,8 @@ image-push-helm-multiarch:
 
 image-build-custom-scorecard-tests:
 	./hack/image/build-custom-scorecard-tests-image.sh $(CUSTOM_SCORECARD_TESTS_BASE_IMAGE):dev
+image-push-custom-scorecard-tests:
+	./hack/image/push-image-tags.sh $(CUSTOM_SCORECARD_TESTS_BASE_IMAGE):dev $(CUSTOM_SCORECARD_TESTS_IMAGE)-$(shell go env GOARCH)
 
 image-build-scorecard-test:
 	./hack/image/build-scorecard-test-image.sh $(SCORECARD_TEST_BASE_IMAGE):dev
@@ -246,6 +247,8 @@ image-push-scorecard-test-kuttl:
 
 image-push-scorecard-test-kuttl-multiarch:
 	./hack/image/push-manifest-list.sh $(SCORECARD_TEST_KUTTL_IMAGE) ${SCORECARD_TEST_KUTTL_ARCHES}
+image-push-custom-scorecard-tests-multiarch:
+	./hack/image/push-manifest-list.sh $(CUSTOM_SCORECARD_TESTS_IMAGE) ${CUSTOM_SCORECARD_TESTS_ARCHES}
 
 ##############################
 # Tests                      #

--- a/changelog/fragments/scorecard-multiarch-images.yhaml
+++ b/changelog/fragments/scorecard-multiarch-images.yhaml
@@ -1,0 +1,5 @@
+entries:
+  - description: Updated the Makefile to build multiarch versions of the
+scorecard-test-kuttl and custom-scorecard-tests images to match the scorecard-test image
+    kind: change
+    breaking: false


### PR DESCRIPTION


**Description of the change:**

now that scorecard-test-kuttl is based off of kuttl v0.5.2 which is a multiarch image, we can build the arm64 and ppc64le images of scorecard-test-kuttl, also this PR pushes the scorecard custom image to assist in testing of that image and be consistent with the other scorecard images.

**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
