### PR TITLE
cleanup e2e tests utils to allow share helpers (useful for sample generating)

### DIFF
--- a/test/e2e-ansible/e2e_ansible_olm_test.go
+++ b/test/e2e-ansible/e2e_ansible_olm_test.go
@@ -38,12 +38,8 @@ var _ = Describe("Integrating ansible Projects with OLM", func() {
 		)
 
 		It("should generate and run a valid OLM bundle and packagemanifests", func() {
-			By("turning off interactive prompts for all generation tasks.")
-			err := tc.DisableOLMBundleInteractiveMode()
-			Expect(err).NotTo(HaveOccurred())
-
 			By("building the bundle")
-			err = tc.Make("bundle", "IMG="+tc.ImageName)
+			err := tc.Make("bundle", "IMG="+tc.ImageName)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("building the operator bundle image")

--- a/test/e2e-ansible/e2e_ansible_suite_test.go
+++ b/test/e2e-ansible/e2e_ansible_suite_test.go
@@ -117,7 +117,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("replacing project Dockerfile to use ansible base image with the dev tag")
 	err = testutils.ReplaceRegexInFile(filepath.Join(tc.Dir, "Dockerfile"), "quay.io/operator-framework/ansible-operator:.*", "quay.io/operator-framework/ansible-operator:dev")
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
 	By("adding Memcached mock task to the role")
 	err = testutils.ReplaceInFile(filepath.Join(tc.Dir, "roles", strings.ToLower(tc.Kind), "tasks", "main.yml"),
@@ -164,6 +164,10 @@ var _ = BeforeSuite(func(done Done) {
 	By("adding RBAC permissions for the Memcached Kind")
 	err = testutils.ReplaceInFile(filepath.Join(tc.Dir, "config", "rbac", "role.yaml"),
 		"# +kubebuilder:scaffold:rules", rolesForBaseOperator)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("turning off interactive prompts for all generation tasks.")
+	err = tc.DisableOLMBundleInteractiveMode()
 	Expect(err).NotTo(HaveOccurred())
 
 	By("checking the kustomize setup")

--- a/test/e2e-go/e2e_go_olm_test.go
+++ b/test/e2e-go/e2e_go_olm_test.go
@@ -36,12 +36,8 @@ var _ = Describe("Integrating Go Projects with OLM", func() {
 		)
 
 		It("should generate and run a valid OLM bundle and packagemanifests", func() {
-			By("turning off interactive prompts for all generation tasks.")
-			err := tc.DisableOLMBundleInteractiveMode()
-			Expect(err).NotTo(HaveOccurred())
-
-			By("building the bundle")
-			err = tc.Make("bundle", "IMG="+tc.ImageName)
+			By("generating the operator bundle")
+			err := tc.Make("bundle", "IMG="+tc.ImageName)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("building the operator bundle image")

--- a/test/e2e-helm/e2e_helm_olm_test.go
+++ b/test/e2e-helm/e2e_helm_olm_test.go
@@ -18,13 +18,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
-	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
 
-	testutils "github.com/operator-framework/operator-sdk/test/utils"
+	"github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
 )
 
 var _ = Describe("Integrating Helm Projects with OLM", func() {
@@ -38,13 +36,6 @@ var _ = Describe("Integrating Helm Projects with OLM", func() {
 			OLMSpecDescriptorsTest    = "olm-spec-descriptors"
 			OLMStatusDescriptorsTest  = "olm-status-descriptors"
 		)
-
-		BeforeEach(func() {
-			By("turning off interactive prompts for all generation tasks.")
-			replace := "operator-sdk generate kustomize manifests"
-			err := testutils.ReplaceInFile(filepath.Join(tc.Dir, "Makefile"), replace, replace+" --interactive=false")
-			Expect(err).NotTo(HaveOccurred())
-		})
 
 		It("should generate and run a valid OLM bundle and packagemanifests", func() {
 			By("building the bundle")

--- a/test/e2e-helm/e2e_helm_suite_test.go
+++ b/test/e2e-helm/e2e_helm_suite_test.go
@@ -108,7 +108,11 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("replacing project Dockerfile to use Helm base image with the dev tag")
 	err = testutils.ReplaceRegexInFile(filepath.Join(tc.Dir, "Dockerfile"), "quay.io/operator-framework/helm-operator:.*", "quay.io/operator-framework/helm-operator:dev")
-	Expect(err).Should(Succeed())
+	Expect(err).NotTo(HaveOccurred())
+
+	By("turning off interactive prompts for all generation tasks.")
+	err = tc.DisableOLMBundleInteractiveMode()
+	Expect(err).NotTo(HaveOccurred())
 
 	By("checking the kustomize setup")
 	err = tc.Make("kustomize")


### PR DESCRIPTION
**Description of the change:**
The only change here now is to move `tc.DisableOLMBundleInteractiveMode()` which will be helpful when we will replace the mock by the samples in the e2e test. 

**Motivation for the change:**

https://github.com/operator-framework/enhancements/pull/47

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
