### PR TITLE
internal/plugins: Add kustomize as a prerequisite of Makefile's bundle target

### DIFF
--- a/changelog/fragments/autogenerated-makefile-bundle-prerequisite-task.yaml
+++ b/changelog/fragments/autogenerated-makefile-bundle-prerequisite-task.yaml
@@ -1,0 +1,27 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Added the `kustomize` make dependency to the `bundle`
+      target scaffolded for Golang projects to install
+      `kustomize` before running.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: bugfix
+
+    # Is this a breaking change?
+    breaking: false
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: (Golang based operators) Update Makefile's bundle target
+      body: >
+        In the `Makefile` file, replace `bundle: manifests`
+        with `bundle: manifests kustomize` to call the kustomize
+        target when the `bundle` target is used.

--- a/hack/generate/samples/internal/ansible/memcached.go
+++ b/hack/generate/samples/internal/ansible/memcached.go
@@ -67,9 +67,6 @@ func (ma *MemcachedAnsible) Run() {
 		"--generate-playbook")
 	pkg.CheckError("creating the project", err)
 
-	err = ma.ctx.Make("kustomize")
-	pkg.CheckError("error to scaffold api", err)
-
 	log.Infof("customizing the sample")
 	err = testutils.UncommentCode(
 		filepath.Join(ma.ctx.Dir, "config", "default", "kustomization.yaml"),

--- a/hack/generate/samples/internal/go/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/memcached_with_webhooks.go
@@ -64,9 +64,6 @@ func (mh *MemcachedGoWithWebhooks) Run() {
 		mh.ctx.Domain)
 	pkg.CheckError("creating the project", err)
 
-	err = mh.ctx.Make("kustomize")
-	pkg.CheckError("error to scaffold api", err)
-
 	err = mh.ctx.CreateAPI(
 		"--group", mh.ctx.Group,
 		"--version", mh.ctx.Version,

--- a/hack/generate/samples/internal/helm/memcached.go
+++ b/hack/generate/samples/internal/helm/memcached.go
@@ -91,9 +91,6 @@ func (mh *MemcachedHelm) Run() {
 		"--helm-chart", helmChartPath)
 	pkg.CheckError("scaffolding apis", err)
 
-	err = mh.ctx.Make("kustomize")
-	pkg.CheckError("running make kustomize", err)
-
 	log.Infof("customizing the sample")
 	log.Infof("enabling prometheus metrics")
 	err = testutils.UncommentCode(

--- a/internal/plugins/manifests/init.go
+++ b/internal/plugins/manifests/init.go
@@ -88,7 +88,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 	makefileBundleFragmentGo = `
 # Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle
-bundle: manifests
+bundle: manifests kustomize
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)

--- a/testdata/go/memcached-operator/Makefile
+++ b/testdata/go/memcached-operator/Makefile
@@ -111,7 +111,7 @@ endif
 
 # Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle
-bundle: manifests
+bundle: manifests kustomize
 	operator-sdk generate kustomize manifests --interactive=false -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)


### PR DESCRIPTION
**Description of the change:**

`bundle` target in the autogenerated Makefile for new golang based operator projects generated
by the operator-sdk make use of the `kustomize` CLI tool. This commit adds the `kustomize` Makefile
target as a prerequisite of the `bundle` target.

**Motivation for the change:**

When running `make bundle` an error is returned if kustomize is not previously installed in `$PATH`.

Execution example:

```
msoriano@localhost:~/go/src/github.com/3scale/apicast-operator (update-operator-sdk-to-110)$ make bundle
which: no kustomize in (/home/msoriano/.rbenv/shims:/home/msoriano/.rbenv/bin:/home/msoriano/.nvm/versions/node/v10.21.0/bin:/usr/share/Modules/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/home/msoriano/.local/bin:/home/msoriano/bin:/usr/local/go/bin:/home/msoriano/go/bin)
/home/msoriano/go/bin/controller-gen "crd:trivialVersions=true" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
operator-sdk-v1.1.0 generate kustomize manifests -q
cd config/manager && /home/msoriano/go/bin/kustomize edit set image controller=controller:latest
/bin/bash: /home/msoriano/go/bin/kustomize: No such file or directory
make: *** [Makefile:126: bundle] Error 127
```

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
