### PR TITLE
Makefile: always build linux binaries when building for an image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,12 @@ image-build: $(foreach i,$(IMAGE_TARGET_LIST),image/$(i)) ## Build all images.
 
 # Build an image.
 IMAGE_REPO ?= quay.io/operator-framework
+image/%: BUILD_DIR = build/_image
+# Images run on the linux kernel, so binaries must always target linux.
+image/%: export GOOS = linux
 image/%: build/%
-	rm -rf build/_image && mkdir -p build/_image && cp build/$* build/_image
-	docker build -t $(IMAGE_REPO)/$*:dev -f ./images/$*/Dockerfile build/_image
-	@rm -rf build/_image
+	docker build -t $(IMAGE_REPO)/$*:dev -f ./images/$*/Dockerfile $(BUILD_DIR)
+	rm -rf $(BUILD_DIR)
 
 ##@ Test
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:** always build binaries destined for images with a linux target

**Motivation for the change:** no other OS targets can run in images

/cc @camilamacedo86 @joelanford 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
