### PR TITLE
add finalizer rbac permission to the go/sample and doc steps

### DIFF
--- a/hack/generate/samples/internal/go/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/memcached_with_webhooks.go
@@ -257,6 +257,7 @@ func GenerateMemcachedGoWithWebhooksSample(samplesPath string) {
 }
 
 const rbacFragment = `
+// +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;`
 

--- a/hack/generate/samples/internal/go/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/memcached_with_webhooks.go
@@ -257,7 +257,7 @@ func GenerateMemcachedGoWithWebhooksSample(samplesPath string) {
 }
 
 const rbacFragment = `
-// +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=get;update;patch
+// +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;`
 

--- a/testdata/go/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -65,6 +65,14 @@ spec:
         - apiGroups:
           - cache.example.com
           resources:
+          - memcacheds/finalizers
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - cache.example.com
+          resources:
           - memcacheds/status
           verbs:
           - get

--- a/testdata/go/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -67,8 +67,6 @@ spec:
           resources:
           - memcacheds/finalizers
           verbs:
-          - get
-          - patch
           - update
         - apiGroups:
           - cache.example.com

--- a/testdata/go/memcached-operator/config/rbac/role.yaml
+++ b/testdata/go/memcached-operator/config/rbac/role.yaml
@@ -33,6 +33,14 @@ rules:
 - apiGroups:
   - cache.example.com
   resources:
+  - memcacheds/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cache.example.com
+  resources:
   - memcacheds/status
   verbs:
   - get

--- a/testdata/go/memcached-operator/config/rbac/role.yaml
+++ b/testdata/go/memcached-operator/config/rbac/role.yaml
@@ -35,8 +35,6 @@ rules:
   resources:
   - memcacheds/finalizers
   verbs:
-  - get
-  - patch
   - update
 - apiGroups:
   - cache.example.com

--- a/testdata/go/memcached-operator/controllers/memcached_controller.go
+++ b/testdata/go/memcached-operator/controllers/memcached_controller.go
@@ -44,6 +44,7 @@ type MemcachedReconciler struct {
 
 // +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
 

--- a/testdata/go/memcached-operator/controllers/memcached_controller.go
+++ b/testdata/go/memcached-operator/controllers/memcached_controller.go
@@ -44,7 +44,7 @@ type MemcachedReconciler struct {
 
 // +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=get;update;patch
+// +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
 

--- a/website/content/en/docs/building-operators/golang/quickstart.md
+++ b/website/content/en/docs/building-operators/golang/quickstart.md
@@ -34,12 +34,6 @@ Create a simple Memcached API:
 operator-sdk create api --group cache --version v1 --kind Memcached --resource=true --controller=true
 ```
 
-**Note** If your cluster is a non-vanilla one then such as OpenShift then, add the RBAC finalizer permission on the `controllers/memcached_controller.go` file and run `make manifests` before continue. 
-
-```go
-// +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=update
-```
-
 ### Build and push the operator image
 
 Use the built-in Makefile targets to build and push your operator. Make

--- a/website/content/en/docs/building-operators/golang/quickstart.md
+++ b/website/content/en/docs/building-operators/golang/quickstart.md
@@ -34,6 +34,12 @@ Create a simple Memcached API:
 operator-sdk create api --group cache --version v1 --kind Memcached --resource=true --controller=true
 ```
 
+**Note** If your cluster is a non-vanilla one then such as OpenShift then, add the RBAC finalizer permission on the `controllers/memcached_controller.go` file and run `make manifests` before continue. 
+
+```go
+// +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=update
+```
+
 ### Build and push the operator image
 
 Use the built-in Makefile targets to build and push your operator. Make

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -258,6 +258,7 @@ The controller needs certain RBAC permissions to interact with the resources it 
 ```Go
 // +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
 

--- a/website/content/en/docs/faqs/faqs.md
+++ b/website/content/en/docs/faqs/faqs.md
@@ -124,4 +124,4 @@ To update `config/rbac/role.yaml` after changing the markers, run `make manifest
 [client.Reader]:https://godoc.org/sigs.k8s.io/controller-runtime/pkg/client#Reader
 [rbac]:https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 [owner-references-permission-enforcement]: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-[rbac_markers]: https://book.kubebuilder.io/reference/markers/rbac.html
+[rbac-markers]: https://book.kubebuilder.io/reference/markers/rbac.html

--- a/website/content/en/docs/faqs/faqs.md
+++ b/website/content/en/docs/faqs/faqs.md
@@ -104,11 +104,11 @@ func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Res
 
 ## I keep hitting errors like "is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on:", how do I fix this?
 
-If you are facing this issue it means that the project is missing the RBAC required permissions to update the finalizer of the API's managed by it on the cluster. The need for this permission is based on the [OwnerReferencesPermissionEnforcement][owner-references-permission-enforcement] plugin which can be enabled in any Kubernetes cluster because it is a feature of the upstream kube-apiserver. 
+If you are facing this issue, it means that the operator is missing the required RBAC permissions to update finalizers on the APIs it manages. This permission is necessary if the [OwnerReferencesPermissionEnforcement][owner-references-permission-enforcement] plugin is enabled in your cluster.
 
-For Helm/Ansible based operators, this permission is available by default in the projects which are scaffolded with `v1`+ plugin version. However, for Go based operators, it will only be added in the future plugins versions supported by SDK (v3+). In this way, to fix set the RBAC permission.
+For Helm and Ansible operators, this permission is configured by default. However for Go operators, it may be necessary to add this permission yourself.
 
-Note that, the RBAC permissions are configured via [RBAC markers][rbac_markers], which are used to generate and update the manifest files present in `config/rbac/`. These markers can be found (and should be defined) on the `Reconcile()` method of each controller. In the Memcached example, they look like the following:
+In Go operators, RBAC permissions are configured via [RBAC markers][rbac-markers], which are used to generate and update the manifest files present in `config/rbac/`. Add the following marker line on your controller's `Reconcile()` method:
 
 ```go
 // +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=update


### PR DESCRIPTION
**Description of the change:**
- Add the RBAC finalizer permission to allow users to test the Go sample project on OCP
- See that for v3+ plugins this permission will be added by default 
- See that it was added as a NOTE to the quick start and by default in the tutorial in order to avoid the issue faced in https://github.com/operator-framework/operator-sdk/issues/3477

**Motivation for the change:**
Closes : https://github.com/operator-framework/operator-sdk/issues/3477

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
