### PR TITLE
changelog/fragments/csv-whdescs-defaults.yaml: change to bugfixes, update descriptions

### DIFF
--- a/changelog/fragments/csv-whdescs-defaults.yaml
+++ b/changelog/fragments/csv-whdescs-defaults.yaml
@@ -1,7 +1,11 @@
 entries:
   - description: >
-      Default a CSV's `spec.webhookDefinition[].admissionReviewVersions` to "v1beta1".
-    kind: addition
+      `generate <bundle|packagemanifests>` now defaults a CSV's `spec.webhookDefinition[].admissionReviewVersions`
+      to []string{"v1beta1"}, as an empty or null value is invalid.
+    kind: bugfix
+    pull_request_override: 3903
   - description: >
-      Default a CSV's `spec.webhookDefinition[].sideEffects` to "None".
-    kind: addition
+      `generate <bundle|packagemanifests>` now defaults a CSV's `spec.webhookDefinition[].sideEffects`
+      to "None", as an empty or null value is invalid.
+    kind: bugfix
+    pull_request_override: 3903


### PR DESCRIPTION
**Description of the change:** change fragment from addition to bugfix

**Motivation for the change:** CSVs are invalid if they don't have `admissionReviewVersion` or `sideEffects` set in webhook definitions, so #3903 should be treated as a bugfix


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
