### PR TITLE
`generate`: default CSV `admissionReviewVersions` and `sideEffects`

### DIFF
--- a/changelog/fragments/csv-whdescs-defaults.yaml
+++ b/changelog/fragments/csv-whdescs-defaults.yaml
@@ -1,0 +1,7 @@
+entries:
+  - description: >
+      Default a CSV's `spec.webhookDefinition[].admissionReviewVersions` to "v1beta1".
+    kind: addition
+  - description: >
+      Default a CSV's `spec.webhookDefinition[].sideEffects` to "None".
+    kind: addition

--- a/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
@@ -290,6 +290,9 @@ func applyWebhooks(c *collector.Manifests, csv *operatorsv1alpha1.ClusterService
 	csv.Spec.WebhookDefinitions = webhookDescriptions
 }
 
+// The default AdmissionReviewVersions set in a CSV if not set in the source webhook.
+var defaultAdmissionReviewVersions = []string{"v1beta1"}
+
 // validatingToWebhookDescription transforms webhook into a WebhookDescription.
 func validatingToWebhookDescription(webhook admissionregv1.ValidatingWebhook, depName string) operatorsv1alpha1.WebhookDescription {
 	description := operatorsv1alpha1.WebhookDescription{
@@ -302,6 +305,13 @@ func validatingToWebhookDescription(webhook admissionregv1.ValidatingWebhook, de
 		SideEffects:             webhook.SideEffects,
 		TimeoutSeconds:          webhook.TimeoutSeconds,
 		AdmissionReviewVersions: webhook.AdmissionReviewVersions,
+	}
+	if len(description.AdmissionReviewVersions) == 0 {
+		description.AdmissionReviewVersions = defaultAdmissionReviewVersions
+	}
+	if description.SideEffects == nil {
+		seNone := admissionregv1.SideEffectClassNone
+		description.SideEffects = &seNone
 	}
 
 	if serviceRef := webhook.ClientConfig.Service; serviceRef != nil {
@@ -330,6 +340,13 @@ func mutatingToWebhookDescription(webhook admissionregv1.MutatingWebhook, depNam
 		TimeoutSeconds:          webhook.TimeoutSeconds,
 		AdmissionReviewVersions: webhook.AdmissionReviewVersions,
 		ReinvocationPolicy:      webhook.ReinvocationPolicy,
+	}
+	if len(description.AdmissionReviewVersions) == 0 {
+		description.AdmissionReviewVersions = defaultAdmissionReviewVersions
+	}
+	if description.SideEffects == nil {
+		seNone := admissionregv1.SideEffectClassNone
+		description.SideEffects = &seNone
 	}
 
 	if serviceRef := webhook.ClientConfig.Service; serviceRef != nil {

--- a/internal/generate/testdata/clusterserviceversions/output/memcached-operator.clusterserviceversion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/output/memcached-operator.clusterserviceversion.yaml
@@ -184,7 +184,8 @@ spec:
     url: https://your.domain
   version: 0.0.1
   webhookdefinitions:
-  - admissionReviewVersions: null
+  - admissionReviewVersions:
+    - v1beta1
     deploymentName: memcached-operator-controller-manager
     failurePolicy: Fail
     generateName: vmemcached.kb.io
@@ -198,10 +199,11 @@ spec:
       - UPDATE
       resources:
       - memcacheds
-    sideEffects: null
+    sideEffects: None
     type: ValidatingAdmissionWebhook
     webhookPath: /validate-cache-my-domain-v1alpha1-memcached
-  - admissionReviewVersions: null
+  - admissionReviewVersions:
+    - v1beta1
     deploymentName: memcached-operator-controller-manager
     failurePolicy: Fail
     generateName: mmemcached.kb.io
@@ -215,6 +217,6 @@ spec:
       - UPDATE
       resources:
       - memcacheds
-    sideEffects: null
+    sideEffects: None
     type: MutatingAdmissionWebhook
     webhookPath: /mutate-cache-my-domain-v1alpha1-memcached


### PR DESCRIPTION
**Description of the change:**
* internal/generate/clusterserviceversion: default admissionReviewVersions to "v1beta1" and sideEffects to "None"

**Motivation for the change:** a CSV is not valid if its webhook definitions do not contain admissionReviewVersions or sideEffects, each of which can be defaulted with reasonable values.

/kind feature

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
