### PR TITLE
restrict autoprefixer version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [build]
   publish = "public"
   base = "website"
-  command = "cd themes/docsy && git submodule update -f --init && cd ../.. && npm install postcss-cli autoprefixer && hugo version && hugo"
+  command = "cd themes/docsy && git submodule update -f --init && cd ../.. && npm install postcss-cli autoprefixer@^9.0.0 && hugo version && hugo"
 
 # "production" environment specific build settings
 [build.environment]


### PR DESCRIPTION
Autoprefixer 10+ requires PostCSS 8+ which is not yet available.

Fixes #3882