### PR TITLE
website: Fix the watches.yaml backticks in the Ansible migration guide

### DIFF
--- a/website/content/en/docs/building-operators/ansible/migration.md
+++ b/website/content/en/docs/building-operators/ansible/migration.md
@@ -88,9 +88,9 @@ spec:
   size: 3
 ```
 
-### Migrating `watches.yaml
+### Migrating `watches.yaml`
 
-Update the `watches.yaml` file with your `roles/playbooks` and check if you have custom options in the `watches.yaml` file of your existing project. If so, update the new `watches.yaml file to match. 
+Update the `watches.yaml` file with your `roles/playbooks` and check if you have custom options in the `watches.yaml` file of your existing project. If so, update the new `watches.yaml` file to match.
 
 In our example, we will replace `# FIXME: Specify the role or playbook for this resource.` with our previous role and it will look like:
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Update the ansible/migration.md documentation, adding the closing backtick to the missing watches.yaml mentions.


**Motivation for the change:**
Minor documentation fix.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
