### PR TITLE
Setting GO111MODULE=on is not required with go version 1.13 and later

### DIFF
--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -29,7 +29,7 @@ To learn about the project directory structure, see [Kubebuilder project layout]
 
 #### A note on dependency management
 
-`operator-sdk init` generates a `go.mod` file to be used with [Go modules][go_mod_wiki]. The `--repo=<path>` flag is required when creating a project outside of `$GOPATH/src`, as scaffolded files require a valid module path. Ensure you [activate module support][activate_modules] by running `export GO111MODULE=on` before using the SDK.
+`operator-sdk init` generates a `go.mod` file to be used with [Go modules][go_mod_wiki]. The `--repo=<path>` flag is required when creating a project outside of `$GOPATH/src`, as scaffolded files require a valid module path. With go versions prior to 1.13 ensure you [activate module support][activate_modules] by running `export GO111MODULE=on` before using the SDK.
 
 ### Manager
 The main program for the operator `main.go` initializes and runs the [Manager][manager_go_doc].


### PR DESCRIPTION
Rational:
https://golang.org/doc/go1.13
The GO111MODULE environment variable continues to default to auto, but the auto setting now activates the module-aware mode of the go command whenever the current working directory contains, or is below a directory containing, a go.mod file — even if the current directory is within GOPATH/src.
