### PR TITLE
Fixes annotations on Ansible development tips

### DIFF
--- a/website/content/en/docs/building-operators/ansible/development-tips.md
+++ b/website/content/en/docs/building-operators/ansible/development-tips.md
@@ -177,7 +177,7 @@ has some mandatory fields:
 - `spec`:  This is the key-value list of variables which are passed to Ansible.
   This field is optional and empty by default.
 - `annotations`: Kubernetes specific annotations to be appended to the CR. See
-  the below section for Ansible Operator specific annotations.
+  the below section for Ansible Operator specific annotations. This field is optional.
 
 #### Annotations for Custom Resource
 
@@ -197,8 +197,8 @@ This is the list of CR annotations which will modify the behavior of the operato
   kind: Foo
   metadata:
     name: example
-  annotations:
-    ansible.operator-sdk/reconcile-period: "30s"
+    annotations:
+      ansible.operator-sdk/reconcile-period: "30s"
   ```
 
 Note that a lower period will correct entropy more quickly, but reduce


### PR DESCRIPTION
**Description of the change:**
Documentation Change
Fixes #3833

**Motivation for the change:**
Incorrect snippet

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [X] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [X] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
