### PR TITLE
[docs] Update doc site to improve navigation

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -113,7 +113,7 @@ algolia_docsearch = false
 
 # User interface configuration
 [params.ui]
-#  Set to true to disable breadcrumb navigation.
+#  Set to true to disable breadcrumb navigation. 
 breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
 sidebar_search_disable = true

--- a/website/config.toml
+++ b/website/config.toml
@@ -113,10 +113,8 @@ algolia_docsearch = false
 
 # User interface configuration
 [params.ui]
-# Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = true
 #  Set to true to disable breadcrumb navigation.
-breadcrumb_disable = true
+breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
 sidebar_search_disable = true
 #  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar

--- a/website/layouts/docs/baseof.html
+++ b/website/layouts/docs/baseof.html
@@ -13,7 +13,9 @@
           <div class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
             {{ partial "sidebar.html" . }}
           </div>
-
+          <div class="d-none d-xl-block col-xl-2 td-toc d-print-none">
+            {{ partial "toc.html" . }}
+          </div>
           <main class="col-12 col-md-9 col-xl-8 pl-md-5 of-docs__wrapper" role="main">
             {{ partial "version-banner.html" . }}
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}


### PR DESCRIPTION
**Description of the change:**

This PR
- Expands the left navigation menu
- Includes a TOC for individual docs on the right
- Includes breadcrumb links on top of the documents for
  faster nav-back to the root folder/any folder
  of the user's choice

**Motivation for the change:**

The current contracted menu does not reveal anything about the content of the 
site to new/first time readers. Displaying a list of topics for the site and a 
table of content of each document will significantly improve the UX of the site 
from the perspective of readers who aren't already familiar with the contents of 
the site. 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
