### PR TITLE
removed customer-scorecard-tests binary that was inadvertly added

### DIFF
--- a/hack/image/build-custom-scorecard-tests-image.sh
+++ b/hack/image/build-custom-scorecard-tests-image.sh
@@ -2,7 +2,12 @@
 
 set -eux
 
+source hack/lib/test_lib.sh
 source hack/lib/image_lib.sh
+
+ROOTDIR="$(pwd)"
+TMPDIR="$(mktemp -d)"
+trap_add 'rm -rf $TMPDIR' EXIT
 
 # build scorecard test image
 WD="$(dirname "$(pwd)")"
@@ -10,12 +15,14 @@ GOOS=linux CGO_ENABLED=0 \
   go build \
   -gcflags "all=-trimpath=${WD}" \
   -asmflags "all=-trimpath=${WD}" \
-  -o images/custom-scorecard-tests/custom-scorecard-tests \
+  -o $TMPDIR/custom-scorecard-tests \
   images/custom-scorecard-tests/cmd/test/main.go
 
 # Build base image
-pushd images/custom-scorecard-tests
-docker build -t "$1" .
+pushd $TMPDIR
+cp -r $ROOTDIR/images/custom-scorecard-tests/bin .
+
+docker build -f $ROOTDIR/images/custom-scorecard-tests/Dockerfile -t $1 .
 # If using a kind cluster, load the image into all nodes.
 load_image_if_kind "$1"
 popd

--- a/hack/image/build-scorecard-test-image.sh
+++ b/hack/image/build-scorecard-test-image.sh
@@ -2,7 +2,12 @@
 
 set -eux
 
+source hack/lib/test_lib.sh
 source hack/lib/image_lib.sh
+
+ROOTDIR="$(pwd)"
+TMPDIR="$(mktemp -d)"
+trap_add 'rm -rf $TMPDIR' EXIT
 
 # build scorecard test image
 WD="$(dirname "$(pwd)")"
@@ -10,12 +15,14 @@ GOOS=linux CGO_ENABLED=0 \
   go build \
   -gcflags "all=-trimpath=${WD}" \
   -asmflags "all=-trimpath=${WD}" \
-  -o images/scorecard-test/scorecard-test \
+  -o $TMPDIR/scorecard-test \
   images/scorecard-test/cmd/test/main.go
 
 # Build base image
-pushd images/scorecard-test
-docker build -t "$1" .
+pushd $TMPDIR
+cp -r $ROOTDIR/images/scorecard-test/bin .
+
+docker build -f $ROOTDIR/images/scorecard-test/Dockerfile -t $1 .
 # If using a kind cluster, load the image into all nodes.
 load_image_if_kind "$1"
 popd

--- a/hack/image/build-scorecard-test-kuttl-image.sh
+++ b/hack/image/build-scorecard-test-kuttl-image.sh
@@ -2,7 +2,12 @@
 
 set -eux
 
+source hack/lib/test_lib.sh
 source hack/lib/image_lib.sh
+
+ROOTDIR="$(pwd)"
+TMPDIR="$(mktemp -d)"
+trap_add 'rm -rf $TMPDIR' EXIT
 
 # build scorecard test kuttl image
 WD="$(dirname "$(pwd)")"
@@ -10,12 +15,14 @@ GOOS=linux CGO_ENABLED=0 \
   go build \
   -gcflags "all=-trimpath=${WD}" \
   -asmflags "all=-trimpath=${WD}" \
-  -o images/scorecard-test-kuttl/scorecard-test-kuttl \
+  -o $TMPDIR/scorecard-test-kuttl \
   images/scorecard-test-kuttl/cmd/test-kuttl/main.go
 
 # Build base image
-pushd images/scorecard-test-kuttl
-docker build -t "$1" .
+pushd $TMPDIR
+cp -r $ROOTDIR/images/scorecard-test-kuttl/bin .
+
+docker build -f $ROOTDIR/images/scorecard-test-kuttl/Dockerfile -t $1 .
 # If using a kind cluster, load the image into all nodes.
 load_image_if_kind "$1"
 popd


### PR DESCRIPTION


**Description of the change:**
this PR removes the binary for custom-scorecard-test that was added by mistake into the repo.

**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
