### PR TITLE
update bundle image name in examples to denote this is a bundle image

### DIFF
--- a/website/content/en/docs/olm-integration/quickstart-bundle.md
+++ b/website/content/en/docs/olm-integration/quickstart-bundle.md
@@ -122,14 +122,14 @@ OLM and Operator Registry consumes Operator bundles via an [index image][index-i
 which are composed of one or more bundles. To build a memcached-operator bundle, run:
 
 ```console
-make bundle-build BUNDLE_IMG=quay.io/<username>/memcached-operator-bundle:<tag>
-docker push quay.io/<username>/memcached-operator-bundle:<tag>
+make bundle-build BUNDLE_IMG=<some-registry>/<username>/memcached-operator-bundle:<tag>
+docker push <some-registry>/<username>/memcached-operator-bundle:<tag>
 ```
 
 Although we've validated on-disk manifests and metadata, we also must make sure the bundle itself is valid:
 
 ```console
-$ operator-sdk bundle validate quay.io/<username>/memcached-operator-bundle:<tag>
+$ operator-sdk bundle validate <some-registry>/<username>/memcached-operator-bundle:<tag>
 INFO[0000] Unpacked image layers                         bundle-dir=/tmp/bundle-716785960 container-tool=docker
 INFO[0000] running docker pull                           bundle-dir=/tmp/bundle-716785960 container-tool=docker
 INFO[0002] running docker save                           bundle-dir=/tmp/bundle-716785960 container-tool=docker

--- a/website/content/en/docs/olm-integration/quickstart-bundle.md
+++ b/website/content/en/docs/olm-integration/quickstart-bundle.md
@@ -122,14 +122,14 @@ OLM and Operator Registry consumes Operator bundles via an [index image][index-i
 which are composed of one or more bundles. To build a memcached-operator bundle, run:
 
 ```console
-$ docker build -f bundle.Dockerfile -t quay.io/<username>/memcached-operator:v0.1.0 .
+make bundle-build BUNDLE_IMG=quay.io/<username>/memcached-operator-bundle:<tag>
+docker push quay.io/<username>/memcached-operator-bundle:<tag>
 ```
 
 Although we've validated on-disk manifests and metadata, we also must make sure the bundle itself is valid:
 
 ```console
-$ docker push quay.io/<username>/memcached-operator:v0.1.0
-$ operator-sdk bundle validate quay.io/<username>/memcached-operator:v0.1.0
+$ operator-sdk bundle validate quay.io/<username>/memcached-operator-bundle:<tag>
 INFO[0000] Unpacked image layers                         bundle-dir=/tmp/bundle-716785960 container-tool=docker
 INFO[0000] running docker pull                           bundle-dir=/tmp/bundle-716785960 container-tool=docker
 INFO[0002] running docker save                           bundle-dir=/tmp/bundle-716785960 container-tool=docker

--- a/website/content/en/docs/olm-integration/quickstart-bundle.md
+++ b/website/content/en/docs/olm-integration/quickstart-bundle.md
@@ -122,14 +122,14 @@ OLM and Operator Registry consumes Operator bundles via an [index image][index-i
 which are composed of one or more bundles. To build a memcached-operator bundle, run:
 
 ```console
-make bundle-build BUNDLE_IMG=<some-registry>/<username>/memcached-operator-bundle:<tag>
-docker push <some-registry>/<username>/memcached-operator-bundle:<tag>
+make bundle-build BUNDLE_IMG=<some-registry>/memcached-operator-bundle:<tag>
+docker push <some-registry>/memcached-operator-bundle:<tag>
 ```
 
 Although we've validated on-disk manifests and metadata, we also must make sure the bundle itself is valid:
 
 ```console
-$ operator-sdk bundle validate <some-registry>/<username>/memcached-operator-bundle:<tag>
+$ operator-sdk bundle validate <some-registry>/memcached-operator-bundle:<tag>
 INFO[0000] Unpacked image layers                         bundle-dir=/tmp/bundle-716785960 container-tool=docker
 INFO[0000] running docker pull                           bundle-dir=/tmp/bundle-716785960 container-tool=docker
 INFO[0002] running docker save                           bundle-dir=/tmp/bundle-716785960 container-tool=docker


### PR DESCRIPTION

**Description of the change:**
This PR updates documentation, the OLM Integration/Bundle Quickstart section.

**Motivation for the change:**
The bundle image build example was not specifying an image name that was different from the operator image name, this seemed confusing to me since these are different images.  I updated the example to include the '-bundle' in the bundle image name to distinguish the image purpose.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
