### PR TITLE
Adding Operator-SDK base image that includes Kustomize

### DIFF
--- a/images/operator-sdk/kustomize.Dockerfile
+++ b/images/operator-sdk/kustomize.Dockerfile
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+RUN microdnf install -y golang make which
+RUN microdnf install -y git
+
+ARG BIN=operator-sdk
+COPY $BIN /usr/local/bin/operator-sdk
+
+# install kustomize
+RUN git clone https://github.com/kubernetes-sigs/kustomize.git
+RUN cd kustomize && \
+    cd kustomize && \
+    go install .
+RUN ~/go/bin/kustomize version
+
+ENTRYPOINT ["/usr/local/bin/operator-sdk"]


### PR DESCRIPTION

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Since the addition of kustomize, I have seen lots of adoption. Adding kustomize to a version of the base image is important for continued usage. Adding operator-sdk image with kustomize installed for usage when building operators.

**Motivation for the change:**
https://github.com/operator-framework/operator-sdk/issues/4000
Controller-gen isn't in this PR, but it could be depending on the feedback.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
