### PR TITLE
Ansible: pin community-kubernetes to <1.0.0 in tests to match ansible project scaffold

### DIFF
--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -15,7 +15,7 @@ pip3 install --user pyasn1==0.4.7 pyasn1-modules==0.2.6 idna==2.8 ipaddress==1.0
 pip3 install --user molecule==3.0.2
 pip3 install --user ansible-lint yamllint
 pip3 install --user docker==4.2.2 openshift jmespath
-ansible-galaxy collection install community.kubernetes
+ansible-galaxy collection install community.kubernetes:<1.0.0
 
 setup_envs $tmp_sdk_root
 

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -15,7 +15,7 @@ pip3 install --user pyasn1==0.4.7 pyasn1-modules==0.2.6 idna==2.8 ipaddress==1.0
 pip3 install --user molecule==3.0.2
 pip3 install --user ansible-lint yamllint
 pip3 install --user docker==4.2.2 openshift jmespath
-ansible-galaxy collection install community.kubernetes:<1.0.0
+ansible-galaxy collection install 'community.kubernetes:<1.0.0'
 
 setup_envs $tmp_sdk_root
 

--- a/test/ansible/requirements.yml
+++ b/test/ansible/requirements.yml
@@ -1,3 +1,4 @@
 collections:
-  - community.kubernetes
+  - name: community.kubernetes
+    version: <1.0.0
   - operator_sdk.util


### PR DESCRIPTION
**Description of the change:**
Pin community-kubernetes to <1.0.0

**Motivation for the change:**
To match ansible project scaffold and fix failing CI

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] ~Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))~
- [ ] ~Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)~
