### PR TITLE
Makefile,release/Makefile: remove custom-scorecard-tests from image build/push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,9 @@ build/operator-sdk build/ansible-operator build/helm-operator:
 
 ##@ Dev images
 
-# Convenience wrappers for building/pushing all images.
+# Convenience wrapper for building all remotely hosted images.
 .PHONY: image-build
-IMAGE_TARGET_LIST := operator-sdk helm-operator ansible-operator scorecard-test scorecard-test-kuttl custom-scorecard-tests
+IMAGE_TARGET_LIST = operator-sdk helm-operator ansible-operator scorecard-test scorecard-test-kuttl
 image-build: $(foreach i,$(IMAGE_TARGET_LIST),image/$(i)) ## Build all images.
 
 # Build an image.

--- a/release/Makefile
+++ b/release/Makefile
@@ -29,12 +29,13 @@ ifeq ($(DRY_RUN),)
 	rm -f ./changelog/fragments/!(00-template.yaml)
 endif
 
+# Convenience wrappers for pushing all remotely hosted images.
 .PHONY: image-push image-push-multiarch
-IMAGE_TARGET_LIST = operator-sdk helm-operator ansible-operator scorecard-test scorecard-test-kuttl custom-scorecard-tests
+IMAGE_TARGET_LIST = operator-sdk helm-operator ansible-operator scorecard-test scorecard-test-kuttl
 image-push: $(foreach i,$(IMAGE_TARGET_LIST),image-push/$(i)) ## Push all images for the host architecture.
 image-push-multiarch: $(foreach i,$(IMAGE_TARGET_LIST),image-push-multiarch/$(i)) ## Push the manifest list for all architectures.
 
-# Push image for an architecture.
+# Push an image for an architecture.
 IMAGE_REPO ?= quay.io/operator-framework
 GO_ARCH := $(shell go env GOARCH)
 image-push/%: IMAGE_PUSH_TAG = $(IMAGE_REPO)/$*-$(GO_ARCH)


### PR DESCRIPTION
**Description of the change:** remove custom-scorecard-tests from image build/push from Makefile rules

**Motivation for the change:** custom-scorecard-tests don't exist remotely so shouldn't be built/pushed with other remote images

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
