### PR TITLE
OWNERS: add OWNERS_ALIASES, add approvers/reviewers who already held roles

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,25 +1,7 @@
 approvers:
-  - hasbro17
-  - estroz
-  - shawn-hurley
-  - joelanford
-  - theishshah
-  - camilamacedo86
-  - jmccormick2001
-  - jmrodri
-  - fabianvf
-  - varshaprasad96
-  - rashmigottipati
+- sdk-admins
+- sdk-approvers
 reviewers:
-  - hasbro17
-  - estroz
-  - shawn-hurley
-  - joelanford
-  - theishshah
-  - camilamacedo86
-  - jmccormick2001
-  - jmrodri
-  - fabianvf
-  - varshaprasad96
-  - rashmigottipati
-  - jberkhahn
+- sdk-admins
+- sdk-approvers
+- sdk-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,31 @@
+
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  # Contributors who can be contacted to perform admin-related tasks on the repo.
+  # This role is a subset of the approver role.
+  sdk-admins:
+  - estroz
+  - joelanford
+  - jmccormick2001
+  - jmrodri
+  - asmacdo
+
+  # Contributors who can approve any PRs in the repo.
+  sdk-approvers:
+  - theishshah
+  - camilamacedo86
+  - fabianvf
+  - varshaprasad96
+  - rashmigottipati
+  - bharathi-tenneti
+
+  # Contributors who can review and LGTM any PRs in the repo.
+  sdk-reviewers:
+  - jberkhahn
+
+  # Contributors who were approvers that are no longer directly involved with the project.
+  # This role is symbolic.
+  sdk-emeritus-approvers:
+  - shawn-hurley
+  - hasbro17


### PR DESCRIPTION
**Description of the change:** add an OWNERS_ALIASES file with appropriate labels for admins, approvers, and reviewers.

**Motivation for the change:** now that https://github.com/operator-framework/community/pull/12 has been merged, the OWNERS and OWNERS_ALIASES files should exist and hold the current set of approvers and reviewers at all times, each of which will have to follow community guidelines from the linked document.

Added @asmacdo to `sdk-approvers` since he meets the criteria and has been acting as an approver for a long time.


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
