### PR TITLE
Centralize the logic for scorecard dev image replacement

### DIFF
--- a/test/e2e-ansible/e2e_ansible_suite_test.go
+++ b/test/e2e-ansible/e2e_ansible_suite_test.go
@@ -104,16 +104,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).NotTo(HaveOccurred())
 
 	By("using dev image for scorecard-test")
-	testutils.ReplaceRegexInFile(
-		filepath.Join(tc.Dir, "config", "scorecard", "patches", "basic.config.yaml"),
-		"quay.io/operator-framework/scorecard-test:.*",
-		"quay.io/operator-framework/scorecard-test:dev",
-	)
-	testutils.ReplaceRegexInFile(
-		filepath.Join(tc.Dir, "config", "scorecard", "patches", "olm.config.yaml"),
-		"quay.io/operator-framework/scorecard-test:.*",
-		"quay.io/operator-framework/scorecard-test:dev",
-	)
+	tc.ReplaceScorecardImagesForDev()
 
 	By("creating the Memcached API")
 	err = tc.CreateAPI(

--- a/test/e2e-go/e2e_go_suite_test.go
+++ b/test/e2e-go/e2e_go_suite_test.go
@@ -106,16 +106,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).NotTo(HaveOccurred())
 
 	By("using dev image for scorecard-test")
-	testutils.ReplaceRegexInFile(
-		filepath.Join(tc.Dir, "config", "scorecard", "patches", "basic.config.yaml"),
-		"quay.io/operator-framework/scorecard-test:.*",
-		"quay.io/operator-framework/scorecard-test:dev",
-	)
-	testutils.ReplaceRegexInFile(
-		filepath.Join(tc.Dir, "config", "scorecard", "patches", "olm.config.yaml"),
-		"quay.io/operator-framework/scorecard-test:.*",
-		"quay.io/operator-framework/scorecard-test:dev",
-	)
+	tc.ReplaceScorecardImagesForDev()
 
 	By("creating an API definition")
 	err = tc.CreateAPI(

--- a/test/e2e-helm/e2e_helm_suite_test.go
+++ b/test/e2e-helm/e2e_helm_suite_test.go
@@ -97,16 +97,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).NotTo(HaveOccurred())
 
 	By("using dev image for scorecard-test")
-	testutils.ReplaceRegexInFile(
-		filepath.Join(tc.Dir, "config", "scorecard", "patches", "basic.config.yaml"),
-		"quay.io/operator-framework/scorecard-test:.*",
-		"quay.io/operator-framework/scorecard-test:dev",
-	)
-	testutils.ReplaceRegexInFile(
-		filepath.Join(tc.Dir, "config", "scorecard", "patches", "olm.config.yaml"),
-		"quay.io/operator-framework/scorecard-test:.*",
-		"quay.io/operator-framework/scorecard-test:dev",
-	)
+	tc.ReplaceScorecardImagesForDev()
 
 	By("creating an API definition")
 	err = tc.CreateAPI(

--- a/test/internal/scorecard.go
+++ b/test/internal/scorecard.go
@@ -23,6 +23,9 @@ import (
 	"path/filepath"
 )
 
+const scorecardImage = "quay.io/operator-framework/scorecard-test:.*"
+const scorecardImageReplace = "quay.io/operator-framework/scorecard-test:dev"
+
 const customScorecardPatch = `
 - op: add
   path: /stages/0/tests/-
@@ -78,4 +81,17 @@ func (tc TestContext) AddScorecardCustomPatchFile() error {
 		return err
 	}
 	return nil
+}
+
+// ReplaceScorecardImagesForDev will replaces the scorecard images in the manifests per dev tag which is built
+// in the CI based on the code changes made.
+func (tc TestContext) ReplaceScorecardImagesForDev() {
+	ReplaceRegexInFile(
+		filepath.Join(tc.Dir, "config", "scorecard", "patches", "basic.config.yaml"),
+		scorecardImage, scorecardImageReplace,
+	)
+	ReplaceRegexInFile(
+		filepath.Join(tc.Dir, "config", "scorecard", "patches", "olm.config.yaml"),
+		scorecardImage, scorecardImageReplace,
+	)
 }


### PR DESCRIPTION
**Description of the change:**
Added a centralization logic for replacing the dev images in scorecard config for e2e tests.
Closes #3912 

**Motivation for the change:**
The dev image replace logic was replicated at 3 places in e2e tests. Hence moved it to the common function.
