### PR TITLE
.github/ISSUE_TEMPLATE: update template comments and add language labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -9,42 +9,55 @@ assignees: ''
 
 ## Bug Report
 
-<!-- 
-Note: Make sure to first check the prerequisites that can be found in the main README file!
-
+<!--
 Thanks for filing an issue! Before hitting the button, please answer these questions.
 Fill in as much of the template below as you can. If you leave out information, we can't help you as well.
+
+Note: Make sure to first check the prerequisites that can be found in the main README.md file!
 -->
 
-**What did you do?**
-A clear and concise description of the steps you took (or insert a code snippet).
+#### What did you do?
 
-**What did you expect to see?**
-A clear and concise description of what you expected to happen (or insert a code snippet).
+<!-- A clear and concise description of the steps you took (or insert a code snippet). -->
 
-**What did you see instead? Under which circumstances?**
-A clear and concise description of what you expected to happen (or insert a code snippet).
+#### What did you expect to see?
 
+<!-- A clear and concise description of what you expected to happen (or insert a code snippet). -->
 
-**Environment**
-* operator-sdk version:
+#### What did you see instead? Under which circumstances?
 
-<!--- Insert operator-sdk release or Git SHA here. -->
+<!-- A clear and concise description of what you expected to happen (or insert a code snippet). -->
 
-* go version:
+#### Environment
 
-<!--- Insert the output of `go version` here -->
+**Operator type:**
 
-* Kubernetes version information:
+<!-- Uncomment one or more of the following lines corresponding to the language of the operator type -->
 
-<!--- Insert the output of `kubectl version` here -->
+<!-- /language go -->
+<!-- /language ansible -->
+<!-- /language helm -->
 
-* Kubernetes cluster kind: 
+**Kubernetes cluster type:**
 
-* Are you writing your operator in ansible, helm, or go?
+<!-- The type of cluster used for testing/deployment, ex. "vanilla", "OpenShift" -->
 
-**Possible Solution**
-<!--- Only if you have suggestions on a fix for the bug -->
+`$ operator-sdk version`
 
-**Additional context**
-Add any other context about the problem here.
+<!-- Insert the output of `operator-sdk version` here. -->
+
+`$ go version` (if language is Go)
+
+<!-- Insert the output of `go version` here -->
+
+`$ kubectl version`
+
+<!-- Insert the output of `kubectl version` here -->
+
+#### Possible Solution
+
+<!-- Only if you have suggestions on a fix for the bug -->
+
+#### Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -9,8 +9,20 @@ assignees: ''
 
 ## Feature Request
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Example: "I have an issue when (...)"
+#### Describe the problem you need a feature to resolve.
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen. Add any considered drawbacks.
+<!--
+A clear and concise description of what the problem is. Example:
+
+I have an issue when ...
+-->
+
+#### Describe the solution you'd like.
+
+<!-- A clear and concise description of what you want to happen. Add any considered drawbacks. -->
+
+<!-- If your request relates to a particular operator type, uncomment one or more of the following lines corresponding to the language of that type -->
+
+<!-- /language go -->
+<!-- /language ansible -->
+<!-- /language helm -->

--- a/.github/ISSUE_TEMPLATE/support-question.md
+++ b/.github/ISSUE_TEMPLATE/support-question.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-<!-- 
+<!--
 Thanks for filing an issue! Before hitting the button, please answer these questions.
 
 Fill in as much of the template below as you can. If you leave out information, we can't help you as well.
@@ -17,31 +17,53 @@ We will try our best to answer the question, but we also have a mailing list and
 
 ## Type of question
 
-**Are you asking about community best practices, how to implement a specific feature, or about general context and help around the operator-sdk?**
+<!-- Uncomment one or more of the following lines depending on what you are asking about: -->
 
+<!-- Best practices -->
+<!-- How to implement a specific feature -->
+<!-- General operator-related help -->
+<!-- Open question -->
 
 ## Question
 
-**What did you do?**
-A clear and concise description of the steps you took (or insert a code snippet).
+#### What did you do?
 
-**What did you expect to see?**
-A clear and concise description of what you expected to happen (or insert a code snippet).
+<!-- A clear and concise description of the steps you took (or insert a code snippet). -->
 
-**What did you see instead? Under which circumstances?**
-A clear and concise description of what you expected to happen (or insert a code snippet).
+#### What did you expect to see?
 
+<!-- A clear and concise description of what you expected to happen (or insert a code snippet). -->
 
-**Environment**
-* operator-sdk version:
+#### What did you see instead? Under which circumstances?
 
-  insert release or Git SHA here
+<!-- A clear and concise description of what you expected to happen (or insert a code snippet). -->
 
-* Kubernetes version information:
+#### Environment
 
-  insert output of `kubectl version` here
+**Operator type:**
 
-* Kubernetes cluster kind: 
+<!-- Uncomment one or more of the following lines corresponding to the language of the operator type -->
 
-**Additional context**
-Add any other context about the question here.
+<!-- /language go -->
+<!-- /language ansible -->
+<!-- /language helm -->
+
+**Kubernetes cluster type:**
+
+<!-- The type of cluster used for testing/deployment, ex. "vanilla", "OpenShift" -->
+
+`$ operator-sdk version`
+
+<!-- Insert the output of `operator-sdk version` here. -->
+
+`$ go version` (if language is Go)
+
+<!-- Insert the output of `go version` here -->
+
+`$ kubectl version`
+
+<!-- Insert the output of `kubectl version` here -->
+
+#### Additional context
+
+<!-- Add any other context about the question here. -->


### PR DESCRIPTION
**Description of the change:** update template comments and add language labels

**Motivation for the change:** all issues should now have a language label corresponding to operator type.

/cc @joelanford @camilamacedo86 @jmrodri 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
