### PR TITLE
ensure that samples will be always generated with the default deps defined in the makefile

### DIFF
--- a/hack/generate/samples/internal/ansible/memcached.go
+++ b/hack/generate/samples/internal/ansible/memcached.go
@@ -47,6 +47,8 @@ func (ma *MemcachedAnsible) Prepare() {
 	err := ma.ctx.Prepare()
 	pkg.CheckError("creating directory for Ansible Sample", err)
 
+	ma.ctx.CleanLocalDependencies()
+
 	log.Infof("setting domain and GVK")
 	ma.ctx.Domain = "example.com"
 	ma.ctx.Version = "v1alpha1"

--- a/hack/generate/samples/internal/go/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/memcached_with_webhooks.go
@@ -48,6 +48,8 @@ func (mh *MemcachedGoWithWebhooks) Prepare() {
 	err := mh.ctx.Prepare()
 	pkg.CheckError("creating directory for Go Sample", err)
 
+	mh.ctx.CleanLocalDependencies()
+
 	log.Infof("setting domain and GVK")
 	mh.ctx.Domain = "example.com"
 	mh.ctx.Version = "v1alpha1"

--- a/hack/generate/samples/internal/helm/memcached.go
+++ b/hack/generate/samples/internal/helm/memcached.go
@@ -46,6 +46,8 @@ func (mh *MemcachedHelm) Prepare() {
 	err := mh.ctx.Prepare()
 	pkg.CheckError("creating directory", err)
 
+	mh.ctx.CleanLocalDependencies()
+
 	log.Infof("setting domain and GVK")
 	mh.ctx.Domain = "example.com"
 	mh.ctx.Version = "v1alpha1"

--- a/hack/generate/samples/internal/pkg/utils.go
+++ b/hack/generate/samples/internal/pkg/utils.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 
@@ -104,4 +105,16 @@ func removeAllAnnotationLines(annotations map[string]string, filePaths []string)
 		}
 	}
 	return nil
+}
+
+// CleanLocalDependencies will remove tool binaries so the correct versions are used for each plugin version.
+func (ctx SampleContext) CleanLocalDependencies() {
+	log.Infof("cleaning local dependencies")
+	cmd := exec.Command("rm", "-f", "which", "controller-gen")
+	_, err := ctx.Run(cmd)
+	CheckError("removing controller-gen from local env", err)
+
+	cmd = exec.Command("rm", "-f", "which", "kustomize")
+	_, err = ctx.Run(cmd)
+	CheckError("removing kustomize from local env", err)
 }


### PR DESCRIPTION
**Description of the change:**
remove controller-gen and kustomize from local env before generating the sample. 

**Motivation for the change:**
ensure that samples will be always generated with the default deps defined in the makefile

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
