### PR TITLE
cleanup e2e: centralize the code to manage the prerequisites

### DIFF
--- a/internal/testutils/utils.go
+++ b/internal/testutils/utils.go
@@ -41,12 +41,12 @@ type TestContext struct {
 	BundleImageName string
 	// ProjectName store the project name
 	ProjectName string
-	// IsPrometheusManagedBySuite is true when the suite tests is installing/uninstalling the Prometheus
-	IsPrometheusManagedBySuite bool
-	// IsOLMManagedBySuite is true when the suite tests is installing/uninstalling the OLM
-	IsOLMManagedBySuite bool
 	// Kubectx stores the k8s context from where the tests are running
 	Kubectx string
+	// isPrometheusManagedBySuite is true when the suite tests is installing/uninstalling the Prometheus
+	isPrometheusManagedBySuite bool
+	// isOLMManagedBySuite is true when the suite tests is installing/uninstalling the OLM
+	isOLMManagedBySuite bool
 }
 
 // NewTestContext returns a TestContext containing a new kubebuilder TestContext.
@@ -55,8 +55,8 @@ func NewTestContext(binary string, env ...string) (tc TestContext, err error) {
 	tc.ProjectName = strings.ToLower(filepath.Base(tc.Dir))
 	tc.ImageName = fmt.Sprintf("quay.io/example/%s:v0.0.1", tc.ProjectName)
 	tc.BundleImageName = fmt.Sprintf("quay.io/example/%s-bundle:v0.0.1", tc.ProjectName)
-	tc.IsOLMManagedBySuite = true
-	tc.IsPrometheusManagedBySuite = true
+	tc.isOLMManagedBySuite = true
+	tc.isPrometheusManagedBySuite = true
 	return tc, err
 }
 
@@ -195,13 +195,13 @@ func (tc TestContext) InstallPrerequisites() {
 	output, err := tc.Kubectl.Command("api-resources")
 	Expect(err).NotTo(HaveOccurred())
 	if strings.Contains(output, "servicemonitors") {
-		tc.IsPrometheusManagedBySuite = false
+		tc.isPrometheusManagedBySuite = false
 	}
 	if strings.Contains(output, "clusterserviceversions") {
-		tc.IsOLMManagedBySuite = false
+		tc.isOLMManagedBySuite = false
 	}
 
-	if tc.IsPrometheusManagedBySuite {
+	if tc.isPrometheusManagedBySuite {
 		By("installing Prometheus")
 		Expect(tc.InstallPrometheusOperManager()).To(Succeed())
 
@@ -214,7 +214,7 @@ func (tc TestContext) InstallPrerequisites() {
 		}, 3*time.Minute, time.Second).Should(Succeed())
 	}
 
-	if tc.IsOLMManagedBySuite {
+	if tc.isOLMManagedBySuite {
 		By("installing OLM")
 		Expect(tc.InstallOLMVersion(OlmVersionForTestSuite)).To(Succeed())
 	}
@@ -227,11 +227,11 @@ func (tc TestContext) IsRunningOnKind() bool {
 
 // UninstallPrerequisites will uninstall all prerequisites installed via InstallPrerequisites()
 func (tc TestContext) UninstallPrerequisites() {
-	if tc.IsPrometheusManagedBySuite {
+	if tc.isPrometheusManagedBySuite {
 		By("uninstalling Prometheus")
 		tc.UninstallPrometheusOperManager()
 	}
-	if tc.IsOLMManagedBySuite {
+	if tc.isOLMManagedBySuite {
 		By("uninstalling OLM")
 		tc.UninstallOLM()
 	}

--- a/test/e2e-ansible/e2e_ansible_olm_test.go
+++ b/test/e2e-ansible/e2e_ansible_olm_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Integrating ansible Projects with OLM", func() {
 			err = tc.Make("bundle-build", "BUNDLE_IMG="+tc.BundleImageName)
 			Expect(err).NotTo(HaveOccurred())
 
-			if isRunningOnKind() {
+			if tc.IsRunningOnKind() {
 				By("loading the bundle image into Kind cluster")
 				err = tc.LoadImageToKindClusterWithName(tc.BundleImageName)
 				Expect(err).NotTo(HaveOccurred())

--- a/test/e2e-ansible/e2e_ansible_suite_test.go
+++ b/test/e2e-ansible/e2e_ansible_suite_test.go
@@ -19,7 +19,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -38,12 +37,6 @@ func TestE2EAnsible(t *testing.T) {
 
 var (
 	tc testutils.TestContext
-	// isPrometheusManagedBySuite is true when the suite tests is installing/uninstalling the Prometheus
-	isPrometheusManagedBySuite = true
-	// isOLMManagedBySuite is true when the suite tests is installing/uninstalling the OLM
-	isOLMManagedBySuite = true
-	// kubectx stores the k8s context from where the tests are running
-	kubectx string
 )
 
 // BeforeSuite run before any specs are run to perform the required actions for all e2e ansible tests.
@@ -57,37 +50,12 @@ var _ = BeforeSuite(func() {
 	By("creating the repository")
 	Expect(tc.Prepare()).To(Succeed())
 
-	By("checking the cluster type")
-	kubectx, err = tc.Kubectl.Command("config", "current-context")
+	By("getting the cluster Kind")
+	tc.Kubectx, err = tc.Kubectl.Command("config", "current-context")
 	Expect(err).NotTo(HaveOccurred())
 
-	By("checking API resources applied on Cluster")
-	output, err := tc.Kubectl.Command("api-resources")
-	Expect(err).NotTo(HaveOccurred())
-	if strings.Contains(output, "servicemonitors") {
-		isPrometheusManagedBySuite = false
-	}
-	if strings.Contains(output, "clusterserviceversions") {
-		isOLMManagedBySuite = false
-	}
-
-	if isPrometheusManagedBySuite {
-		By("installing Prometheus")
-		Expect(tc.InstallPrometheusOperManager()).To(Succeed())
-
-		By("ensuring provisioned Prometheus Manager Service")
-		Eventually(func() error {
-			_, err := tc.Kubectl.Get(
-				false,
-				"Service", "prometheus-operator")
-			return err
-		}, 3*time.Minute, time.Second).Should(Succeed())
-	}
-
-	if isOLMManagedBySuite {
-		By("installing OLM")
-		Expect(tc.InstallOLMVersion(testutils.OlmVersionForTestSuite)).To(Succeed())
-	}
+	By("preparing the prerequisites on cluster")
+	tc.InstallPrerequisites()
 
 	By("setting domain and GVK")
 	tc.Domain = "example.com"
@@ -179,7 +147,7 @@ var _ = BeforeSuite(func() {
 	err = tc.Make("docker-build", "IMG="+tc.ImageName)
 	Expect(err).NotTo(HaveOccurred())
 
-	if isRunningOnKind() {
+	if tc.IsRunningOnKind() {
 		By("loading the required images into Kind cluster")
 		Expect(tc.LoadImageToKindCluster()).To(Succeed())
 		Expect(tc.LoadImageToKindClusterWithName("quay.io/operator-framework/scorecard-test:dev")).To(Succeed())
@@ -193,23 +161,12 @@ var _ = BeforeSuite(func() {
 // AfterSuite run after all the specs have run, regardless of whether any tests have failed to ensures that
 // all be cleaned up
 var _ = AfterSuite(func() {
-	if isPrometheusManagedBySuite {
-		By("uninstalling Prometheus")
-		tc.UninstallPrometheusOperManager()
-	}
-	if isOLMManagedBySuite {
-		By("uninstalling OLM")
-		tc.UninstallOLM()
-	}
+	By("uninstalling prerequisites")
+	tc.UninstallPrerequisites()
 
 	By("destroying container image and work dir")
 	tc.Destroy()
 })
-
-// isRunningOnKind returns true when the tests are executed in a Kind Cluster
-func isRunningOnKind() bool {
-	return strings.Contains(kubectx, "kind")
-}
 
 const memcachedWithBlackListTask = `- name: start memcached
   community.kubernetes.k8s:

--- a/test/e2e-ansible/e2e_ansible_suite_test.go
+++ b/test/e2e-ansible/e2e_ansible_suite_test.go
@@ -50,7 +50,7 @@ var _ = BeforeSuite(func() {
 	By("creating the repository")
 	Expect(tc.Prepare()).To(Succeed())
 
-	By("getting the cluster Kind")
+	By("fetching the current-context")
 	tc.Kubectx, err = tc.Kubectl.Command("config", "current-context")
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e-go/e2e_go_olm_test.go
+++ b/test/e2e-go/e2e_go_olm_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Integrating Go Projects with OLM", func() {
 			err = tc.Make("bundle-build", "BUNDLE_IMG="+tc.BundleImageName)
 			Expect(err).NotTo(HaveOccurred())
 
-			if isRunningOnKind() {
+			if tc.IsRunningOnKind() {
 				By("loading the bundle image into Kind cluster")
 				err = tc.LoadImageToKindClusterWithName(tc.BundleImageName)
 				Expect(err).NotTo(HaveOccurred())

--- a/test/e2e-go/e2e_go_suite_test.go
+++ b/test/e2e-go/e2e_go_suite_test.go
@@ -52,7 +52,7 @@ var _ = BeforeSuite(func() {
 	By("creating a new directory")
 	Expect(tc.Prepare()).To(Succeed())
 
-	By("getting the cluster Kind")
+	By("fetching the current-context")
 	tc.Kubectx, err = tc.Kubectl.Command("config", "current-context")
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e-go/e2e_go_suite_test.go
+++ b/test/e2e-go/e2e_go_suite_test.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -40,12 +39,6 @@ func TestE2EGo(t *testing.T) {
 
 var (
 	tc testutils.TestContext
-	// isPrometheusManagedBySuite is true when the suite tests is installing/uninstalling the Prometheus
-	isPrometheusManagedBySuite = true
-	// isOLMManagedBySuite is true when the suite tests is installing/uninstalling the OLM
-	isOLMManagedBySuite = true
-	// kubectx stores the k8s context from where the tests are running
-	kubectx string
 )
 
 // BeforeSuite run before any specs are run to perform the required actions for all e2e Go tests.
@@ -59,43 +52,17 @@ var _ = BeforeSuite(func() {
 	By("creating a new directory")
 	Expect(tc.Prepare()).To(Succeed())
 
-	By("checking the cluster type")
-	kubectx, err = tc.Kubectl.Command("config", "current-context")
+	By("getting the cluster Kind")
+	tc.Kubectx, err = tc.Kubectl.Command("config", "current-context")
 	Expect(err).NotTo(HaveOccurred())
 
-	By("checking API resources applied on Cluster")
-	output, err := tc.Kubectl.Command("api-resources")
-	Expect(err).NotTo(HaveOccurred())
-	if strings.Contains(output, "servicemonitors") {
-		isPrometheusManagedBySuite = false
-	}
-	if strings.Contains(output, "clusterserviceversions") {
-		isOLMManagedBySuite = false
-	}
-
-	if isPrometheusManagedBySuite {
-		By("installing Prometheus")
-		Expect(tc.InstallPrometheusOperManager()).To(Succeed())
-
-		By("ensuring provisioned Prometheus Manager Service")
-		Eventually(func() error {
-			_, err := tc.Kubectl.Get(
-				false,
-				"Service", "prometheus-operator")
-			return err
-		}, 3*time.Minute, time.Second).Should(Succeed())
-	}
-
-	if isOLMManagedBySuite {
-		By("installing OLM")
-		Expect(tc.InstallOLMVersion(testutils.OlmVersionForTestSuite)).To(Succeed())
-	}
+	By("preparing the prerequisites on cluster")
+	tc.InstallPrerequisites()
 
 	By("initializing a project")
-	projectName := filepath.Base(tc.Dir)
 	err = tc.Init(
 		"--project-version", "3-alpha",
-		"--repo", path.Join("github.com", "example", projectName),
+		"--repo", path.Join("github.com", "example", tc.ProjectName),
 		"--domain", tc.Domain,
 		"--fetch-deps=false")
 	Expect(err).NotTo(HaveOccurred())
@@ -145,7 +112,7 @@ var _ = BeforeSuite(func() {
 	err = tc.Make("docker-build", "IMG="+tc.ImageName)
 	Expect(err).NotTo(HaveOccurred())
 
-	if isRunningOnKind() {
+	if tc.IsRunningOnKind() {
 		By("loading the required images into Kind cluster")
 		Expect(tc.LoadImageToKindCluster()).To(Succeed())
 		Expect(tc.LoadImageToKindClusterWithName("quay.io/operator-framework/scorecard-test:dev")).To(Succeed())
@@ -160,20 +127,9 @@ var _ = BeforeSuite(func() {
 // AfterSuite run after all the specs have run, regardless of whether any tests have failed to ensures that
 // all be cleaned up
 var _ = AfterSuite(func() {
-	if isPrometheusManagedBySuite {
-		By("uninstalling Prometheus")
-		tc.UninstallPrometheusOperManager()
-	}
-	if isOLMManagedBySuite {
-		By("uninstalling OLM")
-		tc.UninstallOLM()
-	}
+	By("uninstalling prerequisites")
+	tc.UninstallPrerequisites()
 
 	By("destroying container image and work dir")
 	tc.Destroy()
 })
-
-// isRunningOnKind returns true when the tests are executed in a Kind Cluster
-func isRunningOnKind() bool {
-	return strings.Contains(kubectx, "kind")
-}

--- a/test/e2e-helm/e2e_helm_olm_test.go
+++ b/test/e2e-helm/e2e_helm_olm_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Integrating Helm Projects with OLM", func() {
 			err := tc.Make("bundle-build", "BUNDLE_IMG="+tc.BundleImageName)
 			Expect(err).NotTo(HaveOccurred())
 
-			if isRunningOnKind() {
+			if tc.IsRunningOnKind() {
 				By("loading the bundle image into Kind cluster")
 				err = tc.LoadImageToKindClusterWithName(tc.BundleImageName)
 				Expect(err).NotTo(HaveOccurred())

--- a/test/e2e-helm/e2e_helm_suite_test.go
+++ b/test/e2e-helm/e2e_helm_suite_test.go
@@ -16,9 +16,7 @@ package e2e_helm_test
 
 import (
 	"path/filepath"
-	"strings"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -37,12 +35,6 @@ func TestE2EHelm(t *testing.T) {
 
 var (
 	tc testutils.TestContext
-	// isPrometheusManagedBySuite is true when the suite tests is installing/uninstalling the Prometheus
-	isPrometheusManagedBySuite = true
-	// isOLMManagedBySuite is true when the suite tests is installing/uninstalling the OLM
-	isOLMManagedBySuite = true
-	// kubectx stores the k8s context from where the tests are running
-	kubectx string
 )
 
 // BeforeSuite run before any specs are run to perform the required actions for all e2e Helm tests.
@@ -56,37 +48,12 @@ var _ = BeforeSuite(func() {
 	By("creating a new directory")
 	Expect(tc.Prepare()).To(Succeed())
 
-	By("checking the cluster type")
-	kubectx, err = tc.Kubectl.Command("config", "current-context")
+	By("getting the cluster Kind")
+	tc.Kubectx, err = tc.Kubectl.Command("config", "current-context")
 	Expect(err).NotTo(HaveOccurred())
 
-	By("checking API resources applied on Cluster")
-	output, err := tc.Kubectl.Command("api-resources")
-	Expect(err).NotTo(HaveOccurred())
-	if strings.Contains(output, "servicemonitors") {
-		isPrometheusManagedBySuite = false
-	}
-	if strings.Contains(output, "clusterserviceversions") {
-		isOLMManagedBySuite = false
-	}
-
-	if isPrometheusManagedBySuite {
-		By("installing Prometheus")
-		Expect(tc.InstallPrometheusOperManager()).To(Succeed())
-
-		By("ensuring provisioned Prometheus Manager Service")
-		Eventually(func() error {
-			_, err := tc.Kubectl.Get(
-				false,
-				"Service", "prometheus-operator")
-			return err
-		}, 3*time.Minute, time.Second).Should(Succeed())
-	}
-
-	if isOLMManagedBySuite {
-		By("installing OLM")
-		Expect(tc.InstallOLMVersion(testutils.OlmVersionForTestSuite)).To(Succeed())
-	}
+	By("preparing the prerequisites on cluster")
+	tc.InstallPrerequisites()
 
 	By("initializing a Helm project")
 	err = tc.Init(
@@ -123,7 +90,7 @@ var _ = BeforeSuite(func() {
 	err = tc.Make("docker-build", "IMG="+tc.ImageName)
 	Expect(err).NotTo(HaveOccurred())
 
-	if isRunningOnKind() {
+	if tc.IsRunningOnKind() {
 		By("loading the required images into Kind cluster")
 		Expect(tc.LoadImageToKindCluster()).To(Succeed())
 		Expect(tc.LoadImageToKindClusterWithName("quay.io/operator-framework/scorecard-test:dev")).To(Succeed())
@@ -137,20 +104,9 @@ var _ = BeforeSuite(func() {
 // AfterSuite run after all the specs have run, regardless of whether any tests have failed to ensures that
 // all be cleaned up
 var _ = AfterSuite(func() {
-	if isPrometheusManagedBySuite {
-		By("uninstalling Prometheus")
-		tc.UninstallPrometheusOperManager()
-	}
-	if isOLMManagedBySuite {
-		By("uninstalling OLM")
-		tc.UninstallOLM()
-	}
+	By("uninstalling prerequisites")
+	tc.UninstallPrerequisites()
 
 	By("destroying container image and work dir")
 	tc.Destroy()
 })
-
-// isRunningOnKind returns true when the tests are executed in a Kind Cluster
-func isRunningOnKind() bool {
-	return strings.Contains(kubectx, "kind")
-}

--- a/test/e2e-helm/e2e_helm_suite_test.go
+++ b/test/e2e-helm/e2e_helm_suite_test.go
@@ -48,7 +48,7 @@ var _ = BeforeSuite(func() {
 	By("creating a new directory")
 	Expect(tc.Prepare()).To(Succeed())
 
-	By("getting the cluster Kind")
+	By("fetching the current-context")
 	tc.Kubectx, err = tc.Kubectl.Command("config", "current-context")
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
**Description of the change:**
centralize the code to manage the prerequisites to install OLM and Prometheus which are equals for all e2e tests

**Motivation for the change:**
- maintainability
- reusability 
- remove code duplications across the e2e tests