### PR TITLE
Updates the incorrect import for the memcache controller example

### DIFF
--- a/example/memcached-operator/memcached_controller.go.tmpl
+++ b/example/memcached-operator/memcached_controller.go.tmpl
@@ -28,7 +28,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	cachev1alpha1 "github.com/example-inc/memcached-operator/api/v1alpha1"
+	cachev1alpha1 "github.com/example-inc/memcached-operator/pkg/apis/cache/v1alpha1"
 )
 
 // MemcachedReconciler reconciles a Memcached object


### PR DESCRIPTION
Signed-off-by: sujil02 <sujil.shah@gmail.com>


Welcome to the Operator SDK! Before contributing, make sure to:


**Description of the change:**

- incorrect import for the Memcache controller example

**Motivation for the change:**

- Learning how to write GO operators and operator test cases. The import for the controller SDK example did not work for me. Took me a while to figure it out. 