### PR TITLE
internal/cmd: add git commit logging in run subcommand

### DIFF
--- a/changelog/fragments/ansible-helm-commit-info.yaml
+++ b/changelog/fragments/ansible-helm-commit-info.yaml
@@ -1,0 +1,7 @@
+entries:
+  - description: >
+      In `ansible-operator` and `helm-operator` run commands, print git commit
+      when logging version information.
+
+    kind: "change"
+    breaking: false

--- a/internal/cmd/ansible-operator/run/cmd.go
+++ b/internal/cmd/ansible-operator/run/cmd.go
@@ -55,7 +55,8 @@ func printVersion() {
 		"Go Version", runtime.Version(),
 		"GOOS", runtime.GOOS,
 		"GOARCH", runtime.GOARCH,
-		"ansible-operator", sdkVersion.Version)
+		"ansible-operator", sdkVersion.Version,
+		"commit", sdkVersion.GitCommit)
 }
 
 func NewCmd() *cobra.Command {

--- a/internal/cmd/helm-operator/run/cmd.go
+++ b/internal/cmd/helm-operator/run/cmd.go
@@ -47,7 +47,8 @@ func printVersion() {
 		"Go Version", runtime.Version(),
 		"GOOS", runtime.GOOS,
 		"GOARCH", runtime.GOARCH,
-		"helm-operator", sdkVersion.Version)
+		"helm-operator", sdkVersion.Version,
+		"commit", sdkVersion.GitCommit)
 }
 
 func NewCmd() *cobra.Command {


### PR DESCRIPTION
**Description of the change:**
Add git commit logging to helm and ansible operator run commands

**Motivation for the change:**
Better traceability for versioning

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] ~Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)~
