### PR TITLE
test-e2e/go : using samples 

### DIFF
--- a/hack/generate/samples/internal/go/v2/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/v2/memcached_with_webhooks.go
@@ -91,6 +91,13 @@ func (mh *MemcachedGoWithWebhooks) Run() {
 	mh.implementingWebhooks()
 	mh.uncommentKustomizationFile()
 
+	sampleFile := filepath.Join("config", "samples",
+		fmt.Sprintf("%s_%s_%s.yaml", mh.ctx.Group, mh.ctx.Version, strings.ToLower(mh.ctx.Kind)))
+
+	log.Infof("updating sample to have size attribute")
+	err = testutils.ReplaceInFile(filepath.Join(mh.ctx.Dir, sampleFile), "foo: bar", "size: 1")
+	pkg.CheckError("updating sample", err)
+
 	mh.ctx.CreateBundle()
 
 	pkg.CheckError("formatting project", mh.ctx.Make("fmt"))
@@ -176,8 +183,13 @@ func (mh *MemcachedGoWithWebhooks) implementingWebhooks() {
 	// Add imports
 	err = kbtestutils.InsertCode(webhookPath,
 		"import (",
-		"\"errors\"")
-	pkg.CheckError("adding imports", err)
+		"\n\t\"errors\"")
+	pkg.CheckError("adding errors import", err)
+
+	err = kbtestutils.InsertCode(webhookPath,
+		"\n\t\"errors\"",
+		"\n\t\"k8s.io/apimachinery/pkg/runtime\"")
+	pkg.CheckError("adding k8s.io/apimachinery/pkg/runtime import", err)
 }
 
 // implementingController will customize the Controller
@@ -225,8 +237,11 @@ func (mh *MemcachedGoWithWebhooks) implementingController() {
 
 // implementingAPI will customize the API
 func (mh *MemcachedGoWithWebhooks) implementingAPI() {
+	typeFilePath := filepath.Join(mh.ctx.Dir, "api", mh.ctx.Version, fmt.Sprintf("%s_types.go", strings.ToLower(mh.ctx.Kind)))
+
+	log.Infof("implementing api spec")
 	err := kbtestutils.InsertCode(
-		filepath.Join(mh.ctx.Dir, "api", mh.ctx.Version, fmt.Sprintf("%s_types.go", strings.ToLower(mh.ctx.Kind))),
+		typeFilePath,
 		fmt.Sprintf("type %sSpec struct {\n\t// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster\n\t// Important: Run \"make\" to regenerate code after modifying this file", mh.ctx.Kind),
 		`
 
@@ -235,9 +250,9 @@ func (mh *MemcachedGoWithWebhooks) implementingAPI() {
 `)
 	pkg.CheckError("inserting spec Status", err)
 
-	log.Infof("implementing MemcachedStatus")
+	log.Infof("implementing api status")
 	err = kbtestutils.InsertCode(
-		filepath.Join(mh.ctx.Dir, "api", mh.ctx.Version, fmt.Sprintf("%s_types.go", strings.ToLower(mh.ctx.Kind))),
+		typeFilePath,
 		fmt.Sprintf("type %sStatus struct {\n\t// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster\n\t// Important: Run \"make\" to regenerate code after modifying this file", mh.ctx.Kind),
 		`
 

--- a/hack/generate/samples/internal/go/v2/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/v2/memcached_with_webhooks.go
@@ -91,13 +91,6 @@ func (mh *MemcachedGoWithWebhooks) Run() {
 	mh.implementingWebhooks()
 	mh.uncommentKustomizationFile()
 
-	sampleFile := filepath.Join("config", "samples",
-		fmt.Sprintf("%s_%s_%s.yaml", mh.ctx.Group, mh.ctx.Version, strings.ToLower(mh.ctx.Kind)))
-
-	log.Infof("updating sample to have size attribute")
-	err = testutils.ReplaceInFile(filepath.Join(mh.ctx.Dir, sampleFile), "foo: bar", "size: 1")
-	pkg.CheckError("updating sample", err)
-
 	mh.ctx.CreateBundle()
 
 	pkg.CheckError("formatting project", mh.ctx.Make("fmt"))
@@ -260,6 +253,13 @@ func (mh *MemcachedGoWithWebhooks) implementingAPI() {
 	Nodes []string `+"`"+`json:"nodes,omitempty"`+"`"+`
 `)
 	pkg.CheckError("inserting Node Status", err)
+
+	sampleFile := filepath.Join("config", "samples",
+		fmt.Sprintf("%s_%s_%s.yaml", mh.ctx.Group, mh.ctx.Version, strings.ToLower(mh.ctx.Kind)))
+
+	log.Infof("updating sample to have size attribute")
+	err = testutils.ReplaceInFile(filepath.Join(mh.ctx.Dir, sampleFile), "foo: bar", "size: 1")
+	pkg.CheckError("updating sample", err)
 }
 
 // GenerateMemcachedGoWithWebhooksSample will call all actions to create the directory and generate the sample

--- a/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
@@ -92,13 +92,6 @@ func (mh *MemcachedGoWithWebhooks) Run() {
 	mh.implementingWebhooks()
 	mh.uncommentKustomizationFile()
 
-	sampleFile := filepath.Join("config", "samples",
-		fmt.Sprintf("%s_%s_%s.yaml", mh.ctx.Group, mh.ctx.Version, strings.ToLower(mh.ctx.Kind)))
-
-	log.Infof("updating sample to have size attribute")
-	err = testutils.ReplaceInFile(filepath.Join(mh.ctx.Dir, sampleFile), "foo: bar", "size: 1")
-	pkg.CheckError("updating sample", err)
-
 	mh.ctx.CreateBundle()
 
 	pkg.CheckError("formatting project", mh.ctx.Make("fmt"))
@@ -251,6 +244,13 @@ func (mh *MemcachedGoWithWebhooks) implementingAPI() {
 	Nodes []string `+"`"+`json:"nodes,omitempty"`+"`"+`
 `)
 	pkg.CheckError("inserting Node Status", err)
+
+	sampleFile := filepath.Join("config", "samples",
+		fmt.Sprintf("%s_%s_%s.yaml", mh.ctx.Group, mh.ctx.Version, strings.ToLower(mh.ctx.Kind)))
+
+	log.Infof("updating sample to have size attribute")
+	err = testutils.ReplaceInFile(filepath.Join(mh.ctx.Dir, sampleFile), "foo: bar", "size: 1")
+	pkg.CheckError("updating sample", err)
 }
 
 // GenerateMemcachedGoWithWebhooksSample will call all actions to create the directory and generate the sample

--- a/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
@@ -92,6 +92,13 @@ func (mh *MemcachedGoWithWebhooks) Run() {
 	mh.implementingWebhooks()
 	mh.uncommentKustomizationFile()
 
+	sampleFile := filepath.Join("config", "samples",
+		fmt.Sprintf("%s_%s_%s.yaml", mh.ctx.Group, mh.ctx.Version, strings.ToLower(mh.ctx.Kind)))
+
+	log.Infof("updating sample to have size attribute")
+	err = testutils.ReplaceInFile(filepath.Join(mh.ctx.Dir, sampleFile), "foo: bar", "size: 1")
+	pkg.CheckError("updating sample", err)
+
 	mh.ctx.CreateBundle()
 
 	pkg.CheckError("formatting project", mh.ctx.Make("fmt"))

--- a/test/e2e-go/e2e_go_cluster_test.go
+++ b/test/e2e-go/e2e_go_cluster_test.go
@@ -124,14 +124,6 @@ var _ = Describe("operator-sdk", func() {
 				return err
 			}, time.Minute, time.Second).Should(Succeed())
 
-			By("ensuring the created resource object gets reconciled in controller")
-			managerContainerLogs := func() string {
-				logOutput, err := tc.Kubectl.Logs(controllerPodName, "-c", "manager")
-				Expect(err).NotTo(HaveOccurred())
-				return logOutput
-			}
-			Eventually(managerContainerLogs, time.Minute, time.Second).Should(ContainSubstring("Successfully Reconciled"))
-
 			By("granting permissions to access the metrics and read the token")
 			_, err = tc.Kubectl.Command(
 				"create",

--- a/test/e2e-go/e2e_go_cluster_test.go
+++ b/test/e2e-go/e2e_go_cluster_test.go
@@ -35,7 +35,7 @@ var _ = Describe("operator-sdk", func() {
 	Context("built with operator-sdk", func() {
 		BeforeEach(func() {
 			metricsClusterRoleBindingName = fmt.Sprintf("%s-metrics-reader", tc.ProjectName)
-
+			reconcileCount++
 			By("deploying project on the cluster")
 			err := tc.Make("deploy", "IMG="+tc.ImageName)
 			Expect(err).NotTo(HaveOccurred())
@@ -179,8 +179,8 @@ var _ = Describe("operator-sdk", func() {
 
 			By("validating that the created resource object gets reconciled in the controller")
 			Expect(metricsOutput).To(ContainSubstring(fmt.Sprintf(
-				`controller_runtime_reconcile_total{controller="%s",result="success"} 3`,
-				strings.ToLower(tc.Kind),
+				`controller_runtime_reconcile_total{controller="%s",result="success"} %d`,
+				strings.ToLower(tc.Kind), reconcileCount,
 			)))
 		})
 	})

--- a/test/e2e-go/e2e_go_olm_test.go
+++ b/test/e2e-go/e2e_go_olm_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Integrating Go Projects with OLM", func() {
 	// the pkg manifest after we comment cert-manager options into the kustomization file.
 	// More info: https://olm.operatorframework.io/docs/advanced-tasks/adding-admission-and-conversion-webhooks/#certificate-authority-requirements
 	BeforeEach(func() {
+		reconcileCount++
 		By("commenting cert-manager")
 		err := testutils.ReplaceInFile(
 			filepath.Join(tc.Dir, "config", "default", "kustomization.yaml"),
@@ -39,7 +40,7 @@ var _ = Describe("Integrating Go Projects with OLM", func() {
 		By("commenting cert-manager")
 		err = testutils.ReplaceInFile(
 			filepath.Join(tc.Dir, "config", "default", "kustomization.yaml"),
-			uncommentedCertManager, commentedCertMaagerKustomizeFields)
+			uncommentedCertManagerKustomizeFields, commentedCertManagerKustomizeFields)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -53,7 +54,7 @@ var _ = Describe("Integrating Go Projects with OLM", func() {
 		By("commenting cert-manager")
 		err = testutils.ReplaceInFile(
 			filepath.Join(tc.Dir, "config", "default", "kustomization.yaml"),
-			commentedCertMaagerKustomizeFields, uncommentedCertManager)
+			commentedCertManagerKustomizeFields, uncommentedCertManagerKustomizeFields)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -87,7 +88,7 @@ var _ = Describe("Integrating Go Projects with OLM", func() {
 	})
 })
 
-const uncommentedCertManager = `# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+const uncommentedCertManagerKustomizeFields = `# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
 - webhookcainjection_patch.yaml
@@ -123,7 +124,7 @@ vars:
     version: v1
     name: webhook-service`
 
-const commentedCertMaagerKustomizeFields = `# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+const commentedCertManagerKustomizeFields = `# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
 # - webhookcainjection_patch.yaml

--- a/test/e2e-go/e2e_go_scorecard_test.go
+++ b/test/e2e-go/e2e_go_scorecard_test.go
@@ -26,6 +26,7 @@ import (
 
 var _ = Describe("Testing Go Projects with Scorecard", func() {
 	Context("with operator-sdk", func() {
+		reconcileCount++
 		const (
 			OLMBundleValidationTest   = "olm-bundle-validation"
 			OLMCRDsHaveValidationTest = "olm-crds-have-validation"

--- a/test/e2e-go/e2e_go_suite_test.go
+++ b/test/e2e-go/e2e_go_suite_test.go
@@ -35,7 +35,7 @@ func TestE2EGo(t *testing.T) {
 }
 
 var (
-	tc testutils.TestContext
+	tc             testutils.TestContext
 	reconcileCount = 0
 )
 

--- a/test/e2e-go/e2e_go_suite_test.go
+++ b/test/e2e-go/e2e_go_suite_test.go
@@ -36,6 +36,7 @@ func TestE2EGo(t *testing.T) {
 
 var (
 	tc testutils.TestContext
+	reconcileCount = 0
 )
 
 // BeforeSuite run before any specs are run to perform the required actions for all e2e Go tests.

--- a/testdata/go/v2/memcached-operator/api/v1alpha1/memcached_webhook.go
+++ b/testdata/go/v2/memcached-operator/api/v1alpha1/memcached_webhook.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"

--- a/testdata/go/v2/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v2/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
             "name": "memcached-sample"
           },
           "spec": {
-            "foo": "bar"
+            "size": 1
           }
         }
       ]

--- a/testdata/go/v2/memcached-operator/config/samples/cache_v1alpha1_memcached.yaml
+++ b/testdata/go/v2/memcached-operator/config/samples/cache_v1alpha1_memcached.yaml
@@ -4,4 +4,4 @@ metadata:
   name: memcached-sample
 spec:
   # Add fields here
-  foo: bar
+  size: 1

--- a/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
             "name": "memcached-sample"
           },
           "spec": {
-            "foo": "bar"
+            "size": 1
           }
         }
       ]

--- a/testdata/go/v3/memcached-operator/config/samples/cache_v1alpha1_memcached.yaml
+++ b/testdata/go/v3/memcached-operator/config/samples/cache_v1alpha1_memcached.yaml
@@ -4,4 +4,4 @@ metadata:
   name: memcached-sample
 spec:
   # Add fields here
-  foo: bar
+  size: 1


### PR DESCRIPTION
**Description of the change:**
- Use Memcached sample instead of re-generate the project.
- Fix/Adjust the e2e tests to work with the sample. 

**Motivation for the change:**

operator-framework/enhancements#47
