### PR TITLE
Remove outdated version validation

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -33,14 +33,6 @@ if ! go version | cut -d" " -f3 | grep -q "$GO_VER"; then
 	exit 1
 fi
 
-# Detect whether versions in code were updated.
-VER_FILE="internal/version/version.go"
-CURR_VER="$(sed -nr 's|\s+Version\s+= "(.+)"|\1|p' "$VER_FILE" | tr -d ' \t\n')"
-if [[ "$VER" != "$CURR_VER" ]]; then
-	echo "version is not set correctly in $VER_FILE"
-	exit 1
-fi
-
 INSTALL_GUIDE_FILE="website/content/en/docs/installation/install-operator-sdk.md"
 CURR_VER_INSTALL_GUIDE_FILE="$(sed -nr 's/.*RELEASE_VERSION=(.+)/\1/p' "$INSTALL_GUIDE_FILE" | tr -d ' \t\n')"
 if [[ "$VER" != "$CURR_VER_INSTALL_GUIDE_FILE" ]]; then


### PR DESCRIPTION
Version information is automatically included, so this validation should be removed.

Had to make this change during the release process.

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
