### PR TITLE
[run bundle] Install plan generation and approval for subscription

### DIFF
--- a/internal/cmd/operator-sdk/run/cmd.go
+++ b/internal/cmd/operator-sdk/run/cmd.go
@@ -34,7 +34,7 @@ Currently only the package manifests format is supported via the 'packagemanifes
 
 	cmd.AddCommand(
 		// TODO(joelanford): enable bundle command when implementation is complete
-		//bundle.NewCmd(),
+		// bundle.NewCmd(cfg),
 		packagemanifests.NewCmd(cfg),
 	)
 

--- a/internal/olm/operator/bundle/install.go
+++ b/internal/olm/operator/bundle/install.go
@@ -79,7 +79,7 @@ func (i *Install) setup(ctx context.Context) error {
 	i.OperatorInstaller.CatalogSourceName = fmt.Sprintf("%s-catalog", i.OperatorInstaller.PackageName)
 	i.OperatorInstaller.StartingCSV = csv.Name
 	i.OperatorInstaller.Channel = strings.Split(labels["operators.operatorframework.io.bundle.channels.v1"], ",")[0]
-
+	i.IndexImageCatalogCreator.BundleImage = i.BundleImage
 	i.IndexImageCatalogCreator.PackageName = i.OperatorInstaller.PackageName
 	i.IndexImageCatalogCreator.InjectBundles = []string{i.BundleImage}
 	i.IndexImageCatalogCreator.InjectBundleMode = "replaces"

--- a/internal/olm/operator/registry/catalog.go
+++ b/internal/olm/operator/registry/catalog.go
@@ -23,8 +23,3 @@ import (
 type CatalogCreator interface {
 	CreateCatalog(ctx context.Context, name string) (*v1alpha1.CatalogSource, error)
 }
-
-// TODO: modify this as necessary.
-type InstallPlanApprover interface {
-	Approve(ctx context.Context, name string) error
-}

--- a/internal/olm/operator/registry/olm_resources.go
+++ b/internal/olm/operator/registry/olm_resources.go
@@ -48,6 +48,17 @@ func withPackageChannel(pkgName, channelName, startingCSV string) func(*v1alpha1
 	}
 }
 
+// withInstallPlanApproval sets the Subscription's install plan approval field
+// to manual
+func withInstallPlanApproval(approval v1alpha1.Approval) func(*v1alpha1.Subscription) {
+	return func(sub *v1alpha1.Subscription) {
+		if sub.Spec == nil {
+			sub.Spec = &v1alpha1.SubscriptionSpec{}
+		}
+		sub.Spec.InstallPlanApproval = approval
+	}
+}
+
 // newSubscription creates a new Subscription for a CSV with a name derived
 // from csvName, the CSV's objectmeta.name, in namespace. opts will be applied
 // to the Subscription object.


### PR DESCRIPTION
**Description of the change:**
- Change subscription approval to manual
- Verify install plan generation for the subscription
- Approve install plan for CSV generation

**Motivation for the change:**
- We don't want the subscription approval to be automatic and would want to change the approval to manual and be able to  approve the install plan that's generated for that subscription which enables us to install and deploy the operator version we intend to run

/cc @joelanford @jmrodri @estroz @bharathi-tenneti 

