### PR TITLE
For Ansible-based Operator, add .gitignore file which was missing.

### DIFF
--- a/changelog/fragments/ansible-gitignore.yaml
+++ b/changelog/fragments/ansible-gitignore.yaml
@@ -2,7 +2,7 @@
 # release notes and/or the migration guide
 entries:
   - description: >
-      For Ansible-based Operator, add `.gitignore` file which was missing.
+      For Ansible-based Operator, add `.gitignore` file.
 
     # kind is one of:
     # - addition
@@ -10,7 +10,7 @@ entries:
     # - deprecation
     # - removal
     # - bugfix
-    kind: "bugfix"
+    kind: "addition"
 
     # Is this a breaking change?
     breaking: false

--- a/changelog/fragments/ansible-gitignore.yaml
+++ b/changelog/fragments/ansible-gitignore.yaml
@@ -1,0 +1,16 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For Ansible-based Operator, add `.gitignore` file which was missing.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/plugins/ansible/v1/scaffolds/init.go
+++ b/internal/plugins/ansible/v1/scaffolds/init.go
@@ -80,6 +80,7 @@ func (s *initScaffolder) scaffold() error {
 	return machinery.NewScaffold().Execute(
 		s.newUniverse(),
 		&templates.Dockerfile{},
+		&templates.GitIgnore{},
 		&templates.RequirementsYml{},
 		&templates.Watches{},
 

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/gitignore.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/gitignore.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &GitIgnore{}
+
+// GitIgnore scaffolds the .gitignore file
+type GitIgnore struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *GitIgnore) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = ".gitignore"
+	}
+
+	f.TemplateBody = gitignoreTemplate
+
+	return nil
+}
+
+const gitignoreTemplate = `
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+bin
+
+# Test binary, build with ` + "`go test -c`" + `
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Kubernetes Generated files - skip generated files, except for vendored files
+
+!vendor/**/zz_generated.*
+
+# editor and IDE paraphernalia
+.idea
+*.swp
+*.swo
+*~
+`

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/gitignore.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/gitignore.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Modifications copyright 2020 The Operator-SDK Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/gitignore.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/gitignore.go
@@ -47,16 +47,6 @@ const gitignoreTemplate = `
 *.dylib
 bin
 
-# Test binary, build with ` + "`go test -c`" + `
-*.test
-
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
-
-# Kubernetes Generated files - skip generated files, except for vendored files
-
-!vendor/**/zz_generated.*
-
 # editor and IDE paraphernalia
 .idea
 *.swp


### PR DESCRIPTION
**Description of the change:**
- For Ansible-based Operator, add `.gitignore` file which was missing.

**Motivation for the change:**
- Following the good practices, users should not commit the binaries that are added to the bin/ dir. 
- Keep all projects/types following the same standard. 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [X] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
