### PR TITLE
ci: use fixed image name when building docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,13 +75,13 @@ IMAGE_TARGET_LIST = operator-sdk helm-operator ansible-operator scorecard-test s
 image-build: $(foreach i,$(IMAGE_TARGET_LIST),image/$(i)) ## Build all images.
 
 # Build an image.
-IMAGE_REPO ?= quay.io/operator-framework
+BUILD_IMAGE_REPO = quay.io/operator-framework
 image/%: BUILD_DIR = build/_image
 # Images run on the linux kernel, so binaries must always target linux.
 image/%: export GOOS = linux
 image/%: build/%
 	mkdir -p ./images/$*/bin && mv $(BUILD_DIR)/$* ./images/$*/bin
-	docker build -t $(IMAGE_REPO)/$*:dev -f ./images/$*/Dockerfile ./images/$*
+	docker build -t $(BUILD_IMAGE_REPO)/$*:dev -f ./images/$*/Dockerfile ./images/$*
 	rm -rf $(BUILD_DIR)
 
 ##@ Test

--- a/release/Makefile
+++ b/release/Makefile
@@ -36,11 +36,12 @@ image-push: $(foreach i,$(IMAGE_TARGET_LIST),image-push/$(i)) ## Push all images
 image-push-multiarch: $(foreach i,$(IMAGE_TARGET_LIST),image-push-multiarch/$(i)) ## Push the manifest list for all architectures.
 
 # Push an image for an architecture.
-IMAGE_REPO ?= quay.io/operator-framework
+BUILD_IMAGE_REPO = quay.io/operator-framework
+IMAGE_REPO ?= $(BUILD_IMAGE_REPO)
 GO_ARCH := $(shell go env GOARCH)
 image-push/%: IMAGE_PUSH_TAG = $(IMAGE_REPO)/$*-$(GO_ARCH)
 image-push/%:
-	./hack/image/push-image-tags.sh $(IMAGE_REPO)/$*:dev $(IMAGE_PUSH_TAG)
+	./hack/image/push-image-tags.sh $(BUILD_IMAGE_REPO)/$*:dev $(IMAGE_PUSH_TAG)
 
 # Push multiarch images.
 ARCHES ?= amd64 arm64 ppc64le s390x


### PR DESCRIPTION
**Description of the change:**

Makefiles use fixed `BUILD_IMAGE_REPO` when building images. `release/Makefile` now uses overridable `IMAGE_REPO` just to set the repo to which images are pushed.

**Motivation for the change:**

When testing the CI deploy phase in forks, contributors need to override `IMAGE_REPO` in their CI settings to push images to their own image repo.

However, we need to use a fixed image name when building the images because the e2e tests assume the fixed image name.