### PR TITLE
doc: fix log statement in multi namespace example

### DIFF
--- a/website/content/en/docs/building-operators/golang/operator-scope.md
+++ b/website/content/en/docs/building-operators/golang/operator-scope.md
@@ -264,7 +264,7 @@ options := ctrl.Options{
 
 // Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)
 if strings.Contains(watchNamespace, ",") {
-    setupLog.Infof("manager will be watching namespace %q", watchNamespace)
+    setupLog.Info(fmt.Sprintf("manager will be watching namespace %q", watchNamespace))
     // configure cluster-scoped with MultiNamespacedCacheBuilder
     options.Namespace = ""
     options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(watchNamespace, ","))

--- a/website/content/en/docs/building-operators/golang/operator-scope.md
+++ b/website/content/en/docs/building-operators/golang/operator-scope.md
@@ -264,7 +264,7 @@ options := ctrl.Options{
 
 // Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)
 if strings.Contains(watchNamespace, ",") {
-    setupLog.Info(fmt.Sprintf("manager will be watching namespace %q", watchNamespace))
+    setupLog.Info("manager set up with multiple namespaces", "namespaces", watchNamespace)
     // configure cluster-scoped with MultiNamespacedCacheBuilder
     options.Namespace = ""
     options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(watchNamespace, ","))


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

The used `Infof` method isn't defined for the `setupLog` logger, so that we have to use `Info` in combination with `fmt.Sprintf` to get the desired log line.

The error for the current example looks as follows:

```
go fmt ./...
go vet ./...
# github.com/ricoberger/vault-secrets-operator
vet: ./main.go:75:12: setupLog.Infof undefined (type logr.Logger has no field or method Infof)
make: *** [vet] Error 2
```

**Motivation for the change:**

Fix the given example in the documentation.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
