### PR TITLE
bump kuttl version to 0.7.1

### DIFF
--- a/images/scorecard-test-kuttl/Dockerfile
+++ b/images/scorecard-test-kuttl/Dockerfile
@@ -1,5 +1,5 @@
 #FROM docker.io/kudobuilder/kuttl@sha256:c9c5edc27ba6e5e994ffd8cea03368c0d4e274f3c7a00f51c1e360feb573f24e
-FROM kudobuilder/kuttl:v0.6.1
+FROM kudobuilder/kuttl:v0.7.1
 
 ENV HOME=/opt/scorecard-test-kuttl \
     USER_NAME=scorecard-test-kuttl \


### PR DESCRIPTION


**Description of the change:**
this PR bumps up the kuttl version used within the scorecard-test-kuttl image to
version v.0.7.1.

**Motivation for the change:**
kuttl version v0.7.1 contains the latest bug fixes plus features that might
be useful to future versions of scorecard-test-kuttl

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
