### PR TITLE
Docs: Re-enable compact left-side bar

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -117,6 +117,8 @@ algolia_docsearch = false
 
 # User interface configuration
 [params.ui]
+# Enable to show the side bar menu in its compact state.
+sidebar_menu_compact = true
 #  Set to true to disable breadcrumb navigation. 
 breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)


### PR DESCRIPTION
Without this feature, the left bar is far too long to be useful.

This is a partial revert of https://github.com/operator-framework/operator-sdk/pull/4002/files#r516232814