### PR TITLE
Add sdk base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,36 +159,36 @@ jobs:
       name: Docker images for arm64
       arch: arm64
       script:
-        - make image-build-ansible image-build-helm image-build-scorecard-test image-build-scorecard-test-kuttl
-        - make image-push-ansible image-push-helm image-push-scorecard-test image-push-scorecard-test-kuttl
+        - make image-build-ansible image-build-helm image-build-scorecard-test image-build-scorecard-test-kuttl image-build-sdk
+        - make image-push-ansible image-push-helm image-push-scorecard-test image-push-scorecard-test-kuttl image-push-sdk
 
     # Build and deploy amd64 docker images
     - <<: *deploy
       name: Docker images for amd64
       arch: amd64
       script:
-        - make image-build-ansible image-build-helm image-build-scorecard-test image-build-scorecard-test-kuttl
-        - make image-push-ansible image-push-helm image-push-scorecard-test image-push-scorecard-test-kuttl
+        - make image-build-ansible image-build-helm image-build-scorecard-test image-build-scorecard-test-kuttl image-build-sdk
+        - make image-push-ansible image-push-helm image-push-scorecard-test image-push-scorecard-test-kuttl image-push-sdk
 
     # Build and deploy ppc64le docker images
     - <<: *deploy
       name: Docker images for ppc64le
       arch: ppc64le
       script:
-        - make image-build-ansible image-build-helm image-build-scorecard-test image-build-scorecard-test-kuttl
-        - make image-push-ansible image-push-helm image-push-scorecard-test image-push-scorecard-test-kuttl
+        - make image-build-ansible image-build-helm image-build-scorecard-test image-build-scorecard-test-kuttl image-build-sdk
+        - make image-push-ansible image-push-helm image-push-scorecard-test image-push-scorecard-test-kuttl image-push-sdk
 
     # Build and deploy s390x docker images
     - <<: *deploy
       name: Docker images for s390x
       arch: s390x
       script:
-        - make image-build-ansible image-build-helm image-build-scorecard-test
-        - make image-push-ansible image-push-helm image-push-scorecard-test
+        - make image-build-ansible image-build-helm image-build-scorecard-test image-build-sdk
+        - make image-push-ansible image-push-helm image-push-scorecard-test image-push-sdk
 
     # Build and deploy ansible multi-arch manifest list
     - stage: deploy-manifest-multiarch
       <<: *manifest-deploy
       name: Manifest lists
       script:
-        - make image-push-ansible-multiarch image-push-helm-multiarch image-push-scorecard-test-multiarch image-push-scorecard-test-kuttl-multiarch
+        - make image-push-ansible-multiarch image-push-helm-multiarch image-push-scorecard-test-multiarch image-push-scorecard-test-kuttl-multiarch image-push-sdk-multiarch

--- a/Makefile
+++ b/Makefile
@@ -31,18 +31,21 @@ GO_BUILD_ARGS = \
 
 ANSIBLE_BASE_IMAGE = quay.io/operator-framework/ansible-operator
 HELM_BASE_IMAGE = quay.io/operator-framework/helm-operator
+OPERATOR_SDK_BASE_IMAGE = quay.io/operator-framework/operator-sdk
 CUSTOM_SCORECARD_TESTS_BASE_IMAGE = quay.io/operator-framework/custom-scorecard-tests
 SCORECARD_TEST_BASE_IMAGE = quay.io/operator-framework/scorecard-test
 SCORECARD_TEST_KUTTL_BASE_IMAGE = quay.io/operator-framework/scorecard-test-kuttl
 
 ANSIBLE_IMAGE ?= $(ANSIBLE_BASE_IMAGE)
 HELM_IMAGE ?= $(HELM_BASE_IMAGE)
+OPERATOR_SDK_IMAGE ?= $(OPERATOR_SDK_BASE_IMAGE)
 CUSTOM_SCORECARD_TESTS_IMAGE ?= $(CUSTOM_SCORECARD_TESTS_BASE_IMAGE)
 SCORECARD_TEST_IMAGE ?= $(SCORECARD_TEST_BASE_IMAGE)
 SCORECARD_TEST_KUTTL_IMAGE ?= $(SCORECARD_TEST_KUTTL_BASE_IMAGE)
 
 ANSIBLE_ARCHES:="amd64" "ppc64le" "arm64" "s390x"
 HELM_ARCHES:="amd64" "ppc64le" "arm64" "s390x"
+OPERATOR_SDK_ARCHES:="amd64" "ppc64le" "arm64" "s390x"
 SCORECARD_TEST_ARCHES:="amd64" "ppc64le" "arm64" "s390x"
 SCORECARD_TEST_KUTTL_ARCHES:="amd64" "ppc64le" "arm64"
 # the custom scorecard test image is a scorecard example only
@@ -184,9 +187,9 @@ build/%.asc: ## Create release signatures for operator-sdk release binaries
 
 image: image-build image-push ## Build and push all images
 
-image-build: image-build-ansible image-build-helm image-build-scorecard-test image-build-scorecard-test-kuttl image-build-custom-scorecard-tests ## Build all images
+image-build: image-build-ansible image-build-helm image-build-scorecard-test image-build-scorecard-test-kuttl image-build-custom-scorecard-tests image-build-sdk ## Build all images
 
-image-push: image-push-ansible image-push-helm image-push-scorecard-test image-push-scorecard-test-kuttl ## Push all images
+image-push: image-push-ansible image-push-helm image-push-scorecard-test image-push-scorecard-test-kuttl image-push-sdk ## Push all images
 
 # Ansible operator image scaffold/build/push.
 .PHONY: image-scaffold-ansible image-build-ansible image-push-ansible image-push-ansible-multiarch
@@ -217,6 +220,18 @@ image-push-helm:
 
 image-push-helm-multiarch:
 	./hack/image/push-manifest-list.sh $(HELM_IMAGE) ${HELM_ARCHES}
+
+.PHONY: image-build-sdk image-push-sdk image-push-sdk-multiarch
+
+image-build-sdk: build/operator-sdk-dev-linux-gnu
+	./hack/image/build-sdk-image.sh $(OPERATOR_SDK_BASE_IMAGE):dev
+
+image-push-sdk:
+	./hack/image/push-image-tags.sh $(OPERATOR_SDK_BASE_IMAGE):dev $(OPERATOR_SDK_IMAGE)-$(shell go env GOARCH)
+
+image-push-sdk-multiarch:
+	./hack/image/push-manifest-list.sh $(OPERATOR_SDK_IMAGE) ${OPERATOR_SDK_ARCHES}
+
 
 # Scorecard test image scaffold/build/push.
 .PHONY: image-build-scorecard-test image-push-scorecard-test image-push-scorecard-test-multiarch

--- a/hack/image/build-sdk-image.sh
+++ b/hack/image/build-sdk-image.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eux
+
+source hack/lib/test_lib.sh
+source hack/lib/image_lib.sh
+
+ROOTDIR="$(pwd)"
+TMPDIR="$(mktemp -d)"
+trap_add 'rm -rf $TMPDIR' EXIT
+
+# build the base image
+pushd $TMPDIR
+cp $ROOTDIR/build/operator-sdk-dev-linux-gnu .
+docker build -f $ROOTDIR/hack/image/sdk/Dockerfile -t $1 .
+
+# TODO(asmacdo) any reason to load image into kind?
+popd

--- a/hack/image/sdk/Dockerfile
+++ b/hack/image/sdk/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi8/ubi
+
+COPY operator-sdk-dev-linux-gnu  /usr/local/bin/operator-sdk
+
+ENTRYPOINT ["/usr/local/bin/operator-sdk"]


### PR DESCRIPTION
The docker image builds, but we need to exercise the tag/push logic before merge 
/hold

This PR results in the creation of 4 new images published to quay: 
- quay.io/repository/operator-framework/operator-sdk-amd64
- quay.io/repository/operator-framework/operator-sdk-s390x
- quay.io/repository/operator-framework/operator-sdk-ppc64le
- quay.io/repository/operator-framework/operator-sdk-arm64