### PR TITLE
cleanup ansible molecule tests: remove invalid and not used task

### DIFF
--- a/hack/generate/samples/internal/ansible/constants.go
+++ b/hack/generate/samples/internal/ansible/constants.go
@@ -230,11 +230,6 @@ const taskForSecret = `- name: Create test service
           targetPort: 8332
           name: rpc
 
-- name: Check if jmespath is installed
-  set_fact:
-    instance_tags: '{{app | json_query(query)}}'
-  vars:
-    query: 'app[*]."memcached"'
 `
 
 // false positive: G101: Potential hardcoded credentials (gosec)


### PR DESCRIPTION
**Description of the change:**
This task is broken and it is not working. To test that, add this task in the Ansible Memcached sample and deploy it to test the call. Then, you will see that it fails. More info:  https://github.com/operator-framework/operator-sdk/issues/4123


**Motivation for the change:**
Cleanup the tests and remove unused/invalid code 