### PR TITLE
Bug 1879917: increase waiting time and add logs

### DIFF
--- a/changelog/fragments/olm-install.yaml
+++ b/changelog/fragments/olm-install.yaml
@@ -1,6 +1,5 @@
 entries:
   - description: >
-      Increase DefaultTimeout to 3 mins to fix the `context deadline exceeded` errors
-      See [Bug 1879917](https://bugzilla.redhat.com/show_bug.cgi?id=1879917).
+      Increase the default timeout of the `operator-sdk olm install` command from 2 to 3 mins to fix the `context deadline exceeded` error faced on OCP clusters. More info: [Bug 1879917](https://bugzilla.redhat.com/show_bug.cgi?id=1879917).
     kind: bugfix
     breaking: false

--- a/changelog/fragments/olm-install.yaml
+++ b/changelog/fragments/olm-install.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      Increase DefaultTimeout to 3 mins to fix the `context deadline exceeded` errors
+      See [Bug 1879917](https://bugzilla.redhat.com/show_bug.cgi?id=1879917).
+    kind: bugfix
+    breaking: false

--- a/internal/olm/client/status.go
+++ b/internal/olm/client/status.go
@@ -95,6 +95,7 @@ func (s Status) HasInstalledResources() (bool, error) {
 	})
 	for _, r := range s.Resources {
 		if r.Resource != nil {
+			log.Infof("Exists olm resource:%v, project:%v, GVK:%v", r.Resource, r.NamespacedName, r.GVK)
 			return true, nil
 		} else if r.Error != nil && !apierrors.IsNotFound(r.Error) {
 			// We know the error is not a "resource not found" error at this point.

--- a/internal/olm/client/status.go
+++ b/internal/olm/client/status.go
@@ -93,10 +93,11 @@ func (s Status) HasInstalledResources() (bool, error) {
 	sort.Slice(s.Resources, func(i int, j int) bool {
 		return s.Resources[i].Resource != nil
 	})
+	existOLM := false
 	for _, r := range s.Resources {
 		if r.Resource != nil {
-			log.Infof("Exists olm resource:%v, project:%v, GVK:%v", r.Resource, r.NamespacedName, r.GVK)
-			return true, nil
+			log.Infof("	Should remove exist OLM resource： Kind:%s, Name:%s", r.GVK.Kind, r.NamespacedName.Name)
+			existOLM = true
 		} else if r.Error != nil && !apierrors.IsNotFound(r.Error) {
 			// We know the error is not a "resource not found" error at this point.
 			// It still may be the equivalent for a CR, "no kind match", if its
@@ -109,6 +110,9 @@ func (s Status) HasInstalledResources() (bool, error) {
 				return false, r.Error
 			}
 		}
+	}
+	if existOLM {
+		return true, nil
 	}
 	return false, nil
 }

--- a/internal/olm/installer/manager.go
+++ b/internal/olm/installer/manager.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	DefaultVersion = "latest"
-	DefaultTimeout = time.Minute * 2
+	DefaultTimeout = time.Minute * 3
 	// DefaultOLMNamespace is the namespace where OLM is installed
 	DefaultOLMNamespace = "olm"
 )

--- a/website/content/en/docs/cli/operator-sdk_olm_install.md
+++ b/website/content/en/docs/cli/operator-sdk_olm_install.md
@@ -17,7 +17,7 @@ operator-sdk olm install [flags]
 
 ```
   -h, --help               help for install
-      --timeout duration   time to wait for the command to complete before failing (default 2m0s)
+      --timeout duration   time to wait for the command to complete before failing (default 3m0s)
       --version string     version of OLM resources to install (default "latest")
 ```
 

--- a/website/content/en/docs/cli/operator-sdk_olm_status.md
+++ b/website/content/en/docs/cli/operator-sdk_olm_status.md
@@ -18,7 +18,7 @@ operator-sdk olm status [flags]
 ```
   -h, --help                   help for status
       --olm-namespace string   namespace where OLM is installed (default "olm")
-      --timeout duration       time to wait for the command to complete before failing (default 2m0s)
+      --timeout duration       time to wait for the command to complete before failing (default 3m0s)
       --version string         version of OLM installed on cluster; if unsetoperator-sdk attempts to auto-discover the version
 ```
 

--- a/website/content/en/docs/cli/operator-sdk_olm_uninstall.md
+++ b/website/content/en/docs/cli/operator-sdk_olm_uninstall.md
@@ -18,7 +18,7 @@ operator-sdk olm uninstall [flags]
 ```
   -h, --help                   help for uninstall
       --olm-namespace string   namespace from where OLM is to be uninstalled. (default "olm")
-      --timeout duration       time to wait for the command to complete before failing (default 2m0s)
+      --timeout duration       time to wait for the command to complete before failing (default 3m0s)
       --version string         version of OLM resources to uninstall.
 ```
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Get the below errors when running the `operator-sdk olm install` and `operator-sdk olm uninstall`
```console
FATA[0127] Failed to install OLM version "latest": failed to create CRDs and resources: Post "https://api.weinliu466.qe.devcluster.openshift.com:6443/apis/operators.coreos.com/v1alpha1/namespaces/olm/catalogsources": context deadline exceeded

INFO[0125]   Deleting Deployment "olm/olm-operator"    
FATA[0126] Failed to uninstall OLM: Delete "https://api.weinliu466.qe.devcluster.openshift.com:6443/apis/apps/v1/namespaces/olm/deployments/olm-operator": context deadline exceeded
```
**Motivation for the change:**

After this PR, it works well.
```console
mac:operator-sdk jianzhang$ operator-sdk olm install
I0917 17:14:11.475751    2413 request.go:621] Throttling request took 1.002013544s, request: GET:https://api.weinliu466.qe.devcluster.openshift.com:6443/apis/batch/v1?timeout=32s
INFO[0005] Fetching CRDs for version "latest"           
INFO[0022] Fetching resources for version "latest"      
I0917 17:14:40.596569    2413 request.go:621] Throttling request took 1.000013765s, request: GET:https://api.weinliu466.qe.devcluster.openshift.com:6443/apis/storage.k8s.io/v1?timeout=32s
I0917 17:14:50.666173    2413 request.go:621] Throttling request took 1.000067992s, request: GET:https://api.weinliu466.qe.devcluster.openshift.com:6443/apis/migration.k8s.io/v1alpha1?timeout=32s
INFO[0057] Creating CRDs and resources                  
INFO[0057]   Creating CustomResourceDefinition "catalogsources.operators.coreos.com" 
INFO[0058]   Creating CustomResourceDefinition "clusterserviceversions.operators.coreos.com" 
INFO[0061]   Creating CustomResourceDefinition "installplans.operators.coreos.com" 
INFO[0063]   Creating CustomResourceDefinition "operatorgroups.operators.coreos.com" 
INFO[0066]   Creating CustomResourceDefinition "operators.operators.coreos.com" 
INFO[0067]   Creating CustomResourceDefinition "subscriptions.operators.coreos.com" 
INFO[0072]   Creating Namespace "olm"                   
INFO[0072]   Creating Namespace "operators"             
INFO[0072]   Creating ServiceAccount "olm/olm-operator-serviceaccount" 
INFO[0073]   Creating ClusterRole "system:controller:operator-lifecycle-manager" 
INFO[0073]   Creating ClusterRoleBinding "olm-operator-binding-olm" 
INFO[0073]   Creating Deployment "olm/olm-operator"     
INFO[0074]   Creating Deployment "olm/catalog-operator" 
INFO[0074]   Creating ClusterRole "aggregate-olm-edit"  
INFO[0075]   Creating ClusterRole "aggregate-olm-view"  
INFO[0075]   Creating OperatorGroup "operators/global-operators" 
I0917 17:15:28.089903    2413 request.go:621] Throttling request took 1.047861959s, request: GET:https://api.weinliu466.qe.devcluster.openshift.com:6443/apis/scheduling.k8s.io/v1beta1?timeout=32s
INFO[0082]   Creating OperatorGroup "olm/olm-operators" 
INFO[0082]   Creating ClusterServiceVersion "olm/packageserver" 
INFO[0083]   Creating CatalogSource "olm/operatorhubio-catalog" 
INFO[0083] Waiting for deployment/olm-operator rollout to complete 
INFO[0084]   Waiting for Deployment "olm/olm-operator" to rollout: 0 of 1 updated replicas are available 
INFO[0087]   Deployment "olm/olm-operator" successfully rolled out 
INFO[0087] Waiting for deployment/catalog-operator rollout to complete 
INFO[0088]   Deployment "olm/catalog-operator" successfully rolled out 
INFO[0088] Waiting for deployment/packageserver rollout to complete 
INFO[0088]   Waiting for Deployment "olm/packageserver" to rollout: 1 out of 2 new replicas have been updated 
INFO[0090]   Waiting for Deployment "olm/packageserver" to rollout: 1 old replicas are pending termination 
INFO[0096]   Deployment "olm/packageserver" successfully rolled out 
INFO[0116] Successfully installed OLM version "latest"  

NAME                                            NAMESPACE    KIND                        STATUS
catalogsources.operators.coreos.com                          CustomResourceDefinition    Installed
clusterserviceversions.operators.coreos.com                  CustomResourceDefinition    Installed
installplans.operators.coreos.com                            CustomResourceDefinition    Installed
operatorgroups.operators.coreos.com                          CustomResourceDefinition    Installed
operators.operators.coreos.com                               CustomResourceDefinition    Installed
subscriptions.operators.coreos.com                           CustomResourceDefinition    Installed
olm                                                          Namespace                   Installed
operators                                                    Namespace                   Installed
olm-operator-serviceaccount                     olm          ServiceAccount              Installed
system:controller:operator-lifecycle-manager                 ClusterRole                 Installed
olm-operator-binding-olm                                     ClusterRoleBinding          Installed
olm-operator                                    olm          Deployment                  Installed
catalog-operator                                olm          Deployment                  Installed
aggregate-olm-edit                                           ClusterRole                 Installed
aggregate-olm-view                                           ClusterRole                 Installed
global-operators                                operators    OperatorGroup               Installed
olm-operators                                   olm          OperatorGroup               Installed
packageserver                                   olm          ClusterServiceVersion       Installed
operatorhubio-catalog                           olm          CatalogSource               Installed

```


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
