### PR TITLE
add e2e test for custom scorecard test

### DIFF
--- a/changelog/fragments/scorecard-custom-e2e.yaml
+++ b/changelog/fragments/scorecard-custom-e2e.yaml
@@ -1,4 +1,0 @@
-entries:
-  - description: Added a e2e test for scorecard custom test.
-    kind: change
-    breaking: false

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -29,7 +29,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
-	"github.com/operator-framework/operator-sdk/test/e2e"
 	kbtestutils "sigs.k8s.io/kubebuilder/test/e2e/utils"
 
 	testutils "github.com/operator-framework/operator-sdk/test/internal"
@@ -83,7 +82,7 @@ var _ = Describe("operator-sdk", func() {
 				"--domain", tc.Domain,
 				"--fetch-deps=false")
 			Expect(err).Should(Succeed())
-			err = e2e.AddScorecardCustomPatchFile()
+			err = tc.AddScorecardCustomPatchFile()
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating an API definition")

--- a/test/internal/scorecard-custom-patch.go
+++ b/test/internal/scorecard-custom-patch.go
@@ -14,7 +14,7 @@
 
 // Modified from https://github.com/kubernetes-sigs/kubebuilder/tree/39224f0/test/e2e/v3
 
-package e2e
+package internal
 
 import (
 	"fmt"
@@ -55,9 +55,9 @@ const customScorecardKustomize = `
     name: config
 `
 
-func ScorecardAddCustomPatchFile(projectName string) error {
+func (tc TestContext) AddScorecardCustomPatchFile() error {
 	// drop in the patch file
-	customScorecardPatchFile := filepath.Join(projectName, "config", "scorecard", "patches", "custom.config.yaml")
+	customScorecardPatchFile := filepath.Join(tc.Dir, "config", "scorecard", "patches", "custom.config.yaml")
 	patchBytes := []byte(customScorecardPatch)
 	err := ioutil.WriteFile(customScorecardPatchFile, patchBytes, 0777)
 	if err != nil {
@@ -66,7 +66,7 @@ func ScorecardAddCustomPatchFile(projectName string) error {
 	}
 
 	// append to config/scorecard/kustomization.yaml
-	kustomizeFile := filepath.Join(projectName, "config", "scorecard", "kustomization.yaml")
+	kustomizeFile := filepath.Join(tc.Dir, "config", "scorecard", "kustomization.yaml")
 	f, err := os.OpenFile(kustomizeFile, os.O_APPEND|os.O_WRONLY, 0777)
 	if err != nil {
 		fmt.Printf("error in opening scorecard kustomization.yaml file %s\n", err.Error())


### PR DESCRIPTION


**Description of the change:**
add a e2e test for scorecard custom image

**Motivation for the change:**

needed an e2e test to insure the custom image is working as expected.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
