### PR TITLE
Fix Migration Guide link

### DIFF
--- a/changelog/fragments/fix-migration-guide-link.yaml
+++ b/changelog/fragments/fix-migration-guide-link.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Fix the migration guide link in the deprecation message of `operator-sdk`
+    kind: "bugfix"
+    breaking: false

--- a/cmd/operator-sdk/main.go
+++ b/cmd/operator-sdk/main.go
@@ -48,7 +48,7 @@ func main() {
 				"See `operator-sdk init -h` and the following doc on how to scaffold a new project:\n" +
 				"https://v0-19-x.sdk.operatorframework.io/docs/golang/quickstart/\n" +
 				"To migrate existing projects to the new layout see:\n" +
-				"https://v0-19-x.sdk.operatorframework.io/docs/golang/project_migration_guide/\n"
+				"https://sdk.operatorframework.io/docs/building-operators/golang/project_migration_guide/\n"
 			projutil.PrintDeprecationWarning(depMsg)
 		}
 		if err := cli.RunLegacy(); err != nil {

--- a/cmd/operator-sdk/main.go
+++ b/cmd/operator-sdk/main.go
@@ -48,7 +48,7 @@ func main() {
 				"See `operator-sdk init -h` and the following doc on how to scaffold a new project:\n" +
 				"https://v0-19-x.sdk.operatorframework.io/docs/golang/quickstart/\n" +
 				"To migrate existing projects to the new layout see:\n" +
-				"https://sdk.operatorframework.io/docs/golang/migration/project_migration_guide/\n"
+				"https://v0-19-x.sdk.operatorframework.io/docs/golang/project_migration_guide/\n"
 			projutil.PrintDeprecationWarning(depMsg)
 		}
 		if err := cli.RunLegacy(); err != nil {


### PR DESCRIPTION
Fixes #3862

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**This Change fixes the Link to project migration guide**


**Project Migration Guide link is broken.:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
