### PR TITLE
fix(Makefile): Add default shell for Makefile

### DIFF
--- a/internal/plugins/envtest/init.go
+++ b/internal/plugins/envtest/init.go
@@ -61,6 +61,8 @@ func initUpdateMakefile(filePath string) error {
 }
 
 const makefileTestTarget = `# Run tests
+# Set default shell as bash
+SHELL := /bin/bash
 ENVTEST_ASSETS_DIR = $(shell pwd)/testbin
 test: generate fmt vet manifests
 	mkdir -p $(ENVTEST_ASSETS_DIR)

--- a/testdata/go/memcached-operator/Makefile
+++ b/testdata/go/memcached-operator/Makefile
@@ -26,6 +26,8 @@ endif
 all: manager
 
 # Run tests
+# Set default shell as bash
+SHELL := /bin/bash
 ENVTEST_ASSETS_DIR = $(shell pwd)/testbin
 test: generate fmt vet manifests
 	mkdir -p $(ENVTEST_ASSETS_DIR)


### PR DESCRIPTION
**Description of the change:**
This commit is to set default shell as bash for Makefile.

Some of the targets (e.g. test) in Make is source command, which is not available
in default Makefile shell (e.g. /bin/sh).

Closes #4203

**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
