### PR TITLE
go/ansible/helm plugins: use rbac/v1 for metrics reader cluster role

### DIFF
--- a/changelog/fragments/plugins-use-rbac-v1.yaml
+++ b/changelog/fragments/plugins-use-rbac-v1.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      In Go, Ansible, and Helm operators, updated the `metrics-reader` ClusterRole
+      to use `rbac.authorization.k8s.io/v1` to be consistent with all other
+      scaffolded RBAC resources.
+    kind: "bugfix"

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/controller-runtime v0.6.3
 	sigs.k8s.io/controller-tools v0.3.0
-	sigs.k8s.io/kubebuilder v1.0.9-0.20201014221150-c993a2a221fe
+	sigs.k8s.io/kubebuilder v1.0.9-0.20201021204649-36124ae2e027
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1223,8 +1223,8 @@ sigs.k8s.io/controller-runtime v0.6.3 h1:SBbr+inLPEKhvlJtrvDcwIpm+uhDvp63Bl72xYJ
 sigs.k8s.io/controller-runtime v0.6.3/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJUzRP4N4JpdAY=
 sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPhJ4=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
-sigs.k8s.io/kubebuilder v1.0.9-0.20201014221150-c993a2a221fe h1:lCo0lK98HmpivySaCDvxDoUUw9YC96zhY3fH/cItuu8=
-sigs.k8s.io/kubebuilder v1.0.9-0.20201014221150-c993a2a221fe/go.mod h1:NatUhFMh/ci8gR+qETvZBIlZ4RTQoNa+9uei7okpgcY=
+sigs.k8s.io/kubebuilder v1.0.9-0.20201021204649-36124ae2e027 h1:2ubws/tSma7ZSqzH7fYIsVl7CvA4jA79VE8YWn9AhH8=
+sigs.k8s.io/kubebuilder v1.0.9-0.20201021204649-36124ae2e027/go.mod h1:NatUhFMh/ci8gR+qETvZBIlZ4RTQoNa+9uei7okpgcY=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/internal/generate/testdata/go/static/basic.operator.yaml
+++ b/internal/generate/testdata/go/static/basic.operator.yaml
@@ -166,7 +166,7 @@ rules:
   verbs:
   - create
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: memcached-operator-metrics-reader

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/config/rbac/auth_proxy_client_clusterrole.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/config/rbac/auth_proxy_client_clusterrole.go
@@ -40,7 +40,7 @@ func (f *ClientClusterRole) SetTemplateDefaults() error {
 	return nil
 }
 
-const clientClusterRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1beta1
+const clientClusterRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/config/rbac/client_cluster_role.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/config/rbac/client_cluster_role.go
@@ -40,7 +40,7 @@ func (f *ClientClusterRole) SetTemplateDefaults() error {
 	return nil
 }
 
-const clientClusterRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1beta1
+const clientClusterRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null

--- a/testdata/ansible/memcached-operator/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/testdata/ansible/memcached-operator/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/testdata/go/memcached-operator/bundle/manifests/memcached-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/testdata/go/memcached-operator/bundle/manifests/memcached-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null

--- a/testdata/go/memcached-operator/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/testdata/go/memcached-operator/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/testdata/helm/memcached-operator/bundle/manifests/memcached-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/testdata/helm/memcached-operator/bundle/manifests/memcached-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null

--- a/testdata/helm/memcached-operator/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/testdata/helm/memcached-operator/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader


### PR DESCRIPTION
**Description of the change:**

In Go, Ansible, and Helm operators, updated the `metrics-reader` ClusterRole to use `rbac.authorization.k8s.io/v1` to be consistent with all other scaffolded RBAC resources.

**Motivation for the change:**

Closes #4072

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
