### PR TITLE
cleanup: call install in the sample target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ generate: cli-doc samples bindata ## Run all non-release generate targets
 cli-doc: ## Generate CLI documentation
 	go run ./hack/generate/cli-doc/gen-cli-doc.go
 
-samples: ## Generate samples
+samples: install ## Generate samples
 	go run ./hack/generate/samples/generate_all.go
 
 changelog: ## Generate CHANGELOG.md and migration guide updates

--- a/hack/tests/sanity-check.sh
+++ b/hack/tests/sanity-check.sh
@@ -10,7 +10,6 @@ go fmt ./...
 make cli-doc
 go run ./hack/generate/changelog/gen-changelog.go -validate-only
 
-make install
 make samples
 
 # Make sure repo is still in a clean state.


### PR DESCRIPTION
**Description of the change:**
- instead of calling the make install in the sanity add it to the samples target

**Motivation for the change:**
- make it easier for contributors since they can face issues just because forgot to run make install before to re-gen the samples. 

