### PR TITLE
Include 0.19.x stream in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,8 +241,6 @@
 
 ## v0.19.1
 
-## v0.19.1
-
 ### Additions
 
 - Added the `--from-version` flag to `generate packagemanifests`. ([#3524](https://github.com/operator-framework/operator-sdk/pull/3524))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,29 @@
 - The `scorecard` subcommand now removes existing pods if the `--wait-time` deadline is exceeded and `--skip-cleanup=false` (the default). Fixes [#3419](https://github.com/operator-framework/operator-sdk/issues/3419). ([#3526](https://github.com/operator-framework/operator-sdk/pull/3526))
 - Fixed a bug in scorecard that caused tests to fail with permission errors when loading the bundle. ([#3428](https://github.com/operator-framework/operator-sdk/pull/3428))
 
+## v0.19.3
+
+### Changes
+
+- **Breaking change**: Changed the `go.operator-sdk.io` plugin to only write a `plugins` PROJECT field and run the OLM integration plugin if the project version is "3-alpha" or above. ([#3716](https://github.com/operator-framework/operator-sdk/pull/3716))
+- Fix CVE-2020-14040 by upgrading to golang.org/x/text v0.3.3. ([#3459](https://github.com/operator-framework/operator-sdk/pull/3459))
+
+### Bug Fixes
+
+- Fixed debug logging in the `bundle validate` subcommand of `operator-sdk`. ([#3812](https://github.com/operator-framework/operator-sdk/pull/3812))
+- Fixed incorrect (cluster) role name assignments in generated CSVs [#3600](https://github.com/operator-framework/operator-sdk/issues/3600). ([#3714](https://github.com/operator-framework/operator-sdk/pull/3714))
+- Fixed issue that caused scorecard to fail loading local bundle due to a bug search method for the bundle metadata directory. ([#3829](https://github.com/operator-framework/operator-sdk/pull/3829))
+- Stop reconciling tasks when the event raised is a rescue in Ansible-based Operators.  More info: [Bugzilla 1856714](https://bugzilla.redhat.com/show_bug.cgi?id=1856714). ([#3727](https://github.com/operator-framework/operator-sdk/pull/3727))
+
+## v0.19.2
+
+### Changes
+
+- The `generate bundle` subcommand no longer requires a default channel be set nor defaults to the first channel provided to `--channels`. ([#3605](https://github.com/operator-framework/operator-sdk/pull/3605))
+- The `bundle validate` subcommand no longer returns an error if a bundle does not have a default channel. ([#3605](https://github.com/operator-framework/operator-sdk/pull/3605))
+
+## v0.19.1
+
 ## v0.19.1
 
 ### Additions


### PR DESCRIPTION
All of the 0.19.x changes were cherry-picked, so the entries will be duplicates. 
Still, it's nice to have the complete changelog in a single file.