### PR TITLE
Disable fact gathering by default

### DIFF
--- a/changelog/fragments/disable_gather_facts.yaml
+++ b/changelog/fragments/disable_gather_facts.yaml
@@ -1,0 +1,38 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      The scaffolded manager deployment for Ansible-based Operators now
+      has the `ANSIBLE_GATHERING` option set to `explicit`. Additionally,
+      if the `ANSIBLE_GATHERING` environment variable is set to explicit
+      when running a role directly, the `--role-skip-facts` argument will
+      be passed to `ansible-runner`.
+
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: Ansible Operator fact gathering causes performance regression
+      body: |
+        To disable fact gathering by default for your operator, you will need to
+        add the following entry to the manager container in`config/manager/manager.yaml`:
+
+        ```yaml
+                  env:
+                    - name: ANSIBLE_GATHERING
+                      value: explicit
+        ```

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/config/manager/manager.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/config/manager/manager.go
@@ -74,6 +74,9 @@ spec:
           args:
             - "--enable-leader-election"
             - "--leader-election-id={{ .ProjectName }}"
+          env:
+            - name: ANSIBLE_GATHERING
+              value: explicit
           image: {{ .Image }}
       terminationGracePeriodSeconds: 10
 `

--- a/test/e2e-ansible/e2e_ansible_cluster_test.go
+++ b/test/e2e-ansible/e2e_ansible_cluster_test.go
@@ -145,6 +145,7 @@ var _ = Describe("Running ansible projects", func() {
 			Eventually(managerContainerLogs, time.Minute, time.Second).Should(ContainSubstring(
 				"Ansible-runner exited successfully"))
 			Eventually(managerContainerLogs, time.Minute, time.Second).ShouldNot(ContainSubstring("failed=1"))
+			Eventually(managerContainerLogs, time.Minute, time.Second).ShouldNot(ContainSubstring("[Gathering Facts]"))
 
 			By("ensuring no liveness probe fail events")
 			verifyControllerProbe := func() string {

--- a/website/content/en/docs/building-operators/ansible/reference/advanced_options.md
+++ b/website/content/en/docs/building-operators/ansible/reference/advanced_options.md
@@ -232,7 +232,6 @@ Ansible-runner will perform the task relevant to the command specified by the us
 ```
 ---
 - name: Playbook to print debug messages
-  gather_facts: false
   hosts: localhost
   tasks:
     - name: Get the decrypted message variable


### PR DESCRIPTION
**Description of the change:**
With the migration to kubebuilder style scaffolding, we dropped the `ANSIBLE_GATHERING='explicit'` environment variable on the operator's deployment. This causes a performance regression, as gathering facts can increase execution time by 30% for certain playbooks, and the gathered facts do not generally have any applicability to the operator use-case. 

This also makes it so that when running roles directly, we disable fact gathering if `ANSIBLE_GATHERING` is set to explicit. This allows the user to avoid the aforementioned performance penalty without needing to wrap their role in a playbook.

Fixes #2358 

**Motivation for the change:**
Performance regression due to an oversight when migrating to kubebuilder.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
