### PR TITLE
operator-sdk/internal/generate: fix CSV path segments for multi-field structs

### DIFF
--- a/changelog/fragments/fix-csv-generate-path-segments.yaml
+++ b/changelog/fragments/fix-csv-generate-path-segments.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Fixed an issue during CSV generation that caused incorrect paths to
+      be used in `specDescriptors` and `statusDescriptors`.
+    kind: "bugfix"

--- a/internal/generate/clusterserviceversion/bases/definitions/ast.go
+++ b/internal/generate/clusterserviceversion/bases/definitions/ast.go
@@ -66,7 +66,7 @@ func (g generator) getMarkedChildrenOfField(root markers.FieldInfo) (map[string]
 						}
 						// Create a new set of path segments using the parent's segments
 						// and add the field to the next fields to search.
-						parentSegments := make([]string, len(field.pathSegments))
+						parentSegments := make([]string, len(field.pathSegments), len(field.pathSegments)+1)
 						copy(parentSegments, field.pathSegments)
 						f := &fieldInfo{
 							FieldInfo:    finfo,

--- a/internal/generate/clusterserviceversion/bases/definitions/ast.go
+++ b/internal/generate/clusterserviceversion/bases/definitions/ast.go
@@ -66,9 +66,11 @@ func (g generator) getMarkedChildrenOfField(root markers.FieldInfo) (map[string]
 						}
 						// Create a new set of path segments using the parent's segments
 						// and add the field to the next fields to search.
+						parentSegments := make([]string, len(field.pathSegments))
+						copy(parentSegments, field.pathSegments)
 						f := &fieldInfo{
 							FieldInfo:    finfo,
-							pathSegments: append(field.pathSegments, segment),
+							pathSegments: append(parentSegments, segment),
 						}
 						fields = append(fields, f)
 						// Marked fields get collected for the caller to parse.

--- a/internal/generate/testdata/clusterserviceversions/bases/with-ui-metadata.clusterserviceversion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/bases/with-ui-metadata.clusterserviceversion.yaml
@@ -15,6 +15,35 @@ spec:
       kind: Memcached
       name: memcacheds.cache.example.com
       specDescriptors:
+      - description: List of Providers
+        displayName: Providers
+        path: providers
+      - description: Foo represents the Foo provider
+        displayName: Foo Provider
+        path: providers[0].foo
+      - description: CredentialsSecret is a reference to a secret containing authentication details for the Foo server
+        displayName: Secret Containing the Credentials
+        path: providers[0].foo.credentialsSecret
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - description: Key represents the specific key to reference from the secret
+        displayName: Key within the secret
+        path: providers[0].foo.credentialsSecret.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name represents the name of the secret
+        displayName: Name of the secret
+        path: providers[0].foo.credentialsSecret.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Namespace represents the namespace containing the secret
+        displayName: Namespace containing the secret
+        path: providers[0].foo.credentialsSecret.namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Size is the size of the memcached deployment
         displayName: Size
         path: size

--- a/internal/generate/testdata/clusterserviceversions/output/memcached-operator.clusterserviceversion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/output/memcached-operator.clusterserviceversion.yaml
@@ -27,6 +27,35 @@ spec:
       kind: Memcached
       name: memcacheds.cache.example.com
       specDescriptors:
+      - description: List of Providers
+        displayName: Providers
+        path: providers
+      - description: Foo represents the Foo provider
+        displayName: Foo Provider
+        path: providers[0].foo
+      - description: CredentialsSecret is a reference to a secret containing authentication details for the Foo server
+        displayName: Secret Containing the Credentials
+        path: providers[0].foo.credentialsSecret
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:Secret
+      - description: Key represents the specific key to reference from the secret
+        displayName: Key within the secret
+        path: providers[0].foo.credentialsSecret.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name represents the name of the secret
+        displayName: Name of the secret
+        path: providers[0].foo.credentialsSecret.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Namespace represents the namespace containing the secret
+        displayName: Namespace containing the secret
+        path: providers[0].foo.credentialsSecret.namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Size is the size of the memcached deployment
         displayName: Size
         path: size

--- a/internal/generate/testdata/go/api/v1alpha1/memcached_types.go
+++ b/internal/generate/testdata/go/api/v1alpha1/memcached_types.go
@@ -23,6 +23,40 @@ type MemcachedSpec struct {
 	// Size is the size of the memcached deployment
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	Size int32 `json:"size"`
+
+	// List of Providers
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Providers"
+	Providers []Provider `json:"providers,omitempty"`
+}
+
+// Provider represents the container for a single provider
+type Provider struct {
+	// Foo represents the Foo provider
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Foo Provider"
+	Foo *FooProvider `json:"foo,omitempty"`
+}
+
+// FooProvider represents integration with Foo
+type FooProvider struct {
+	// CredentialsSecret is a reference to a secret containing authentication details for the Foo server
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Secret Containing the Credentials",xDescriptors="urn:alm:descriptor:io.kubernetes:Secret"
+	// +kubebuilder:validation:Required
+	CredentialsSecret *SecretRef `json:"credentialsSecret"`
+}
+
+// SecretRef represents a reference to an item within a Secret
+type SecretRef struct {
+	// Name represents the name of the secret
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Name of the secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
+	Name string `json:"name"`
+
+	// Namespace represents the namespace containing the secret
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Namespace containing the secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
+	Namespace string `json:"namespace"`
+
+	// Key represents the specific key to reference from the secret
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Key within the secret",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced","urn:alm:descriptor:com.tectonic.ui:text"}
+	Key string `json:"key,omitempty"`
 }
 
 // MemcachedStatus defines the observed state of Memcached


### PR DESCRIPTION
**Description of the change:**

Fixes a bug that causes path segments to inadvertently re-use memory from other path segments, causing `specDescriptors` and `statusDescriptors` fields to end up with incorrect paths.

**Motivation for the change:**

Fix bug = good :)

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
