### PR TITLE
remove references to --manifests command in generate packagemanifest docs

### DIFF
--- a/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
+++ b/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
@@ -39,8 +39,7 @@ it with OLM. This command generates a set of manifests in a versioned directory 
 your operator. Typically one would run 'generate kustomize manifests' first to (re)generate kustomize bases
 consumed by this command.
 
-Set '--version' to supply a semantic version for your new package. This is a required flag when running
-'generate packagemanifests --manifests'.
+Set '--version' to supply a semantic version for your new package.
 
 More information on the package manifests format:
 https://github.com/operator-framework/operator-registry/#manifest-format
@@ -61,7 +60,7 @@ https://github.com/operator-framework/operator-registry/#manifest-format
   ├── bases
   │   └── memcached-operator.clusterserviceversion.yaml
   └── kustomization.yaml
-  $ kustomize build config/manifests | operator-sdk generate packagemanifests --manifests --version 0.0.1
+  $ kustomize build config/manifests | operator-sdk generate packagemanifests --version 0.0.1
   Generating package manifests version 0.0.1
   ...
 

--- a/website/content/en/docs/cli/operator-sdk_generate_packagemanifests.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_packagemanifests.md
@@ -16,8 +16,7 @@ it with OLM. This command generates a set of manifests in a versioned directory 
 your operator. Typically one would run 'generate kustomize manifests' first to (re)generate kustomize bases
 consumed by this command.
 
-Set '--version' to supply a semantic version for your new package. This is a required flag when running
-'generate packagemanifests --manifests'.
+Set '--version' to supply a semantic version for your new package.
 
 More information on the package manifests format:
 https://github.com/operator-framework/operator-registry/#manifest-format
@@ -45,7 +44,7 @@ operator-sdk generate packagemanifests [flags]
   ├── bases
   │   └── memcached-operator.clusterserviceversion.yaml
   └── kustomization.yaml
-  $ kustomize build config/manifests | operator-sdk generate packagemanifests --manifests --version 0.0.1
+  $ kustomize build config/manifests | operator-sdk generate packagemanifests --version 0.0.1
   Generating package manifests version 0.0.1
   ...
 


### PR DESCRIPTION
Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

**Description of the change:**
Quick change to docs which makes reference to a flag `--manifests` which doesn't seem to exist in the `generate packagemanifests` action anymorew.

```
Flags:
      --channel string         Channel name for the generated package
      --crds-dir string        Root directory for CustomResoureDefinition manifests
      --default-channel        Use the channel passed to --channel as the package manifest file's default channel
      --deploy-dir string      Root directory for operator manifests such as Deployments and RBAC, ex. 'deploy'. This directory is different from that passed to --input-dir
      --from-version string    Semantic version of the operator being upgraded from
  -h, --help                   help for packagemanifests
      --input-dir string       Directory to read existing package manifests from. This directory is the parent of individual versioned package directories, and different from --deploy-dir
      --kustomize-dir string   Directory containing kustomize bases and a kustomization.yaml for operator-framework manifests (default "config/manifests")
      --output-dir string      Directory in which to write package manifests
  -q, --quiet                  Run in quiet mode
      --stdout                 Write package to stdout
      --update-objects         Update non-CSV objects in this package, ex. CustomResoureDefinitions, Roles (default true)
  -v, --version string         Semantic version of the packaged operator
```

**Motivation for the change:**
Cleaner docs!


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [X] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
