### PR TITLE
cleanup: helm gitignore

### DIFF
--- a/changelog/fragments/helm-gitignore.yaml
+++ b/changelog/fragments/helm-gitignore.yaml
@@ -1,0 +1,16 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For Helm-based Operators, cleanup the file `.gitignore` in order to not have invalid instructions for the type.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/gitignore.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/gitignore.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Modifications copyright 2020 The Operator-SDK Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -46,16 +47,6 @@ const gitignoreTemplate = `
 *.so
 *.dylib
 bin
-
-# Test binary, build with ` + "`go test -c`" + `
-*.test
-
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
-
-# Kubernetes Generated files - skip generated files, except for vendored files
-
-!vendor/**/zz_generated.*
 
 # editor and IDE paraphernalia
 .idea


### PR DESCRIPTION
**Description of the change:**
- For Helm-based Operators, cleanup the file `.gitignore` in order to not have invalid instructions for the type.

**Motivation for the change:**
- keep standard across the project
- helm operator has no go files and should not have its instructions in the gitignore as well. 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [X] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
