### PR TITLE
add github action to rerun travis tests on PRs

### DIFF
--- a/.github/workflows/run-travis-jobs.yml
+++ b/.github/workflows/run-travis-jobs.yml
@@ -1,0 +1,25 @@
+name: Rerun-Travis-Jobs
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rerun-travis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: khan/pull-request-comment-trigger@master
+        id: check
+        with:
+          trigger: '/rerun-tests'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+      - run: |
+          gem install travis
+          travis restart --no-interactive --pro --token "$TRAVIS_TOKEN"
+        if: steps.check.outputs.triggered == 'true'
+        env:
+          TRAVIS_TOKEN: '${{ secrets.TRAVIS_TOKEN }}'


### PR DESCRIPTION
Fixes #3712

This PR adds a github action to rerun the travis job of a PR by commenting '/rerun-tests' on that PR.

Some notes:
1. It depends on [this github action written by someone else](https://github.com/Khan/pull-request-comment-trigger) to detect the comment and respond. We could fork that repo and maintain it ourselves if that is a concern. This implementation fires a job everytime anyone makes a comment on a PR, I'm not sure if it would be possible to implement a github action that doesn't have that overhead.
2. I opted to install ruby and the travis cli gem dynamically at runtime. This saves us from having to build and maintain our own custom github action docker image, but means the action takes a couple seconds to run.
3. There has to be a secret added to the repo called TRAVIS_TOKEN that contains a travis token of someone who has access to rerun builds in Travis. I used my personal token for my fork, I'm not sure if there' s a way to generate one that is generic and not associated with a specific user.