### PR TITLE
[v1.0.x] *: use CI-built scorecard images during e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,16 +276,16 @@ test-subcommand-olm-install:
 
 test-e2e: test-e2e-go test-e2e-ansible test-e2e-ansible-molecule test-e2e-helm ## Run the e2e tests
 
-test-e2e-go:
+test-e2e-go: image-build-scorecard-test
 	./hack/tests/e2e-go.sh
 
-test-e2e-ansible: image-build-ansible
+test-e2e-ansible: image-build-ansible image-build-scorecard-test
 	./hack/tests/e2e-ansible.sh
 
 test-e2e-ansible-molecule: image-build-ansible
 	./hack/tests/e2e-ansible-molecule.sh
 
-test-e2e-helm: image-build-helm
+test-e2e-helm: image-build-helm image-build-scorecard-test
 	./hack/tests/e2e-helm.sh
 
 # Integration tests.

--- a/hack/image/build-ansible-image.sh
+++ b/hack/image/build-ansible-image.sh
@@ -15,5 +15,6 @@ cp $ROOTDIR/build/ansible-operator-dev-linux-gnu .
 docker build -f $ROOTDIR/hack/image/ansible/Dockerfile -t $1 .
 
 # If using a kind cluster, load the image into all nodes.
+setup_envs $tmp_sdk_root
 load_image_if_kind "$1"
 popd

--- a/hack/image/build-helm-image.sh
+++ b/hack/image/build-helm-image.sh
@@ -15,5 +15,6 @@ cp $ROOTDIR/build/helm-operator-dev-linux-gnu .
 docker build -f $ROOTDIR/hack/image/helm/Dockerfile -t $1 .
 
 # If using a kind cluster, load the image into all nodes.
+setup_envs $tmp_sdk_root
 load_image_if_kind "$1"
 popd

--- a/hack/image/build-scorecard-test-image.sh
+++ b/hack/image/build-scorecard-test-image.sh
@@ -17,5 +17,6 @@ GOOS=linux CGO_ENABLED=0 \
 pushd images/scorecard-test
 docker build -t "$1" .
 # If using a kind cluster, load the image into all nodes.
+setup_envs $tmp_sdk_root
 load_image_if_kind "$1"
 popd

--- a/hack/image/build-scorecard-test-kuttl-image.sh
+++ b/hack/image/build-scorecard-test-kuttl-image.sh
@@ -17,5 +17,6 @@ GOOS=linux CGO_ENABLED=0 \
 pushd images/scorecard-test-kuttl
 docker build -t "$1" .
 # If using a kind cluster, load the image into all nodes.
+setup_envs $tmp_sdk_root
 load_image_if_kind "$1"
 popd

--- a/hack/tests/e2e-ansible.sh
+++ b/hack/tests/e2e-ansible.sh
@@ -184,6 +184,8 @@ header_text "Adding a second Kind to test watching multiple GVKs"
 operator-sdk create api --kind=Foo --group ansible --version=v1alpha1
 sed -i".bak" -e 's/# FIXME.*/role: \/dev\/null/g' watches.yaml;rm -f watches.yaml.bak
 
+sed -i".bak" -E -e 's/(FROM quay.io\/operator-framework\/scorecard-test)(:.*)?/\1:dev/g' config/scorecard/patches/basic.config.yaml; rm -f config/scorecard/patches/basic.config.yaml.bak
+sed -i".bak" -E -e 's/(FROM quay.io\/operator-framework\/scorecard-test)(:.*)?/\1:dev/g' config/scorecard/patches/olm.config.yaml; rm -f config/scorecard/patches/olm.config.yaml.bak
 sed -i".bak" -E -e 's/(FROM quay.io\/operator-framework\/ansible-operator)(:.*)?/\1:dev/g' Dockerfile; rm -f Dockerfile.bak
 IMG=$DEST_IMAGE make docker-build
 # If using a kind cluster, load the image into all nodes.

--- a/hack/tests/e2e-go.sh
+++ b/hack/tests/e2e-go.sh
@@ -13,6 +13,18 @@ tests=$test_dir/e2e
 export TRACE=1
 export GO111MODULE=on
 
+###########################################################################
+### DO NOT UNCOMMENT THESE LINES UNLESS YOU KNOW WHAT YOU'RE DOING !!!! ###
+###                                                                     ###
+### They cause the integration image not to be loaded into kind in      ###
+### TravisCI.                                                           ###
+###                                                                     ###
+###########################################################################
+###
+###    #prepare_staging_dir $tmp_sdk_root
+###    #fetch_envtest_tools $tmp_sdk_root
+###
+###########################################################################
 setup_envs $tmp_sdk_root
 
 docker pull gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0

--- a/test/e2e-helm/e2e_helm_suite_test.go
+++ b/test/e2e-helm/e2e_helm_suite_test.go
@@ -97,6 +97,18 @@ var _ = BeforeSuite(func(done Done) {
 		"--domain", tc.Domain)
 	Expect(err).Should(Succeed())
 
+	By("using dev image for scorecard-test")
+	testutils.ReplaceRegexInFile(
+		filepath.Join(tc.Dir, "config", "scorecard", "patches", "basic.config.yaml"),
+		"quay.io/operator-framework/scorecard-test:.*",
+		"quay.io/operator-framework/scorecard-test:dev",
+	)
+	testutils.ReplaceRegexInFile(
+		filepath.Join(tc.Dir, "config", "scorecard", "patches", "olm.config.yaml"),
+		"quay.io/operator-framework/scorecard-test:.*",
+		"quay.io/operator-framework/scorecard-test:dev",
+	)
+
 	By("creating an API definition")
 	err = tc.CreateAPI(
 		"--group", tc.Group,

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -83,6 +83,18 @@ var _ = Describe("operator-sdk", func() {
 				"--fetch-deps=false")
 			Expect(err).Should(Succeed())
 
+			By("using dev image for scorecard-test")
+			testutils.ReplaceRegexInFile(
+				filepath.Join(tc.Dir, "config", "scorecard", "patches", "basic.config.yaml"),
+				"quay.io/operator-framework/scorecard-test:.*",
+				"quay.io/operator-framework/scorecard-test:dev",
+			)
+			testutils.ReplaceRegexInFile(
+				filepath.Join(tc.Dir, "config", "scorecard", "patches", "olm.config.yaml"),
+				"quay.io/operator-framework/scorecard-test:.*",
+				"quay.io/operator-framework/scorecard-test:dev",
+			)
+
 			By("creating an API definition")
 			err = tc.CreateAPI(
 				"--group", tc.Group,

--- a/test/internal/utils.go
+++ b/test/internal/utils.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	. "github.com/onsi/ginkgo" //nolint:golint
@@ -101,6 +102,22 @@ func ReplaceInFile(path, old, new string) {
 	b, err := ioutil.ReadFile(path)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	s := strings.Replace(string(b), old, new, -1)
+	ExpectWithOffset(1, s).NotTo(Equal(string(b)), "No replacement occurred")
+	err = ioutil.WriteFile(path, []byte(s), info.Mode())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+}
+
+// ReplaceRegexInFile finds all strings that match `match` and replaces them
+// with `replace` in the file at path.
+func ReplaceRegexInFile(path, match, replace string) {
+	matcher, err := regexp.Compile(match)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	info, err := os.Stat(path)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	b, err := ioutil.ReadFile(path)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	s := matcher.ReplaceAllString(string(b), replace)
+	ExpectWithOffset(1, s).NotTo(Equal(string(b)), "No replacement occurred")
 	err = ioutil.WriteFile(path, []byte(s), info.Mode())
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 }


### PR DESCRIPTION
**Description of the change:**
Backport of #3909 

**Motivation for the change:**
Unblock release of v1.0.1
