### PR TITLE
Make bundle validate subcommand respect verbosity

### DIFF
--- a/changelog/fragments/bundle-validate-verbose.yaml
+++ b/changelog/fragments/bundle-validate-verbose.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: Fixed debug logging in the `bundle validate` subcommand of `operator-sdk`
+    kind: "bugfix"
+    breaking: false

--- a/internal/cmd/operator-sdk/bundle/validate.go
+++ b/internal/cmd/operator-sdk/bundle/validate.go
@@ -97,11 +97,7 @@ func makeValidateCmd() *cobra.Command {
 			// Note that it allows the JSON result be redirected to the Stdout. E.g
 			// if we run the command with `| jq . > result.json` the command will print just the logs
 			// and the file will have only the JSON result.
-			logger := log.NewEntry(internal.NewLoggerTo(os.Stderr))
-			if viper.GetBool(flags.VerboseOpt) {
-				logger.Logger.SetLevel(log.DebugLevel)
-			}
-
+			logger := createLogger(viper.GetBool(flags.VerboseOpt))
 			if err = c.validate(args); err != nil {
 				return fmt.Errorf("invalid command args: %v", err)
 			}
@@ -123,6 +119,15 @@ func makeValidateCmd() *cobra.Command {
 	c.addToFlagSet(cmd.Flags())
 
 	return cmd
+}
+
+// createLogger creates a new logrus Entry that is optionally verbose.
+func createLogger(verbose bool) *log.Entry {
+	logger := log.NewEntry(internal.NewLoggerTo(os.Stderr))
+	if verbose {
+		logger.Logger.SetLevel(log.DebugLevel)
+	}
+	return logger
 }
 
 // validate verifies the command args

--- a/internal/cmd/operator-sdk/bundle/validate.go
+++ b/internal/cmd/operator-sdk/bundle/validate.go
@@ -93,15 +93,14 @@ func makeValidateCmd() *cobra.Command {
 		Use:   "validate",
 		Short: "Validate an operator bundle",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			if viper.GetBool(flags.VerboseOpt) {
-				log.SetLevel(log.DebugLevel)
-			}
-
 			// Always print non-output logs to stderr as to not pollute actual command output.
 			// Note that it allows the JSON result be redirected to the Stdout. E.g
 			// if we run the command with `| jq . > result.json` the command will print just the logs
 			// and the file will have only the JSON result.
 			logger := log.NewEntry(internal.NewLoggerTo(os.Stderr))
+			if viper.GetBool(flags.VerboseOpt) {
+				logger.Logger.SetLevel(log.DebugLevel)
+			}
 
 			if err = c.validate(args); err != nil {
 				return fmt.Errorf("invalid command args: %v", err)

--- a/internal/cmd/operator-sdk/bundle/validate_test.go
+++ b/internal/cmd/operator-sdk/bundle/validate_test.go
@@ -18,6 +18,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/operator-framework/operator-sdk/internal/cmd/operator-sdk/bundle/internal"
+	log "github.com/sirupsen/logrus"
 )
 
 var _ = Describe("Running a bundle validate command", func() {
@@ -35,6 +36,19 @@ var _ = Describe("Running a bundle validate command", func() {
 			Expect(flag).NotTo(BeNil())
 			Expect(flag.Shorthand).To(Equal("o"))
 			Expect(flag.DefValue).To(Equal(internal.Text))
+		})
+	})
+
+	Describe("Creating a logger", func() {
+		It("that is Info Level when not verbose", func() {
+			verbose := false
+			logger := createLogger(verbose)
+			Expect(logger.Logger.GetLevel()).To(Equal(log.InfoLevel))
+		})
+		It("that is Debug level if verbose", func() {
+			verbose := true
+			logger := createLogger(verbose)
+			Expect(logger.Logger.GetLevel()).To(Equal(log.DebugLevel))
 		})
 	})
 


### PR DESCRIPTION
Make bundle validate subcommand respect verbosity

This makes the `bundle validate` subcommand respect the verbosity level
by setting it directly in the logger that's actually used, and not in
the global logger as was done previously.

Closes: #3793