### PR TITLE
*: use CI-built scorecard images during e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,16 +286,16 @@ test-subcommand-olm-install:
 
 test-e2e: test-e2e-go test-e2e-ansible test-e2e-ansible-molecule test-e2e-helm ## Run the e2e tests
 
-test-e2e-go:
+test-e2e-go: image-build-scorecard-test image-build-custom-scorecard-tests
 	./hack/tests/e2e-go.sh
 
-test-e2e-ansible: image-build-ansible
+test-e2e-ansible: image-build-ansible image-build-scorecard-test
 	./hack/tests/e2e-ansible.sh
 
 test-e2e-ansible-molecule: image-build-ansible
 	./hack/tests/e2e-ansible-molecule.sh
 
-test-e2e-helm: image-build-helm
+test-e2e-helm: image-build-helm image-build-scorecard-test
 	./hack/tests/e2e-helm.sh
 
 # Integration tests.

--- a/hack/image/build-ansible-image.sh
+++ b/hack/image/build-ansible-image.sh
@@ -15,5 +15,6 @@ cp $ROOTDIR/build/ansible-operator-dev-linux-gnu .
 docker build -f $ROOTDIR/hack/image/ansible/Dockerfile -t $1 .
 
 # If using a kind cluster, load the image into all nodes.
+setup_envs $tmp_sdk_root
 load_image_if_kind "$1"
 popd

--- a/hack/image/build-custom-scorecard-tests-image.sh
+++ b/hack/image/build-custom-scorecard-tests-image.sh
@@ -24,5 +24,6 @@ cp -r $ROOTDIR/images/custom-scorecard-tests/bin .
 
 docker build -f $ROOTDIR/images/custom-scorecard-tests/Dockerfile -t $1 .
 # If using a kind cluster, load the image into all nodes.
+setup_envs $tmp_sdk_root
 load_image_if_kind "$1"
 popd

--- a/hack/image/build-helm-image.sh
+++ b/hack/image/build-helm-image.sh
@@ -15,5 +15,6 @@ cp $ROOTDIR/build/helm-operator-dev-linux-gnu .
 docker build -f $ROOTDIR/hack/image/helm/Dockerfile -t $1 .
 
 # If using a kind cluster, load the image into all nodes.
+setup_envs $tmp_sdk_root
 load_image_if_kind "$1"
 popd

--- a/hack/image/build-scorecard-test-image.sh
+++ b/hack/image/build-scorecard-test-image.sh
@@ -24,5 +24,6 @@ cp -r $ROOTDIR/images/scorecard-test/bin .
 
 docker build -f $ROOTDIR/images/scorecard-test/Dockerfile -t $1 .
 # If using a kind cluster, load the image into all nodes.
+setup_envs $tmp_sdk_root
 load_image_if_kind "$1"
 popd

--- a/hack/image/build-scorecard-test-kuttl-image.sh
+++ b/hack/image/build-scorecard-test-kuttl-image.sh
@@ -24,5 +24,6 @@ cp -r $ROOTDIR/images/scorecard-test-kuttl/bin .
 
 docker build -f $ROOTDIR/images/scorecard-test-kuttl/Dockerfile -t $1 .
 # If using a kind cluster, load the image into all nodes.
+setup_envs $tmp_sdk_root
 load_image_if_kind "$1"
 popd

--- a/hack/tests/e2e-go.sh
+++ b/hack/tests/e2e-go.sh
@@ -13,6 +13,18 @@ tests=$test_dir/e2e-go
 export TRACE=1
 export GO111MODULE=on
 
+###########################################################################
+### DO NOT UNCOMMENT THESE LINES UNLESS YOU KNOW WHAT YOU'RE DOING !!!! ###
+###                                                                     ###
+### They cause the integration image not to be loaded into kind in      ###
+### TravisCI.                                                           ###
+###                                                                     ###
+###########################################################################
+###
+###    #prepare_staging_dir $tmp_sdk_root
+###    #fetch_envtest_tools $tmp_sdk_root
+###
+###########################################################################
 setup_envs $tmp_sdk_root
 
 go test $tests -v -ginkgo.v

--- a/test/e2e-ansible/e2e_ansible_suite_test.go
+++ b/test/e2e-ansible/e2e_ansible_suite_test.go
@@ -103,6 +103,18 @@ var _ = BeforeSuite(func(done Done) {
 		"--domain", tc.Domain)
 	Expect(err).NotTo(HaveOccurred())
 
+	By("using dev image for scorecard-test")
+	testutils.ReplaceRegexInFile(
+		filepath.Join(tc.Dir, "config", "scorecard", "patches", "basic.config.yaml"),
+		"quay.io/operator-framework/scorecard-test:.*",
+		"quay.io/operator-framework/scorecard-test:dev",
+	)
+	testutils.ReplaceRegexInFile(
+		filepath.Join(tc.Dir, "config", "scorecard", "patches", "olm.config.yaml"),
+		"quay.io/operator-framework/scorecard-test:.*",
+		"quay.io/operator-framework/scorecard-test:dev",
+	)
+
 	By("creating the Memcached API")
 	err = tc.CreateAPI(
 		"--group", tc.Group,

--- a/test/e2e-go/e2e_go_suite_test.go
+++ b/test/e2e-go/e2e_go_suite_test.go
@@ -105,6 +105,18 @@ var _ = BeforeSuite(func(done Done) {
 	err = tc.AddScorecardCustomPatchFile()
 	Expect(err).NotTo(HaveOccurred())
 
+	By("using dev image for scorecard-test")
+	testutils.ReplaceRegexInFile(
+		filepath.Join(tc.Dir, "config", "scorecard", "patches", "basic.config.yaml"),
+		"quay.io/operator-framework/scorecard-test:.*",
+		"quay.io/operator-framework/scorecard-test:dev",
+	)
+	testutils.ReplaceRegexInFile(
+		filepath.Join(tc.Dir, "config", "scorecard", "patches", "olm.config.yaml"),
+		"quay.io/operator-framework/scorecard-test:.*",
+		"quay.io/operator-framework/scorecard-test:dev",
+	)
+
 	By("creating an API definition")
 	err = tc.CreateAPI(
 		"--group", tc.Group,

--- a/test/e2e-helm/e2e_helm_suite_test.go
+++ b/test/e2e-helm/e2e_helm_suite_test.go
@@ -96,6 +96,18 @@ var _ = BeforeSuite(func(done Done) {
 		"--domain", tc.Domain)
 	Expect(err).NotTo(HaveOccurred())
 
+	By("using dev image for scorecard-test")
+	testutils.ReplaceRegexInFile(
+		filepath.Join(tc.Dir, "config", "scorecard", "patches", "basic.config.yaml"),
+		"quay.io/operator-framework/scorecard-test:.*",
+		"quay.io/operator-framework/scorecard-test:dev",
+	)
+	testutils.ReplaceRegexInFile(
+		filepath.Join(tc.Dir, "config", "scorecard", "patches", "olm.config.yaml"),
+		"quay.io/operator-framework/scorecard-test:.*",
+		"quay.io/operator-framework/scorecard-test:dev",
+	)
+
 	By("creating an API definition")
 	err = tc.CreateAPI(
 		"--group", tc.Group,

--- a/test/internal/scorecard-custom-patch.go
+++ b/test/internal/scorecard-custom-patch.go
@@ -30,7 +30,7 @@ const customScorecardPatch = `
     entrypoint:
     - custom-scorecard-tests
     - customtest1
-    image: quay.io/operator-framework/custom-scorecard-tests:master
+    image: quay.io/operator-framework/custom-scorecard-tests:dev
     labels:
       suite: custom
       test: customtest1
@@ -40,7 +40,7 @@ const customScorecardPatch = `
     entrypoint:
     - custom-scorecard-tests
     - customtest2
-    image: quay.io/operator-framework/custom-scorecard-tests:master
+    image: quay.io/operator-framework/custom-scorecard-tests:dev
     labels:
       suite: custom
       test: customtest2


### PR DESCRIPTION
**Description of the change:**
Use CI-built scorecard images during e2e tests

**Motivation for the change:**
Right now, we use either master or the latest release image during CI. However, this has 2 problems:
1. It doesn't test any changes to these images that may have happened in PRs
2. It fails during releases PRs because the release image is not yet built and pushed.

This is related to #3845.