### PR TITLE
Refactoring generate subcommands for to support older layouts

### DIFF
--- a/changelog/fragments/refactor-generate-subcommands.yaml
+++ b/changelog/fragments/refactor-generate-subcommands.yaml
@@ -1,0 +1,9 @@
+entries:
+    - description: >
+        Added the `--package <name>` flag to all `generate` subcommands. This flag is required by `generate bundle|packagemanifests` when not run in a project.
+      kind: "addition"
+      breaking: false 
+    - description: >
+        Refactored the `generate bundle|packagemanifest` commands to generate bundles/package manifest data outside of projects.
+      kind: "bugfix"
+      breaking: false

--- a/hack/generate/samples/internal/pkg/utils.go
+++ b/hack/generate/samples/internal/pkg/utils.go
@@ -22,7 +22,6 @@ import (
 	"regexp"
 
 	log "github.com/sirupsen/logrus"
-	"sigs.k8s.io/kubebuilder/v2/pkg/model/config"
 
 	"github.com/operator-framework/operator-sdk/internal/annotations/metrics"
 )
@@ -54,7 +53,7 @@ func (ctx *SampleContext) CreateBundle() {
 // available in git history.
 func (ctx SampleContext) StripBundleAnnotations() (err error) {
 	// Remove metadata labels.
-	metadataAnnotations := metrics.MakeBundleMetadataLabels(&config.Config{})
+	metadataAnnotations := metrics.MakeBundleMetadataLabels("")
 	metadataFiles := []string{
 		filepath.Join(ctx.Dir, "bundle", "metadata", "annotations.yaml"),
 		filepath.Join(ctx.Dir, "bundle.Dockerfile"),
@@ -64,7 +63,7 @@ func (ctx SampleContext) StripBundleAnnotations() (err error) {
 	}
 
 	// Remove manifests annotations.
-	manifestsAnnotations := metrics.MakeBundleObjectAnnotations(&config.Config{})
+	manifestsAnnotations := metrics.MakeBundleObjectAnnotations("")
 	manifestsFiles := []string{
 		filepath.Join(ctx.Dir, "bundle", "manifests", ctx.ProjectName+".clusterserviceversion.yaml"),
 		filepath.Join(ctx.Dir, "config", "manifests", "bases", ctx.ProjectName+".clusterserviceversion.yaml"),

--- a/internal/annotations/metrics/metrics.go
+++ b/internal/annotations/metrics/metrics.go
@@ -89,7 +89,7 @@ func isUnreleased(input string) bool {
 // getSDKProjectLayout returns the `layout` field in PROJECT file that is v3.
 // If not, it will return "go" because that was the only project type supported for project versions < v3.
 func getSDKProjectLayout(cfg *config.Config) string {
-	if !cfg.IsV3() || cfg.Layout == "" {
+	if cfg == nil || !cfg.IsV3() || cfg.Layout == "" {
 		return "go"
 	}
 	return cfg.Layout

--- a/internal/annotations/metrics/metrics.go
+++ b/internal/annotations/metrics/metrics.go
@@ -18,8 +18,6 @@ import (
 	"regexp"
 	"strings"
 
-	"sigs.k8s.io/kubebuilder/v2/pkg/model/config"
-
 	sdkversion "github.com/operator-framework/operator-sdk/internal/version"
 )
 
@@ -43,20 +41,20 @@ const (
 
 // MakeBundleMetadataLabels returns the SDK metric labels which will be added
 // to bundle resources like bundle.Dockerfile and annotations.yaml.
-func MakeBundleMetadataLabels(cfg *config.Config) map[string]string {
+func MakeBundleMetadataLabels(layout string) map[string]string {
 	return map[string]string{
 		mediaTypeBundleAnnotation: mediaTypeV1,
 		builderBundleAnnotation:   getSDKBuilder(sdkversion.Version),
-		layoutBundleAnnotation:    getSDKProjectLayout(cfg),
+		layoutBundleAnnotation:    layout,
 	}
 }
 
 // MakeObjectAnnotations returns the SDK metric annotations which will be added
 // to CustomResourceDefinitions and ClusterServiceVersions.
-func MakeBundleObjectAnnotations(cfg *config.Config) map[string]string {
+func MakeBundleObjectAnnotations(layout string) map[string]string {
 	return map[string]string{
 		BuilderObjectAnnotation: getSDKBuilder(sdkversion.Version),
-		LayoutObjectAnnotation:  getSDKProjectLayout(cfg),
+		LayoutObjectAnnotation:  layout,
 	}
 }
 
@@ -84,13 +82,4 @@ func isUnreleased(input string) bool {
 	}
 	re := regexp.MustCompile(`v[0-9]+\.[0-9]+\.[0-9]+-.+`)
 	return re.MatchString(input)
-}
-
-// getSDKProjectLayout returns the `layout` field in PROJECT file that is v3.
-// If not, it will return "go" because that was the only project type supported for project versions < v3.
-func getSDKProjectLayout(cfg *config.Config) string {
-	if cfg == nil || !cfg.IsV3() || cfg.Layout == "" {
-		return "go"
-	}
-	return cfg.Layout
 }

--- a/internal/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/generate/bundle/cmd.go
@@ -21,8 +21,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-
-	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 )
 
 //nolint:maligned
@@ -68,36 +66,31 @@ func NewCmd() *cobra.Command {
 				c.metadata = true
 			}
 
-			cfg, err := projutil.ReadConfig()
-			if err != nil {
-				return fmt.Errorf("error reading configuration: %v", err)
-			}
-
-			if err := c.setDefaults(cfg); err != nil {
+			if err := c.setDefaults(); err != nil {
 				return err
 			}
 
 			// Validate command args before running so a preceding mode doesn't run
 			// before a following validation fails.
 			if c.manifests {
-				if err = c.validateManifests(cfg); err != nil {
+				if err := c.validateManifests(); err != nil {
 					return fmt.Errorf("invalid command options: %v", err)
 				}
 			}
 			if c.metadata {
-				if err = c.validateMetadata(cfg); err != nil {
+				if err := c.validateMetadata(); err != nil {
 					return fmt.Errorf("invalid command options: %v", err)
 				}
 			}
 
 			// Run command logic.
 			if c.manifests {
-				if err = c.runManifests(cfg); err != nil {
+				if err := c.runManifests(); err != nil {
 					log.Fatalf("Error generating bundle manifests: %v", err)
 				}
 			}
 			if c.metadata {
-				if err = c.runMetadata(cfg); err != nil {
+				if err := c.runMetadata(); err != nil {
 					log.Fatalf("Error generating bundle metadata: %v", err)
 				}
 			}

--- a/internal/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/generate/bundle/cmd.go
@@ -30,7 +30,6 @@ type bundleCmd struct {
 	metadata  bool
 
 	// Common options.
-	projectName  string
 	version      string
 	inputDir     string
 	outputDir    string
@@ -44,6 +43,10 @@ type bundleCmd struct {
 	channels       string
 	defaultChannel string
 	overwrite      bool
+
+	// These are set if a PROJECT config is not present.
+	layout      string
+	packageName string
 }
 
 // NewCmd returns the 'bundle' command configured for the new project layout.
@@ -124,4 +127,6 @@ func (c *bundleCmd) addFlagsTo(fs *pflag.FlagSet) {
 	fs.StringVar(&c.defaultChannel, "default-channel", "", "The default channel for the bundle")
 	fs.BoolVar(&c.overwrite, "overwrite", true, "Overwrite the bundle's metadata and Dockerfile if they exist")
 	fs.BoolVarP(&c.quiet, "quiet", "q", false, "Run in quiet mode")
+
+	fs.StringVar(&c.packageName, "package", "", "Bundle's package name")
 }

--- a/internal/cmd/operator-sdk/generate/internal/genutil.go
+++ b/internal/cmd/operator-sdk/generate/internal/genutil.go
@@ -28,7 +28,6 @@ import (
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/kubebuilder/v2/pkg/model/config"
 	"sigs.k8s.io/yaml"
 )
 
@@ -155,13 +154,7 @@ func IsNotExist(path string) bool {
 // GetOperatorName returns the name of the operator which is by default the projectName attribute of the PROJECT file
 // However, the Go projects built with the plugin version v2 has not this attribute and then, for this case
 // the operatorName will be the current directory.
-func GetOperatorName(cfg *config.Config) (string, error) {
-	if cfg.ProjectName != "" {
-		return cfg.ProjectName, nil
-	}
-	if cfg.IsV3() {
-		return "", errors.New("project config file must contain 'projectName'")
-	}
+func GetOperatorName() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("error getting current directory: %v", err)

--- a/internal/cmd/operator-sdk/generate/internal/genutil.go
+++ b/internal/cmd/operator-sdk/generate/internal/genutil.go
@@ -26,7 +26,6 @@ import (
 	"github.com/blang/semver"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
 )
@@ -151,17 +150,11 @@ func IsNotExist(path string) bool {
 	return err != nil && errors.Is(err, os.ErrNotExist)
 }
 
-// GetOperatorName returns the name of the operator which is by default the projectName attribute of the PROJECT file
-// However, the Go projects built with the plugin version v2 has not this attribute and then, for this case
-// the operatorName will be the current directory.
-func GetOperatorName() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("error getting current directory: %v", err)
+// IsExist returns true if path exists on disk.
+func IsExist(path string) bool {
+	if path == "" {
+		return false
 	}
-	projectName := strings.ToLower(filepath.Base(dir))
-	if err := validation.IsDNS1123Label(projectName); err != nil {
-		return "", fmt.Errorf("project name (%s) is invalid: %v", projectName, err)
-	}
-	return projectName, nil
+	_, err := os.Stat(path)
+	return err == nil || errors.Is(err, os.ErrExist)
 }

--- a/internal/cmd/operator-sdk/generate/packagemanifests/cmd.go
+++ b/internal/cmd/operator-sdk/generate/packagemanifests/cmd.go
@@ -63,7 +63,7 @@ func NewCmd() *cobra.Command {
 			if err != nil {
 				log.Fatal(fmt.Errorf("error reading configuration: %v", err))
 			}
-			if err := c.setDefaults(cfg); err != nil {
+			if err := c.setDefaults(); err != nil {
 				return err
 			}
 

--- a/internal/cmd/operator-sdk/generate/packagemanifests/cmd.go
+++ b/internal/cmd/operator-sdk/generate/packagemanifests/cmd.go
@@ -21,14 +21,11 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-
-	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 )
 
 //nolint:maligned
 type packagemanifestsCmd struct {
 	// Common options.
-	projectName   string
 	version       string
 	fromVersion   string
 	inputDir      string
@@ -43,6 +40,10 @@ type packagemanifestsCmd struct {
 	// Package manifest options.
 	channelName      string
 	isDefaultChannel bool
+
+	// These are set if a PROJECT config is not present.
+	layout      string
+	packageName string
 }
 
 // NewCmd returns the 'packagemanifests' command configured for the new project layout.
@@ -59,18 +60,14 @@ func NewCmd() *cobra.Command {
 				return fmt.Errorf("command %s doesn't accept any arguments", cmd.CommandPath())
 			}
 
-			cfg, err := projutil.ReadConfig()
-			if err != nil {
-				log.Fatal(fmt.Errorf("error reading configuration: %v", err))
-			}
 			if err := c.setDefaults(); err != nil {
 				return err
 			}
 
-			if err = c.validate(); err != nil {
+			if err := c.validate(); err != nil {
 				return fmt.Errorf("invalid command options: %v", err)
 			}
-			if err = c.run(cfg); err != nil {
+			if err := c.run(); err != nil {
 				log.Fatalf("Error generating package manifests: %v", err)
 			}
 
@@ -101,4 +98,6 @@ func (c *packagemanifestsCmd) addFlagsTo(fs *pflag.FlagSet) {
 		"ex. CustomResoureDefinitions, Roles")
 	fs.BoolVarP(&c.quiet, "quiet", "q", false, "Run in quiet mode")
 	fs.BoolVar(&c.stdout, "stdout", false, "Write package to stdout")
+
+	fs.StringVar(&c.packageName, "package", "", "Package name")
 }

--- a/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
+++ b/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
@@ -78,8 +78,8 @@ https://github.com/operator-framework/operator-registry/#manifest-format
 const defaultRootDir = "packagemanifests"
 
 // setDefaults sets command defaults.
-func (c *packagemanifestsCmd) setDefaults(cfg *config.Config) (err error) {
-	if c.projectName, err = genutil.GetOperatorName(cfg); err != nil {
+func (c *packagemanifestsCmd) setDefaults() (err error) {
+	if c.projectName, err = genutil.GetOperatorName(); err != nil {
 		return err
 	}
 
@@ -183,7 +183,7 @@ func (c packagemanifestsCmd) run(cfg *config.Config) error {
 		opts = append(opts, gencsv.WithPackageWriter(c.outputDir))
 	}
 
-	if err := csvGen.Generate(cfg, opts...); err != nil {
+	if err := csvGen.Generate(opts...); err != nil {
 		return fmt.Errorf("error generating ClusterServiceVersion: %v", err)
 	}
 

--- a/internal/generate/clusterserviceversion/bases/clusterserviceversion.go
+++ b/internal/generate/clusterserviceversion/bases/clusterserviceversion.go
@@ -62,7 +62,6 @@ type ClusterServiceVersion struct {
 // GetBase returns a base v1alpha1.ClusterServiceVersion, populated
 // either with default values or, if b.BasePath is set, bytes from disk.
 func (b ClusterServiceVersion) GetBase() (base *v1alpha1.ClusterServiceVersion, err error) {
-	fmt.Printf("\nb.basepath:\t%v\n", b.BasePath)
 	if b.BasePath != "" {
 		if base, err = readClusterServiceVersionBase(b.BasePath); err != nil {
 			return nil, fmt.Errorf("error reading existing ClusterServiceVersion base %s: %v", b.BasePath, err)
@@ -80,7 +79,6 @@ func (b ClusterServiceVersion) GetBase() (base *v1alpha1.ClusterServiceVersion, 
 	}
 
 	if b.APIsDir != "" {
-		fmt.Printf("\nb.ApisDir:\t%v\nb.opty:\t%v\n\n", b.APIsDir, b.OperatorName)
 		switch b.OperatorType {
 		case projutil.OperatorTypeGo:
 			// Update descriptions from the APIs dir.

--- a/internal/generate/clusterserviceversion/bases/clusterserviceversion.go
+++ b/internal/generate/clusterserviceversion/bases/clusterserviceversion.go
@@ -62,6 +62,7 @@ type ClusterServiceVersion struct {
 // GetBase returns a base v1alpha1.ClusterServiceVersion, populated
 // either with default values or, if b.BasePath is set, bytes from disk.
 func (b ClusterServiceVersion) GetBase() (base *v1alpha1.ClusterServiceVersion, err error) {
+	fmt.Printf("\nb.basepath:\t%v\n", b.BasePath)
 	if b.BasePath != "" {
 		if base, err = readClusterServiceVersionBase(b.BasePath); err != nil {
 			return nil, fmt.Errorf("error reading existing ClusterServiceVersion base %s: %v", b.BasePath, err)
@@ -79,6 +80,7 @@ func (b ClusterServiceVersion) GetBase() (base *v1alpha1.ClusterServiceVersion, 
 	}
 
 	if b.APIsDir != "" {
+		fmt.Printf("\nb.ApisDir:\t%v\nb.opty:\t%v\n\n", b.APIsDir, b.OperatorName)
 		switch b.OperatorType {
 		case projutil.OperatorTypeGo:
 			// Update descriptions from the APIs dir.

--- a/internal/generate/clusterserviceversion/clusterserviceversion.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion.go
@@ -24,10 +24,7 @@ import (
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/kubebuilder/v2/pkg/model/config"
 
-	metricsannotations "github.com/operator-framework/operator-sdk/internal/annotations/metrics"
 	"github.com/operator-framework/operator-sdk/internal/generate/clusterserviceversion/bases"
 	"github.com/operator-framework/operator-sdk/internal/generate/collector"
 	genutil "github.com/operator-framework/operator-sdk/internal/generate/internal"
@@ -41,10 +38,7 @@ const (
 
 var (
 	// Internal errors.
-	noGetBaseError               = genutil.InternalError("getBase must be set")
-	noGetWriterError             = genutil.InternalError("getWriter must be set")
-	baseVersionNotAllowedError   = genutil.InternalError("cannot set version when generating a base")
-	baseCollectorNotAllowedError = genutil.InternalError("cannot set collector when generating a base")
+	noGetWriterError = genutil.InternalError("getWriter must be set")
 )
 
 // ClusterServiceVersion configures ClusterServiceVersion manifest generation.
@@ -58,11 +52,9 @@ type Generator struct {
 	FromVersion string
 	// Collector holds all manifests relevant to the Generator.
 	Collector *collector.Manifests
+	// Annotations are applied to the resulting CSV.
+	Annotations map[string]string
 
-	// Project configuration.
-	config *config.Config
-	// Func that returns a base CSV.
-	getBase getBaseFunc
 	// Func that returns the writer the generated CSV's bytes are written to.
 	getWriter func() (io.Writer, error)
 	// If the CSV is destined for a bundle this will be the path of the updated
@@ -71,58 +63,14 @@ type Generator struct {
 	bundledPath string
 }
 
-// Type of Generator.getBase.
-type getBaseFunc func() (*operatorsv1alpha1.ClusterServiceVersion, error)
-
 // Option is a function that modifies a Generator.
 type Option func(*Generator) error
-
-// WithBaseCreator creates a Generator's base CSV to a kustomize-style base.
-func WithBaseCreator(cfg *config.Config, inputDir, apisDir string, ilvl projutil.InteractiveLevel) Option {
-	return func(g *Generator) error {
-		//g.getBase = g.makeKustomizeBaseGetter(inputDir, apisDir, ilvl)
-		basePath := filepath.Join(inputDir, "bases", makeCSVFileName(g.OperatorName))
-		if genutil.IsNotExist(basePath) {
-			basePath = ""
-		}
-
-		g.getBase = g.makeBaseCreator(cfg, basePath, apisDir, requiresInteraction(basePath, ilvl))
-		return nil
-	}
-}
-
-// WithBase sets a Generator's base CSV to a kustomize-style base.
-func WithBase(inputDir, apisDir string, ilvl projutil.InteractiveLevel) Option {
-	return func(g *Generator) error {
-		g.getBase = g.makeKustomizeBaseGetter(inputDir, apisDir, ilvl)
-		return nil
-	}
-}
 
 // WithWriter sets a Generator's writer to w.
 func WithWriter(w io.Writer) Option {
 	return func(g *Generator) error {
 		g.getWriter = func() (io.Writer, error) {
 			return w, nil
-		}
-		return nil
-	}
-}
-
-// WithBaseWriter sets a Generator's writer to a kustomize-style base file
-// under <dir>/bases.
-func WithBaseWriter(dir string) Option {
-	return func(g *Generator) error {
-		fileName := makeCSVFileName(g.OperatorName)
-		g.getWriter = func() (io.Writer, error) {
-			return genutil.Open(filepath.Join(dir, "bases"), fileName)
-		}
-		// Bases should not be updated with a version or manifests.
-		if g.Version != "" {
-			return baseVersionNotAllowedError
-		}
-		if g.Collector != nil {
-			return baseCollectorNotAllowedError
 		}
 		return nil
 	}
@@ -158,10 +106,6 @@ func WithPackageWriter(dir string) Option {
 
 // Generate configures the generator with col and opts then runs it.
 func (g *Generator) Generate(opts ...Option) (err error) {
-	g.config, err = projutil.ReadConfig()
-	if err == nil {
-		fmt.Printf("config %+v\n", g.config)
-	}
 	for _, opt := range opts {
 		if err = opt(g); err != nil {
 			return err
@@ -176,10 +120,9 @@ func (g *Generator) Generate(opts ...Option) (err error) {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("\ncsv after g.generate()\n%+v\n", csv)
 
-	// Add sdk labels to csv
-	g.setSDKAnnotations(csv)
+	// Add extra annotations to csv
+	g.setAnnotations(csv)
 
 	w, err := g.getWriter()
 	if err != nil {
@@ -189,22 +132,34 @@ func (g *Generator) Generate(opts ...Option) (err error) {
 }
 
 // setSDKAnnotations adds SDK metric labels to the base if they do not exist.
-func (g Generator) setSDKAnnotations(csv *v1alpha1.ClusterServiceVersion) {
+func (g Generator) setAnnotations(csv *v1alpha1.ClusterServiceVersion) {
 	annotations := csv.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
-
-	for key, value := range metricsannotations.MakeBundleObjectAnnotations(g.config) {
-		annotations[key] = value
+	for k, v := range g.Annotations {
+		annotations[k] = v
 	}
 	csv.SetAnnotations(annotations)
 }
 
 // generate runs a configured Generator.
-func (g *Generator) generate() (*operatorsv1alpha1.ClusterServiceVersion, error) {
-	if g.getBase == nil {
-		return nil, noGetBaseError
+func (g *Generator) generate() (base *operatorsv1alpha1.ClusterServiceVersion, err error) {
+	if g.Collector == nil {
+		return nil, fmt.Errorf("cannot generate CSV without a manifests collection")
+	}
+
+	// Search for a CSV in the collector with a name matching the package name,
+	// but prefer an exact match "<package name>.vX.Y.Z" to preserve existing behavior.
+	var oldBase *operatorsv1alpha1.ClusterServiceVersion
+	csvNamePrefix := g.OperatorName + "."
+	oldBaseCSVName := genutil.MakeCSVName(g.OperatorName, "X.Y.Z")
+	for _, csv := range g.Collector.ClusterServiceVersions {
+		if csv.GetName() == oldBaseCSVName {
+			oldBase = csv.DeepCopy()
+		} else if base == nil && strings.HasPrefix(csv.GetName(), csvNamePrefix) {
+			base = csv.DeepCopy()
+		}
 	}
 
 	if base == nil && oldBase == nil {
@@ -223,14 +178,8 @@ func (g *Generator) generate() (*operatorsv1alpha1.ClusterServiceVersion, error)
 		}
 	}
 
-	if err = g.updateVersions(base); err != nil {
+	if err := ApplyTo(g.Collector, base); err != nil {
 		return nil, err
-	}
-
-	if g.Collector != nil {
-		if err := ApplyTo(g.Collector, base); err != nil {
-			return nil, err
-		}
 	}
 
 	return base, nil
@@ -239,78 +188,6 @@ func (g *Generator) generate() (*operatorsv1alpha1.ClusterServiceVersion, error)
 // makeCSVFileName returns a CSV file name containing name.
 func makeCSVFileName(name string) string {
 	return strings.ToLower(name) + csvYamlFileExt
-}
-
-// makeKustomizeBaseGetter returns a function that gets a kustomize-style base.
-func (g Generator) makeKustomizeBaseGetter(inputDir, apisDir string, ilvl projutil.InteractiveLevel) getBaseFunc {
-	basePath := filepath.Join(inputDir, "bases", makeCSVFileName(g.OperatorName))
-	if genutil.IsNotExist(basePath) {
-		basePath = ""
-	}
-
-	return g.makeBaseGetter(basePath, apisDir, requiresInteraction(basePath, ilvl))
-}
-
-func (g Generator) makeBaseCreator(cfg *config.Config, basePath, apisDir string, interactive bool) getBaseFunc {
-	gvks := make([]schema.GroupVersionKind, len(cfg.Resources))
-	for i, gvk := range cfg.Resources {
-		gvks[i].Group = fmt.Sprintf("%s.%s", gvk.Group, cfg.Domain)
-		gvks[i].Version = gvk.Version
-		gvks[i].Kind = gvk.Kind
-	}
-	return func() (*operatorsv1alpha1.ClusterServiceVersion, error) {
-		b := bases.ClusterServiceVersion{
-			OperatorName: g.OperatorName,
-			OperatorType: g.OperatorType,
-			BasePath:     basePath,
-			APIsDir:      apisDir,
-			GVKs:         gvks,
-			Interactive:  interactive,
-		}
-		return b.GetBase()
-	}
-}
-
-// makeBaseGetter returns a function that gets a base from inputDir.
-// apisDir is used by getBaseFunc to populate base fields.
-func (g Generator) makeBaseGetter(basePath, apisDir string, interactive bool) getBaseFunc {
-	var gvks []schema.GroupVersionKind
-	if g.Collector != nil {
-		if g.Collector.V1CustomResourceDefinitions != nil {
-			for _, crd := range g.Collector.V1CustomResourceDefinitions {
-				for _, version := range crd.Spec.Versions {
-					gvks = append(gvks, schema.GroupVersionKind{
-						Group:   crd.Spec.Group,
-						Version: version.Name,
-						Kind:    crd.Spec.Names.Kind,
-					})
-				}
-			}
-		}
-		if g.Collector.V1beta1CustomResourceDefinitions != nil {
-			for _, crd := range g.Collector.V1beta1CustomResourceDefinitions {
-				for _, version := range crd.Spec.Versions {
-					gvks = append(gvks, schema.GroupVersionKind{
-						Group:   crd.Spec.Group,
-						Version: version.Name,
-						Kind:    crd.Spec.Names.Kind,
-					})
-				}
-			}
-		}
-	}
-
-	return func() (*operatorsv1alpha1.ClusterServiceVersion, error) {
-		b := bases.ClusterServiceVersion{
-			OperatorName: g.OperatorName,
-			OperatorType: g.OperatorType,
-			BasePath:     basePath,
-			APIsDir:      apisDir,
-			GVKs:         gvks,
-			Interactive:  interactive,
-		}
-		return b.GetBase()
-	}
 }
 
 // requiresInteraction checks if the combination of ilvl and basePath existence
@@ -346,10 +223,6 @@ func (g Generator) updateVersionsWithReplaces(csv *operatorsv1alpha1.ClusterServ
 	}
 
 	// Set replaces by default.
-<<<<<<< HEAD
-	// TODO: consider all possible CSV versioning schemes supported  by OLM.
-=======
->>>>>>> cad71a15... added changelog
 	if oldVer != "0.0.0" && newVer != oldVer {
 		csv.Spec.Replaces = oldName
 	}

--- a/internal/generate/testdata/clusterserviceversions/bases/memcached-operator.clusterserviceversion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/bases/memcached-operator.clusterserviceversion.yaml
@@ -1,24 +1,13 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  annotations:
-    alm-examples: '[]'
-    capabilities: Basic Install
   name: memcached-operator.vX.Y.Z
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
-  customresourcedefinitions:
-    owned:
-    - displayName: Memcached App
-      kind: Memcached
-      name: memcacheds.cache.example.com
-      version: v1alpha1
-  description: Memcached Operator description. TODO.
+  customresourcedefinitions: {}
+  # displayName is a required field.
   displayName: Memcached Operator
-  icon:
-  - base64data: ""
-    mediatype: ""
   install:
     spec:
       deployments: null
@@ -32,16 +21,4 @@ spec:
     type: MultiNamespace
   - supported: true
     type: AllNamespaces
-  keywords:
-  - memcached-operator
-  links:
-  - name: Memcached Operator
-    url: https://memcached-operator.domain
-  maintainers:
-  - email: your@email.com
-    name: Maintainer Name
-  maturity: alpha
-  provider:
-    name: Provider Name
-    url: https://your.domain
   version: 0.0.0

--- a/internal/generate/testdata/clusterserviceversions/output/with-ui-metadata.clusterserviceversion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/output/with-ui-metadata.clusterserviceversion.yaml
@@ -15,16 +15,60 @@ metadata:
           }
         }
       ]
+    capabilities: Basic Install
   name: memcached-operator.v0.0.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - kind: Memcached
+    - description: Memcached is the Schema for the memcacheds API
+      displayName: Memcached App Display Name
+      kind: Memcached
       name: memcacheds.cache.example.com
+      specDescriptors:
+      - description: List of Providers
+        displayName: Providers
+        path: providers
+      - description: Foo represents the Foo provider
+        displayName: Foo Provider
+        path: providers[0].foo
+      - description: CredentialsSecret is a reference to a secret containing authentication details for the Foo server
+        displayName: Secret Containing the Credentials
+        path: providers[0].foo.credentialsSecret
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - description: Key represents the specific key to reference from the secret
+        displayName: Key within the secret
+        path: providers[0].foo.credentialsSecret.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name represents the name of the secret
+        displayName: Name of the secret
+        path: providers[0].foo.credentialsSecret.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Namespace represents the namespace containing the secret
+        displayName: Namespace containing the secret
+        path: providers[0].foo.credentialsSecret.namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Size is the size of the memcached deployment
+        displayName: Size
+        path: size
+      statusDescriptors:
+      - description: Nodes are the names of the memcached pods
+        displayName: Nodes
+        path: nodes
       version: v1alpha1
+  description: Memcached Operator description. TODO.
   displayName: Memcached Operator
+  icon:
+  - base64data: ""
+    mediatype: ""
   install:
     spec:
       clusterPermissions:
@@ -155,6 +199,18 @@ spec:
     type: MultiNamespace
   - supported: true
     type: AllNamespaces
+  keywords:
+  - memcached-operator
+  links:
+  - name: Memcached Operator
+    url: https://memcached-operator.domain
+  maintainers:
+  - email: your@email.com
+    name: Maintainer Name
+  maturity: alpha
+  provider:
+    name: Provider Name
+    url: https://your.domain
   version: 0.0.1
   webhookdefinitions:
   - admissionReviewVersions:

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -89,6 +89,26 @@ func ReadConfig() (*config.Config, error) {
 	if err = c.Unmarshal(b); err != nil {
 		return nil, err
 	}
+
+	fmt.Printf("config %+v\n", c)
+	/*
+		TODO: remove
+
+			config &{
+				Version:3-alpha
+				Domain:example.com
+				Repo:github.com/example-inc/memcached-operator
+				ProjectName:memcached-operator
+				Resources:
+					[{Group:cache
+					Version:v1alpha1
+					Kind:Memcached}]
+				MultiGroup:false
+				Layout:go.kubebuilder.io/v2
+				Plugins:map[go.sdk.operatorframework.io/v2-alpha:map[]
+			}
+
+	*/
 	return c, nil
 }
 

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -89,26 +89,6 @@ func ReadConfig() (*config.Config, error) {
 	if err = c.Unmarshal(b); err != nil {
 		return nil, err
 	}
-
-	fmt.Printf("config %+v\n", c)
-	/*
-		TODO: remove
-
-			config &{
-				Version:3-alpha
-				Domain:example.com
-				Repo:github.com/example-inc/memcached-operator
-				ProjectName:memcached-operator
-				Resources:
-					[{Group:cache
-					Version:v1alpha1
-					Kind:Memcached}]
-				MultiGroup:false
-				Layout:go.kubebuilder.io/v2
-				Plugins:map[go.sdk.operatorframework.io/v2-alpha:map[]
-			}
-
-	*/
 	return c, nil
 }
 
@@ -124,6 +104,15 @@ func PluginKeyToOperatorType(pluginKey string) OperatorType {
 		return OperatorTypeAnsible
 	}
 	return OperatorTypeUnknown
+}
+
+// GetProjectLayout returns the `layout` field in PROJECT file that is v3.
+// If not, it will return "go" because that was the only project type supported for project versions < v3.
+func GetProjectLayout(cfg *config.Config) string {
+	if cfg == nil || !cfg.IsV3() || cfg.Layout == "" {
+		return "go"
+	}
+	return cfg.Layout
 }
 
 var flagRe = regexp.MustCompile("(.* )?-v(.* )?")

--- a/website/content/en/docs/cli/operator-sdk_generate_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_bundle.md
@@ -90,6 +90,7 @@ operator-sdk generate bundle [flags]
       --metadata                 Generate bundle metadata and Dockerfile
       --output-dir string        Directory to write the bundle to
       --overwrite                Overwrite the bundle's metadata and Dockerfile if they exist (default true)
+      --package string           Bundle's package name
   -q, --quiet                    Run in quiet mode
       --stdout                   Write bundle manifest to stdout
   -v, --version string           Semantic version of the operator in the generated bundle. Only set if creating a new bundle or upgrading your operator

--- a/website/content/en/docs/cli/operator-sdk_generate_kustomize_manifests.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_kustomize_manifests.md
@@ -50,8 +50,9 @@ operator-sdk generate kustomize manifests [flags]
       --apis-dir string     Root directory for API type defintions
   -h, --help                help for manifests
       --input-dir string    Directory containing existing kustomize files
-      --interactive         When set or no kustomize base exists, an interactive command prompt will be presented to accept non-inferrable metadata
+      --interactive         When set to false, if no kustomize base exists, an interactive command prompt will be presented to accept non-inferrable metadata
       --output-dir string   Directory to write kustomize files
+      --package string      Package name
   -q, --quiet               Run in quiet mode
 ```
 

--- a/website/content/en/docs/cli/operator-sdk_generate_packagemanifests.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_packagemanifests.md
@@ -70,6 +70,7 @@ operator-sdk generate packagemanifests [flags]
       --input-dir string       Directory to read existing package manifests from. This directory is the parent of individual versioned package directories, and different from --deploy-dir
       --kustomize-dir string   Directory containing kustomize bases and a kustomization.yaml for operator-framework manifests (default "config/manifests")
       --output-dir string      Directory in which to write package manifests
+      --package string         Package name
   -q, --quiet                  Run in quiet mode
       --stdout                 Write package to stdout
       --update-objects         Update non-CSV objects in this package, ex. CustomResoureDefinitions, Roles (default true)


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Pre-Extract operator details to successfully run `operator-sdk generate  <bundle|packagemanifests>`

**Motivation for the change:**
Operators created using older SDK versions (<v0.19) have a different project layout than the current [Kubebuilder project layout](https://book.kubebuilder.io/cronjob-tutorial/basic-project.html), which restricts them from generating bundles or package manifests, using the latest versions of Operator SDK.

<!--
**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
-->