### PR TITLE
[v0.19.x] *: bump operator-registry to v1.14.3

### DIFF
--- a/changelog/fragments/bump-operator-registry.yaml
+++ b/changelog/fragments/bump-operator-registry.yaml
@@ -1,0 +1,3 @@
+entries:
+  - description: Resolves an issue with default channel bundle validation. The default channel label is not required.
+    kind: "bugfix"

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
 	github.com/operator-framework/api v0.3.13
-	github.com/operator-framework/operator-registry v1.13.4
+	github.com/operator-framework/operator-registry v1.14.3
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -812,8 +812,8 @@ github.com/operator-framework/api v0.3.7-0.20200602203552-431198de9fc2 h1:2KtDe3
 github.com/operator-framework/api v0.3.7-0.20200602203552-431198de9fc2/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
 github.com/operator-framework/api v0.3.13 h1:Rg+6sdgP7KMOUGNP83s+5gPo7IwTH3mZ85ZFml9SPXY=
 github.com/operator-framework/api v0.3.13/go.mod h1:Xbje9x0SHmh0nihE21kpesB38vk3cyxnE6JdDS8Jo1Q=
-github.com/operator-framework/operator-registry v1.13.4 h1:GH7essHnVRP4kYgAWYV9obsS0Cnaj/KjT3BmQXmKAOE=
-github.com/operator-framework/operator-registry v1.13.4/go.mod h1:YhnIzOVjRU2ZwZtzt+fjcjW8ujJaSFynBEu7QVKaSdU=
+github.com/operator-framework/operator-registry v1.14.3 h1:WiIYJy9cfnbzvlwoO5ikgqHnj/WwKLqItJlTz5EeEzQ=
+github.com/operator-framework/operator-registry v1.14.3/go.mod h1:0x4Kkl/1LaK5g/6XgEiJrHF/jEAW3QKYg91M4sYuN0o=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 h1:+OLn68pqasWca0z5ryit9KGfp3sUsW4Lqg32iRMJyzs=


### PR DESCRIPTION
**Description of the change:**
Bump `operator-framework/operator-registry` to v1.14.3.

**Motivation for the change:**
Resolves an issue with default channel bundle validation. The default channel label is not required.

Backport of #3953

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] ~Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)~
