### PR TITLE
internal/olm/operator: do not suppress the real error

### DIFF
--- a/changelog/fragments/return-olm-install-error.yaml
+++ b/changelog/fragments/return-olm-install-error.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      `olm` and `run` subcommands will print aggregated resource errors when either OLM or an operator fail to install, respectively.
+    kind: change
+

--- a/internal/olm/installer/client.go
+++ b/internal/olm/installer/client.go
@@ -80,11 +80,11 @@ func (c Client) InstallVersion(ctx context.Context, namespace, version string) (
 
 	status := c.GetObjectsStatus(ctx, objs...)
 	installed, err := status.HasInstalledResources()
-	if installed {
+	if err != nil {
+		return nil, fmt.Errorf("detected errored OLM resources: %v", err)
+	} else if installed {
 		return nil, errors.New(
 			"detected existing OLM resources: OLM must be completely uninstalled before installation")
-	} else if err != nil {
-		return nil, errors.New("detected errored OLM resources, see resource statuses for more details")
 	}
 
 	log.Print("Creating CRDs and resources")
@@ -165,7 +165,9 @@ func (c Client) GetStatus(ctx context.Context, namespace, version string) (*olmr
 
 	status := c.GetObjectsStatus(ctx, objs...)
 	installed, err := status.HasInstalledResources()
-	if !installed && err == nil {
+	if err != nil {
+		return nil, fmt.Errorf("the OLM installation has resource errors: %v", err)
+	} else if !installed {
 		return nil, olmresourceclient.ErrOLMNotInstalled
 	}
 	return &status, nil


### PR DESCRIPTION
**Description of the change:**
Returning the real errors occurred in installing the operator is useful
for debugging the failures.

**Motivation of the change:**
When the operator installation failed due to CRD parsing failures but the logs showed no clues of that error.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:

- [ ] Add a new changelog fragment in changelog/fragments (see changelog/fragments/00-template.yaml)
- [ ]  Add or update relevant sections of the docs website in website/content/en/docs