### PR TITLE
Replace method 'Should(Succeed())' with 'NotTo(HaveOccurred())'

### DIFF
--- a/test/e2e-ansible/e2e_ansible_cluster_test.go
+++ b/test/e2e-ansible/e2e_ansible_cluster_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Running ansible projects", func() {
 
 			By("deploying project on the cluster")
 			err := tc.Make("deploy", "IMG="+tc.ImageName)
-			Expect(err).Should(Succeed())
+			Expect(err).NotTo(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting Curl Pod created")

--- a/test/e2e-ansible/e2e_ansible_olm_test.go
+++ b/test/e2e-ansible/e2e_ansible_olm_test.go
@@ -64,12 +64,12 @@ var _ = Describe("Integrating ansible Projects with OLM", func() {
 			if isRunningOnKind() {
 				By("loading the bundle image into Kind cluster")
 				err = tc.LoadImageToKindClusterWithName(bundleImage)
-				Expect(err).Should(Succeed())
+				Expect(err).NotTo(HaveOccurred())
 			}
 
 			By("adding the 'packagemanifests' rule to the Makefile")
 			err = tc.AddPackagemanifestsTarget()
-			Expect(err).Should(Succeed())
+			Expect(err).NotTo(HaveOccurred())
 
 			By("generating the operator package manifests")
 			err = tc.Make("packagemanifests", "IMG="+tc.ImageName)

--- a/test/e2e-ansible/e2e_ansible_suite_test.go
+++ b/test/e2e-ansible/e2e_ansible_suite_test.go
@@ -60,7 +60,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("checking the cluster type")
 	kubectx, err = tc.Kubectl.Command("config", "current-context")
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("checking API resources applied on Cluster")
 	output, err := tc.Kubectl.Command("api-resources")
@@ -101,7 +101,7 @@ var _ = BeforeSuite(func(done Done) {
 		"--plugins", "ansible",
 		"--project-version", "3-alpha",
 		"--domain", tc.Domain)
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("creating the Memcached API")
 	err = tc.CreateAPI(
@@ -110,7 +110,7 @@ var _ = BeforeSuite(func(done Done) {
 		"--kind", tc.Kind,
 		"--generate-playbook",
 		"--generate-role")
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("replacing project Dockerfile to use ansible base image with the dev tag")
 	testutils.ReplaceRegexInFile(filepath.Join(tc.Dir, "Dockerfile"), "quay.io/operator-framework/ansible-operator:.*", "quay.io/operator-framework/ansible-operator:dev")
@@ -134,7 +134,7 @@ var _ = BeforeSuite(func(done Done) {
 		"--version", tc.Version,
 		"--kind", "Memfin",
 		"--generate-role")
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("adding task to delete config map")
 	testutils.ReplaceInFile(filepath.Join(tc.Dir, "roles", "memfin", "tasks", "main.yml"),
@@ -150,7 +150,7 @@ var _ = BeforeSuite(func(done Done) {
 		"--version", tc.Version,
 		"--kind", "Foo",
 		"--generate-role")
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("adding RBAC permissions for the Memcached Kind")
 	testutils.ReplaceInFile(filepath.Join(tc.Dir, "config", "rbac", "role.yaml"),
@@ -158,16 +158,16 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("checking the kustomize setup")
 	err = tc.Make("kustomize")
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("building the project image")
 	err = tc.Make("docker-build", "IMG="+tc.ImageName)
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	if isRunningOnKind() {
 		By("loading the project image into Kind cluster")
 		err = tc.LoadImageToKindCluster()
-		Expect(err).Should(Succeed())
+		Expect(err).NotTo(HaveOccurred())
 	}
 
 	close(done)

--- a/test/e2e-go/e2e_go_cluster_test.go
+++ b/test/e2e-go/e2e_go_cluster_test.go
@@ -40,7 +40,7 @@ var _ = Describe("operator-sdk", func() {
 
 			By("deploying project on the cluster")
 			err := tc.Make("deploy", "IMG="+tc.ImageName)
-			Expect(err).Should(Succeed())
+			Expect(err).NotTo(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("cleaning up the operator and resources")

--- a/test/e2e-go/e2e_go_olm_test.go
+++ b/test/e2e-go/e2e_go_olm_test.go
@@ -60,12 +60,12 @@ var _ = Describe("Integrating Go Projects with OLM", func() {
 			if isRunningOnKind() {
 				By("loading the bundle image into Kind cluster")
 				err = tc.LoadImageToKindClusterWithName(bundleImage)
-				Expect(err).Should(Succeed())
+				Expect(err).NotTo(HaveOccurred())
 			}
 
 			By("adding the 'packagemanifests' rule to the Makefile")
 			err = tc.AddPackagemanifestsTarget()
-			Expect(err).Should(Succeed())
+			Expect(err).NotTo(HaveOccurred())
 
 			By("generating the operator package manifests")
 			err = tc.Make("packagemanifests", "IMG="+tc.ImageName)

--- a/test/e2e-go/e2e_go_suite_test.go
+++ b/test/e2e-go/e2e_go_suite_test.go
@@ -62,7 +62,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("checking the cluster type")
 	kubectx, err = tc.Kubectl.Command("config", "current-context")
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("checking API resources applied on Cluster")
 	output, err := tc.Kubectl.Command("api-resources")
@@ -99,7 +99,7 @@ var _ = BeforeSuite(func(done Done) {
 		"--repo", path.Join("github.com", "example", projectName),
 		"--domain", tc.Domain,
 		"--fetch-deps=false")
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("by adding scorecard custom patch file")
 	err = tc.AddScorecardCustomPatchFile()
@@ -114,7 +114,7 @@ var _ = BeforeSuite(func(done Done) {
 		"--resource",
 		"--controller",
 		"--make=false")
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("implementing the API")
 	Expect(kbtestutils.InsertCode(
@@ -132,16 +132,16 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("checking the kustomize setup")
 	err = tc.Make("kustomize")
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("building the project image")
 	err = tc.Make("docker-build", "IMG="+tc.ImageName)
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	if isRunningOnKind() {
 		By("loading the project image into Kind cluster")
 		err = tc.LoadImageToKindCluster()
-		Expect(err).Should(Succeed())
+		Expect(err).NotTo(HaveOccurred())
 	}
 
 	close(done)

--- a/test/e2e-helm/e2e_helm_cluster_test.go
+++ b/test/e2e-helm/e2e_helm_cluster_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Running Helm projects", func() {
 
 			By("deploying project on the cluster")
 			err := tc.Make("deploy", "IMG="+tc.ImageName)
-			Expect(err).Should(Succeed())
+			Expect(err).NotTo(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting Curl Pod created")

--- a/test/e2e-helm/e2e_helm_olm_test.go
+++ b/test/e2e-helm/e2e_helm_olm_test.go
@@ -64,12 +64,12 @@ var _ = Describe("Integrating Helm Projects with OLM", func() {
 			if isRunningOnKind() {
 				By("loading the bundle image into Kind cluster")
 				err = tc.LoadImageToKindClusterWithName(bundleImage)
-				Expect(err).Should(Succeed())
+				Expect(err).NotTo(HaveOccurred())
 			}
 
 			By("adding the 'packagemanifests' rule to the Makefile")
 			err = tc.AddPackagemanifestsTarget()
-			Expect(err).Should(Succeed())
+			Expect(err).NotTo(HaveOccurred())
 
 			By("generating the operator package manifests")
 			err = tc.Make("packagemanifests", "IMG="+tc.ImageName)

--- a/test/e2e-helm/e2e_helm_suite_test.go
+++ b/test/e2e-helm/e2e_helm_suite_test.go
@@ -59,7 +59,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("checking the cluster type")
 	kubectx, err = tc.Kubectl.Command("config", "current-context")
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("checking API resources applied on Cluster")
 	output, err := tc.Kubectl.Command("api-resources")
@@ -94,30 +94,30 @@ var _ = BeforeSuite(func(done Done) {
 		"--plugins", "helm",
 		"--project-version", "3-alpha",
 		"--domain", tc.Domain)
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("creating an API definition")
 	err = tc.CreateAPI(
 		"--group", tc.Group,
 		"--version", tc.Version,
 		"--kind", tc.Kind)
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("replacing project Dockerfile to use Helm base image with the dev tag")
 	testutils.ReplaceRegexInFile(filepath.Join(tc.Dir, "Dockerfile"), "quay.io/operator-framework/helm-operator:.*", "quay.io/operator-framework/helm-operator:dev")
 
 	By("checking the kustomize setup")
 	err = tc.Make("kustomize")
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("building the project image")
 	err = tc.Make("docker-build", "IMG="+tc.ImageName)
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	if isRunningOnKind() {
 		By("loading the project image into Kind cluster")
 		err = tc.LoadImageToKindCluster()
-		Expect(err).Should(Succeed())
+		Expect(err).NotTo(HaveOccurred())
 	}
 
 	close(done)


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Replace expect method `Expect(err).Should(Succeed())` with `Expect(err).NotTo(HaveOccurred())`

**Motivation for the change:**
For better readability 

Fixes: #3896 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
