### PR TITLE
hack/generate/samples: strip operator-sdk metrics annotations

### DIFF
--- a/hack/generate/samples/internal/ansible/memcached.go
+++ b/hack/generate/samples/internal/ansible/memcached.go
@@ -76,7 +76,7 @@ func (ma *MemcachedAnsible) Run() {
 	ma.addingAnsibleTask()
 	ma.addingMoleculeMockData()
 
-	pkg.RunOlmIntegration(ma.ctx)
+	ma.ctx.CreateBundle()
 }
 
 // addingMoleculeMockData will customize the molecule data

--- a/hack/generate/samples/internal/go/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/memcached_with_webhooks.go
@@ -90,7 +90,7 @@ func (mh *MemcachedGoWithWebhooks) Run() {
 	mh.implementingWebhooks()
 	mh.uncommentKustomizationFile()
 
-	pkg.RunOlmIntegration(mh.ctx)
+	mh.ctx.CreateBundle()
 
 	// Clean up built binaries, if any.
 	pkg.CheckError("cleaning up", os.RemoveAll(filepath.Join(mh.ctx.Dir, "bin")))

--- a/hack/generate/samples/internal/helm/memcached.go
+++ b/hack/generate/samples/internal/helm/memcached.go
@@ -103,7 +103,7 @@ func (mh *MemcachedHelm) Run() {
 		"# +kubebuilder:scaffold:rules", policyRolesFragment)
 	pkg.CheckError("adding customized roles", err)
 
-	pkg.RunOlmIntegration(mh.ctx)
+	mh.ctx.CreateBundle()
 }
 
 // GenerateMemcachedHelmSample will call all actions to create the directory and generate the sample

--- a/internal/testutils/olm.go
+++ b/internal/testutils/olm.go
@@ -82,7 +82,7 @@ func (tc TestContext) AddPackagemanifestsTarget() error {
 }
 
 // DisableOLMBundleInterativeMode will update the Makefile to disable the interactive mode
-func (tc TestContext) DisableOLMBundleInteractiveMode() error {
+func (tc TestContext) DisableManifestsInteractiveMode() error {
 	// Todo: check if we cannot improve it since the replace/content will exists in the
 	// pkgmanifest target if it be scaffolded before this call
 	content := "operator-sdk generate kustomize manifests"

--- a/test/e2e-go/e2e_go_olm_test.go
+++ b/test/e2e-go/e2e_go_olm_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Integrating Go Projects with OLM", func() {
 
 		It("should generate and run a valid OLM bundle and packagemanifests", func() {
 			By("turning off interactive prompts for all generation tasks.")
-			err := tc.DisableOLMBundleInteractiveMode()
+			err := tc.DisableManifestsInteractiveMode()
 			Expect(err).NotTo(HaveOccurred())
 
 			By("building the bundle")

--- a/test/e2e-go/e2e_go_suite_test.go
+++ b/test/e2e-go/e2e_go_suite_test.go
@@ -101,7 +101,7 @@ var _ = BeforeSuite(func() {
 		"#- ../prometheus", "#")).To(Succeed())
 
 	By("turning off interactive prompts for all generation tasks.")
-	err = tc.DisableOLMBundleInteractiveMode()
+	err = tc.DisableManifestsInteractiveMode()
 	Expect(err).NotTo(HaveOccurred())
 
 	By("checking the kustomize setup")

--- a/testdata/ansible/memcached-operator/bundle.Dockerfile
+++ b/testdata/ansible/memcached-operator/bundle.Dockerfile
@@ -5,9 +5,6 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=memcached-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.1.0+git
-LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.project_layout=ansible.sdk.operatorframework.io/v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 COPY bundle/manifests /manifests/

--- a/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -16,8 +16,6 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.1.0+git
-    operators.operatorframework.io/project_layout: ansible.sdk.operatorframework.io/v1
   name: memcached-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/testdata/ansible/memcached-operator/bundle/metadata/annotations.yaml
+++ b/testdata/ansible/memcached-operator/bundle/metadata/annotations.yaml
@@ -4,8 +4,5 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: memcached-operator
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.1.0+git
-  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
-  operators.operatorframework.io.metrics.project_layout: ansible.sdk.operatorframework.io/v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/testdata/ansible/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/ansible/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
@@ -4,8 +4,6 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.1.0+git
-    operators.operatorframework.io/project_layout: ansible.sdk.operatorframework.io/v1
   name: memcached-operator.vX.Y.Z
   namespace: placeholder
 spec:

--- a/testdata/go/memcached-operator/bundle.Dockerfile
+++ b/testdata/go/memcached-operator/bundle.Dockerfile
@@ -5,9 +5,6 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=memcached-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.1.0+git
-LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 COPY bundle/manifests /manifests/

--- a/testdata/go/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -16,8 +16,6 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.1.0+git
-    operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
   name: memcached-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/testdata/go/memcached-operator/bundle/metadata/annotations.yaml
+++ b/testdata/go/memcached-operator/bundle/metadata/annotations.yaml
@@ -4,8 +4,5 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: memcached-operator
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.1.0+git
-  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
-  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2
   operators.operatorframework.io.test.config.v1: tests/scorecard/
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/testdata/go/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
@@ -4,8 +4,6 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.1.0+git
-    operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
   name: memcached-operator.vX.Y.Z
   namespace: placeholder
 spec:

--- a/testdata/helm/memcached-operator/bundle.Dockerfile
+++ b/testdata/helm/memcached-operator/bundle.Dockerfile
@@ -5,9 +5,6 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=memcached-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.1.0+git
-LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.project_layout=helm.sdk.operatorframework.io/v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 COPY bundle/manifests /manifests/

--- a/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -56,8 +56,6 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.1.0+git
-    operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
   name: memcached-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/testdata/helm/memcached-operator/bundle/metadata/annotations.yaml
+++ b/testdata/helm/memcached-operator/bundle/metadata/annotations.yaml
@@ -4,8 +4,5 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: memcached-operator
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.1.0+git
-  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
-  operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/testdata/helm/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/helm/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
@@ -4,8 +4,6 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.1.0+git
-    operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
   name: memcached-operator.vX.Y.Z
   namespace: placeholder
 spec:


### PR DESCRIPTION
**Description of the change:**
- hack/generate/samples: added `SampleContext.StripBundleAnnotations()` which removes all operator-sdk metrics labels from metadata and manifests in a bundle
- *: renamed exported testutils to align with their functionality

**Motivation for the change:** This PR removes metrics annotations from samples in testdata/, which are inherently versioned by git. Removing these annotations permits proper release tagging of samples.


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
