### PR TITLE
Drop the use of memecached in Go migration docs

### DIFF
--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -172,7 +172,7 @@ To update `config/rbac/role.yaml` after changing the markers, run `make manifest
 
 By default, new projects are cluster-scoped (i.e. they have cluster-scoped permissions and watch all namespaces). Read the [operator scope documentation][operator-scope] for more information about changing the scope of your operator.
 
-See the complete migrated `memecached_controller.go` code [here][memcached_controller].
+See the complete migrated `memcached_controller.go` code [here][memcached_controller].
 
 ## Migrate `main.go`
 


### PR DESCRIPTION
**Description of the change:**

Replace "memecached" with "memcached"

**Motivation for the change:**

I like memes as much as anyone, but they probably don't belong in this particular documentation page.

**Checklist**

I don't think this issue warrants a changelog entry.