### PR TITLE
bump kuttl version to 0.6.1 in scorecard-test-kuttl

### DIFF
--- a/changelog/fragments/scorecard-kuttl-image-bump-061.yaml
+++ b/changelog/fragments/scorecard-kuttl-image-bump-061.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: Updated scorecard-test-kuttl image to kuttl v0.6.1
+    kind: change
+    breaking: false

--- a/images/scorecard-test-kuttl/Dockerfile
+++ b/images/scorecard-test-kuttl/Dockerfile
@@ -1,6 +1,6 @@
 # Base image
 #FROM docker.io/kudobuilder/kuttl@sha256:c9c5edc27ba6e5e994ffd8cea03368c0d4e274f3c7a00f51c1e360feb573f24e
-FROM kudobuilder/kuttl:v0.5.2
+FROM kudobuilder/kuttl:v0.6.1
 
 ENV TESTKUTTL=/usr/local/bin/scorecard-test-kuttl \
     USER_UID=1001 \


### PR DESCRIPTION

**Description of the change:**
This PR bumps the kuttl version to v0.6.1 that is used within the scorecard-test-kuttl
image as its base.

**Motivation for the change:**
This version has bug fixes and new features that we will make use of eventually.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
