### PR TITLE
Bugfix: Helm operator: add finalizers permission for created APIs

### DIFF
--- a/changelog/fragments/helm-roles-permissions.yaml
+++ b/changelog/fragments/helm-roles-permissions.yaml
@@ -2,7 +2,7 @@
 # release notes and/or the migration guide
 entries:
   - description: >
-      In Helm projects, fix operator permissions for Openshift deployments by adding a `<resource>/finalizers` rule in the operator's role and to the resources `serviceaccounts` and `services`.
+      In Helm projects, fix operator permissions for Openshift deployments by adding a `<resource>/finalizers` rule in the operator's role.
 
     # kind is one of:
     # - addition
@@ -14,20 +14,3 @@ entries:
 
     # Is this a breaking change?
     breaking: no
-
-    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
-    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
-    #
-    # The generator auto-detects the PR number from the commit
-    # message in which this file was originally added.
-    #
-    # What is the pull request number (without the "#")?
-    # pull_request_override: 0
-
-
-    # Migration can be defined to automatically add a section to
-    # the migration guide. This is required for breaking changes.
-    migration:
-      header: Header text for the migration section
-      body: >
-        Body of the migration section.

--- a/changelog/fragments/helm-roles-permissions.yaml
+++ b/changelog/fragments/helm-roles-permissions.yaml
@@ -13,4 +13,4 @@ entries:
     kind: "bugfix"
 
     # Is this a breaking change?
-    breaking: no
+    breaking: false

--- a/changelog/fragments/helm-roles-permissions.yaml
+++ b/changelog/fragments/helm-roles-permissions.yaml
@@ -1,0 +1,33 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      In Helm projects, fix operator permissions for Openshift deployments by adding a `<resource>/finalizers` rule in the operator's role and to the resources `serviceaccounts` and `services`.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: no
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: Header text for the migration section
+      body: >
+        Body of the migration section.

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/config/rbac/role.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/config/rbac/role.go
@@ -111,6 +111,8 @@ rules:
       - pods
       - pods/exec
       - pods/log
+      - serviceaccounts
+      - services
     verbs:
       - create
       - delete
@@ -145,6 +147,7 @@ const rulesFragment = `  ##
     resources:
       - {{.Resource.Plural}}
       - {{.Resource.Plural}}/status
+      - {{.Resource.Plural}}/finalizers
     verbs:
       - create
       - delete

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/config/rbac/role.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/config/rbac/role.go
@@ -111,8 +111,6 @@ rules:
       - pods
       - pods/exec
       - pods/log
-      - serviceaccounts
-      - services
     verbs:
       - create
       - delete


### PR DESCRIPTION
**Description of the change:**
Users identified that the tool was not scaffolding RBAC permissions which are required for the Helm operator works successfully in OCP.

**Motivation for the change:**

Closes: #3767