### PR TITLE
Update advance topics

### DIFF
--- a/website/content/en/docs/building-operators/golang/advanced-topics.md
+++ b/website/content/en/docs/building-operators/golang/advanced-topics.md
@@ -53,7 +53,7 @@ To add a 3rd party resource to an operator, you must add it to the Manager's sch
 
 #### Register with the Manager's scheme
 
-Call the `AddToScheme()` function for your 3rd party resource and pass it the Manager's scheme via `mgr.GetScheme()` in `main.go`.
+Call the `AddToScheme()` function for your 3rd party resource and pass it the Manager's scheme via `mgr.GetScheme()` or `scheme` in `main.go`.
 Example:
 ```go
 import (

--- a/website/content/en/docs/building-operators/golang/advanced-topics.md
+++ b/website/content/en/docs/building-operators/golang/advanced-topics.md
@@ -44,7 +44,7 @@ import (
 func init() {
 
     // Setup Scheme for all resources
-    utilruntime.Must(cachev1alpha1.AddToScheme(mgr.GetScheme()))
+    utilruntime.Must(cachev1alpha1.AddToScheme(scheme))
     // +kubebuilder:scaffold:scheme
 }
 ```
@@ -64,9 +64,9 @@ func init() {
     ...
 
     // Adding the routev1
-    utilruntime.Must(clientgoscheme.AddToScheme(mgr.GetScheme()))
+    utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-    utilruntime.Must(routev1.AddToScheme(mgr.GetScheme()))
+    utilruntime.Must(routev1.AddToScheme(scheme))
     // +kubebuilder:scaffold:scheme
 
     ...


### PR DESCRIPTION
## Description of the change:
Update advance topic guide for golang developers

utilruntime.Must(routev1.AddToScheme(mgr.GetScheme())) to utilruntime.Must(clientgoscheme.AddToScheme(scheme))

## Motivation for the change:

Generated operator with operator-sdk has init function which already defines: utilruntime.Must(clientgoscheme.AddToScheme(scheme))
If want to add new schemes, we can follow the same pattern. instead of calledmgr.GetScheme()

## Checklist

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [X ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
