### PR TITLE
internal/*: define ImageVersion, which is set to the most recent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 SHELL = /bin/bash
 
+# IMAGE_VERSION represents the ansible-operator, helm-operator, and scorecard subproject versions.
+# This value must be updated to the release tag of the most recent release, a change that must
+# occur in the release commit. IMAGE_VERSION will be removed once each subproject that uses this
+# version is moved to a separate repo and release process.
+export IMAGE_VERSION = v1.1.0
 # Build-time variables to inject into binaries
 export SIMPLE_VERSION = $(shell (test "$(shell git describe)" = "$(shell git describe --abbrev=0)" && echo $(shell git describe)) || echo $(shell git describe --abbrev=0)+git)
 export GIT_VERSION = $(shell git describe --dirty --tags --always)
@@ -20,6 +25,7 @@ GO_BUILD_ARGS = \
     -X '$(REPO)/internal/version.GitVersion=$(GIT_VERSION)' \
     -X '$(REPO)/internal/version.GitCommit=$(GIT_COMMIT)' \
     -X '$(REPO)/internal/version.KubernetesVersion=v$(K8S_VERSION)' \
+    -X '$(REPO)/internal/version.ImageVersion=$(IMAGE_VERSION)' \
   " \
 
 export GO111MODULE = on

--- a/changelog/fragments/go-version-bug.yaml
+++ b/changelog/fragments/go-version-bug.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: >
+      Removed redundant platform information from `operator-sdk version` output
+    kind: bugfix

--- a/internal/cmd/ansible-operator/version/cmd.go
+++ b/internal/cmd/ansible-operator/version/cmd.go
@@ -40,5 +40,5 @@ func run() {
 		version = ver.Version
 	}
 	fmt.Printf("ansible-operator version: %q, commit: %q, kubernetes version: %q, go version: %q, GOOS: %q, GOARCH: %q\n",
-		version, ver.GitCommit, ver.KubernetesVersion, ver.GoVersion, runtime.GOOS, runtime.GOARCH)
+		version, ver.GitCommit, ver.KubernetesVersion, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 }

--- a/internal/cmd/ansible-operator/version/cmd_test.go
+++ b/internal/cmd/ansible-operator/version/cmd_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Running a version command", func() {
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("version: %q", version)))
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("commit: %q", ver.GitCommit)))
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("kubernetes version: %q", ver.KubernetesVersion)))
-			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("go version: %q", ver.GoVersion)))
+			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("go version: %q", runtime.Version())))
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("GOOS: %q", runtime.GOOS)))
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("GOARCH: %q", runtime.GOARCH)))
 		})

--- a/internal/cmd/helm-operator/version/cmd.go
+++ b/internal/cmd/helm-operator/version/cmd.go
@@ -40,5 +40,5 @@ func run() {
 		version = ver.Version
 	}
 	fmt.Printf("helm-operator version: %q, commit: %q, kubernetes version: %q, go version: %q, GOOS: %q, GOARCH: %q\n",
-		version, ver.GitCommit, ver.KubernetesVersion, ver.GoVersion, runtime.GOOS, runtime.GOARCH)
+		version, ver.GitCommit, ver.KubernetesVersion, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 }

--- a/internal/cmd/helm-operator/version/cmd_test.go
+++ b/internal/cmd/helm-operator/version/cmd_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Running a version command", func() {
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("version: %q", version)))
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("commit: %q", ver.GitCommit)))
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("kubernetes version: %q", ver.KubernetesVersion)))
-			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("go version: %q", ver.GoVersion)))
+			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("go version: %q", runtime.Version())))
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("GOOS: %q", runtime.GOOS)))
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("GOARCH: %q", runtime.GOARCH)))
 		})

--- a/internal/cmd/operator-sdk/version/cmd.go
+++ b/internal/cmd/operator-sdk/version/cmd.go
@@ -36,5 +36,5 @@ func NewCmd() *cobra.Command {
 
 func run() {
 	fmt.Printf("operator-sdk version: %q, commit: %q, kubernetes version: %q, go version: %q, GOOS: %q, GOARCH: %q\n",
-		ver.GitVersion, ver.GitCommit, ver.KubernetesVersion, ver.GoVersion, runtime.GOOS, runtime.GOARCH)
+		ver.GitVersion, ver.GitCommit, ver.KubernetesVersion, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 }

--- a/internal/cmd/operator-sdk/version/cmd_test.go
+++ b/internal/cmd/operator-sdk/version/cmd_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Running a version command", func() {
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("version: %q", version)))
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("commit: %q", ver.GitCommit)))
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("kubernetes version: %q", ver.KubernetesVersion)))
-			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("go version: %q", ver.GoVersion)))
+			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("go version: %q", runtime.Version())))
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("GOOS: %q", runtime.GOOS)))
 			Expect(stdoutString).To(ContainSubstring(fmt.Sprintf("GOARCH: %q", runtime.GOARCH)))
 		})

--- a/internal/plugins/ansible/v1/scaffolds/init.go
+++ b/internal/plugins/ansible/v1/scaffolds/init.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/model/config"
 	"sigs.k8s.io/kubebuilder/pkg/plugin/scaffold"
 
+	"github.com/operator-framework/operator-sdk/internal/kubebuilder/machinery"
 	"github.com/operator-framework/operator-sdk/internal/plugins/ansible/v1/scaffolds/internal/templates"
 	"github.com/operator-framework/operator-sdk/internal/plugins/ansible/v1/scaffolds/internal/templates/config/kdefault"
 	"github.com/operator-framework/operator-sdk/internal/plugins/ansible/v1/scaffolds/internal/templates/config/manager"
@@ -32,17 +33,19 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/plugins/ansible/v1/scaffolds/internal/templates/molecule/mdefault"
 	"github.com/operator-framework/operator-sdk/internal/plugins/ansible/v1/scaffolds/internal/templates/molecule/mkind"
 	"github.com/operator-framework/operator-sdk/internal/plugins/ansible/v1/scaffolds/internal/templates/playbooks"
-	ansibleroles "github.com/operator-framework/operator-sdk/internal/plugins/ansible/v1/scaffolds/internal/templates/roles"
-
-	"github.com/operator-framework/operator-sdk/internal/kubebuilder/machinery"
+	"github.com/operator-framework/operator-sdk/internal/plugins/ansible/v1/scaffolds/internal/templates/roles"
+	"github.com/operator-framework/operator-sdk/internal/version"
 )
 
 const (
-	// KustomizeVersion is the kubernetes-sigs/kustomize version to be used in the project
-	KustomizeVersion = "v3.5.4"
+	// kustomizeVersion is the sigs.k8s.io/kustomize version to be used in the project
+	kustomizeVersion = "v3.5.4"
 
 	imageName = "controller:latest"
 )
+
+// ansibleOperatorVersion is set to the version of ansible-operator at compile-time.
+var ansibleOperatorVersion = version.ImageVersion
 
 var _ scaffold.Scaffolder = &initScaffolder{}
 
@@ -79,7 +82,12 @@ func (s *initScaffolder) Scaffold() error {
 func (s *initScaffolder) scaffold() error {
 	return machinery.NewScaffold().Execute(
 		s.newUniverse(),
-		&templates.Dockerfile{},
+		&templates.Dockerfile{AnsibleOperatorVersion: ansibleOperatorVersion},
+		&templates.Makefile{
+			Image:                  imageName,
+			KustomizeVersion:       kustomizeVersion,
+			AnsibleOperatorVersion: ansibleOperatorVersion,
+		},
 		&templates.GitIgnore{},
 		&templates.RequirementsYml{},
 		&templates.Watches{},
@@ -103,8 +111,7 @@ func (s *initScaffolder) scaffold() error {
 		&kdefault.Kustomize{},
 		&kdefault.AuthProxyPatch{},
 
-		&templates.Makefile{},
-		&ansibleroles.Placeholder{},
+		&roles.Placeholder{},
 		&playbooks.Placeholder{},
 
 		&mdefault.Converge{},

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
@@ -18,11 +18,9 @@ limitations under the License.
 package templates
 
 import (
-	"strings"
+	"errors"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-
-	"github.com/operator-framework/operator-sdk/internal/version"
 )
 
 var _ file.Template = &Makefile{}
@@ -37,7 +35,7 @@ type Makefile struct {
 	// Kustomize version to use in the project
 	KustomizeVersion string
 
-	// AnsibleOperatorVersion is the version of the base image and operator binary used in the project
+	// AnsibleOperatorVersion is the version of the ansible-operator binary downloaded by the Makefile.
 	AnsibleOperatorVersion string
 }
 
@@ -56,11 +54,11 @@ func (f *Makefile) SetTemplateDefaults() error {
 	}
 
 	if f.KustomizeVersion == "" {
-		f.KustomizeVersion = "v3.5.4"
+		return errors.New("kustomize version is required in scaffold")
 	}
 
 	if f.AnsibleOperatorVersion == "" {
-		f.AnsibleOperatorVersion = strings.TrimSuffix(version.Version, "+git")
+		return errors.New("ansible-operator version is required in scaffold")
 	}
 
 	return nil

--- a/internal/plugins/helm/v1/scaffolds/init.go
+++ b/internal/plugins/helm/v1/scaffolds/init.go
@@ -19,7 +19,6 @@ package scaffolds
 
 import (
 	"os"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model"
 	"sigs.k8s.io/kubebuilder/pkg/model/config"
@@ -36,14 +35,14 @@ import (
 )
 
 const (
-	// KustomizeVersion is the kubernetes-sigs/kustomize version to be used in the project
-	KustomizeVersion = "v3.5.4"
+	// kustomizeVersion is the sigs.k8s.io/kustomize version to be used in the project
+	kustomizeVersion = "v3.5.4"
 
 	imageName = "controller:latest"
 )
 
-// HelmOperatorVersion is the version of the helm binary used in the Makefile
-var HelmOperatorVersion = strings.TrimSuffix(version.Version, "+git")
+// helmOperatorVersion is set to the version of helm-operator at compile-time.
+var helmOperatorVersion = version.ImageVersion
 
 var _ scaffold.Scaffolder = &initScaffolder{}
 
@@ -84,13 +83,13 @@ func (s *initScaffolder) scaffold() error {
 	return machinery.NewScaffold().Execute(
 		s.newUniverse(),
 		&templates.Dockerfile{
-			HelmOperatorVersion: HelmOperatorVersion,
+			HelmOperatorVersion: helmOperatorVersion,
 		},
 		&templates.GitIgnore{},
 		&templates.Makefile{
 			Image:               imageName,
-			KustomizeVersion:    KustomizeVersion,
-			HelmOperatorVersion: HelmOperatorVersion,
+			KustomizeVersion:    kustomizeVersion,
+			HelmOperatorVersion: helmOperatorVersion,
 		},
 		&templates.Watches{},
 		&rbac.AuthProxyRole{},

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/dockerfile.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/dockerfile.go
@@ -15,6 +15,8 @@
 package templates
 
 import (
+	"errors"
+
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
 
@@ -24,7 +26,7 @@ var _ file.Template = &Dockerfile{}
 type Dockerfile struct {
 	file.TemplateMixin
 
-	// HelmOperatorVersion is the version of the base image and operator binary used in the project
+	// HelmOperatorVersion is the version of the Dockerfile's base image.
 	HelmOperatorVersion string
 }
 
@@ -35,6 +37,10 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 	}
 
 	f.TemplateBody = dockerfileTemplate
+
+	if f.HelmOperatorVersion == "" {
+		return errors.New("helm-operator version is required in scaffold")
+	}
 
 	return nil
 }

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/makefile.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/makefile.go
@@ -18,11 +18,9 @@ limitations under the License.
 package templates
 
 import (
-	"strings"
+	"errors"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-
-	"github.com/operator-framework/operator-sdk/internal/version"
 )
 
 var _ file.Template = &Makefile{}
@@ -37,7 +35,7 @@ type Makefile struct {
 	// Kustomize version to use in the project
 	KustomizeVersion string
 
-	// HelmOperatorVersion is the version of the base image and operator binary used in the project
+	// HelmOperatorVersion is the version of the helm-operator binary downloaded by the Makefile.
 	HelmOperatorVersion string
 }
 
@@ -56,11 +54,11 @@ func (f *Makefile) SetTemplateDefaults() error {
 	}
 
 	if f.KustomizeVersion == "" {
-		f.KustomizeVersion = "v3.5.4"
+		return errors.New("kustomize version is required in scaffold")
 	}
 
 	if f.HelmOperatorVersion == "" {
-		f.HelmOperatorVersion = strings.TrimSuffix(version.Version, "+git")
+		return errors.New("helm-operator version is required in scaffold")
 	}
 
 	return nil

--- a/internal/plugins/scorecard/init.go
+++ b/internal/plugins/scorecard/init.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"text/template"
 
 	"github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
@@ -32,6 +31,9 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/scorecard"
 	"github.com/operator-framework/operator-sdk/internal/version"
 )
+
+// scorecardVersion is set to the version of scorecard at compile-time.
+var scorecardVersion = version.ImageVersion
 
 const (
 	// kustomization.yaml file template for the scorecard componentconfig. This should always be written to
@@ -63,8 +65,7 @@ const (
 )
 
 // defaultTestImageTag points to the latest-released image.
-var defaultTestImageTag = fmt.Sprintf("quay.io/operator-framework/scorecard-test:%s",
-	strings.TrimSuffix(version.Version, "+git"))
+var defaultTestImageTag = fmt.Sprintf("quay.io/operator-framework/scorecard-test:%s", scorecardVersion)
 
 // defaultDir is the default directory in which to generate kustomize bases and the kustomization.yaml.
 var defaultDir = filepath.Join("config", "scorecard")

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -14,16 +14,17 @@
 
 package version
 
-import (
-	"fmt"
-	"runtime"
-)
-
-//var needs to be used instead of const for ldflags
+// var needs to be used instead of const for ldflags
 var (
 	Version           = "unknown"
 	GitVersion        = "unknown"
 	GitCommit         = "unknown"
 	KubernetesVersion = "unknown"
-	GoVersion         = fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+
+	// ImageVersion represents the ansible-operator, helm-operator, and scorecard subproject versions,
+	// which is used in each plugin to specify binary and/or image versions. This is set to the
+	// most recent operator-sdk release tag such that samples are generated with the correct versions
+	// in a release commit. Once each element that uses this version is moved to a separate repo
+	// and release process, this variable will be removed.
+	ImageVersion = "unknown"
 )


### PR DESCRIPTION
**Description of the change:**
- internal/*: define ImageVersion, which is set to the most recent of operator-sdk repo tag or release commit's future tag. This variable is consumed by ansible-operator, helm-operator, and scorecard plugins
- Makefile: set IMAGE_VERSION to v1.1.0, and set ImageVersion in ldflags

**Motivation for the change:** samples generated for a release commit will have incorrect versions, specifically the major+minor version preceding the soon-to-be-released version, in the current release setup because these versions depend on a release's git tag which has not been created yet. Setting this version explicitly in the Makefile breaks this cycle, allowing samples to be generated with a version that has not been released yet; these will still pass e2e tests because image tags are substituted anyway.

This PR makes no user-facing changes (except changing the `operator-sdk version` output string, which I would consider a bugfix and can add a fragment if desired).

Closes #4061

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
