### PR TITLE
internal/cmd: add build info metric in helm/ansible operators

### DIFF
--- a/changelog/fragments/helm-ansible-version-metric.yaml
+++ b/changelog/fragments/helm-ansible-version-metric.yaml
@@ -1,0 +1,9 @@
+entries:
+  - description: >
+      In Ansible-based operators, added the `ansible_operator_build_info`
+      metric to instrument commit and version information.
+    kind: "addition"
+  - description: >
+      In Helm-based operators, added the `helm_operator_build_info`
+      metric to instrument commit and version information.
+    kind: "addition"

--- a/internal/ansible/metrics/metrics.go
+++ b/internal/ansible/metrics/metrics.go
@@ -20,6 +20,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	sdkVersion "github.com/operator-framework/operator-sdk/internal/version"
 )
 
 const (
@@ -27,6 +29,17 @@ const (
 )
 
 var (
+	buildInfo = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subsystem,
+			Name:      "build_info",
+			Help:      "Build information for the ansible-operator binary",
+			ConstLabels: map[string]string{
+				"commit":  sdkVersion.GitCommit,
+				"version": sdkVersion.Version,
+			},
+		})
+
 	reconcileResults = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: subsystem,
@@ -62,6 +75,11 @@ func recoverMetricPanic() {
 		logf.Log.WithName("metrics").Error(fmt.Errorf("%v", r),
 			"Recovering from metric function")
 	}
+}
+
+func RegisterBuildInfo(r prometheus.Registerer) {
+	buildInfo.Set(1)
+	r.MustRegister(buildInfo)
 }
 
 func ReconcileSucceeded(gvk string) {

--- a/internal/cmd/ansible-operator/run/cmd.go
+++ b/internal/cmd/ansible-operator/run/cmd.go
@@ -33,9 +33,11 @@ import (
 	zapf "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/operator-framework/operator-sdk/internal/ansible/controller"
 	"github.com/operator-framework/operator-sdk/internal/ansible/flags"
+	"github.com/operator-framework/operator-sdk/internal/ansible/metrics"
 	"github.com/operator-framework/operator-sdk/internal/ansible/proxy"
 	"github.com/operator-framework/operator-sdk/internal/ansible/proxy/controllermap"
 	"github.com/operator-framework/operator-sdk/internal/ansible/runner"
@@ -81,6 +83,7 @@ func NewCmd() *cobra.Command {
 
 func run(cmd *cobra.Command, f *flags.Flags) {
 	printVersion()
+	metrics.RegisterBuildInfo(crmetrics.Registry)
 
 	cfg, err := config.GetConfig()
 	if err != nil {

--- a/internal/cmd/helm-operator/run/cmd.go
+++ b/internal/cmd/helm-operator/run/cmd.go
@@ -31,9 +31,11 @@ import (
 	zapf "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/operator-framework/operator-sdk/internal/helm/controller"
 	"github.com/operator-framework/operator-sdk/internal/helm/flags"
+	"github.com/operator-framework/operator-sdk/internal/helm/metrics"
 	"github.com/operator-framework/operator-sdk/internal/helm/release"
 	"github.com/operator-framework/operator-sdk/internal/helm/watches"
 	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
@@ -73,6 +75,7 @@ func NewCmd() *cobra.Command {
 
 func run(cmd *cobra.Command, f *flags.Flags) {
 	printVersion()
+	metrics.RegisterBuildInfo(crmetrics.Registry)
 
 	cfg, err := config.GetConfig()
 	if err != nil {

--- a/internal/helm/metrics/metrics.go
+++ b/internal/helm/metrics/metrics.go
@@ -1,0 +1,44 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	sdkVersion "github.com/operator-framework/operator-sdk/internal/version"
+)
+
+const (
+	subsystem = "helm_operator"
+)
+
+var (
+	buildInfo = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subsystem,
+			Name:      "build_info",
+			Help:      "Build information for the helm-operator binary",
+			ConstLabels: map[string]string{
+				"commit":  sdkVersion.GitCommit,
+				"version": sdkVersion.Version,
+			},
+		},
+	)
+)
+
+func RegisterBuildInfo(r prometheus.Registerer) {
+	buildInfo.Set(1)
+	r.MustRegister(buildInfo)
+}


### PR DESCRIPTION

**Description of the change:**
Added the `ansible_operator_build_info` and `helm_operator_build_info` metrics to instrument commit and version information for the Ansible and Helm operators, respectively.

**Motivation for the change:**

Expose runtime version information to augment stamp versions in bundle and CSV metadata.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
