### PR TITLE
waitForStatefulsets in e2eutils

### DIFF
--- a/pkg/test/e2eutil/wait_util.go
+++ b/pkg/test/e2eutil/wait_util.go
@@ -38,7 +38,12 @@ func WaitForDeployment(t *testing.T, kubeclient kubernetes.Interface, namespace,
 	return waitForDeployment(t, kubeclient, namespace, name, replicas, retryInterval, timeout, false)
 }
 
-// WaitForOperatorDeployment has the same functionality as WaitForDeployment but will no wait for the deployment if the
+func WaitForStatefulSet(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, replicas int,
+	retryInterval, timeout time.Duration) error {
+	return waitForStatefulSet(t, kubeclient, namespace, name, replicas, retryInterval, timeout, false)
+}
+
+// WaitForOperatorDeployment has the same functionality as WaitForDeployment but will not wait for the deployment if the
 // test was run with a locally run operator (--up-local flag)
 func WaitForOperatorDeployment(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, replicas int,
 	retryInterval, timeout time.Duration) error {


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

- I am writing e2e tests for https://github.com/druid-io/druid-operator, we need to check the status of both deployments as well as statefulsets. As of now the e2eutil only had a function for supporting waitForDeployments. 
- This PR does the same action for statefulsets.
**Checklist**
If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
