### PR TITLE
sample generation fixes

### DIFF
--- a/hack/generate/samples/internal/helm/memcached.go
+++ b/hack/generate/samples/internal/helm/memcached.go
@@ -17,7 +17,6 @@ package helm
 import (
 	"os"
 	"path/filepath"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 
@@ -55,12 +54,6 @@ func (mh *MemcachedHelm) Prepare() {
 
 // Run runs the steps to generate the sample
 func (mh *MemcachedHelm) Run() {
-	current, err := os.Getwd()
-	if err != nil {
-		log.Error(err)
-		os.Exit(1)
-	}
-
 	// When operator-sdk scaffolds Helm projects, it tries to use the discovery API of a Kubernetes
 	// cluster to intelligently build the RBAC rules that the operator will require based on the
 	// content of the helm chart.
@@ -73,15 +66,12 @@ func (mh *MemcachedHelm) Run() {
 	os.Setenv("KUBECONFIG", "broken_so_we_generate_static_default_rules")
 
 	log.Infof("creating the project")
-	err = mh.ctx.Init(
+	err := mh.ctx.Init(
 		"--plugins", "helm",
 		"--domain", mh.ctx.Domain)
 	pkg.CheckError("creating the project", err)
 
-	log.Infof("handling work path to get helm chart mock data")
-	projectPath := strings.Split(current, "operator-sdk/")[0]
-	projectPath = strings.Replace(projectPath, "operator-sdk", "", 1)
-	helmChartPath := filepath.Join(projectPath, "operator-sdk/hack/generate/samples/internal/helm/testdata/memcached-0.0.1.tgz")
+	helmChartPath := "../../../hack/generate/samples/internal/helm/testdata/memcached-0.0.1.tgz"
 	log.Infof("using the helm chart in: (%v)", helmChartPath)
 
 	err = mh.ctx.CreateAPI(

--- a/hack/generate/samples/internal/pkg/utils.go
+++ b/hack/generate/samples/internal/pkg/utils.go
@@ -46,9 +46,6 @@ func (ctx *SampleContext) CreateBundle() {
 
 	err = ctx.StripBundleAnnotations()
 	CheckError("stripping bundle annotations", err)
-
-	err = ctx.Make("bundle-build", "BUNDLE_IMG="+ctx.BundleImageName)
-	CheckError("running make bundle-build", err)
 }
 
 // StripBundleAnnotations removes all annotations applied to bundle manifests and metadata


### PR DESCRIPTION
**Description of the change:**

1. Hardcode the helm chart path for the helm sample generation
2. Don't run `make bundle-build` during sample generation

**Motivation for the change:**

1. The previous method of building the full helm chart path fails when "operator-sdk" appears multiple times in the path, which can happen on developer machines and in CI systems that clone the repo in a subdirectory of a path containing the project name.
2. `make bundle-build` does not change a project, so it is not needed during sample generation.
