### PR TITLE
Auto-generate cncf maintainers file from OWNERS and OWNERS_ALIASES

### DIFF
--- a/.cncf-maintainers
+++ b/.cncf-maintainers
@@ -1,0 +1,25 @@
+approvers:
+- asmacdo
+- camilamacedo86
+- estroz
+- fabianvf
+- jmccormick2001
+- jmrodri
+- joelanford
+- marc-obrien
+- rashmigottipati
+- theishshah
+- varshaprasad96
+reviewers:
+- asmacdo
+- camilamacedo86
+- estroz
+- fabianvf
+- jberkhahn
+- jmccormick2001
+- jmrodri
+- joelanford
+- marc-obrien
+- rashmigottipati
+- theishshah
+- varshaprasad96

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ export PATH := $(PWD)/$(BUILD_DIR):$(PWD)/$(TOOLS_DIR):$(PATH)
 
 .PHONY: generate
 generate: build # Generate CLI docs and samples
+	go run ./hack/generate/cncf-maintainers/main.go
 	go run ./hack/generate/cli-doc/gen-cli-doc.go
 	go run ./hack/generate/samples/generate_all.go
 

--- a/hack/generate/cncf-maintainers/main.go
+++ b/hack/generate/cncf-maintainers/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
+)
+
+type ownersMap map[string][]string
+type aliasesMap struct {
+	Aliases map[string][]string `json:"aliases,omitempty"`
+}
+
+func main() {
+	ownersData, err := ioutil.ReadFile("OWNERS")
+	if err != nil {
+		log.Fatal(err)
+	}
+	aliasData, err := ioutil.ReadFile("OWNERS_ALIASES")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var owners ownersMap
+	if err := yaml.Unmarshal(ownersData, &owners); err != nil {
+		log.Fatal(err)
+	}
+
+	var aliases aliasesMap
+	if err := yaml.Unmarshal(aliasData, &aliases); err != nil {
+		log.Fatal(err)
+	}
+
+	expandedOwners := make(map[string]sets.String)
+	for group, ownersAliases := range owners {
+		expandedOwners[group] = sets.NewString()
+		for _, alias := range ownersAliases {
+			if members, ok := aliases.Aliases[alias]; ok {
+				expandedOwners[group].Insert(members...)
+			}
+		}
+	}
+
+	outOwners := make(map[string][]string)
+	for g, m := range expandedOwners {
+		outOwners[g] = m.List()
+	}
+
+	out, err := yaml.Marshal(outOwners)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := ioutil.WriteFile(".cncf-maintainers", out, 0644); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/hack/generate/cncf-maintainers/main.go
+++ b/hack/generate/cncf-maintainers/main.go
@@ -39,6 +39,8 @@ func main() {
 		for _, alias := range ownersAliases {
 			if members, ok := aliases.Aliases[alias]; ok {
 				expandedOwners[group].Insert(members...)
+			} else {
+				log.Fatalf("alias %q is listed in OWNERS group %q but was not found in OWNERS_ALIASES", alias, group)
 			}
 		}
 	}


### PR DESCRIPTION
**Description of the change:**

Automatically generate a flattened maintainers file from the `OWNERS` and `OWNERS_ALIASES` files in the SDK repo.

**Motivation for the change:**

CNCF needs a single file listing individual maintainers to keep mailing lists updated. This requirement is incompatible with our existing `OWNERS` and `OWNERS_ALIASES` mappings.

See: https://github.com/operator-framework/operator-sdk/commit/575412115cd60452f0ee4d2abd04eab76f46741e#commitcomment-43450277

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] ~Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))~
- [ ] ~Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)~
