### PR TITLE
test-e2e/samples/cleanup: centralize code to integrate the project with OLM

### DIFF
--- a/hack/generate/samples/internal/ansible/memcached.go
+++ b/hack/generate/samples/internal/ansible/memcached.go
@@ -77,7 +77,7 @@ func (ma *MemcachedAnsible) Run() {
 	ma.addingMoleculeMockData()
 
 	log.Infof("creating the bundle")
-	err = ma.ctx.CreateBundle()
+	err = ma.ctx.GenerateBundle()
 	pkg.CheckError("creating the bundle", err)
 
 	log.Infof("striping bundle annotations")

--- a/hack/generate/samples/internal/ansible/memcached.go
+++ b/hack/generate/samples/internal/ansible/memcached.go
@@ -76,7 +76,13 @@ func (ma *MemcachedAnsible) Run() {
 	ma.addingAnsibleTask()
 	ma.addingMoleculeMockData()
 
-	ma.ctx.CreateBundle()
+	log.Infof("creating the bundle")
+	err = ma.ctx.CreateBundle()
+	pkg.CheckError("creating the bundle", err)
+
+	log.Infof("striping bundle annotations")
+	err = ma.ctx.StripBundleAnnotations()
+	pkg.CheckError("striping bundle annotations", err)
 }
 
 // addingMoleculeMockData will customize the molecule data

--- a/hack/generate/samples/internal/go/v2/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/v2/memcached_with_webhooks.go
@@ -93,7 +93,13 @@ func (mh *MemcachedGoWithWebhooks) Run() {
 	mh.implementingWebhooks()
 	mh.uncommentKustomizationFile()
 
-	mh.ctx.CreateBundle()
+	log.Infof("creating the bundle")
+	err = mh.ctx.CreateBundle()
+	pkg.CheckError("creating the bundle", err)
+
+	log.Infof("striping bundle annotations")
+	err = mh.ctx.StripBundleAnnotations()
+	pkg.CheckError("striping bundle annotations", err)
 
 	pkg.CheckError("formatting project", mh.ctx.Make("fmt"))
 

--- a/hack/generate/samples/internal/go/v2/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/v2/memcached_with_webhooks.go
@@ -94,7 +94,7 @@ func (mh *MemcachedGoWithWebhooks) Run() {
 	mh.uncommentKustomizationFile()
 
 	log.Infof("creating the bundle")
-	err = mh.ctx.CreateBundle()
+	err = mh.ctx.GenerateBundle()
 	pkg.CheckError("creating the bundle", err)
 
 	log.Infof("striping bundle annotations")

--- a/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
@@ -94,7 +94,13 @@ func (mh *MemcachedGoWithWebhooks) Run() {
 	mh.implementingWebhooks()
 	mh.uncommentKustomizationFile()
 
-	mh.ctx.CreateBundle()
+	log.Infof("creating the bundle")
+	err = mh.ctx.CreateBundle()
+	pkg.CheckError("creating the bundle", err)
+
+	log.Infof("striping bundle annotations")
+	err = mh.ctx.StripBundleAnnotations()
+	pkg.CheckError("striping bundle annotations", err)
 
 	pkg.CheckError("formatting project", mh.ctx.Make("fmt"))
 

--- a/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
@@ -95,7 +95,7 @@ func (mh *MemcachedGoWithWebhooks) Run() {
 	mh.uncommentKustomizationFile()
 
 	log.Infof("creating the bundle")
-	err = mh.ctx.CreateBundle()
+	err = mh.ctx.GenerateBundle()
 	pkg.CheckError("creating the bundle", err)
 
 	log.Infof("striping bundle annotations")

--- a/hack/generate/samples/internal/helm/memcached.go
+++ b/hack/generate/samples/internal/helm/memcached.go
@@ -94,7 +94,7 @@ func (mh *MemcachedHelm) Run() {
 	pkg.CheckError("adding customized roles", err)
 
 	log.Infof("creating the bundle")
-	err = mh.ctx.CreateBundle()
+	err = mh.ctx.GenerateBundle()
 	pkg.CheckError("creating the bundle", err)
 
 	log.Infof("striping bundle annotations")

--- a/hack/generate/samples/internal/helm/memcached.go
+++ b/hack/generate/samples/internal/helm/memcached.go
@@ -93,7 +93,13 @@ func (mh *MemcachedHelm) Run() {
 		"# +kubebuilder:scaffold:rules", policyRolesFragment)
 	pkg.CheckError("adding customized roles", err)
 
-	mh.ctx.CreateBundle()
+	log.Infof("creating the bundle")
+	err = mh.ctx.CreateBundle()
+	pkg.CheckError("creating the bundle", err)
+
+	log.Infof("striping bundle annotations")
+	err = mh.ctx.StripBundleAnnotations()
+	pkg.CheckError("striping bundle annotations", err)
 }
 
 // GenerateMemcachedHelmSample will call all actions to create the directory and generate the sample

--- a/hack/generate/samples/internal/pkg/utils.go
+++ b/hack/generate/samples/internal/pkg/utils.go
@@ -34,19 +34,6 @@ func CheckError(msg string, err error) {
 	}
 }
 
-// CreateBundle runs all commands to create an operator bundle.
-func (ctx *SampleContext) CreateBundle() {
-	log.Infof("integrating project with OLM")
-	err := ctx.DisableManifestsInteractiveMode()
-	CheckError("disabling `generate kustomize manifests` interactive mode", err)
-
-	err = ctx.Make("bundle", "IMG="+ctx.ImageName)
-	CheckError("running make bundle", err)
-
-	err = ctx.StripBundleAnnotations()
-	CheckError("stripping bundle annotations", err)
-}
-
 // StripBundleAnnotations removes all annotations applied to bundle manifests and metadata
 // by operator-sdk/internal/annotations/metrics annotators. Doing so decouples samples
 // from which operator-sdk version they were build with, as this information is already

--- a/internal/testutils/olm.go
+++ b/internal/testutils/olm.go
@@ -90,8 +90,8 @@ func (tc TestContext) DisableManifestsInteractiveMode() error {
 	return ReplaceInFile(filepath.Join(tc.Dir, "Makefile"), content, replace)
 }
 
-// CreateBundle runs all commands to create an operator bundle.
-func (tc TestContext) CreateBundle() error {
+// GenerateBundle runs all commands to create an operator bundle.
+func (tc TestContext) GenerateBundle() error {
 	if err := tc.DisableManifestsInteractiveMode(); err != nil {
 		return err
 	}

--- a/internal/testutils/olm.go
+++ b/internal/testutils/olm.go
@@ -89,3 +89,16 @@ func (tc TestContext) DisableManifestsInteractiveMode() error {
 	replace := content + " --interactive=false"
 	return ReplaceInFile(filepath.Join(tc.Dir, "Makefile"), content, replace)
 }
+
+// CreateBundle runs all commands to create an operator bundle.
+func (tc TestContext) CreateBundle() error {
+	if err := tc.DisableManifestsInteractiveMode(); err != nil {
+		return err
+	}
+
+	if err := tc.Make("bundle", "IMG="+tc.ImageName); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/test/e2e-ansible/e2e_ansible_olm_test.go
+++ b/test/e2e-ansible/e2e_ansible_olm_test.go
@@ -26,17 +26,13 @@ var _ = Describe("Integrating ansible Projects with OLM", func() {
 		const operatorVersion = "0.0.1"
 
 		It("should generate and run a valid OLM bundle and packagemanifests", func() {
-			By("building the bundle")
-			err := tc.Make("bundle", "IMG="+tc.ImageName)
-			Expect(err).NotTo(HaveOccurred())
-
 			By("building the operator bundle image")
-			err = tc.Make("bundle-build", "BUNDLE_IMG="+tc.BundleImageName)
+			err := tc.Make("bundle-build", "BUNDLE_IMG="+tc.BundleImageName)
 			Expect(err).NotTo(HaveOccurred())
 
 			if tc.IsRunningOnKind() {
 				By("loading the bundle image into Kind cluster")
-				err = tc.LoadImageToKindClusterWithName(tc.BundleImageName)
+				err := tc.LoadImageToKindClusterWithName(tc.BundleImageName)
 				Expect(err).NotTo(HaveOccurred())
 			}
 

--- a/test/e2e-ansible/e2e_ansible_olm_test.go
+++ b/test/e2e-ansible/e2e_ansible_olm_test.go
@@ -30,12 +30,6 @@ var _ = Describe("Integrating ansible Projects with OLM", func() {
 			err := tc.Make("bundle-build", "BUNDLE_IMG="+tc.BundleImageName)
 			Expect(err).NotTo(HaveOccurred())
 
-			if tc.IsRunningOnKind() {
-				By("loading the bundle image into Kind cluster")
-				err := tc.LoadImageToKindClusterWithName(tc.BundleImageName)
-				Expect(err).NotTo(HaveOccurred())
-			}
-
 			By("adding the 'packagemanifests' rule to the Makefile")
 			err = tc.AddPackagemanifestsTarget()
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e-ansible/e2e_ansible_suite_test.go
+++ b/test/e2e-ansible/e2e_ansible_suite_test.go
@@ -122,7 +122,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	By("creating bundle image")
-	err = tc.CreateBundle()
+	err = tc.GenerateBundle()
 	Expect(err).NotTo(HaveOccurred())
 })
 

--- a/test/e2e-ansible/e2e_ansible_suite_test.go
+++ b/test/e2e-ansible/e2e_ansible_suite_test.go
@@ -121,8 +121,8 @@ var _ = BeforeSuite(func() {
 		Expect(tc.LoadImageToKindClusterWithName("quay.io/operator-framework/scorecard-test:dev")).To(Succeed())
 	}
 
-	By("building the bundle")
-	err = tc.Make("bundle", "IMG="+tc.ImageName)
+	By("creating bundle image")
+	err = tc.CreateBundle()
 	Expect(err).NotTo(HaveOccurred())
 })
 

--- a/test/e2e-go/e2e_go_suite_test.go
+++ b/test/e2e-go/e2e_go_suite_test.go
@@ -83,19 +83,9 @@ var _ = BeforeSuite(func() {
 		Expect(tc.LoadImageToKindClusterWithName("quay.io/operator-framework/custom-scorecard-tests:dev")).To(Succeed())
 	}
 
-	By("generating the operator bundle")
-	err = tc.Make("bundle", "IMG="+tc.ImageName)
+	By("creating bundle image")
+	err = tc.CreateBundle()
 	Expect(err).NotTo(HaveOccurred())
-
-	By("building the operator bundle image")
-	err = tc.Make("bundle-build", "BUNDLE_IMG="+tc.BundleImageName)
-	Expect(err).NotTo(HaveOccurred())
-
-	if tc.IsRunningOnKind() {
-		By("loading the bundle image into Kind cluster")
-		err = tc.LoadImageToKindClusterWithName(tc.BundleImageName)
-		Expect(err).NotTo(HaveOccurred())
-	}
 
 	By("installing cert manager bundle")
 	Expect(tc.InstallCertManager(true)).To(Succeed())

--- a/test/e2e-go/e2e_go_suite_test.go
+++ b/test/e2e-go/e2e_go_suite_test.go
@@ -84,7 +84,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	By("creating bundle image")
-	err = tc.CreateBundle()
+	err = tc.GenerateBundle()
 	Expect(err).NotTo(HaveOccurred())
 
 	By("installing cert manager bundle")

--- a/test/e2e-helm/e2e_helm_olm_test.go
+++ b/test/e2e-helm/e2e_helm_olm_test.go
@@ -30,12 +30,6 @@ var _ = Describe("Integrating Helm Projects with OLM", func() {
 			err := tc.Make("bundle-build", "BUNDLE_IMG="+tc.BundleImageName)
 			Expect(err).NotTo(HaveOccurred())
 
-			if tc.IsRunningOnKind() {
-				By("loading the bundle image into Kind cluster")
-				err = tc.LoadImageToKindClusterWithName(tc.BundleImageName)
-				Expect(err).NotTo(HaveOccurred())
-			}
-
 			By("adding the 'packagemanifests' rule to the Makefile")
 			err = tc.AddPackagemanifestsTarget()
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e-helm/e2e_helm_suite_test.go
+++ b/test/e2e-helm/e2e_helm_suite_test.go
@@ -87,8 +87,8 @@ var _ = BeforeSuite(func() {
 		Expect(tc.LoadImageToKindClusterWithName("quay.io/operator-framework/scorecard-test:dev")).To(Succeed())
 	}
 
-	By("generating the operator bundle")
-	err = tc.Make("bundle", "IMG="+tc.ImageName)
+	By("creating bundle image")
+	err = tc.CreateBundle()
 	Expect(err).NotTo(HaveOccurred())
 })
 

--- a/test/e2e-helm/e2e_helm_suite_test.go
+++ b/test/e2e-helm/e2e_helm_suite_test.go
@@ -88,7 +88,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	By("creating bundle image")
-	err = tc.CreateBundle()
+	err = tc.GenerateBundle()
 	Expect(err).NotTo(HaveOccurred())
 })
 


### PR DESCRIPTION
**Description of the change:**
- Move the olm helpers in the `hack/generate/samples/internal/pkg/utils.go` to `internal/testutils/olm.go`. Reason: allow samples and tests to use the same helper and keep it in a more appropriate place. 
- Remove the duplicates calls made in the e2e tests which are already done in the samples in the e2e tests
- Use the e2e test the helper instead of duplicate the code. 


**Motivation for the change:**
- Maintainability
- Reduce CI effort by not calling make bundle twice. 
- Centralize the steps to integrate the projects with OLM and keep samples and e2e tests using the same func
- Reduce the duplication of code as of the calls made 

