### PR TITLE
Makefile,internal/version: inject version based on git tree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ x_base_steps:
       # that it can properly exit the test early with success
       - source hack/ci/check-doc-only-update.sh
       - travis_retry make tidy
+      - git fetch origin --unshallow --tags
     install:
       - make install
       - make setup-k8s
@@ -63,10 +64,8 @@ x_base_steps:
   - &deploy
     before_install:
       - travis_retry make tidy
+      - git fetch origin --unshallow --tags
     install: make install
-    before_script:
-      - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
-      - git fetch --unshallow --tags
     after_success:
       - echo "Image build succeeded, and docker image tagged and pushed to repository"
     after_failure:
@@ -77,8 +76,7 @@ x_base_steps:
   # Manifest list deploy job
   - &manifest-deploy
     before_script:
-      - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
-      - git fetch --unshallow --tags
+      - git fetch origin --unshallow --tags
       # TODO: remove the chmod command when docker-ce on travis is upgraded to 18.09.0+.
       # We need /etc/docker to be accessible to non-root users.
       # See https://github.com/moby/moby/pull/37847.
@@ -106,6 +104,8 @@ jobs:
     # Run the sanity tests
     - stage: check
       name: Sanity Tests
+      before_install:
+        - git fetch origin --unshallow --tags
       script:
         - make test-sanity
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ else
   Q = @
 endif
 
-VERSION = $(shell git describe --dirty --tags --always)
+SIMPLE_VERSION=$(shell (test "$(shell git describe)" = "$(shell git describe --abbrev=0)" && echo $(shell git describe)) || echo $(shell git describe --abbrev=0)+git)
+GIT_VERSION = $(shell git describe --dirty --tags --always)
 GIT_COMMIT = $(shell git rev-parse HEAD)
 K8S_VERSION = v1.18.2
 GOLANGCI_LINT_VER = "1.30.0"
@@ -22,7 +23,8 @@ GO_BUILD_ARGS = \
   -gcflags "all=-trimpath=$(shell go env GOPATH)" \
   -asmflags "all=-trimpath=$(shell go env GOPATH)" \
   -ldflags " \
-    -X '$(REPO)/internal/version.GitVersion=$(VERSION)' \
+    -X '$(REPO)/internal/version.Version=$(SIMPLE_VERSION)' \
+    -X '$(REPO)/internal/version.GitVersion=$(GIT_VERSION)' \
     -X '$(REPO)/internal/version.GitCommit=$(GIT_COMMIT)' \
     -X '$(REPO)/internal/version.KubernetesVersion=$(K8S_VERSION)' \
   " \
@@ -119,21 +121,21 @@ gen-changelog: ## Generate CHANGELOG.md and migration guide updates
 .PHONY: release_builds release
 
 release_builds := \
-	build/operator-sdk-$(VERSION)-aarch64-linux-gnu \
-	build/operator-sdk-$(VERSION)-x86_64-linux-gnu \
-	build/operator-sdk-$(VERSION)-x86_64-apple-darwin \
-	build/operator-sdk-$(VERSION)-ppc64le-linux-gnu \
-	build/operator-sdk-$(VERSION)-s390x-linux-gnu \
-	build/ansible-operator-$(VERSION)-aarch64-linux-gnu \
-	build/ansible-operator-$(VERSION)-x86_64-linux-gnu \
-	build/ansible-operator-$(VERSION)-x86_64-apple-darwin \
-	build/ansible-operator-$(VERSION)-ppc64le-linux-gnu \
-	build/ansible-operator-$(VERSION)-s390x-linux-gnu \
-	build/helm-operator-$(VERSION)-aarch64-linux-gnu \
-	build/helm-operator-$(VERSION)-x86_64-linux-gnu \
-	build/helm-operator-$(VERSION)-x86_64-apple-darwin \
-	build/helm-operator-$(VERSION)-ppc64le-linux-gnu \
-	build/helm-operator-$(VERSION)-s390x-linux-gnu
+	build/operator-sdk-$(GIT_VERSION)-aarch64-linux-gnu \
+	build/operator-sdk-$(GIT_VERSION)-x86_64-linux-gnu \
+	build/operator-sdk-$(GIT_VERSION)-x86_64-apple-darwin \
+	build/operator-sdk-$(GIT_VERSION)-ppc64le-linux-gnu \
+	build/operator-sdk-$(GIT_VERSION)-s390x-linux-gnu \
+	build/ansible-operator-$(GIT_VERSION)-aarch64-linux-gnu \
+	build/ansible-operator-$(GIT_VERSION)-x86_64-linux-gnu \
+	build/ansible-operator-$(GIT_VERSION)-x86_64-apple-darwin \
+	build/ansible-operator-$(GIT_VERSION)-ppc64le-linux-gnu \
+	build/ansible-operator-$(GIT_VERSION)-s390x-linux-gnu \
+	build/helm-operator-$(GIT_VERSION)-aarch64-linux-gnu \
+	build/helm-operator-$(GIT_VERSION)-x86_64-linux-gnu \
+	build/helm-operator-$(GIT_VERSION)-x86_64-apple-darwin \
+	build/helm-operator-$(GIT_VERSION)-ppc64le-linux-gnu \
+	build/helm-operator-$(GIT_VERSION)-s390x-linux-gnu
 
 release: clean $(release_builds) $(release_builds:=.asc) ## Release the Operator SDK
 

--- a/internal/cmd/operator-sdk/version/cmd.go
+++ b/internal/cmd/operator-sdk/version/cmd.go
@@ -35,10 +35,6 @@ func NewCmd() *cobra.Command {
 }
 
 func run() {
-	version := ver.GitVersion
-	if version == "unknown" {
-		version = ver.Version
-	}
 	fmt.Printf("operator-sdk version: %q, commit: %q, kubernetes version: %q, go version: %q, GOOS: %q, GOARCH: %q\n",
-		version, ver.GitCommit, ver.KubernetesVersion, ver.GoVersion, runtime.GOOS, runtime.GOARCH)
+		ver.GitVersion, ver.GitCommit, ver.KubernetesVersion, ver.GoVersion, runtime.GOOS, runtime.GOARCH)
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -21,7 +21,7 @@ import (
 
 //var needs to be used instead of const for ldflags
 var (
-	Version           = "v1.0.0+git"
+	Version           = "unknown"
 	GitVersion        = "unknown"
 	GitCommit         = "unknown"
 	KubernetesVersion = "unknown"

--- a/website/content/en/docs/contribution-guidelines/release.md
+++ b/website/content/en/docs/contribution-guidelines/release.md
@@ -249,7 +249,6 @@ $ GEN_CHANGELOG_TAG=v1.3.0 make gen-changelog
 
 Commit the following changes:
 
-- `internal/version/version.go`: update `Version` to `v1.3.0`.
 - `website/content/en/docs/installation/install-operator-sdk.md`: update the linux and macOS URLs to point to the new release URLs.
 - `CHANGELOG.md`: commit changes (updated by changelog generation).
 - `website/content/en/docs/upgrading-sdk-version/v1.3.0.md`: commit changes (created by changelog generation).
@@ -327,7 +326,6 @@ $ git push -f upstream v1.3.x
 
 Check out a new branch from `master` or release branch and commit the following changes:
 
-- `internal/version/version.go`: update `Version` to `v1.3.0+git`.
 - **(Major and minor releases only)** `website/config.toml`: update `version_menu = "v1.3"` to `version_menu = "Releases"`.
 
 ---


### PR DESCRIPTION
**Description of the change:**
Remove hard-coded version string in `internal/version/version.go`

This is an initial fully-backward compatible change for other code within the SDK that depends on this value (e.g. scaffolding image reference tags based on the SDK version). In a future PR, we could probably remove `internal/version.Version` entirely and depend only on `internal/version.GitVersion`

**Motivation for the change:**
We can automatically inject the correct string based on reading the git tree when building from the Makefile. This reduces the number of steps and manual changes that are necessary as part of the release process.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] ~Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))~
- [ ] ~Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)~
