### PR TITLE
Ignore some untracked files

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -14,7 +14,7 @@ if ! [[ "$VER" =~ ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
 	exit 1
 fi
 
-if git ls-files --others | grep -Ev 'build/operator-sdk-v.+'; then
+if git ls-files --others  --exclude-standard | grep -Ev 'build/operator-sdk-v.+'; then
 	echo "directory has untracked files"
 	exit 1
 fi


### PR DESCRIPTION
Specifically, installing the docs locally generates files that trip up
this command.

I made this change to bring down a change from the 1.0+ [release script](https://github.com/operator-framework/operator-sdk/blob/master/release.sh#L20)