### PR TITLE
cleanup: delete catsrc and operatorgroup even if subscription is not found

### DIFF
--- a/changelog/fragments/fix-cleanup.yaml
+++ b/changelog/fragments/fix-cleanup.yaml
@@ -1,0 +1,7 @@
+entries:
+  - description: >
+      Fixed an issue in `operator-sdk cleanup` that caused catalog
+      source and operator group objects not to be cleaned up if a
+      previous `operator-sdk run` command failed. 
+    kind: bugfix
+    breaking: false

--- a/changelog/fragments/fix-cleanup.yaml
+++ b/changelog/fragments/fix-cleanup.yaml
@@ -1,7 +1,7 @@
 entries:
   - description: >
-      Fixed an issue in `operator-sdk cleanup` that caused catalog
-      source and operator group objects not to be cleaned up if a
-      previous `operator-sdk run` command failed. 
+      Fixed an issue in `operator-sdk cleanup` that caused `CatalogSource`
+      and `OperatorGroup` objects not to be cleaned up if a
+      previous `operator-sdk run` command failed.
     kind: bugfix
     breaking: false

--- a/internal/olm/operator/bundle/install.go
+++ b/internal/olm/operator/bundle/install.go
@@ -77,7 +77,7 @@ func (i *Install) setup(ctx context.Context) error {
 	}
 
 	i.OperatorInstaller.PackageName = labels[registrybundle.PackageLabel]
-	i.OperatorInstaller.CatalogSourceName = fmt.Sprintf("%s-catalog", i.OperatorInstaller.PackageName)
+	i.OperatorInstaller.CatalogSourceName = operator.CatalogNameForPackage(i.OperatorInstaller.PackageName)
 	i.OperatorInstaller.StartingCSV = csv.Name
 	i.OperatorInstaller.SupportedInstallModes = operator.GetSupportedInstallModes(csv.Spec.InstallModes)
 	i.OperatorInstaller.Channel = strings.Split(labels[registrybundle.ChannelsLabel], ",")[0]

--- a/internal/olm/operator/helpers.go
+++ b/internal/olm/operator/helpers.go
@@ -14,6 +14,14 @@
 
 package operator
 
+import (
+	"fmt"
+)
+
 const (
 	SDKOperatorGroupName = "operator-sdk-og"
 )
+
+func CatalogNameForPackage(pkg string) string {
+	return fmt.Sprintf("%s-catalog", pkg)
+}

--- a/internal/olm/operator/packagemanifests/install.go
+++ b/internal/olm/operator/packagemanifests/install.go
@@ -74,7 +74,7 @@ func (i *Install) setup() error {
 	}
 
 	i.OperatorInstaller.PackageName = pkg.PackageName
-	i.OperatorInstaller.CatalogSourceName = fmt.Sprintf("%s-catalog", i.OperatorInstaller.PackageName)
+	i.OperatorInstaller.CatalogSourceName = operator.CatalogNameForPackage(i.OperatorInstaller.PackageName)
 	i.OperatorInstaller.StartingCSV = bundle.CSV.GetName()
 	i.OperatorInstaller.SupportedInstallModes = operator.GetSupportedInstallModes(bundle.CSV.Spec.InstallModes)
 

--- a/internal/olm/operator/uninstall.go
+++ b/internal/olm/operator/uninstall.go
@@ -51,6 +51,14 @@ func NewUninstall(cfg *Configuration) *Uninstall {
 	}
 }
 
+type ErrPackageNotFound struct {
+	PackageName string
+}
+
+func (e ErrPackageNotFound) Error() string {
+	return fmt.Sprintf("package %q not found", e.PackageName)
+}
+
 func (u *Uninstall) Run(ctx context.Context) error {
 	if u.DeleteAll {
 		u.DeleteCRDs = true
@@ -70,54 +78,56 @@ func (u *Uninstall) Run(ctx context.Context) error {
 			break
 		}
 	}
-	if sub == nil {
-		return fmt.Errorf("operator package %q not found", u.Package)
-	}
 
-	catsrcKey := types.NamespacedName{
-		Namespace: sub.Spec.CatalogSourceNamespace,
-		Name:      sub.Spec.CatalogSource,
-	}
 	catsrc := &v1alpha1.CatalogSource{}
-	if err := u.config.Client.Get(ctx, catsrcKey, catsrc); err != nil {
-		return fmt.Errorf("get catalog source: %v", err)
-	}
 	catsrc.SetGroupVersionKind(v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CatalogSourceKind))
-
-	// Since the install plan is owned by the subscription, we need to
-	// read all of the resource references from the install plan before
-	// deleting the subscription.
-	var crds, csvs, others []controllerutil.Object
-	if sub.Status.InstallPlanRef != nil {
-		ipKey := types.NamespacedName{
-			Namespace: sub.Status.InstallPlanRef.Namespace,
-			Name:      sub.Status.InstallPlanRef.Name,
+	if sub != nil {
+		catsrcKey := types.NamespacedName{
+			Namespace: sub.Spec.CatalogSourceNamespace,
+			Name:      sub.Spec.CatalogSource,
 		}
-		var err error
-		crds, csvs, others, err = u.getInstallPlanResources(ctx, ipKey)
-		if err != nil {
-			return fmt.Errorf("get install plan resources: %v", err)
+		if err := u.config.Client.Get(ctx, catsrcKey, catsrc); err != nil {
+			return fmt.Errorf("get catalog source: %v", err)
 		}
-	}
 
-	// Delete the subscription first, so that no further installs or upgrades
-	// of the operator occur while we're cleaning up.
-	if err := u.deleteObjects(ctx, false, sub); err != nil {
-		return err
-	}
+		// Since the install plan is owned by the subscription, we need to
+		// read all of the resource references from the install plan before
+		// deleting the subscription.
+		var crds, csvs, others []controllerutil.Object
+		if sub.Status.InstallPlanRef != nil {
+			ipKey := types.NamespacedName{
+				Namespace: sub.Status.InstallPlanRef.Namespace,
+				Name:      sub.Status.InstallPlanRef.Name,
+			}
+			var err error
+			crds, csvs, others, err = u.getInstallPlanResources(ctx, ipKey)
+			if err != nil {
+				return fmt.Errorf("get install plan resources: %v", err)
+			}
+		}
 
-	if u.DeleteCRDs {
-		// Ensure CustomResourceDefinitions are deleted next, so that the operator
-		// has a chance to handle CRs that have finalizers.
-		if err := u.deleteObjects(ctx, true, crds...); err != nil {
+		// Delete the subscription first, so that no further installs or upgrades
+		// of the operator occur while we're cleaning up.
+		if err := u.deleteObjects(ctx, false, sub); err != nil {
 			return err
 		}
-	}
 
-	// Delete CSVs and all other objects created by the install plan.
-	objects := append(csvs, others...)
-	if err := u.deleteObjects(ctx, true, objects...); err != nil {
-		return err
+		if u.DeleteCRDs {
+			// Ensure CustomResourceDefinitions are deleted next, so that the operator
+			// has a chance to handle CRs that have finalizers.
+			if err := u.deleteObjects(ctx, true, crds...); err != nil {
+				return err
+			}
+		}
+
+		// Delete CSVs and all other objects created by the install plan.
+		objects := append(csvs, others...)
+		if err := u.deleteObjects(ctx, true, objects...); err != nil {
+			return err
+		}
+	} else {
+		catsrc.SetNamespace(u.config.Namespace)
+		catsrc.SetName(CatalogNameForPackage(u.Package))
 	}
 
 	// Delete the catalog source. This assumes that all underlying resources related
@@ -147,6 +157,9 @@ func (u *Uninstall) Run(ctx context.Context) error {
 				}
 			}
 		}
+	}
+	if sub == nil {
+		return &ErrPackageNotFound{u.Package}
 	}
 	return nil
 }


### PR DESCRIPTION
**Description of the change:**

Updates the `operator-sdk cleanup` subcommand to cleanup the catalog source and operator group even when a subscription for the operator does not exist.

**Motivation for the change:**

In the event that a user runs `operator-sdk run` and an error occurs after the operator group and catalog source are created, but before a subscription is created, the operator group and catalog source must be manually cleaned up before retrying the `operator-sdk run` command.

In 1.1.0, the `operator-sdk cleanup` command will not cleanup the operator group and catalog source in this scenario.

This PR updates the `operator-sdk cleanup` command so that even when a subscription does not exist, it looks for the expected catalog source and operator group, and deletes them if they exist.

Closes #4085 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] ~Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)~
