### PR TITLE
Makefile: run cli-doc generator directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ setup-k8s:
 generate: cli-doc samples bindata ## Run all non-release generate targets
 
 cli-doc: ## Generate CLI documentation
-	./hack/generate/cli-doc/cli-doc.sh
+	go run ./hack/generate/cli-doc/gen-cli-doc.go
 
 samples: ## Generate samples
 	go run ./hack/generate/samples/generate_all.go

--- a/hack/generate/cli-doc/gen-cli-doc.sh
+++ b/hack/generate/cli-doc/gen-cli-doc.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-go run ./hack/generate/cli-doc/gen-cli-doc.go

--- a/hack/tests/sanity-check.sh
+++ b/hack/tests/sanity-check.sh
@@ -7,11 +7,11 @@ go fmt ./...
 
 ./hack/check-license.sh
 ./hack/check-error-log-msg-format.sh
-./hack/generate/cli-doc/gen-cli-doc.sh
+make cli-doc
 go run ./hack/generate/changelog/gen-changelog.go -validate-only
 
 make install
-go run ./hack/generate/samples/generate_all.go
+make samples
 
 # Make sure repo is still in a clean state.
 git diff --exit-code


### PR DESCRIPTION


<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
* Makefile: run gen-cli-doc.go directly
* hack/: remove unecessary gen-cli-doc wrapper script, run make targets where possible in sanity-check.sh

**Motivation for the change:** thin wrapper script is unnecessary, also fixes CI

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
