### PR TITLE
bugfix: use the tags in the scorecard scaffolded manifests

### DIFF
--- a/changelog/fragments/scorecard_scaffolded_version.yaml
+++ b/changelog/fragments/scorecard_scaffolded_version.yaml
@@ -2,7 +2,7 @@
 # release notes and/or the migration guide
 entries:
   - description: >
-      Scaffold scorecard manifests with the tags releases.
+      When scaffolding scorecard configurations, use release versions instead of `latest` in image tags.
 
     # kind is one of:
     # - addition
@@ -14,4 +14,3 @@ entries:
 
     # Is this a breaking change?
     breaking: false
-

--- a/changelog/fragments/scorecard_scaffolded_version.yaml
+++ b/changelog/fragments/scorecard_scaffolded_version.yaml
@@ -1,0 +1,17 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Scaffold scorecard manifests with the tags releases.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false
+

--- a/internal/plugins/scorecard/init.go
+++ b/internal/plugins/scorecard/init.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/operator-framework/operator-sdk/internal/plugins/util/kustomize"
 	"github.com/operator-framework/operator-sdk/internal/scorecard"
+	"github.com/operator-framework/operator-sdk/internal/version"
 )
 
 const (
@@ -54,16 +56,15 @@ patchesJson6902:
 )
 
 const (
-	// defaultTestImageTag points to the latest-released image.
-	// TODO: change the tag to "latest" once config scaffolding is in a release,
-	// as the new config spec won't work with the current latest image.
-	defaultTestImageTag = "quay.io/operator-framework/scorecard-test:master"
-
 	// defaultConfigName is the default scorecard componentconfig's metadata.name,
 	// which must be set on all kustomize-able bases. This name is only used for
 	// `kustomize build` pattern match and not for on-cluster creation.
 	defaultConfigName = "config"
 )
+
+// defaultTestImageTag points to the latest-released image.
+var defaultTestImageTag = fmt.Sprintf("quay.io/operator-framework/scorecard-test:%s",
+	strings.TrimSuffix(version.Version, "+git"))
 
 // defaultDir is the default directory in which to generate kustomize bases and the kustomization.yaml.
 var defaultDir = filepath.Join("config", "scorecard")


### PR DESCRIPTION
**Description of the change:**
- Scorecard manifests created using the image with tags. 

**Motivation for the change:**

Closes: https://github.com/operator-framework/operator-sdk/issues/3840

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [X] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
