### PR TITLE
Timeout

### DIFF
--- a/internal/cmd/helm-operator/run/cmd.go
+++ b/internal/cmd/helm-operator/run/cmd.go
@@ -145,9 +145,13 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 	for _, w := range ws {
 		// Register the controller with the factory.
 		err := controller.Add(mgr, controller.WatchOptions{
-			Namespace:               namespace,
-			GVK:                     w.GroupVersionKind,
-			ManagerFactory:          release.NewManagerFactory(mgr, w.ChartDir),
+			Namespace: namespace,
+			GVK:       w.GroupVersionKind,
+			ManagerFactory: release.NewManagerFactory(release.ManagerFactoryOptions{
+				ChartDir:  w.ChartDir,
+				CRManager: mgr,
+				Timeout:   f.Timeout,
+			}),
 			ReconcilePeriod:         f.ReconcilePeriod,
 			WatchDependentResources: *w.WatchDependentResources,
 			OverrideValues:          w.OverrideValues,

--- a/internal/helm/flags/flag.go
+++ b/internal/helm/flags/flag.go
@@ -15,6 +15,7 @@
 package flags
 
 import (
+	"flag"
 	"runtime"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 // Flags - Options to be used by a helm operator
 type Flags struct {
 	ReconcilePeriod         time.Duration
+	Timeout                 time.Duration
 	WatchesFile             string
 	MetricsAddress          string
 	EnableLeaderElection    bool
@@ -34,6 +36,11 @@ type Flags struct {
 
 // AddTo - Add the helm operator flags to the the flagset
 func (f *Flags) AddTo(flagSet *pflag.FlagSet) {
+	flag.DurationVar(&f.Timeout,
+		"timeout",
+		time.Minute*5,
+		"time to wait for any individual Kubernetes operation (like Jobs for hooks)",
+	)
 	flagSet.DurationVar(&f.ReconcilePeriod,
 		"reconcile-period",
 		time.Minute,


### PR DESCRIPTION
relates #4102

**Description of the change:**
Adds a timeout flag to helm operator's manager. This instructs the helm action to timeout after a set duration, default is set to 5m just like helm cli.

I updated the context passed down from reconcile. The packages being called ignore their context, so it's not currently useful for timing out those packages. 

**Motivation for the change:**
Helm by default implements a timeout. This timeout is used when using the --wait command to have helm give up after attempting an action for a period of time. The current operator does not implement any timeout and instead returns immediately after any action.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
