### PR TITLE
[v0.19.x] Relax csv name validation

### DIFF
--- a/changelog/fragments/relax-csv-name-validation-v0.19.x.yaml
+++ b/changelog/fragments/relax-csv-name-validation-v0.19.x.yaml
@@ -3,6 +3,6 @@
 entries:
   - description: >
       Resolved an issue that caused bundle validation to unnecessarily restrict CSV names
-      to a specific format.
+      to a specific format. Now, only DNS-1123 subdomain validity is verified.
     kind: "bugfix"
     breaking: false

--- a/changelog/fragments/relax-csv-name-validation-v0.19.x.yaml
+++ b/changelog/fragments/relax-csv-name-validation-v0.19.x.yaml
@@ -1,0 +1,8 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Resolved an issue that caused bundle validation to unnecessarily restrict CSV names
+      to a specific format.
+    kind: "bugfix"
+    breaking: false

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
-	github.com/operator-framework/api v0.3.8
+	github.com/operator-framework/api v0.3.13
 	github.com/operator-framework/operator-registry v1.13.4
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -765,6 +765,8 @@ github.com/operator-framework/api v0.3.7-0.20200602203552-431198de9fc2 h1:2KtDe3
 github.com/operator-framework/api v0.3.7-0.20200602203552-431198de9fc2/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
 github.com/operator-framework/api v0.3.8 h1:tJykTCmwGKZBsPVTCfxbwz6nTF6dzmKydWJtC40erc8=
 github.com/operator-framework/api v0.3.8/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
+github.com/operator-framework/api v0.3.13 h1:Rg+6sdgP7KMOUGNP83s+5gPo7IwTH3mZ85ZFml9SPXY=
+github.com/operator-framework/api v0.3.13/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
 github.com/operator-framework/operator-registry v1.13.4 h1:GH7essHnVRP4kYgAWYV9obsS0Cnaj/KjT3BmQXmKAOE=
 github.com/operator-framework/operator-registry v1.13.4/go.mod h1:YhnIzOVjRU2ZwZtzt+fjcjW8ujJaSFynBEu7QVKaSdU=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=

--- a/go.sum
+++ b/go.sum
@@ -763,8 +763,6 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/operator-framework/api v0.3.7-0.20200602203552-431198de9fc2 h1:2KtDe3jI6ftXGj5M875WVvv6pBIk4K9DyrwPuE+XfOc=
 github.com/operator-framework/api v0.3.7-0.20200602203552-431198de9fc2/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
-github.com/operator-framework/api v0.3.8 h1:tJykTCmwGKZBsPVTCfxbwz6nTF6dzmKydWJtC40erc8=
-github.com/operator-framework/api v0.3.8/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
 github.com/operator-framework/api v0.3.13 h1:Rg+6sdgP7KMOUGNP83s+5gPo7IwTH3mZ85ZFml9SPXY=
 github.com/operator-framework/api v0.3.13/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
 github.com/operator-framework/operator-registry v1.13.4 h1:GH7essHnVRP4kYgAWYV9obsS0Cnaj/KjT3BmQXmKAOE=

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [build]
   publish = "public"
   base = "website"
-  command = "cd themes/docsy && git submodule update -f --init && cd ../.. && npm install postcss-cli autoprefixer && hugo version && hugo"
+  command = "cd themes/docsy && git submodule update -f --init && cd ../.. && npm install postcss-cli autoprefixer@^9.0.0 && hugo version && hugo"
 
 # "production" environment specific build settings
 [build.environment]


### PR DESCRIPTION
**Description of the change:**
Bump to operator-framework/api v0.3.13

**Motivation for the change:**
Resolved an issue that caused bundle validation to unnecessarily restrict CSV names to a specific format.

Now bundle validation applies the same CSV name validation as the kubernetes API server does (i.e. must be a DNS1123 subdomain)

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
