### PR TITLE
Makefile: add submodule checkout to 'test-links'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ test-sanity: generate fix ## Test repo formatting, linting, etc.
 
 .PHONY: test-links
 test-links: ## Test doc links
+	git submodule update --init --recursive website/
 	./hack/check-links.sh
 
 .PHONY: test-unit


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:** checkout website submodules in `make test-links`


**Motivation for the change:** initializes website submodules if not already

Closes #4092


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
