### PR TITLE
Relax csv name validation

### DIFF
--- a/changelog/fragments/relax-csv-name-validation.yaml
+++ b/changelog/fragments/relax-csv-name-validation.yaml
@@ -3,6 +3,6 @@
 entries:
   - description: >
       Resolved an issue that caused bundle validation to unnecessarily restrict CSV names
-      to a specific format.
+      to a specific format. Now, only DNS-1123 subdomain validity is verified.
     kind: "bugfix"
     breaking: false

--- a/changelog/fragments/relax-csv-name-validation.yaml
+++ b/changelog/fragments/relax-csv-name-validation.yaml
@@ -1,0 +1,8 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Resolved an issue that caused bundle validation to unnecessarily restrict CSV names
+      to a specific format.
+    kind: "bugfix"
+    breaking: false

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/markbates/inflect v1.0.4
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
-	github.com/operator-framework/api v0.3.12-0.20200731162302-333d0644352a
+	github.com/operator-framework/api v0.3.13
 	github.com/operator-framework/operator-lib v0.1.0
 	github.com/operator-framework/operator-registry v1.13.4
 	github.com/prometheus/client_golang v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -573,8 +573,8 @@ github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.m
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/operator-framework/api v0.3.7-0.20200602203552-431198de9fc2/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
-github.com/operator-framework/api v0.3.12-0.20200731162302-333d0644352a h1:x/oRKFmHiAAkNUNEeVcmlCfSFcJBtWSuWT7UcrnqQ7U=
-github.com/operator-framework/api v0.3.12-0.20200731162302-333d0644352a/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
+github.com/operator-framework/api v0.3.13 h1:Rg+6sdgP7KMOUGNP83s+5gPo7IwTH3mZ85ZFml9SPXY=
+github.com/operator-framework/api v0.3.13/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
 github.com/operator-framework/operator-lib v0.1.0 h1:7Qy6v2ZccvCeFLWEkrGnN+U+DkaeIWp0gAZaBM9T3DI=
 github.com/operator-framework/operator-lib v0.1.0/go.mod h1:HLw61JTIEeq0YLeVf4dwYx/zt4DmLGZUVWI1y3Lf5Hg=
 github.com/operator-framework/operator-registry v1.13.4 h1:GH7essHnVRP4kYgAWYV9obsS0Cnaj/KjT3BmQXmKAOE=


### PR DESCRIPTION
**Description of the change:**
Bump to operator-framework/api v0.3.13

**Motivation for the change:**
Resolved an issue that caused bundle validation to unnecessarily restrict CSV names to a specific format.

Now bundle validation applies the same CSV name validation as the kubernetes API server does (i.e. must be a DNS1123 subdomain)

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
