### PR TITLE
remove definition of namespace scope from CRD scope section.

### DIFF
--- a/website/content/en/docs/building-operators/golang/crds-scope.md
+++ b/website/content/en/docs/building-operators/golang/crds-scope.md
@@ -7,7 +7,7 @@ weight: 60
 ## Overview
 
 The CustomResourceDefinition (CRD) scope can also be changed for cluster-scoped operators so that there is only a single 
-instance (for a given name) of the CRD to manage across the cluster.
+instance (for a given name) of the Custom Resource (CR) to manage across the cluster.
 
 The CRD manifests are generated in `config/crd/bases`. For each CRD that needs to be cluster-scoped, its manifest 
 should specify `spec.scope: Cluster`.
@@ -16,12 +16,7 @@ To ensure that the CRD is always generated with `scope: Cluster`, add the marker
 `// +kubebuilder:resource:path=<resource>,scope=Cluster`, or if already present replace `scope={Namespaced -> Cluster}`, 
 above the CRD's Go type definition in `api/<version>/<kind>_types.go` or `apis/<group>/<version>/<kind>_types.go` 
 if you are using the `multigroup` layout. Note that the `<resource>` 
-element must be the same lower-case plural value of the CRD's Kind, `spec.names.plural`. 
-
-## CRD cluster-scoped usage 
-
-A cluster scope is ideal for operators that manage custom resources (CR's) that can be created in more than 
-one namespace in a cluster. 
+element must be the same lower-case plural value of the CRD's Kind, `spec.names.plural`.  
 
 **NOTE**: When a `Manager` instance is created in the `main.go` file, it receives the namespace(s) as Options. 
 These namespace(s) should be watched and cached for the Client which is provided by the Controllers. Only clients 

--- a/website/content/en/docs/building-operators/golang/crds-scope.md
+++ b/website/content/en/docs/building-operators/golang/crds-scope.md
@@ -20,7 +20,7 @@ element must be the same lower-case plural value of the CRD's Kind, `spec.names.
 
 **NOTE**: When a `Manager` instance is created in the `main.go` file, it receives the namespace(s) as Options. 
 These namespace(s) should be watched and cached for the Client which is provided by the Controllers. Only clients 
-provided by cluster-scoped projects where the `Namespace` attribute is `""` will be able to manage cluster-scoped CRD's. 
+provided by cluster-scoped projects where the `Namespace` attribute is `""` will be able to manage cluster-scoped CRs. 
 For more information see the [Manager][manager_user_guide] topic in the user guide and the 
 [Manager Options][manager_options].
 


### PR DESCRIPTION
**Description of the change:**
To eliminate confusion, remove definition of namespace scope from CRD scope section


**Motivation for the change:**
Definition of cluster-scoped CRD was incorrect and caused confusion.