### PR TITLE
Make `bundle validate` subcommand respect verbosity

### DIFF
--- a/cmd/operator-sdk/bundle/validate.go
+++ b/cmd/operator-sdk/bundle/validate.go
@@ -123,15 +123,14 @@ func makeValidateCmd() *cobra.Command {
 		Use:   "validate",
 		Short: "Validate an operator bundle",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			if viper.GetBool(flags.VerboseOpt) {
-				log.SetLevel(log.DebugLevel)
-			}
-
 			// Always print non-output logs to stderr as to not pollute actual command output.
 			// Note that it allows the JSON result be redirected to the Stdout. E.g
 			// if we run the command with `| jq . > result.json` the command will print just the logs
 			// and the file will have only the JSON result.
 			logger := log.NewEntry(internal.NewLoggerTo(os.Stderr))
+			if viper.GetBool(flags.VerboseOpt) {
+				logger.Logger.SetLevel(log.DebugLevel)
+			}
 
 			if err = c.validate(args); err != nil {
 				return fmt.Errorf("invalid command args: %v", err)


### PR DESCRIPTION
Make bundle validate subcommand respect verbosity

This makes the `bundle validate` subcommand respect the verbosity level
by setting it directly in the logger that's actually used, and not in
the global logger as was done previously.

Closes: #3793

Note that this applies to v0.19.x