### PR TITLE
doc: improve/fix memcached go tutorial

### DIFF
--- a/website/content/en/docs/building-operators/ansible/tutorial.md
+++ b/website/content/en/docs/building-operators/ansible/tutorial.md
@@ -13,6 +13,14 @@ please [migrate][migration-guide], or consult the [legacy docs][legacy-quickstar
 - Go through the [installation guide][install-guide].
 - User authorized with `cluster-admin` permissions.
 
+## Overview
+
+We will create a sample project to let you know how it works and this sample will:
+
+- Create a Memcached Deployment if it doesn't exist
+- Ensure that the Deployment size is the same as specified by the Memcached CR spec
+- Update the Memcached CR status using the status writer with the names of the memcached pods
+
 ## Create a new project
 
 Use the CLI to create a new memcached-operator project:

--- a/website/content/en/docs/building-operators/golang/references/openapi-validation.md
+++ b/website/content/en/docs/building-operators/golang/references/openapi-validation.md
@@ -1,0 +1,18 @@
+---
+title: OpenAPI validation
+linkTitle: OpenAPI validation
+weight: 70
+---
+
+OpenAPIv3 schemas are added to CRD manifests in the `spec.validation` block when the manifests are generated. This validation block allows Kubernetes to validate the properties in a Memcached Custom Resource when it is created or updated.
+
+[Markers][markers] (annotations) are available to configure validations for your API. These markers will always have a `+kubebuilder:validation` prefix.
+
+Usage of markers in API code is discussed in the kubebuilder [CRD generation][generating-crd] and [marker][markers] documentation. A full list of OpenAPIv3 validation markers can be found [here][crd-markers].
+
+To learn more about OpenAPI v3.0 validation schemas in CRDs, refer to the [Kubernetes Documentation][doc-validation-schema].
+
+[markers]: https://book.kubebuilder.io/reference/markers.html
+[crd-markers]: https://book.kubebuilder.io/reference/markers/crd-validation.html
+[generating-crd]: https://book.kubebuilder.io/reference/generating-crd.html
+[doc-validation-schema]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -16,11 +16,9 @@ please [migrate][migration-guide], or consult the [legacy docs][legacy-quickstar
 
 ## Overview
 
-By using operators, it’s possible not only to provide all expected resources but also to manage them dynamically, programmatically, and at execution time. To illustrate this idea, imagine if someone accidentally changed a configuration or removed a resource by mistake; in this case, the operator could fix it without any human intervention. 
-
 We will create a sample project to let you know how it works and this sample will:
 
-- Create a memcached Deployment if it doesn't exist
+- Create a Memcached Deployment if it doesn't exist
 - Ensure that the Deployment size is the same as specified by the Memcached CR spec
 - Update the Memcached CR status using the status writer with the names of the memcached pods
 
@@ -77,7 +75,7 @@ This will scaffold the Memcached resource API at `api/v1alpha1/memcached_types.g
 
 **Note:** This guide will cover the default case of a single group API. If you would like to support Multi-Group APIs see the [Single Group to Multi-Group][multigroup-kubebuilder-doc] doc.
 
-#### Understanding API’s
+#### Understanding API
 
 The goal of this command is to create Custom Resource (CR) and Custom Resource Definition (CRD) resources for the Memcached Kind. This command is creating the API with the group `cache.example.com`, and version `v1alpha1`  which uniquely identifies the new CRD of the Memcached Kind. For more info see [Extend the Kubernetes API with CustomResourceDefinitions][[kubernetes-extend-api]]. 
 
@@ -87,15 +85,16 @@ Consequently, by using the Operator SDK tool, we can create our APIs and objects
 
 Let’s think about the classic scenario where the goal is to have an application and its database running on the platform with Kubernetes. Then, one object could represent the App, and another one could represent the DB. By having one CRD to describe the App and another one for the DB, we will not be hurting concepts such as encapsulation, the single responsibility principle, and cohesion. Damaging these concepts could cause unexpected side effects, such as difficulty in extending, reuse, or maintenance, just to mention a few.
 
-In conclusion, the App CRD will have as its controller the DB CRD. Imagine, that a Deployment and Service are required for the application run so that the App’s Controller will provide these resources in this example. Similarly, the DB’s controller will have the business logic implementation of its objects.
+In conclusion, the App CRD will have its controller which would be responsible for things like creating Deployments that contain the App and creating Services to access it. Similarly, we would create a CRD to represent the DB, and deploy a controller that would manage DB instances. 
 
-In this way, for each CRD, one controller should be produced according to the design set by the controller-runtime.
+In general, it's recommended to have one controller responsible for manage each API(CRD) created on the project in order to 
+not go against the design goals set by [controller-runtime][controller-runtime].
 
 ### Define the API
 
-In this example, we will define that the Memcached Kind (CRD) will have the attribute size which will specify the quantity of Memcached instances will be deployed. Also, we will create an attribute to its Status which will store the Pod Names. 
+In this example, we will define that the Memcached Kind (CRD) will have a size Spec which will specify the quantity of Memcached instances will be deployed. Also, we will add a nodes Status that will store the Pod names.
 
-**NOTE** The status field here is just to illustrate the idea but for it would be recommended use [Conditionals][conditionals] instead of that.
+**NOTE** The Node field is just to illustrate an example of a Status field. In real cases, it would be recommended to use [Conditions][conditionals].
 
 Define the API for the Memcached Custom Resource(CR) by modifying the Go type definitions at `api/v1alpha1/memcached_types.go` to have the following spec and status:
 
@@ -198,7 +197,7 @@ There are a number of other useful configurations that can be made when initialz
 
 ### Reconcile loop
 
-The reconcile function is responsible for synchronizing the resources and their specifications according to the business logic implemented on them. In this way, it works like a loop, and it does not stop until all conditionals match its implementation. The following is pseudo-code with an example that clarifies it.
+The reconcile function is responsible for synchronizing the desired state as represented by their Specs and the actual state of the system. In this way, it works like a loop, and it does not stop until all conditionals match its implementation. The following is pseudo-code with an example that clarifies it.
 
 ```go
 reconcile App {
@@ -511,3 +510,4 @@ Also see the [advanced topics][advanced_topics] doc for more use cases and under
 [rbac-k8s-doc]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 [olm-integration]: /docs/olm-integration
 [openapi-validation]: /docs/building-operators/golang/references/openapi-validation
+[controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -75,17 +75,9 @@ This will scaffold the Memcached resource API at `api/v1alpha1/memcached_types.g
 
 **Note:** This guide will cover the default case of a single group API. If you would like to support Multi-Group APIs see the [Single Group to Multi-Group][multigroup-kubebuilder-doc] doc.
 
-#### Understanding API
+#### Understanding Kubernetes APIs
 
-The goal of this command is to create Custom Resource (CR) and Custom Resource Definition (CRD) resources for the Memcached Kind. This command is creating the API with the group `cache.example.com`, and version `v1alpha1`  which uniquely identifies the new CRD of the Memcached Kind. For more info see [Extend the Kubernetes API with CustomResourceDefinitions][[kubernetes-extend-api]]. 
-
-Consequently, by using the Operator SDK tool, we can create our APIs and objects that will represent our solutions on these platforms. Here will adds only a single kind of resource; however, it could have as many Kinds as needed (1…N). Basically, the CRDs are a definition of our customized Objects, and the CRs are an instance of it.
-
-#### Getting a better idea
-
-Let’s think about the classic scenario where the goal is to have an application and its database running on the platform with Kubernetes. Then, one object could represent the App, and another one could represent the DB. By having one CRD to describe the App and another one for the DB, we will not be hurting concepts such as encapsulation, the single responsibility principle, and cohesion. Damaging these concepts could cause unexpected side effects, such as difficulty in extending, reuse, or maintenance, just to mention a few.
-
-In conclusion, the App CRD will have its controller which would be responsible for things like creating Deployments that contain the App and creating Services to access it. Similarly, we would create a CRD to represent the DB, and deploy a controller that would manage DB instances. 
+For an in-depth explanation of Kubernetes APIs and the group-version-kind model, check out these [kubebuilder docs][kb-doc-gkvs].
 
 In general, it's recommended to have one controller responsible for manage each API(CRD) created on the project in order to 
 not go against the design goals set by [controller-runtime][controller-runtime].
@@ -342,7 +334,6 @@ operator-sdk run bundle $BUNDLE_IMG
 
 Check out the [docs][quickstart-bundle] for a deep dive into `operator-sdk`'s OLM integration.
 
-
 ## Create a Memcached CR
 
 Update the sample Memcached CR manifest at `config/samples/cache_v1alpha1_memcached.yaml` and define the `spec` as the following:
@@ -480,3 +471,4 @@ Also see the [advanced topics][advanced_topics] doc for more use cases and under
 [olm-integration]: /docs/olm-integration
 [openapi-validation]: /docs/building-operators/golang/references/openapi-validation
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime
+[kb-doc-gkvs]: https://book.kubebuilder.io/cronjob-tutorial/gvks.html

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -92,9 +92,9 @@ not go against the design goals set by [controller-runtime][controller-runtime].
 
 ### Define the API
 
-In this example, we will define that the Memcached Kind (CRD) will have a size Spec which will specify the quantity of Memcached instances will be deployed. Also, we will add a nodes Status that will store the Pod names.
+In this example, we will define that the Memcached Kind (CRD) will have a `MemcachedSpec.Size` field which will specify the quantity of Memcached instances will be deployed, and a `MemcachedStatus.Nodes` field that will store a CR's Pod names.
 
-**NOTE** The Node field is just to illustrate an example of a Status field. In real cases, it would be recommended to use [Conditions][conditionals].
+**Note** The Node field is just to illustrate an example of a Status field. In real cases, it would be recommended to use [Conditions][conditionals].
 
 Define the API for the Memcached Custom Resource(CR) by modifying the Go type definitions at `api/v1alpha1/memcached_types.go` to have the following spec and status:
 
@@ -145,7 +145,7 @@ make manifests
 
 This makefile target will invoke [controller-gen][controller_tools] to generate the CRD manifests at `config/crd/bases/cache.example.com_memcacheds.yaml`.
 
-**Note** If you would like to define validations for the CRD's fields see the [OpenAPI valiation][openapi-validation] doc.
+**Note** If you would like to read further into CRD validation, see the [OpenAPI valiation][openapi-validation] doc.
 
 ## Implement the Controller
 
@@ -197,38 +197,7 @@ There are a number of other useful configurations that can be made when initialz
 
 ### Reconcile loop
 
-The reconcile function is responsible for synchronizing the desired state as represented by their Specs and the actual state of the system. In this way, it works like a loop, and it does not stop until all conditionals match its implementation. The following is pseudo-code with an example that clarifies it.
-
-```go
-reconcile App {
- 
-   // Check if a Deployment for the app exists, if not create one
-   // If has an error, then go to the beginning of the reconcile
-   if err != nil {
-       return reconcile.Result{}, err 
-   } 
-    
-   // Check if a Service for the app exists, if not create one 
-   // If has an error, then go to the beginning of the reconcile
-   if err != nil {
-       return reconcile.Result{}, err 
-   }  
- 
-   // Looking for Database CR/CRD 
-   // Check the Database Deployments Replicas size
-   // If deployment.replicas size != cr.size, then update it
-   // Then, go to the beginning of the reconcile
-   if err != nil {
-       return reconcile.Result{Requeue: true}, nil
-   }  
-   ...
-    
-   // If it is at the end of the loop, then:
-   // All was done successfully and the reconcile can stop  
-   return reconcile.Result{}, nil
- 
-}
-```
+The reconcile function is responsible for synchronizing the desired state as represented by their Specs and the actual state of the system. In this way, it works like a loop, and it does not stop until all conditionals match its implementation. 
 
 The following are a few possible return options to restart the Reconcile:
 
@@ -305,7 +274,7 @@ There are three ways to run the operator:
 - Managed by the [Operator Lifecycle Manager (OLM)][doc-olm] in [bundle][quickstart-bundle] format
 
 
-The following steps will show how to deploy the operator on the Cluster. However, to run locally for development purposes and outside of a Cluster use the target `make run`.
+The following steps will show how to deploy the operator on the Cluster. However, to run locally for development purposes and outside of a Cluster use the target `make install run`.
 
 ### Build and push the image
 

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -143,7 +143,7 @@ This makefile target will invoke [controller-gen][controller_tools] to generate 
 
 For this example replace the generated controller file `controllers/memcached_controller.go` with the example [`memcached_controller.go`][memcached_controller] implementation.
 
-**Note**: The next two subsections explain how the controller watches resources and how the reconcile loop is triggered. Skip to the [Build](#Build-and-push-the-image) section to see how to build and run the operator.
+**Note**: The next two subsections explain how the controller watches resources and how the reconcile loop is triggered. Skip to the [Build](#build-and-push-the-image) section to see how to build and run the operator.
 
 ### Resources watched by the Controller
 

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -151,7 +151,7 @@ This makefile target will invoke [controller-gen][controller_tools] to generate 
 
 For this example replace the generated controller file `controllers/memcached_controller.go` with the example [`memcached_controller.go`][memcached_controller] implementation.
 
-**Note**: The next two subsections explain how the controller watches resources and how the reconcile loop is triggered. Skip to the [Build](#build-and-run-the-operator) section to see how to build and run the operator.
+**Note**: The next two subsections explain how the controller watches resources and how the reconcile loop is triggered. Skip to the [Build](#Build-and-push-the-image) section to see how to build and run the operator.
 
 ### Resources watched by the Controller
 

--- a/website/content/en/docs/building-operators/helm/tutorial.md
+++ b/website/content/en/docs/building-operators/helm/tutorial.md
@@ -13,6 +13,14 @@ please [migrate][migration-guide], or consult the [legacy docs][legacy-quickstar
 - Go through the [installation guide][install-guide].
 - User authorized with `cluster-admin` permissions.
 
+## Overview
+
+We will create a sample project to let you know how it works and this sample will:
+
+- Create a Memcached Deployment if it doesn't exist
+- Ensure that the Deployment size is the same as specified by the Memcached CR spec
+- Update the Memcached CR status using the status writer with the names of the memcached pods
+
 ## Create a new project
 
 Use the CLI to create a new Helm-based nginx-operator project:


### PR DESCRIPTION
**Description**
- remove webhooks statements from tutorial since it does not use webhooks might bring confusion
- add as next step integrate the project with OLM instead of use webhooks which shows that is more aligned with the goal
- move the open API validation and multigroup support to reference since both are not features used in the example
- add clarifications over the reconcile and APIs to make clear how it works and address common questions such as https://github.com/operator-framework/operator-sdk/issues/4013, https://github.com/operator-framework/operator-sdk/issues/4030, #4077
- add an overview to clarifies the goal of the tutorial. 
- add a note to make clear that k8s recommends use conditionals for the status definitions 