### PR TITLE
update v1alpha1 to v1 at memcached_controller.go

### DIFF
--- a/example/memcached-operator/memcached_controller.go.tmpl
+++ b/example/memcached-operator/memcached_controller.go.tmpl
@@ -28,7 +28,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	cachev1alpha1 "github.com/example-inc/memcached-operator/api/v1alpha1"
+	cachev1 "github.com/example-inc/memcached-operator/api/v1"
 )
 
 // MemcachedReconciler reconciles a Memcached object
@@ -48,7 +48,7 @@ func (r *MemcachedReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("memcached", req.NamespacedName)
 
 	// Fetch the Memcached instance
-	memcached := &cachev1alpha1.Memcached{}
+	memcached := &cachev1.Memcached{}
 	err := r.Get(ctx, req.NamespacedName, memcached)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -122,7 +122,7 @@ func (r *MemcachedReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 }
 
 // deploymentForMemcached returns a memcached Deployment object
-func (r *MemcachedReconciler) deploymentForMemcached(m *cachev1alpha1.Memcached) *appsv1.Deployment {
+func (r *MemcachedReconciler) deploymentForMemcached(m *cachev1.Memcached) *appsv1.Deployment {
 	ls := labelsForMemcached(m.Name)
 	replicas := m.Spec.Size
 
@@ -176,7 +176,7 @@ func getPodNames(pods []corev1.Pod) []string {
 
 func (r *MemcachedReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&cachev1alpha1.Memcached{}).
+		For(&cachev1.Memcached{}).
 		Owns(&appsv1.Deployment{}).
 		Complete(r)
 }


### PR DESCRIPTION
update v1alpha1 to v1 at memcached_controller.go;
the command creates api in "quick start"(https://sdk.operatorframework.io/docs/building-operators/golang/quickstart/) is:
`operator-sdk create api --group cache --version v1 --kind Memcached --resource=true --controller=true`
and the version is v1 instead of v1alpha1

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
