### PR TITLE
Modify olm version in e2e test

### DIFF
--- a/test/e2e-ansible/e2e_ansible_suite_test.go
+++ b/test/e2e-ansible/e2e_ansible_suite_test.go
@@ -86,7 +86,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	if isOLMManagedBySuite {
 		By("installing OLM")
-		Expect(tc.InstallOLM()).To(Succeed())
+		Expect(tc.InstallOLMVersion(testutils.OlmVersionForTestSuite)).To(Succeed())
 	}
 
 	By("setting domain and GKV")

--- a/test/e2e-go/e2e_go_suite_test.go
+++ b/test/e2e-go/e2e_go_suite_test.go
@@ -88,7 +88,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	if isOLMManagedBySuite {
 		By("installing OLM")
-		Expect(tc.InstallOLM()).To(Succeed())
+		Expect(tc.InstallOLMVersion(testutils.OlmVersionForTestSuite)).To(Succeed())
 	}
 
 	By("initializing a project")

--- a/test/e2e-helm/e2e_helm_suite_test.go
+++ b/test/e2e-helm/e2e_helm_suite_test.go
@@ -85,7 +85,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	if isOLMManagedBySuite {
 		By("installing OLM")
-		Expect(tc.InstallOLM()).To(Succeed())
+		Expect(tc.InstallOLMVersion(testutils.OlmVersionForTestSuite)).To(Succeed())
 	}
 
 	By("initializing a Helm project")

--- a/test/utils/olm.go
+++ b/test/utils/olm.go
@@ -23,6 +23,10 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/model/config"
 )
 
+const (
+	OlmVersionForTestSuite = "0.15.1"
+)
+
 var makefilePackagemanifestsFragment = `
 # Options for "packagemanifests".
 ifneq ($(origin FROM_VERSION), undefined)


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Install OLM version "0.15.1" for e2e tests as
install manifests are present in sdk locally.

**Motivation for the change:**
To reduce calls to GitHub.

Issue: #3964 

Note: Latest version of OLM is still being tested in `subcommand-olm-install.sh` and `install_test.go` - this wouldn't eliminate requests to GitHub entirely.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
