### PR TITLE
change the operator pods' checking

### DIFF
--- a/internal/olm/client/client.go
+++ b/internal/olm/client/client.go
@@ -324,16 +324,14 @@ func (c Client) checkPodErrors(ctx context.Context, depSelectors *metav1.LabelSe
 	}
 	for _, p := range podList.Items {
 		for _, cs := range p.Status.ContainerStatuses {
-			if !cs.Ready {
-				if cs.State.Waiting != nil {
-					containerName := p.Name + ":" + cs.Name
-					podErr = append(podErr, podError{
-						resourceError{
-							name:  containerName,
-							issue: cs.State.Waiting.Message,
-						},
-					})
-				}
+			if !cs.Ready && cs.State.Waiting != nil {
+				containerName := p.Name + ":" + cs.Name
+				podErr = append(podErr, podError{
+					resourceError{
+						name:  containerName,
+						issue: cs.State.Waiting.Message,
+					},
+				})
 			}
 		}
 	}


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Adress some issues in the [merged PR 3819](https://github.com/operator-framework/operator-sdk/pull/3819)


**Motivation for the change:**

- `Succeeded` means the Pod finished and exited. For the operator pods, they should be running all the time to monitor the CRs, so, the expected status should be `Running`, not `Succeeded`.

- Sometimes, there are multi containers in a Pod. Should add the container name to distinguish them.


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
