### PR TITLE
ansible v1alpha1 to v1 at memcached_controller.yml

### DIFF
--- a/website/content/en/docs/building-operators/ansible/tutorial.md
+++ b/website/content/en/docs/building-operators/ansible/tutorial.md
@@ -42,7 +42,7 @@ $ operator-sdk create api -h
 Next, we will create a `Memcached` API.
 
 ```sh
-$ operator-sdk create api --group cache --version v1alpha1 --kind Memcached --generate-role
+$ operator-sdk create api --group cache --version v1 --kind Memcached --generate-role
 ```
 
 The scaffolded operator has the following structure:
@@ -109,10 +109,10 @@ Roles, so edit `roles/memcached/defaults/main.yml`:
 size: 1
 ```
 
-Finally, update the `Memcached` sample, `config/samples/cache_v1alpha1_memcached.yaml`:
+Finally, update the `Memcached` sample, `config/samples/cache_v1_memcached.yaml`:
 
 ```yaml
-apiVersion: cache.example.com/v1alpha1
+apiVersion: cache.example.com/v1
 kind: Memcached
 metadata:
   name: memcached-sample
@@ -183,7 +183,7 @@ memcached-operator       1         1         1            1           1m
 Create the resource, the operator will do the rest.
 
 ```sh
-$ kubectl apply -f config/samples/cache_v1alpha1_memcached.yaml
+$ kubectl apply -f config/samples/cache_v1_memcached.yaml
 ```
 
 Verify that Memcached pods are created


### PR DESCRIPTION
update v1alpha1 to v1 at cache_v1_memcached.yaml
In "Ansible tutorial"(https://sdk.operatorframework.io/docs/building-operators/ansible/tutorial/)
Following the same version as in "Quickstart"(https://sdk.operatorframework.io/docs/building-operators/ansible/quickstart/)

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Update the docs to be consistent between the ansible tutorial.

**Motivation for the change:**
To be consistent and make it easier for developers to going from the quickstart to the tutorial.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
