### PR TITLE
ansible-operator|helm-operator: add the kubernetes auth clients

### DIFF
--- a/changelog/fragments/fix-ansible-helm-auth-providers.yaml
+++ b/changelog/fragments/fix-ansible-helm-auth-providers.yaml
@@ -1,0 +1,8 @@
+entries:
+  - description: >
+      Added kubernetes authentication clients to `ansible-operator` and 
+      `helm-operator` to enable authentication to gcp, azure, etc. kubernetes 
+      clusters.
+
+    kind: bugfix
+    breaking: false

--- a/cmd/ansible-operator/main.go
+++ b/cmd/ansible-operator/main.go
@@ -17,6 +17,10 @@ package main
 import (
 	"log"
 
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that `exec-entrypoint` and `run` can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
 	"github.com/spf13/cobra"
 
 	"github.com/operator-framework/operator-sdk/internal/cmd/ansible-operator/run"

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -17,6 +17,10 @@ package main
 import (
 	"log"
 
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that `exec-entrypoint` and `run` can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
 	"github.com/spf13/cobra"
 
 	"github.com/operator-framework/operator-sdk/internal/cmd/helm-operator/run"


### PR DESCRIPTION
This PR adds the kubernetes auth clients to the ansible-operator and
helm-operator binaries.

Closes #3973

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

This PR adds the kubernetes auth clients to the ansible and helm operator binaries.

**Motivation for the change:**

The change enables the ansible and helm operator binaries to run in local mode using gcp, azure, etc auth providers.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
