### PR TITLE
:book: fix broken links

### DIFF
--- a/website/content/en/docs/building-operators/golang/project_migration_guide.md
+++ b/website/content/en/docs/building-operators/golang/project_migration_guide.md
@@ -363,7 +363,7 @@ E.g `kubectl logs deployment.apps/memcached-operator-controller-manager -n memca
 [ginkgo]: https://onsi.github.io/ginkgo/
 [gomega]: https://onsi.github.io/gomega/
 [builder]: https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.1/pkg/builder?tab=doc
-[writing-controller-tests]: https://book.kubebuilder.io/reference/writing-tests.html?highlight=controller,test#writing-controller-tests
+[writing-controller-tests]: https://book.kubebuilder.io/cronjob-tutorial/writing-tests.html
 [openapi-gen]: https://github.com/kubernetes/kube-openapi/tree/master/cmd/openapi-gen 
 [controller-runtime-leader]: https://godoc.org/sigs.k8s.io/controller-runtime/pkg/manager#LeaderElectionRunnable
 [operator-lib]: https://github.com/operator-framework/operator-lib/

--- a/website/content/en/docs/upgrading-sdk-version/v1.0.0-alpha.1.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.0.0-alpha.1.md
@@ -29,7 +29,7 @@ The following subcommands were removed:
 | `operator-sdk migrate`        | Removed support for hybrid operators, no migration                                                       | [#3385](https://github.com/operator-framework/operator-sdk/pull/3385)
 | `operator-sdk print-deps`     | Removed, no migration                                                                                    | [#3385](https://github.com/operator-framework/operator-sdk/pull/3385)
 | `operator-sdk run local`      | Use `make run`                                                                                           | [#3406](https://github.com/operator-framework/operator-sdk/pull/3406)
-| `operator-sdk test`           | Use controller-runtime's [envtest](https://book.kubebuilder.io/reference/testing/envtest.html) framework | [#3409](https://github.com/operator-framework/operator-sdk/pull/3409)
+| `operator-sdk test`           | Use controller-runtime's [envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.2/pkg/envtest?tab=doc) framework | [#3409](https://github.com/operator-framework/operator-sdk/pull/3409)
 
 ## Useful libraries have been split out into a separate repository
 

--- a/website/content/en/docs/upgrading-sdk-version/v1.0.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.0.0.md
@@ -178,7 +178,7 @@ The following subcommands were removed:
 | `operator-sdk migrate`        | Removed support for hybrid operators, no migration                                                       | [#3385](https://github.com/operator-framework/operator-sdk/pull/3385)
 | `operator-sdk print-deps`     | Removed, no migration                                                                                    | [#3385](https://github.com/operator-framework/operator-sdk/pull/3385)
 | `operator-sdk run local`      | Use `make run`                                                                                           | [#3406](https://github.com/operator-framework/operator-sdk/pull/3406)
-| `operator-sdk test`           | Use controller-runtime's [envtest](https://book.kubebuilder.io/reference/testing/envtest.html) framework | [#3409](https://github.com/operator-framework/operator-sdk/pull/3409)
+| `operator-sdk test`           | Use controller-runtime's [envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.2/pkg/envtest?tab=doc) framework | [#3409](https://github.com/operator-framework/operator-sdk/pull/3409)
 
 ### Useful libraries have been split out into a separate repository
 


### PR DESCRIPTION
The updates on the Writing tests docs in upstream were published in prod which causes the broken link in the CI. 