### PR TITLE
mark cr status false when release fails

### DIFF
--- a/internal/helm/controller/reconcile.go
+++ b/internal/helm/controller/reconcile.go
@@ -247,7 +247,7 @@ func (r HelmOperatorReconciler) Reconcile(request reconcile.Request) (reconcile.
 			log.Error(err, "Release failed")
 			status.SetCondition(types.HelmAppCondition{
 				Type:    types.ConditionReleaseFailed,
-				Status:  types.StatusTrue,
+				Status:  types.StatusFalse,
 				Reason:  types.ReasonUpgradeError,
 				Message: err.Error(),
 			})


### PR DESCRIPTION
**Description of the change:**
When our chart fails to install, the status shows an error but status is marked as ready.
```
    Status:                True  <<<<<<< Should be false
    Type:                  Initialized
    Last Transition Time:  2020-10-26T19:41:53Z
    Message:               failed to install release: unable to build kubernetes objects from release manifest: [unable to recognize "": no matches for kind "Certificate" in version "cert-manager.io/v1alpha2", unable to recognize "": no matches for kind "Issuer" in version "cert-manager.io/v1alpha2"]
```

**Motivation for the change:**
The status should reflect that an error has occurred.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [/] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [/] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
