### PR TITLE
[run bundle] refactor catalog source and registry pod creation

### DIFF
--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -18,10 +18,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/operator-framework/operator-sdk/internal/olm/operator"
 	"github.com/operator-framework/operator-sdk/internal/olm/operator/registry/index"
@@ -50,40 +51,24 @@ func (c IndexImageCatalogCreator) CreateCatalog(ctx context.Context, name string
 		return nil, fmt.Errorf("get database path: %v", err)
 	}
 
-	fmt.Printf("IndexImageCatalogCreator.IndexImage:        %q\n", c.IndexImage)
-	fmt.Printf("IndexImageCatalogCreator.IndexImageDBPath:  %v\n", dbPath)
-	fmt.Printf("IndexImageCatalogCreator.InjectBundles:     %q\n", strings.Join(c.InjectBundles, ","))
-	fmt.Printf("IndexImageCatalogCreator.InjectBundleMode:  %q\n", c.InjectBundleMode)
-
 	// create a basic catalog source type
 	cs := newCatalogSource(name, c.cfg.Namespace,
 		withSDKPublisher(c.PackageName))
 
-	// initialize and create the registry pod with provided index image
-	registryPod, err := c.createRegistryPod(ctx, dbPath)
+	// create catalog source resource
+	if err := c.cfg.Client.Create(ctx, cs); err != nil {
+		return nil, fmt.Errorf("error creating catalog source: %v", err)
+	}
+
+	// create registry pod
+	pod, err := c.createRegistryPod(ctx, dbPath, cs)
 	if err != nil {
-		return nil, fmt.Errorf("error in creating registry pod: %v", err)
-	}
-
-	// get registry pod i.e corev1.Pod type
-	pod, err := registryPod.GetPod()
-	if err != nil {
-		return nil, fmt.Errorf("error in getting registry pod: %v", err)
-	}
-
-	// make catalog source the owner of registry pod object
-	if err := controllerutil.SetOwnerReference(cs, pod, c.cfg.Scheme); err != nil {
-		return nil, fmt.Errorf("error in setting registry pod owner reference: %v", err)
-	}
-
-	// wait for registry pod to be running
-	if err := registryPod.VerifyPodRunning(ctx); err != nil {
-		return nil, fmt.Errorf("registry pod is not running: %v", err)
+		return nil, fmt.Errorf("error creating registry pod: %v", err)
 	}
 
 	// update catalog source with source type, address and annotations
-	if err := c.updateCatalogSource(pod.Status.PodIP, cs); err != nil {
-		return nil, fmt.Errorf("error in updating catalog source: %v", err)
+	if err := c.updateCatalogSource(ctx, pod.Status.PodIP, cs); err != nil {
+		return nil, fmt.Errorf("error updating catalog source: %v", err)
 	}
 
 	return cs, nil
@@ -102,35 +87,64 @@ func (c IndexImageCatalogCreator) getDBPath(ctx context.Context) (string, error)
 	return defaultDBPath, nil
 }
 
-func (c IndexImageCatalogCreator) createRegistryPod(ctx context.Context, dbPath string) (*index.RegistryPod, error) {
-	// Create registry pod, assigning its owner as the catalog source
-	registryPod, err := index.NewRegistryPod(c.cfg.Client, dbPath, c.BundleImage, c.cfg.Namespace)
+func (c IndexImageCatalogCreator) createRegistryPod(ctx context.Context, dbPath string, cs *v1alpha1.CatalogSource) (*corev1.Pod, error) {
+	// Initialize registry pod
+	registryPod, err := index.NewRegistryPod(c.cfg, dbPath, c.BundleImage)
 	if err != nil {
-		return nil, fmt.Errorf("error in initializing registry pod")
+		return nil, fmt.Errorf("error initializing registry pod: %v", err)
 	}
 
-	if err = registryPod.Create(ctx); err != nil {
-		return nil, fmt.Errorf("error in creating registry pod")
+	var pod *corev1.Pod
+	// Create registry pod
+	if pod, err = registryPod.Create(ctx, cs); err != nil {
+		return nil, fmt.Errorf("error creating registry pod: %v", err)
 	}
 
-	return registryPod, nil
+	return pod, nil
 }
 
-func (c IndexImageCatalogCreator) updateCatalogSource(podAddr string, cs *v1alpha1.CatalogSource) error {
-	// Update catalog source with source type as grpc and address to point to the pod IP
-	cs.Spec.SourceType = v1alpha1.SourceTypeGrpc
-	cs.Spec.Address = index.GetRegistryPodHost(podAddr)
-
-	// Update catalog source with annotations for index image,
-	// injected bundle, and registry add mode
+func (c IndexImageCatalogCreator) updateCatalogSource(ctx context.Context, podAddr string, cs *v1alpha1.CatalogSource) error {
+	// JSON marshal injected bundles
 	injectedBundlesJSON, err := json.Marshal(c.InjectBundles)
 	if err != nil {
-		return fmt.Errorf("error in json marshal injected bundles: %v", err)
+		return fmt.Errorf("error marshaling injected bundles: %v", err)
 	}
-	cs.ObjectMeta.Annotations = map[string]string{
+
+	// Get catalog source key
+	catsrcKey := types.NamespacedName{
+		Namespace: cs.GetNamespace(),
+		Name:      cs.GetName(),
+	}
+
+	// Annotations for catalog source
+	annotationMapping := map[string]string{
 		"operators.operatorframework.io/index-image":        c.IndexImage,
 		"operators.operatorframework.io/inject-bundle-mode": c.InjectBundleMode,
 		"operators.operatorframework.io/injected-bundles":   string(injectedBundlesJSON),
+	}
+	// Update catalog source with source type as grpc and address as the pod IP,
+	// and annotations for index image, injected bundles, and registry bundle add mode
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := c.cfg.Client.Get(ctx, catsrcKey, cs); err != nil {
+			return fmt.Errorf("error getting catalog source: %v", err)
+		}
+		cs.Spec.Address = index.GetRegistryPodHost(podAddr)
+		cs.Spec.SourceType = v1alpha1.SourceTypeGrpc
+		annotations := cs.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string, len(annotationMapping))
+		}
+		for k, v := range annotationMapping {
+			annotations[k] = v
+		}
+		cs.SetAnnotations(annotations)
+
+		if err := c.cfg.Client.Update(ctx, cs); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("error setting grpc source type and address for catalog source: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
- Few minor fixes to get catalog source create, wait and update working correctly for run bundle subcommand
- Tested these changes manually by running the command and it works correctly
- Leaving watiForCatalogSource() function commented out for now