### PR TITLE
website: re-point master links to v1.1.x

### DIFF
--- a/website/content/en/docs/advanced-topics/scorecard/custom-tests.md
+++ b/website/content/en/docs/advanced-topics/scorecard/custom-tests.md
@@ -288,13 +288,13 @@ connection to invoke the Kube API.
 
 
 [client_go]: https://github.com/kubernetes/client-go
-[olm_tests]: https://github.com/operator-framework/operator-sdk/blob/master/internal/scorecard/tests/olm.go
-[basic_tests]: https://github.com/operator-framework/operator-sdk/blob/master/internal/scorecard/tests/basic.go
-[config_yaml]: https://github.com/operator-framework/operator-sdk/blob/master/internal/scorecard/testdata/bundle/tests/scorecard/config.yaml
-[scorecard_main_func]: https://github.com/operator-framework/operator-sdk/blob/master/images/scorecard-test/cmd/test/main.go
+[olm_tests]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/internal/scorecard/tests/olm.go
+[basic_tests]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/internal/scorecard/tests/basic.go
+[config_yaml]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/internal/scorecard/testdata/bundle/tests/scorecard/config.yaml
+[scorecard_main_func]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/images/scorecard-test/cmd/test/main.go
 [custom_scorecard_repo]: https://github.com/operator-framework/operator-sdk
 [user_doc]: /docs/advanced-topics/scorecard/scorecard/
-[scorecard_binary]: https://github.com/operator-framework/operator-sdk/blob/master/images/custom-scorecard-tests/cmd/test/main.go
-[sample_makefile]: https://github.com/operator-framework/operator-sdk/blob/master/Makefile
+[scorecard_binary]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/images/custom-scorecard-tests/cmd/test/main.go
+[sample_makefile]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/Makefile
 [kustomize-patchJson6902]: https://kubernetes-sigs.github.io/kustomize/api-reference/kustomization/patchesjson6902/
 [testresults]:https://github.com/operator-framework/api/blob/333d064/pkg/apis/scorecard/v1alpha3/test_types.go#L35

--- a/website/content/en/docs/advanced-topics/scorecard/scorecard.md
+++ b/website/content/en/docs/advanced-topics/scorecard/scorecard.md
@@ -267,5 +267,5 @@ if the test image follows the above guidelines.
 
 [quickstart-bundle]: /docs/olm-integration/quickstart-bundle
 [cli-scorecard]: /docs/cli/operator-sdk_scorecard/
-[custom-image]: https://github.com/operator-framework/operator-sdk/blob/master/images/custom-scorecard-tests/cmd/test/main.go
+[custom-image]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/images/custom-scorecard-tests/cmd/test/main.go
 [olm-bundle]:https://github.com/operator-framework/operator-registry#manifest-format

--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -339,7 +339,7 @@ E.g `kubectl logs deployment.apps/memcached-operator-controller-manager -n memca
 [integration-doc]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/integrating-kubebuilder-and-osdk.md
 [quickstart]: /docs/building-operators/golang/quickstart/
 [metrics]: https://book.kubebuilder.io/reference/metrics.html?highlight=metr#metrics
-[memcached_controller]: https://github.com/operator-framework/operator-sdk/blob/master/testdata/go/memcached-operator/controllers/memcached_controller.go
+[memcached_controller]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/testdata/go/memcached-operator/controllers/memcached_controller.go
 [rbac_markers]: https://book.kubebuilder.io/reference/markers/rbac.html
 [kube-auth-proxy]: https://github.com/brancz/kube-rbac-proxy
 [markers]: https://book.kubebuilder.io/reference/markers.html?highlight=markers#marker-syntax

--- a/website/content/en/docs/building-operators/golang/references/client.md
+++ b/website/content/en/docs/building-operators/golang/references/client.md
@@ -572,6 +572,6 @@ func labelsForApp(name string) map[string]string {
 [code-scheme-default]:https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/client.go#L51
 [doc-k8s-core]:https://godoc.org/k8s.io/api/core/v1
 [doc-reconcile-reconciler]:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Reconciler
-[doc-osdk-handle]:https://github.com/operator-framework/operator-sdk/blob/master/design/milestone-0.0.2/action-api.md#handler
+[doc-osdk-handle]:https://github.com/operator-framework/operator-sdk/blob/v1.1.x/design/milestone-0.0.2/action-api.md#handler
 [doc-types-nsname]:https://godoc.org/k8s.io/apimachinery/pkg/types#NamespacedName
 [cr-status-subresource]:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource

--- a/website/content/en/docs/building-operators/golang/references/logging.md
+++ b/website/content/en/docs/building-operators/golang/references/logging.md
@@ -260,7 +260,7 @@ If you do not want to use `logr` as your logging tool, you can remove `logr`-spe
 [repo_zapr]:https://godoc.org/github.com/go-logr/zapr
 [godoc_logr_logger]:https://godoc.org/github.com/go-logr/logr#Logger
 [site_struct_logging]:https://www.client9.com/structured-logging-in-golang/
-[code_memcached_controller]: https://github.com/operator-framework/operator-sdk/blob/master/testdata/go/memcached-operator/controllers/memcached_controller.go
+[code_memcached_controller]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/testdata/go/memcached-operator/controllers/memcached_controller.go
 [logfmt_repo]:https://github.com/jsternberg/zap-logfmt
 [controller_runtime_zap]:https://github.com/kubernetes-sigs/controller-runtime/tree/master/pkg/log/zap
 [logging_godocs]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/log/zap#Options.BindFlags

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -484,7 +484,7 @@ Also see the [advanced topics][advanced_topics] doc for more use cases and under
 [markers]: https://book.kubebuilder.io/reference/markers.html
 [crd-markers]: https://book.kubebuilder.io/reference/markers/crd-validation.html
 [rbac-markers]: https://book.kubebuilder.io/reference/markers/rbac.html
-[memcached_controller]: https://github.com/operator-framework/operator-sdk/blob/master/testdata/go/memcached-operator/controllers/memcached_controller.go
+[memcached_controller]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/testdata/go/memcached-operator/controllers/memcached_controller.go
 [builder_godocs]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/builder#example-Builder
 [legacy_quickstart_doc]:https://v0-19-x.sdk.operatorframework.io/docs/golang/legacy/quickstart/
 [activate_modules]: https://github.com/golang/go/wiki/Modules#how-to-install-and-activate-module-support

--- a/website/content/en/docs/contribution-guidelines/developer-guide.md
+++ b/website/content/en/docs/contribution-guidelines/developer-guide.md
@@ -79,5 +79,5 @@ $ make cli-doc
 [dev-docs]: /docs/contribution-guidelines/documentation
 [dev-release]: /docs/contribution-guidelines/releasing
 [travis]: https://docs.travis-ci.com/
-[travis.yml]: https://github.com/operator-framework/operator-sdk/blob/master/.travis.yml
+[travis.yml]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/.travis.yml
 [travis-setup]: https://docs.travis-ci.com/user/tutorial/#to-get-started-with-travis-ci-using-github

--- a/website/content/en/docs/contribution-guidelines/releasing.md
+++ b/website/content/en/docs/contribution-guidelines/releasing.md
@@ -365,14 +365,14 @@ See [this section](#locking-down-branches) for steps to do so.
 You've now fully released a new version of the Operator SDK. Good work! 
 
 [install-guide]: /docs/installation/install-operator-sdk
-[doc-maintainers]: https://github.com/operator-framework/operator-sdk/blob/master/MAINTAINERS
-[doc-owners]: https://github.com/operator-framework/operator-sdk/blob/master/OWNERS
+[doc-maintainers]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/MAINTAINERS
+[doc-owners]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/OWNERS
 [doc-readme-prereqs]: /docs/installation/install-operator-sdk#prerequisites-for-compilation
 [doc-git-default-key]:https://help.github.com/en/articles/telling-git-about-your-signing-key
 [doc-gpg-default-key]:https://lists.gnupg.org/pipermail/gnupg-users/2001-September/010163.html
 [link-github-gpg-key-upload]:https://github.com/settings/keys
 [link-git-config-gpg-key]:https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work
-[doc-changelog]: https://github.com/operator-framework/operator-sdk/blob/master/CHANGELOG.md
+[doc-changelog]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/CHANGELOG.md
 [backports]:/docs/upgrading-sdk-version/backport-policy
 [release-page]:https://github.com/operator-framework/operator-sdk/releases
 [homebrew]:https://brew.sh/

--- a/website/content/en/docs/contribution-guidelines/testing.md
+++ b/website/content/en/docs/contribution-guidelines/testing.md
@@ -44,4 +44,4 @@ All the tests are run through the [`Makefile`][makefile]. Run `make help` for a 
 [minikube]: https://kubernetes.io/docs/setup/learning-environment/minikube/
 [kind]: https://kind.sigs.k8s.io/
 [envtest-setup]: /docs/building-operators/golang/references/envtest-setup
-[makefile]: https://github.com/operator-framework/operator-sdk/blob/master/Makefile
+[makefile]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/Makefile

--- a/website/content/en/docs/olm-integration/testing-deployment.md
+++ b/website/content/en/docs/olm-integration/testing-deployment.md
@@ -50,7 +50,7 @@ hence its intended purpose being testing only.
 
 
 [olm]:https://github.com/operator-framework/operator-lifecycle-manager/
-[sdk-olm-design]:https://github.com/operator-framework/operator-sdk/blob/master/proposals/sdk-integration-with-olm.md
+[sdk-olm-design]:https://github.com/operator-framework/operator-sdk/blob/v1.1.x/proposals/sdk-integration-with-olm.md
 [doc-cli-overview]:/docs/olm-integration/cli-overview
 [package-manifests]:https://github.com/operator-framework/operator-registry/tree/v1.5.3#manifest-format
 [csv-install-modes]:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#operator-metadata

--- a/website/content/en/docs/overview/_overview.md
+++ b/website/content/en/docs/overview/_overview.md
@@ -81,14 +81,14 @@ Operator SDK is under Apache 2.0 license. See the [LICENSE][license_file] file f
 [ansible-guide]:/docs/building-operators/ansible/quickstart/
 [bug_guide]:/docs/contribution-guidelines/reporting-issues/
 [capability_levels]: /docs/advanced-topics/operator-capabilities/operator-capabilities
-[contrib]: https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
+[contrib]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/CONTRIBUTING.MD
 [controller_runtime]: https://github.com/kubernetes-sigs/controller-runtime
 [faq]: /docs/faqs/faqs
 [getting_started]: https://github.com/operator-framework/getting-started/blob/master/README.md
 [golang-guide]:/docs/building-operators/golang/quickstart/
 [helm-guide]:/docs/building-operators/helm/quickstart/
 [install_guide]: /docs/installation/install-operator-sdk/
-[license_file]:https://github.com/operator-framework/operator-sdk/blob/master/LICENSE
+[license_file]:https://github.com/operator-framework/operator-sdk/blob/v1.1.x/LICENSE
 [of-blog]: https://coreos.com/blog/introducing-operator-framework
 [of-home]: https://github.com/operator-framework
 [operator_link]: https://coreos.com/operators/

--- a/website/content/en/docs/upgrading-sdk-version/version-upgrade-guide.md
+++ b/website/content/en/docs/upgrading-sdk-version/version-upgrade-guide.md
@@ -636,7 +636,7 @@ Replace `*` per verbs in order to solve the issue [671](https://github.com/opera
 - **Breaking change:** An existing CSV's `spec.customresourcedefinitions.owned` is now always overwritten except for each name, version, and kind on invoking olm-catalog gen-csv when Go API code annotations are present.
 - **Potentially Breaking change:** Be aware that there are potentially other breaking changes due to the controller-runtime and Kubernetes version be upgraded from `v0.4.0` to `v1.16.2, respectively. There may be breaking changes to Go client code due to both of those changes.
 
-For further detailed information see [CHANGELOG](https://github.com/operator-framework/operator-sdk/blob/master/CHANGELOG.md#v0130)
+For further detailed information see [CHANGELOG](https://github.com/operator-framework/operator-sdk/blob/v1.1.x/CHANGELOG.md#v0130)
 
 ## `v0.14.x`
 
@@ -839,7 +839,7 @@ You can also use the fully-qualified name without declaring the collection:
 
 **Notable Changes**
 
-These notable changes contain just the most important user-facing changes. See the [CHANGELOG](https://github.com/operator-framework/operator-sdk/blob/master/CHANGELOG.md#v0141) for details of the release.
+These notable changes contain just the most important user-facing changes. See the [CHANGELOG](https://github.com/operator-framework/operator-sdk/blob/v1.1.x/CHANGELOG.md#v0141) for details of the release.
 
 **Ansible version update**
 
@@ -945,7 +945,7 @@ With:
 oprator-sdk run exec-entrypoint helm --watches-file=$HOME/watches.yaml
 ```
 
-See the [CHANGELOG](https://github.com/operator-framework/operator-sdk/blob/master/CHANGELOG.md#v0151) for details of the release.
+See the [CHANGELOG](https://github.com/operator-framework/operator-sdk/blob/v1.1.x/CHANGELOG.md#v0151) for details of the release.
 
 ## v0.16.x
 
@@ -1374,7 +1374,7 @@ first `COPY` from `COPY /*.yaml manifests/` to `COPY deploy/olm-catalog/<operato
 [migrating-to-modules]: https://github.com/golang/go/wiki/Modules#migrating-to-modules
 [modules-wiki]: https://github.com/golang/go/wiki/Modules#migrating-to-modules
 [print-deps-cli]: https://v0-19-x.sdk.operatorframework.io/docs/cli/operator-sdk_print-deps/
-[changelog]: https://github.com/operator-framework/operator-sdk/blob/master/CHANGELOG.md
+[changelog]: https://github.com/operator-framework/operator-sdk/blob/v1.1.x/CHANGELOG.md
 [release-notes]: https://github.com/operator-framework/operator-sdk/releases
 [v0.1.0-migration-guide]: ../v0.1.0-migration-guide
 [manifest-format]: https://github.com/operator-framework/operator-registry#manifest-format


### PR DESCRIPTION
**Description of the change:**

Change all links in the `v1.1.x` branch that refer to `master` to use `v1.1.x` instead.

**Motivation for the change:**

We should not have links to `master` on release branches because they can break without notice.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
