### PR TITLE
internal/olm/installer: prepend 'v' to semvers >= 0.17.0

### DIFF
--- a/changelog/fragments/olm-version-v.yaml
+++ b/changelog/fragments/olm-version-v.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: >
+      Format version string passed to `olm` subcommands so releases download correctly.
+    kind: bugfix

--- a/internal/olm/installer/client.go
+++ b/internal/olm/installer/client.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/blang/semver"
 	olmapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	olmmanifests "github.com/operator-framework/operator-sdk/internal/bindata/olm"
 	log "github.com/sirupsen/logrus"
@@ -176,13 +177,15 @@ func (c Client) GetStatus(ctx context.Context, namespace, version string) (*olmr
 func (c Client) getResources(ctx context.Context, version string) ([]unstructured.Unstructured, error) {
 	log.Infof("Fetching CRDs for version %q", version)
 
+	version = formatVersion(version)
+
 	var crdResources, olmResources []unstructured.Unstructured
 	var err error
 
 	// If the manifests for the requested version are saved as bindata in SDK, use
 	// them instead of fetching them from
 	if olmmanifests.HasVersion(version) {
-		log.Infof("Using locally stored resource manifests")
+		log.Infof("Using locally stored resource manifests for resolved version %q", version)
 		crdResources, err = getPackagedManifests(crdManifestBindataPath)
 		if err != nil {
 			return nil, err
@@ -193,7 +196,7 @@ func (c Client) getResources(ctx context.Context, version string) ([]unstructure
 			return nil, err
 		}
 	} else {
-		log.Infof("Fetching resources for version %q", version)
+		log.Infof("Fetching resources for resolved version %q", version)
 		crdResources, err = c.getCRDs(ctx, version)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch CRDs: %v", err)
@@ -239,6 +242,20 @@ func getPackagedManifests(manifestPath string) ([]unstructured.Unstructured, err
 		return nil, err
 	}
 	return resources, nil
+}
+
+// formatVersion returns version if version is not semver, or version prepended with "v"
+// if version < 0.17.0 (when OLM changed release tag formats).
+func formatVersion(version string) string {
+	sv, err := semver.ParseTolerant(version)
+	if err != nil {
+		// Use version as-is, since it might not be semver intentionally.
+		return version
+	}
+	if sv.Major == 0 && sv.Minor < 17 {
+		return sv.String()
+	}
+	return "v" + sv.String()
 }
 
 func (c Client) crdsURL(version string) string {

--- a/internal/olm/installer/client_test.go
+++ b/internal/olm/installer/client_test.go
@@ -1,0 +1,80 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installer
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("helpers", func() {
+	Describe("formatVersion", func() {
+		const (
+			latest            = "latest"
+			zeroSixteen       = "0.16.0"
+			vZeroSixteen      = "v" + zeroSixteen
+			zeroSixteenOne    = "0.16.1"
+			vZeroSixteenOne   = "v" + zeroSixteenOne
+			zeroSeventeen     = "0.17.0"
+			vZeroSeventeen    = "v" + zeroSeventeen
+			zeroSeventeenOne  = "0.17.1"
+			vZeroSeventeenOne = "v" + zeroSeventeenOne
+			oneTwoThree       = "1.2.3"
+			vOneTwoThree      = "v" + oneTwoThree
+		)
+
+		It("returns a non semantic version as-is", func() {
+			By(fmt.Sprintf("receiving %s", latest))
+			Expect(formatVersion(latest)).To(Equal(latest))
+		})
+
+		It("returns a v-prepended semantic version", func() {
+			By(fmt.Sprintf("receiving %s", zeroSeventeen))
+			Expect(formatVersion(zeroSeventeen)).To(Equal(vZeroSeventeen))
+
+			By(fmt.Sprintf("receiving %s", vZeroSeventeen))
+			Expect(formatVersion(vZeroSeventeen)).To(Equal(vZeroSeventeen))
+
+			By(fmt.Sprintf("receiving %s", zeroSeventeenOne))
+			Expect(formatVersion(zeroSeventeenOne)).To(Equal(vZeroSeventeenOne))
+
+			By(fmt.Sprintf("receiving %s", vZeroSeventeenOne))
+			Expect(formatVersion(vZeroSeventeenOne)).To(Equal(vZeroSeventeenOne))
+
+			By(fmt.Sprintf("receiving %s", oneTwoThree))
+			Expect(formatVersion(oneTwoThree)).To(Equal(vOneTwoThree))
+
+			By(fmt.Sprintf("receiving %s", vOneTwoThree))
+			Expect(formatVersion(vOneTwoThree)).To(Equal(vOneTwoThree))
+		})
+
+		It("returns a format semantic version", func() {
+			By(fmt.Sprintf("receiving %s", zeroSixteen))
+			Expect(formatVersion(zeroSixteen)).To(Equal(zeroSixteen))
+
+			By(fmt.Sprintf("receiving %s", vZeroSixteen))
+			Expect(formatVersion(vZeroSixteen)).To(Equal(zeroSixteen))
+
+			By(fmt.Sprintf("receiving %s", zeroSixteenOne))
+			Expect(formatVersion(zeroSixteenOne)).To(Equal(zeroSixteenOne))
+
+			By(fmt.Sprintf("receiving %s", vZeroSixteenOne))
+			Expect(formatVersion(vZeroSixteenOne)).To(Equal(zeroSixteenOne))
+		})
+
+	})
+})

--- a/internal/olm/installer/installer_suite_test.go
+++ b/internal/olm/installer/installer_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installer
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestRegistry(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Installer Suite")
+}


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:** prepend `v` to semver strings passed to `olm` subcommands

**Motivation for the change:** OLM versions now have a `v` prefix.


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
