### PR TITLE
MD5 out... in with SHA256

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,4 +24,11 @@ issues:
   exclude-rules:
     - linters:
       - gosec
+      # these exclusion rules are for current failures in the code base for gosec which are
+      # excluded for future PRs which include:
+      # G110: Potential DoS vulnerability via decompression bomb
+      # G204: Audit use of command execution
+      # G306: Poor file permissions used when writing to a new file
+      # G404: Insecure random number source (rand)
+      # G601: Implicit memory aliasing of items from a range statement
       text: "G110|G601|G404|G204|G306"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,3 +19,9 @@ linters:
     - gosimple
     - unconvert
     - gocyclo
+    - gosec
+issues:
+  exclude-rules:
+    - linters:
+      - gosec
+      text: "G110|G601|G404|G204|G306"

--- a/internal/olm/operator/registry/configmap/configmap.go
+++ b/internal/olm/operator/registry/configmap/configmap.go
@@ -120,7 +120,7 @@ func makeObjectFileName(b []byte, names ...string) string {
 	return fileName + "yaml"
 }
 
-// hashContents creates a base32-encoded md5 digest of b's bytes.
+// hashContents creates a sha256 digest of b's bytes.
 func hashContents(b []byte) string {
 	h := sha256.New()
 	_, _ = h.Write(b)

--- a/internal/olm/operator/registry/configmap/configmap.go
+++ b/internal/olm/operator/registry/configmap/configmap.go
@@ -16,7 +16,7 @@ package configmap
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/base32"
 	"fmt"
 	"strings"
@@ -122,7 +122,7 @@ func makeObjectFileName(b []byte, names ...string) string {
 
 // hashContents creates a base32-encoded md5 digest of b's bytes.
 func hashContents(b []byte) string {
-	h := md5.New()
+	h := sha256.New()
 	_, _ = h.Write(b)
 	enc := base32.StdEncoding.WithPadding(base32.NoPadding)
 	return enc.EncodeToString(h.Sum(nil))


### PR DESCRIPTION
This is a move away from MD5 which is known to be [broken](https://www.md5online.org/blog/why-md5-is-not-safe/).   This was discussed on a thread on [slack](https://kubernetes.slack.com/archives/C017UU45SHL/p1596812929074800), with this being the recommended solution.   Additionally the original [PR](https://github.com/operator-framework/operator-sdk/pull/3683)  was closed and could not be reopened after a rebase... that PR has several threads of conversation which I think have been resolved but should be considered as part of the reivew.

**Description of the change:**

1. MD5 replaced with sha256
2. lint checker added to make sure md5 isn't used in the future

**Motivation for the change:**

MD5 has been publicly reported as [broken](https://www.md5online.org/blog/why-md5-is-not-safe/) since 2010

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Signed-off-by: Ken Sipe kensipe@gmail.com