### PR TITLE
Fix missing url for operator_install

### DIFF
--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -453,7 +453,7 @@ The following guides build off the operator created in this example, adding adva
 
 Also see the [advanced topics][advanced_topics] doc for more use cases and under the hood details.
 
-
+[operator_install]: https://sdk.operatorframework.io/docs/installation/install-operator-sdk/
 [go_tool]:https://golang.org/dl/
 [docker_tool]:https://docs.docker.com/install/
 [kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/


### PR DESCRIPTION
There is a missing url for operator_install in [Golang tutorial page](https://sdk.operatorframework.io/docs/building-operators/golang/tutorial/). Then I add a link for it.