### PR TITLE
testutils/cleanup: remove InstallOLM method that is no lonnger used

### DIFF
--- a/internal/testutils/utils.go
+++ b/internal/testutils/utils.go
@@ -60,12 +60,6 @@ func NewTestContext(binary string, env ...string) (tc TestContext, err error) {
 	return tc, err
 }
 
-// InstallOLM runs 'operator-sdk olm install' and returns any errors emitted by that command.
-func (tc TestContext) InstallOLM() error {
-	err := tc.InstallOLMVersion("latest")
-	return err
-}
-
 // InstallOLM runs 'operator-sdk olm install' for specific version
 // and returns any errors emitted by that command.
 func (tc TestContext) InstallOLMVersion(version string) error {


### PR DESCRIPTION
**Description of the change:**
The InstallOLM is not used at all. So, we can remove it in order to keep the maintanability. 
