### PR TITLE
release/Makefile: honor GOOS and GOARCH when building release binaries

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -77,26 +77,23 @@ dist/operator-sdk-%-x86_64-linux-gnu: GOARGS = GOOS=linux GOARCH=amd64
 dist/operator-sdk-%-x86_64-apple-darwin: GOARGS = GOOS=darwin GOARCH=amd64
 dist/operator-sdk-%-ppc64le-linux-gnu: GOARGS = GOOS=linux GOARCH=ppc64le
 dist/operator-sdk-%-s390x-linux-gnu: GOARGS = GOOS=linux GOARCH=s390x
-dist/operator-sdk-%-linux-gnu: GOARGS = GOOS=linux
 
 dist/ansible-operator-%-aarch64-linux-gnu: GOARGS = GOOS=linux GOARCH=arm64
 dist/ansible-operator-%-x86_64-linux-gnu: GOARGS = GOOS=linux GOARCH=amd64
 dist/ansible-operator-%-x86_64-apple-darwin: GOARGS = GOOS=darwin GOARCH=amd64
 dist/ansible-operator-%-ppc64le-linux-gnu: GOARGS = GOOS=linux GOARCH=ppc64le
 dist/ansible-operator-%-s390x-linux-gnu: GOARGS = GOOS=linux GOARCH=s390x
-dist/ansible-operator-%-linux-gnu: GOARGS = GOOS=linux
 
 dist/helm-operator-%-aarch64-linux-gnu: GOARGS = GOOS=linux GOARCH=arm64
 dist/helm-operator-%-x86_64-linux-gnu: GOARGS = GOOS=linux GOARCH=amd64
 dist/helm-operator-%-x86_64-apple-darwin: GOARGS = GOOS=darwin GOARCH=amd64
 dist/helm-operator-%-ppc64le-linux-gnu: GOARGS = GOOS=linux GOARCH=ppc64le
 dist/helm-operator-%-s390x-linux-gnu: GOARGS = GOOS=linux GOARCH=s390x
-dist/helm-operator-%-linux-gnu: GOARGS = GOOS=linux
 
 dist/%: ## Build the operator-sdk release binaries
 	{ \
 	cmdpkg=$$(echo $* | sed -E "s/(operator-sdk|ansible-operator|helm-operator).*/\1/"); \
-	go build $(GO_BUILD_ARGS) -o $@ ./cmd/$$cmdpkg; \
+	$(GOARGS) go build $(GO_BUILD_ARGS) -o $@ ./cmd/$$cmdpkg; \
 	}
 
 dist/%.asc: ## Create release signatures for operator-sdk release binaries


### PR DESCRIPTION
**Description of the change:**

Use `GOARGS` when building release binaries.

**Motivation for the change:**

`GOARGS` is used to configure `GOOS` and `GOARCH` when building release binaries. This fix ensures that the correct OS and architecture settings are used during the release.

Closes #4216 