### PR TITLE
Use rpm installed setuptools

### DIFF
--- a/hack/image/ansible/Dockerfile
+++ b/hack/image/ansible/Dockerfile
@@ -16,7 +16,8 @@ ENV HOME=/opt/ansible \
 RUN yum clean all && rm -rf /var/cache/yum/* \
  && yum -y update \
  && yum install -y libffi-devel openssl-devel python36-devel gcc python3-pip python3-setuptools \
- && pip3 install --no-cache-dir --ignore-installed ipaddress \
+ && pip3 install --no-cache-dir \
+      ipaddress \
       ansible-runner==1.3.4 \
       ansible-runner-http==1.0.0 \
       openshift~=0.10.0 \


### PR DESCRIPTION
Using `--ignore-installed` with pip causes it to ignore the fact that
setuptools has already been installed by rpm. This results in the newest
version of setuptools (50.0.0) to be pulled in.

Setuptools 50 includes a backwards incompatible change to the way that
non-binary installs happen, which breaks the installation of
`ruamel.yaml.clib` on architectures that must install from source
because there is not a built wheel.