### PR TITLE
go.mod: bump operator-registry to v1.14.3 for bundle validation improvements

### DIFF
--- a/changelog/fragments/bump-operator-registry.yaml
+++ b/changelog/fragments/bump-operator-registry.yaml
@@ -1,0 +1,3 @@
+entries:
+  - description: Resolves an issue with default channel bundle validation. The default channel label is not required.
+    kind: "bugfix"

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/gomega v1.10.1
 	github.com/operator-framework/api v0.3.13
 	github.com/operator-framework/operator-lib v0.1.0
-	github.com/operator-framework/operator-registry v1.13.4
+	github.com/operator-framework/operator-registry v1.14.3
 	github.com/prometheus/client_golang v1.5.1
 	github.com/sergi/go-diff v1.0.0
 	github.com/sirupsen/logrus v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -577,8 +577,8 @@ github.com/operator-framework/api v0.3.13 h1:Rg+6sdgP7KMOUGNP83s+5gPo7IwTH3mZ85Z
 github.com/operator-framework/api v0.3.13/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
 github.com/operator-framework/operator-lib v0.1.0 h1:7Qy6v2ZccvCeFLWEkrGnN+U+DkaeIWp0gAZaBM9T3DI=
 github.com/operator-framework/operator-lib v0.1.0/go.mod h1:HLw61JTIEeq0YLeVf4dwYx/zt4DmLGZUVWI1y3Lf5Hg=
-github.com/operator-framework/operator-registry v1.13.4 h1:GH7essHnVRP4kYgAWYV9obsS0Cnaj/KjT3BmQXmKAOE=
-github.com/operator-framework/operator-registry v1.13.4/go.mod h1:YhnIzOVjRU2ZwZtzt+fjcjW8ujJaSFynBEu7QVKaSdU=
+github.com/operator-framework/operator-registry v1.14.3 h1:WiIYJy9cfnbzvlwoO5ikgqHnj/WwKLqItJlTz5EeEzQ=
+github.com/operator-framework/operator-registry v1.14.3/go.mod h1:0x4Kkl/1LaK5g/6XgEiJrHF/jEAW3QKYg91M4sYuN0o=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=


### PR DESCRIPTION
**Description of the change:**
Bump `operator-framework/operator-registry` to v1.14.3.

**Motivation for the change:**
Resolves an issue with default channel bundle validation. The default channel label is not required.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] ~Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)~
