### PR TITLE
internal/ansible: set role and playbook path defaults, pass role path to ansible-runner

### DIFF
--- a/changelog/fragments/default-ansible-paths.yaml
+++ b/changelog/fragments/default-ansible-paths.yaml
@@ -1,0 +1,7 @@
+entries:
+  - description: >
+      Set default ansible-operator role path to `<project-root>/roles/<lower-kind>`
+    kind: bugfix
+  - description: >
+      Pass the Ansible roles path to ansible-runner when called from the ansible-operator binary
+    kind: bugfix


### PR DESCRIPTION
**Description of the change:**
- internal/ansible/runner: pass role path to ansible-runner when executing a playbook
- internal/ansible/watches: default role and playbook paths to `<project-root>/roles` and `<project-root>/playbooks/<lower-kind>.yaml`, respectively

**Motivation for the change:** the solution to #4071 is twofold:
1. Roles are not scaffolded at any of the default paths `ansible-runner` expects, so the `Watches.Roles` field should be set explicitly to the path created by `ansibe/v1` _and_ `--roles-path` should be set to this path when running a playbook since the playbook does not support path specification.

/kind bug

Closes #4071 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
