### PR TITLE
[e2e-test] Added the ginkgo style checks for e2e tests

### DIFF
--- a/test/e2e-ansible/e2e_ansible_cluster_test.go
+++ b/test/e2e-ansible/e2e_ansible_cluster_test.go
@@ -94,9 +94,7 @@ var _ = Describe("Running ansible projects", func() {
 
 				By("ensuring the created controller-manager Pod")
 				podNames := kbtestutils.GetNonEmptyLines(podOutput)
-				if len(podNames) != 1 {
-					return fmt.Errorf("expect 1 controller pods running, but got %d", len(podNames))
-				}
+				Expect(podNames).To(HaveLen(1))
 				controllerPodName = podNames[0]
 				Expect(controllerPodName).Should(ContainSubstring("controller-manager"))
 

--- a/test/e2e-ansible/e2e_ansible_olm_test.go
+++ b/test/e2e-ansible/e2e_ansible_olm_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Integrating ansible Projects with OLM", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = json.Unmarshal(scorecardOutputBytes, &scorecardOutput)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(scorecardOutput.Items)).To(Equal(1))
+			Expect(scorecardOutput.Items).To(HaveLen(1))
 			Expect(scorecardOutput.Items[0].Status.Results[0].State).To(Equal(v1alpha3.PassState))
 
 			By("running the package")

--- a/test/e2e-go/e2e_go_cluster_test.go
+++ b/test/e2e-go/e2e_go_cluster_test.go
@@ -83,9 +83,7 @@ var _ = Describe("operator-sdk", func() {
 
 				By("ensuring the created controller-manager Pod")
 				podNames := kbtestutils.GetNonEmptyLines(podOutput)
-				if len(podNames) != 1 {
-					return fmt.Errorf("expect 1 controller pods running, but got %d", len(podNames))
-				}
+				Expect(podNames).To(HaveLen(1))
 				controllerPodName = podNames[0]
 				Expect(controllerPodName).Should(ContainSubstring("controller-manager"))
 

--- a/test/e2e-go/e2e_go_olm_test.go
+++ b/test/e2e-go/e2e_go_olm_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Integrating Go Projects with OLM", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = json.Unmarshal(scorecardOutputBytes, &scorecardOutput)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(scorecardOutput.Items)).To(Equal(1))
+			Expect(scorecardOutput.Items).To(HaveLen(1))
 			Expect(scorecardOutput.Items[0].Status.Results[0].State).To(Equal(v1alpha3.PassState))
 
 			By("running custom scorecard tests")
@@ -102,7 +102,7 @@ var _ = Describe("Integrating Go Projects with OLM", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = json.Unmarshal(scorecardOutputBytes, &scorecardOutput)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(scorecardOutput.Items)).To(Equal(2))
+			Expect(scorecardOutput.Items).To(HaveLen(2))
 
 			By("running olm scorecard tests")
 			runOLMScorecardCmd := exec.Command(tc.BinaryName, "scorecard", "bundle",

--- a/test/e2e-helm/e2e_helm_cluster_test.go
+++ b/test/e2e-helm/e2e_helm_cluster_test.go
@@ -82,9 +82,7 @@ var _ = Describe("Running Helm projects", func() {
 
 				By("ensuring the created controller-manager Pod")
 				podNames := kbtestutils.GetNonEmptyLines(podOutput)
-				if len(podNames) != 1 {
-					return fmt.Errorf("expect 1 controller pods running, but got %d", len(podNames))
-				}
+				Expect(podNames).To(HaveLen(1))
 				controllerPodName = podNames[0]
 				Expect(controllerPodName).Should(ContainSubstring("controller-manager"))
 

--- a/test/e2e-helm/e2e_helm_olm_test.go
+++ b/test/e2e-helm/e2e_helm_olm_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Integrating Helm Projects with OLM", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = json.Unmarshal(scorecardOutputBytes, &scorecardOutput)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(scorecardOutput.Items)).To(Equal(1))
+			Expect(scorecardOutput.Items).To(HaveLen(1))
 			Expect(scorecardOutput.Items[0].Status.Results[0].State).To(Equal(v1alpha3.PassState))
 
 			By("running the package")


### PR DESCRIPTION
**Description of the change:**
Added the ginkgo style checks for error messages rather then generating the error messages using fmt.Errorf()

Fixes #3771 

**Motivation for the change:**
The changes was suggested in [#3499 (comment)](https://github.com/operator-framework/operator-sdk/pull/3499#discussion_r472553300) to better improve the readability of e2e tests.
