### PR TITLE
e2e: use regex replace to forcibly replace scaffolded Dockerfile base image strings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,12 @@ linters:
     - gosec
 issues:
   exclude-rules:
+    # Allow dot imports for ginkgo and gomega
+    - source: ginkgo|gomega
+      linters:
+      - golint
+      text: "should not use dot imports"
+
     - linters:
       - gosec
       # these exclusion rules are for current failures in the code base for gosec which are

--- a/internal/cmd/operator-sdk/bundle/internal/result_test.go
+++ b/internal/cmd/operator-sdk/bundle/internal/result_test.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/onsi/ginkgo" //nolint:golint
-	. "github.com/onsi/gomega" //nolint:golint
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/test/e2e-ansible/e2e_ansible_suite_test.go
+++ b/test/e2e-ansible/e2e_ansible_suite_test.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/operator-framework/operator-sdk/internal/version"
 	testutils "github.com/operator-framework/operator-sdk/test/internal"
 )
 
@@ -114,8 +113,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).Should(Succeed())
 
 	By("replacing project Dockerfile to use ansible base image with the dev tag")
-	version := strings.TrimSuffix(version.Version, "+git")
-	testutils.ReplaceInFile(filepath.Join(tc.Dir, "Dockerfile"), version, "dev")
+	testutils.ReplaceRegexInFile(filepath.Join(tc.Dir, "Dockerfile"), "quay.io/operator-framework/ansible-operator:.*", "quay.io/operator-framework/ansible-operator:dev")
 
 	By("adding Memcached mock task to the role")
 	testutils.ReplaceInFile(filepath.Join(tc.Dir, "roles", strings.ToLower(tc.Kind), "tasks", "main.yml"),

--- a/test/e2e-helm/e2e_helm_cluster_test.go
+++ b/test/e2e-helm/e2e_helm_cluster_test.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo" //nolint:golint
-	. "github.com/onsi/gomega" //nolint:golint
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	kbtestutils "sigs.k8s.io/kubebuilder/test/e2e/utils"
 
 	testutils "github.com/operator-framework/operator-sdk/test/internal"

--- a/test/e2e-helm/e2e_helm_local_test.go
+++ b/test/e2e-helm/e2e_helm_local_test.go
@@ -17,8 +17,8 @@ package e2e_helm_test
 import (
 	"os/exec"
 
-	. "github.com/onsi/ginkgo" //nolint:golint
-	. "github.com/onsi/gomega" //nolint:golint
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Running Helm projects", func() {

--- a/test/e2e-helm/e2e_helm_suite_test.go
+++ b/test/e2e-helm/e2e_helm_suite_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/operator-framework/operator-sdk/internal/version"
 	testutils "github.com/operator-framework/operator-sdk/test/internal"
 )
 
@@ -105,8 +104,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).Should(Succeed())
 
 	By("replacing project Dockerfile to use Helm base image with the dev tag")
-	version := strings.TrimSuffix(version.Version, "+git")
-	testutils.ReplaceInFile(filepath.Join(tc.Dir, "Dockerfile"), version, "dev")
+	testutils.ReplaceRegexInFile(filepath.Join(tc.Dir, "Dockerfile"), "quay.io/operator-framework/helm-operator:.*", "quay.io/operator-framework/helm-operator:dev")
 
 	By("checking the kustomize setup")
 	err = tc.Make("kustomize")

--- a/test/internal/utils.go
+++ b/test/internal/utils.go
@@ -20,11 +20,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
-	. "github.com/onsi/ginkgo" //nolint:golint
-	. "github.com/onsi/gomega" //nolint:golint
-
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	kbtestutils "sigs.k8s.io/kubebuilder/test/e2e/utils"
 )
 
@@ -101,6 +101,22 @@ func ReplaceInFile(path, old, new string) {
 	b, err := ioutil.ReadFile(path)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	s := strings.Replace(string(b), old, new, -1)
+	ExpectWithOffset(1, s).NotTo(Equal(string(b)), "No replacement occurred")
+	err = ioutil.WriteFile(path, []byte(s), info.Mode())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+}
+
+// ReplaceRegexInFile finds all strings that match `match` and replaces them
+// with `replace` in the file at path.
+func ReplaceRegexInFile(path, match, replace string) {
+	matcher, err := regexp.Compile(match)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	info, err := os.Stat(path)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	b, err := ioutil.ReadFile(path)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	s := matcher.ReplaceAllString(string(b), replace)
+	ExpectWithOffset(1, s).NotTo(Equal(string(b)), "No replacement occurred")
 	err = ioutil.WriteFile(path, []byte(s), info.Mode())
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 }


### PR DESCRIPTION
**Description of the change:**
Use regex replacement to forcibly replace scaffolded Dockerfile base image strings

(Also ignore dot imports of ginkgo and gomega when linting)

**Motivation for the change:**
Follow-up from #3854 to ensure latest changes are tested in e2e tests

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
