### PR TITLE
`generate`: correctly set CSV webhookDefinition deployment names

### DIFF
--- a/changelog/fragments/3761.yaml
+++ b/changelog/fragments/3761.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      `generate <bundle|packagemanifests>` will populate a CSV's `webhookDefinition[].deploymentName`
+      by selecting an input Deployment via its PodTemplate labels using a webhook Service's label selectors,
+      defaulting to "<service.metadata.name>-service" if none is selected.
+    kind: bugfix

--- a/internal/generate/clusterserviceversion/clusterserviceversion_updaters_test.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_updaters_test.go
@@ -1,0 +1,143 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterserviceversion
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/operator-framework/operator-sdk/internal/generate/collector"
+)
+
+var _ = Describe("findMatchingDeploymentAndServiceForWebhook", func() {
+
+	var (
+		c   *collector.Manifests
+		wcc admissionregv1.WebhookClientConfig
+
+		depName1     = "dep-name-1"
+		depName2     = "dep-name-2"
+		serviceName1 = "service-name-1"
+		serviceName2 = "service-name-2"
+	)
+
+	BeforeEach(func() {
+		c = &collector.Manifests{}
+		wcc = admissionregv1.WebhookClientConfig{}
+		wcc.Service = &admissionregv1.ServiceReference{}
+	})
+
+	Context("webhook config has a matching service name", func() {
+		By("parsing one deployment and one service with one label")
+		It("returns the first service and deployment", func() {
+			labels := map[string]string{"operator-name": "test-operator"}
+			c.Deployments = []appsv1.Deployment{newDeployment(depName1, labels)}
+			c.Services = []corev1.Service{newService(serviceName1, labels)}
+			wcc.Service.Name = serviceName1
+			depName, serviceName := findMatchingDeploymentAndServiceForWebhook(c, wcc)
+			Expect(depName).To(Equal(depName1))
+			Expect(serviceName).To(Equal(serviceName1))
+		})
+
+		By("parsing two deployments and two services with non-intersecting labels")
+		It("returns the first service and deployment", func() {
+			labels1 := map[string]string{"operator-name": "test-operator"}
+			labels2 := map[string]string{"foo": "bar"}
+			c.Deployments = []appsv1.Deployment{
+				newDeployment(depName1, labels1),
+				newDeployment(depName2, labels2),
+			}
+			c.Services = []corev1.Service{
+				newService(serviceName1, labels1),
+				newService(serviceName2, labels2),
+			}
+			wcc.Service.Name = serviceName1
+			depName, serviceName := findMatchingDeploymentAndServiceForWebhook(c, wcc)
+			Expect(depName).To(Equal(depName1))
+			Expect(serviceName).To(Equal(serviceName1))
+		})
+
+		By("parsing two deployments and two services with a label subset")
+		It("returns the first service and second deployment", func() {
+			labels1 := map[string]string{"operator-name": "test-operator"}
+			labels2 := map[string]string{"operator-name": "test-operator", "foo": "bar"}
+			c.Deployments = []appsv1.Deployment{
+				newDeployment(depName2, labels2),
+				newDeployment(depName1, labels1),
+			}
+			c.Services = []corev1.Service{newService(serviceName1, labels1)}
+			wcc.Service.Name = serviceName1
+			depName, serviceName := findMatchingDeploymentAndServiceForWebhook(c, wcc)
+			Expect(depName).To(Equal(depName2))
+			Expect(serviceName).To(Equal(serviceName1))
+		})
+	})
+
+	Context("webhook config does not have a matching service", func() {
+		By("parsing one deployment and one service with one label")
+		It("returns neither service nor deployment name", func() {
+			labels := map[string]string{"operator-name": "test-operator"}
+			c.Deployments = []appsv1.Deployment{newDeployment(depName1, labels)}
+			c.Services = []corev1.Service{newService(serviceName1, labels)}
+			wcc.Service.Name = serviceName2
+			depName, serviceName := findMatchingDeploymentAndServiceForWebhook(c, wcc)
+			Expect(depName).To(BeEmpty())
+			Expect(serviceName).To(BeEmpty())
+		})
+	})
+
+	Context("webhook config has a matching service but labels do not match", func() {
+		By("parsing one deployment and one service with one label")
+		It("returns the first service and no deployment", func() {
+			labels1 := map[string]string{"operator-name": "test-operator"}
+			labels2 := map[string]string{"foo": "bar"}
+			c.Deployments = []appsv1.Deployment{newDeployment(depName1, labels1)}
+			c.Services = []corev1.Service{newService(serviceName1, labels2)}
+			wcc.Service.Name = serviceName1
+			depName, serviceName := findMatchingDeploymentAndServiceForWebhook(c, wcc)
+			Expect(depName).To(BeEmpty())
+			Expect(serviceName).To(Equal(serviceName1))
+		})
+
+		By("parsing one deployment and one service with two intersecting labels")
+		It("returns the first service and no deployment", func() {
+			labels1 := map[string]string{"operator-name": "test-operator", "foo": "bar"}
+			labels2 := map[string]string{"foo": "bar", "baz": "bat"}
+			c.Deployments = []appsv1.Deployment{newDeployment(depName1, labels1)}
+			c.Services = []corev1.Service{newService(serviceName1, labels2)}
+			wcc.Service.Name = serviceName1
+			depName, serviceName := findMatchingDeploymentAndServiceForWebhook(c, wcc)
+			Expect(depName).To(BeEmpty())
+			Expect(serviceName).To(Equal(serviceName1))
+		})
+	})
+})
+
+func newDeployment(name string, labels map[string]string) appsv1.Deployment {
+	dep := appsv1.Deployment{}
+	dep.SetName(name)
+	dep.Spec.Template.SetLabels(labels)
+	return dep
+}
+
+func newService(name string, labels map[string]string) corev1.Service {
+	s := corev1.Service{}
+	s.SetName(name)
+	s.Spec.Selector = labels
+	return s
+}

--- a/internal/generate/collector/manifests.go
+++ b/internal/generate/collector/manifests.go
@@ -45,6 +45,7 @@ type Manifests struct {
 	ClusterRoleBindings              []rbacv1.ClusterRoleBinding
 	Deployments                      []appsv1.Deployment
 	ServiceAccounts                  []corev1.ServiceAccount
+	Services                         []corev1.Service
 	V1CustomResourceDefinitions      []apiextv1.CustomResourceDefinition
 	V1beta1CustomResourceDefinitions []apiextv1beta1.CustomResourceDefinition
 	ValidatingWebhooks               []admissionregv1.ValidatingWebhook
@@ -61,6 +62,7 @@ var (
 	roleBindingGK          = rbacv1.SchemeGroupVersion.WithKind("RoleBinding").GroupKind()
 	clusterRoleBindingGK   = rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding").GroupKind()
 	serviceAccountGK       = corev1.SchemeGroupVersion.WithKind("ServiceAccount").GroupKind()
+	serviceGK              = corev1.SchemeGroupVersion.WithKind("Service").GroupKind()
 	deploymentGK           = appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind()
 	crdGK                  = apiextv1.SchemeGroupVersion.WithKind("CustomResourceDefinition").GroupKind()
 	validatingWebhookCfgGK = admissionregv1.SchemeGroupVersion.WithKind("ValidatingWebhookConfiguration").GroupKind()
@@ -104,6 +106,8 @@ func (c *Manifests) UpdateFromDirs(deployDir, crdsDir string) error {
 				err = c.addClusterRoleBindings(manifest)
 			case serviceAccountGK:
 				err = c.addServiceAccounts(manifest)
+			case serviceGK:
+				err = c.addServices(manifest)
 			case deploymentGK:
 				err = c.addDeployments(manifest)
 			case crdGK:
@@ -172,6 +176,8 @@ func (c *Manifests) UpdateFromReader(r io.Reader) error {
 			err = c.addClusterRoleBindings(manifest)
 		case serviceAccountGK:
 			err = c.addServiceAccounts(manifest)
+		case serviceGK:
+			err = c.addServices(manifest)
 		case deploymentGK:
 			err = c.addDeployments(manifest)
 		case crdGK:
@@ -262,6 +268,18 @@ func (c *Manifests) addServiceAccounts(rawManifests ...[]byte) error {
 			return err
 		}
 		c.ServiceAccounts = append(c.ServiceAccounts, sa)
+	}
+	return nil
+}
+
+// addServices assumes all manifest data in rawManifests are Services and adds them to the collector.
+func (c *Manifests) addServices(rawManifests ...[]byte) error {
+	for _, rawManifest := range rawManifests {
+		s := corev1.Service{}
+		if err := yaml.Unmarshal(rawManifest, &s); err != nil {
+			return err
+		}
+		c.Services = append(c.Services, s)
 	}
 	return nil
 }

--- a/internal/generate/testdata/clusterserviceversions/output/memcached-operator.clusterserviceversion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/output/memcached-operator.clusterserviceversion.yaml
@@ -109,6 +109,10 @@ spec:
                 - /manager
                 image: controller:latest
                 name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
                 resources:
                   limits:
                     cpu: 100m
@@ -116,7 +120,16 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 20Mi
+                volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                  name: cert
+                  readOnly: true
               terminationGracePeriodSeconds: 10
+              volumes:
+              - name: cert
+                secret:
+                  defaultMode: 420
+                  secretName: webhook-server-cert
       permissions:
       - rules:
         - apiGroups:
@@ -170,3 +183,38 @@ spec:
     name: Provider Name
     url: https://your.domain
   version: 0.0.1
+  webhookdefinitions:
+  - admissionReviewVersions: null
+    deploymentName: memcached-operator-controller-manager
+    failurePolicy: Fail
+    generateName: vmemcached.kb.io
+    rules:
+    - apiGroups:
+      - cache.example.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - memcacheds
+    sideEffects: null
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-cache-my-domain-v1alpha1-memcached
+  - admissionReviewVersions: null
+    deploymentName: memcached-operator-controller-manager
+    failurePolicy: Fail
+    generateName: mmemcached.kb.io
+    rules:
+    - apiGroups:
+      - cache.example.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - memcacheds
+    sideEffects: null
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-cache-my-domain-v1alpha1-memcached

--- a/internal/generate/testdata/go/static/basic.operator.yaml
+++ b/internal/generate/testdata/go/static/basic.operator.yaml
@@ -62,6 +62,31 @@ status:
   conditions: []
   storedVersions: []
 ---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: memcached-operator-mutating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: memcached-operator-webhook-service
+      namespace: memcached-operator-system
+      path: /mutate-cache-my-domain-v1alpha1-memcached
+  failurePolicy: Fail
+  name: mmemcached.kb.io
+  rules:
+  - apiGroups:
+    - cache.example.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - memcacheds
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -206,6 +231,18 @@ spec:
   selector:
     control-plane: controller-manager
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: memcached-operator-webhook-service
+  namespace: memcached-operator-system
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -241,6 +278,10 @@ spec:
         - /manager
         image: controller:latest
         name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
         resources:
           limits:
             cpu: 100m
@@ -248,7 +289,16 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
       terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert
 ---
 apiVersion: cache.example.com/v1alpha1
 kind: Memcached
@@ -256,3 +306,28 @@ metadata:
   name: memcached-sample
 spec:
   foo: bar
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: memcached-operator-validating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: memcached-operator-webhook-service
+      namespace: memcached-operator-system
+      path: /validate-cache-my-domain-v1alpha1-memcached
+  failurePolicy: Fail
+  name: vmemcached.kb.io
+  rules:
+  - apiGroups:
+    - cache.example.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - memcacheds


### PR DESCRIPTION
**Description of the change:**
* internal/generate: set webhook deployment name by searching for deployments selected by webhook services

**Motivation for the change:** an element of a CSV's `spec.webhookDefinitions`'s deployment name was being inferred from the webhook config's service reference name, which often does not match the deployment's name. Instead, we can look up what service a webhook is using, then use the service's label selector to look up the deployment via labels on the pods for which the service will proxy.

/cc @varshaprasad96 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
