### PR TITLE
feat: setup lint to check govet and gofmt instead of shell + fix gofmt lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,10 @@
 run:
+  # required because the CI/Travis sometimes take to long to run
   timeout: 5m
+
+  # skip files that should not be checked
+  skip-files:
+    - internal/bindata/olm/manifests-0.15.1.go
 linters:
   enable:
     - nakedret
@@ -22,6 +27,8 @@ linters:
     - unconvert
     - gocyclo
     - gosec
+    - govet
+    - gofmt
 issues:
   exclude-rules:
     # Allow dot imports for ginkgo and gomega

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ bindata: ## Update project bindata
 .PHONY: fix
 fix: ## Fixup files in the repo.
 	go mod tidy
-	go fmt ./...
+	# the golangci-lint run --fix automatically fix issues when the linter/check supports auto-fix
+	# Note: only gofmt, gosimple and goimport checks used supports auto-fix
+	./tools/scripts/fetch golangci-lint 1.31.0 && ./tools/bin/golangci-lint run --fix
 
 .PHONY: clean
 clean: ## Cleanup build artifacts and tool binaries.
@@ -129,7 +131,6 @@ test-sanity: generate fix ## Test repo formatting, linting, etc.
 	./hack/check-license.sh
 	./hack/check-error-log-msg-format.sh
 	go run ./hack/generate/changelog/gen-changelog.go -validate-only
-	go vet ./...
 	./tools/scripts/fetch golangci-lint 1.31.0 && ./tools/bin/golangci-lint run
 	git diff --exit-code # diff again to ensure other checks don't change repo
 

--- a/internal/ansible/controller/reconcile_test.go
+++ b/internal/ansible/controller/reconcile_test.go
@@ -78,7 +78,7 @@ func TestReconcile(t *testing.T) {
 			ManageStatus:    true,
 			Runner: &fake.Runner{
 				JobEvents: []eventapi.JobEvent{
-					eventapi.JobEvent{
+					{
 						Event:   eventapi.EventPlaybookOnStats,
 						Created: eventapi.EventTime{Time: eventTime},
 					},
@@ -138,7 +138,7 @@ func TestReconcile(t *testing.T) {
 			ManageStatus: true,
 			Runner: &fake.Runner{
 				JobEvents: []eventapi.JobEvent{
-					eventapi.JobEvent{
+					{
 						Event:   eventapi.EventRunnerOnFailed,
 						Created: eventapi.EventTime{Time: eventTime},
 						EventData: map[string]interface{}{
@@ -147,7 +147,7 @@ func TestReconcile(t *testing.T) {
 							},
 						},
 					},
-					eventapi.JobEvent{
+					{
 						Event:   eventapi.EventPlaybookOnStats,
 						Created: eventapi.EventTime{Time: eventTime},
 					},
@@ -212,7 +212,7 @@ func TestReconcile(t *testing.T) {
 			ManageStatus: false,
 			Runner: &fake.Runner{
 				JobEvents: []eventapi.JobEvent{
-					eventapi.JobEvent{
+					{
 						Event:   eventapi.EventRunnerOnFailed,
 						Created: eventapi.EventTime{Time: eventTime},
 						EventData: map[string]interface{}{
@@ -221,7 +221,7 @@ func TestReconcile(t *testing.T) {
 							},
 						},
 					},
-					eventapi.JobEvent{
+					{
 						Event:   eventapi.EventPlaybookOnStats,
 						Created: eventapi.EventTime{Time: eventTime},
 					},
@@ -253,7 +253,7 @@ func TestReconcile(t *testing.T) {
 			ManageStatus:    true,
 			Runner: &fake.Runner{
 				JobEvents: []eventapi.JobEvent{
-					eventapi.JobEvent{
+					{
 						Event:   eventapi.EventPlaybookOnStats,
 						Created: eventapi.EventTime{Time: eventTime},
 					},
@@ -324,7 +324,7 @@ func TestReconcile(t *testing.T) {
 			ReconcilePeriod: 5 * time.Second,
 			Runner: &fake.Runner{
 				JobEvents: []eventapi.JobEvent{
-					eventapi.JobEvent{
+					{
 						Event:   eventapi.EventPlaybookOnStats,
 						Created: eventapi.EventTime{Time: eventTime},
 					},
@@ -361,7 +361,7 @@ func TestReconcile(t *testing.T) {
 			ManageStatus:    true,
 			Runner: &fake.Runner{
 				JobEvents: []eventapi.JobEvent{
-					eventapi.JobEvent{
+					{
 						Event:   eventapi.EventPlaybookOnStats,
 						Created: eventapi.EventTime{Time: eventTime},
 					},
@@ -444,7 +444,7 @@ func TestReconcile(t *testing.T) {
 			ReconcilePeriod: 5 * time.Second,
 			Runner: &fake.Runner{
 				JobEvents: []eventapi.JobEvent{
-					eventapi.JobEvent{
+					{
 						Created: eventapi.EventTime{Time: eventTime},
 					},
 				},
@@ -494,7 +494,7 @@ func TestReconcile(t *testing.T) {
 			ManageStatus:    false,
 			Runner: &fake.Runner{
 				JobEvents: []eventapi.JobEvent{
-					eventapi.JobEvent{
+					{
 						Event:   eventapi.EventPlaybookOnStats,
 						Created: eventapi.EventTime{Time: eventTime},
 					},

--- a/internal/ansible/controller/status/utils_test.go
+++ b/internal/ansible/controller/status/utils_test.go
@@ -96,7 +96,7 @@ func TestGetCondition(t *testing.T) {
 			condType: RunningConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: RunningConditionType,
 					},
 				},
@@ -110,7 +110,7 @@ func TestGetCondition(t *testing.T) {
 			condType: RunningConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: FailureConditionType,
 					},
 				},
@@ -122,7 +122,7 @@ func TestGetCondition(t *testing.T) {
 			condType: FailureConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: FailureConditionType,
 					},
 				},
@@ -136,7 +136,7 @@ func TestGetCondition(t *testing.T) {
 			condType: FailureConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: RunningConditionType,
 					},
 				},
@@ -167,7 +167,7 @@ func TestRemoveCondition(t *testing.T) {
 			condType: RunningConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: RunningConditionType,
 					},
 				},
@@ -179,7 +179,7 @@ func TestRemoveCondition(t *testing.T) {
 			condType: RunningConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: FailureConditionType,
 					},
 				},
@@ -191,7 +191,7 @@ func TestRemoveCondition(t *testing.T) {
 			condType: FailureConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: FailureConditionType,
 					},
 				},
@@ -203,7 +203,7 @@ func TestRemoveCondition(t *testing.T) {
 			condType: FailureConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: RunningConditionType,
 					},
 				},
@@ -247,7 +247,7 @@ func TestSetCondition(t *testing.T) {
 			name: "update running condition",
 			status: &Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type:               RunningConditionType,
 						Status:             v1.ConditionTrue,
 						Reason:             SuccessfulReason,
@@ -264,7 +264,7 @@ func TestSetCondition(t *testing.T) {
 			name: "do not update running condition",
 			status: &Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type:               RunningConditionType,
 						Status:             v1.ConditionTrue,
 						Reason:             RunningReason,

--- a/internal/ansible/proxy/cache_response.go
+++ b/internal/ansible/proxy/cache_response.go
@@ -73,7 +73,7 @@ func (c *cacheResponseHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 		}
 
 		if c.restMapper == nil {
-			c.restMapper = meta.NewDefaultRESTMapper([]schema.GroupVersion{schema.GroupVersion{
+			c.restMapper = meta.NewDefaultRESTMapper([]schema.GroupVersion{{
 				Group:   r.APIGroup,
 				Version: r.APIVersion,
 			}})

--- a/internal/ansible/proxy/inject_owner.go
+++ b/internal/ansible/proxy/inject_owner.go
@@ -65,7 +65,7 @@ func (i *injectOwnerReferenceHandler) ServeHTTP(w http.ResponseWriter, req *http
 		}
 
 		if i.restMapper == nil {
-			i.restMapper = meta.NewDefaultRESTMapper([]schema.GroupVersion{schema.GroupVersion{
+			i.restMapper = meta.NewDefaultRESTMapper([]schema.GroupVersion{{
 				Group:   r.APIGroup,
 				Version: r.APIVersion,
 			}})

--- a/internal/ansible/watches/watches_test.go
+++ b/internal/ansible/watches/watches_test.go
@@ -135,7 +135,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 	twoSeconds := time.Second * 2
 
 	validWatches := []Watch{
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -148,7 +148,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			WatchClusterScopedResources: false,
 			SnakeCaseParameters:         true,
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -165,7 +165,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 				Vars: map[string]interface{}{"sentinel": "finalizer_running"},
 			},
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -177,7 +177,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			WatchDependentResources:     true,
 			WatchClusterScopedResources: true,
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -187,7 +187,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			ReconcilePeriod: zeroSeconds,
 			ManageStatus:    true,
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -196,7 +196,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			Playbook:     validTemplate.ValidPlaybook,
 			ManageStatus: true,
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -205,7 +205,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			Playbook:     validTemplate.ValidPlaybook,
 			ManageStatus: false,
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -214,7 +214,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			Playbook:     validTemplate.ValidPlaybook,
 			ManageStatus: true,
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -228,7 +228,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 				Vars:     map[string]interface{}{"sentinel": "finalizer_running"},
 			},
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -241,7 +241,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 				Vars: map[string]interface{}{"sentinel": "finalizer_running"},
 			},
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -251,7 +251,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			ManageStatus:            true,
 			MaxConcurrentReconciles: 1,
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -261,7 +261,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			ManageStatus:            true,
 			MaxConcurrentReconciles: 1,
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -271,7 +271,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			ManageStatus:            true,
 			MaxConcurrentReconciles: 4,
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -281,7 +281,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			ManageStatus:     true,
 			AnsibleVerbosity: 2,
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -291,7 +291,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			ManageStatus:     true,
 			AnsibleVerbosity: 2,
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -301,7 +301,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			ManageStatus:     true,
 			AnsibleVerbosity: 4,
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -311,7 +311,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			ManageStatus: true,
 			Vars:         map[string]interface{}{"sentinel": "reconciling"},
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -320,7 +320,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			Role:         filepath.Join(cwd, "testdata", "ansible_collections", "nameSpace", "collection", "roles", "someRole"),
 			ManageStatus: true,
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",
@@ -346,7 +346,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			},
 			ManageStatus: true,
 		},
-		Watch{
+		{
 			GroupVersionKind: schema.GroupVersionKind{
 				Version: "v1alpha1",
 				Group:   "app.example.com",

--- a/internal/bindata/olm/versions.go
+++ b/internal/bindata/olm/versions.go
@@ -15,7 +15,7 @@
 package olm
 
 var availableVersions = map[string]struct{}{
-	"0.15.1": struct{}{},
+	"0.15.1": {},
 }
 
 // HasVersion returns whether version maps to released OLM manifests as bindata.

--- a/internal/scorecard/tests/bundle_test.go
+++ b/internal/scorecard/tests/bundle_test.go
@@ -137,17 +137,17 @@ var _ = Describe("Basic and OLM tests", func() {
 				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
 						Owned: []operatorsv1alpha1.CRDDescription{
-							operatorsv1alpha1.CRDDescription{
+							{
 								Name:    "Test",
 								Version: "v1",
 								Kind:    "TestKind",
 								StatusDescriptors: []operatorsv1alpha1.StatusDescriptor{
-									operatorsv1alpha1.StatusDescriptor{
+									{
 										Path: "status",
 									},
 								},
 								SpecDescriptors: []operatorsv1alpha1.SpecDescriptor{
-									operatorsv1alpha1.SpecDescriptor{
+									{
 										Path: "spec",
 									},
 								},
@@ -246,7 +246,7 @@ var _ = Describe("Basic and OLM tests", func() {
 			})
 			It("should fail when CRs do not have spec field specified", func() {
 				cr := []unstructured.Unstructured{
-					unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{},
 					},
 				}
@@ -255,7 +255,7 @@ var _ = Describe("Basic and OLM tests", func() {
 			})
 			It("should pass when CRs do have spec field specified", func() {
 				cr := []unstructured.Unstructured{
-					unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"spec": map[string]interface{}{
 								"spec": "val",
@@ -278,10 +278,10 @@ var _ = Describe("Basic and OLM tests", func() {
 		)
 
 		crd = []*apiextv1.CustomResourceDefinition{
-			&apiextv1.CustomResourceDefinition{
+			{
 				Spec: apiextv1.CustomResourceDefinitionSpec{
 					Versions: []apiextv1.CustomResourceDefinitionVersion{
-						apiextv1.CustomResourceDefinitionVersion{
+						{
 							Name: "v1",
 							Schema: &apiextv1.CustomResourceValidation{
 								OpenAPIV3Schema: &apiextv1.JSONSchemaProps{
@@ -289,9 +289,9 @@ var _ = Describe("Basic and OLM tests", func() {
 									Schema:      "URL",
 									Description: "Schema for test",
 									Properties: map[string]apiextv1.JSONSchemaProps{
-										"spec": apiextv1.JSONSchemaProps{
+										"spec": {
 											Properties: map[string]apiextv1.JSONSchemaProps{
-												"node": apiextv1.JSONSchemaProps{
+												"node": {
 													ID: "node",
 												},
 											},
@@ -375,13 +375,13 @@ var _ = Describe("Basic and OLM tests", func() {
 		It("Should pass when CSV has Owned CRD's with resources", func() {
 			crd = operatorsv1alpha1.CustomResourceDefinitions{
 				Owned: []operatorsv1alpha1.CRDDescription{
-					operatorsv1alpha1.CRDDescription{
+					{
 						Name:              "Test",
 						Version:           "v1",
 						Kind:              "Test",
 						StatusDescriptors: make([]operatorsv1alpha1.StatusDescriptor, 0),
 						Resources: []operatorsv1alpha1.APIResourceReference{
-							operatorsv1alpha1.APIResourceReference{
+							{
 								Name:    "operator",
 								Kind:    "Test",
 								Version: "v1",
@@ -398,7 +398,7 @@ var _ = Describe("Basic and OLM tests", func() {
 
 			crd = operatorsv1alpha1.CustomResourceDefinitions{
 				Owned: []operatorsv1alpha1.CRDDescription{
-					operatorsv1alpha1.CRDDescription{
+					{
 						Name:              "Test",
 						Version:           "v1",
 						Kind:              "Test",


### PR DESCRIPTION
**Description of the change:**
- Replace linters check go fmt and go vet which has been done via shell in the sanity to be done via the linter.  
- Ignore linter check in the bindata file 
- update makefile target fix to fix go fmt via golangci-lint --fix option
- perform the fixes: 

```shell
$ ./tools/bin/golangci-lint run
internal/bindata/olm/versions.go:18: File is not `gofmt`-ed with `-s` (gofmt)
	"0.15.1": struct{}{},
internal/ansible/watches/watches_test.go:138: File is not `gofmt`-ed with `-s` (gofmt)
		Watch{
internal/ansible/controller/status/utils_test.go:99: File is not `gofmt`-ed with `-s` (gofmt)
					Condition{
```



**Motivation for the change:**
- Make all lint checks be centralized in the lint instead of having lint + shell script to do address this nit ( maintainability )
- Allow contributors easily fix the syntax issues such as missing spaces and go fmt via the `make fix` instead of respected that they are able to run `./tools/scripts/fetch golangci-lint 1.31.0 && ./tools/bin/golangci-lint run --fix`
- Allow govet and gofmt issues be raised via comments in the code when/if we are able to address here the GA to do teh check as it is done in the Kubebuilder and operator-lib:

<img width="648" alt="Screen Shot 2020-10-20 at 13 20 10" src="https://user-images.githubusercontent.com/7708031/96614978-a129e980-12f8-11eb-82fb-ca5e5c8a9cd9.png">

 
**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
