### PR TITLE
[v0.19.x] ansible-operator|helm-operator: add the kubernetes auth clients

### DIFF
--- a/changelog/fragments/fix-ansible-helm-auth-providers.yaml
+++ b/changelog/fragments/fix-ansible-helm-auth-providers.yaml
@@ -1,0 +1,8 @@
+entries:
+  - description: >
+      Added kubernetes authentication clients to `ansible-operator` and 
+      `helm-operator` to enable authentication to gcp, azure, etc. kubernetes 
+      clusters.
+
+    kind: bugfix
+    breaking: false

--- a/cmd/ansible-operator/main.go
+++ b/cmd/ansible-operator/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/operator-framework/operator-sdk/pkg/ansible"

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/operator-framework/operator-sdk/pkg/helm"


### PR DESCRIPTION
This PR adds the kubernetes auth clients to the ansible-operator and
helm-operator binaries.

Backport of #3974