### PR TITLE
generate: add `order=<int>` CSV marker fields

### DIFF
--- a/changelog/fragments/csv-order.yaml
+++ b/changelog/fragments/csv-order.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Added [`order=<int>`](https://sdk.operatorframework.io/docs/building-operators/golang/references/markers/#usage) marker fields to CSV markers.
+
+    kind: addition

--- a/internal/generate/clusterserviceversion/bases/definitions/crd_test.go
+++ b/internal/generate/clusterserviceversion/bases/definitions/crd_test.go
@@ -1,0 +1,208 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package definitions
+
+import (
+	"math/rand"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"sigs.k8s.io/controller-tools/pkg/markers"
+	"sigs.k8s.io/kubebuilder/v2/test/e2e/utils"
+)
+
+var _ = Describe("getTypedDescriptors", func() {
+	var (
+		markedFields map[string][]*fieldInfo
+		out          []interface{}
+	)
+
+	BeforeEach(func() {
+		markedFields = make(map[string][]*fieldInfo)
+	})
+
+	It("handles an empty set of marked fields", func() {
+		out = getTypedDescriptors(markedFields, reflect.TypeOf(v1alpha1.SpecDescriptor{}), spec)
+		Expect(out).To(HaveLen(0))
+	})
+	It("returns one spec descriptor for one spec marker on a field", func() {
+		markedFields[""] = []*fieldInfo{
+			{
+				FieldInfo: markers.FieldInfo{
+					Markers: markers.MarkerValues{
+						"": []interface{}{
+							Descriptor{"spec", "Foo", []string{"urn:alm:descriptor:com.tectonic.ui:text"}, nil},
+						},
+					},
+				},
+			},
+		}
+		out = getTypedDescriptors(markedFields, reflect.TypeOf(v1alpha1.SpecDescriptor{}), spec)
+		Expect(out).To(HaveLen(1))
+		Expect(out).To(BeEquivalentTo([]interface{}{
+			v1alpha1.SpecDescriptor{
+				DisplayName:  "Foo",
+				XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:text"},
+			},
+		}))
+	})
+	It("returns no spec descriptors for one status marker on a field", func() {
+		markedFields[""] = []*fieldInfo{
+			{
+				FieldInfo: markers.FieldInfo{
+					Markers: markers.MarkerValues{
+						"": []interface{}{
+							Descriptor{"status", "Foo", []string{"urn:alm:descriptor:com.tectonic.ui:text"}, nil},
+						},
+					},
+				},
+			},
+		}
+		out = getTypedDescriptors(markedFields, reflect.TypeOf(v1alpha1.SpecDescriptor{}), spec)
+		Expect(out).To(HaveLen(0))
+	})
+	It("returns one status descriptor for one status marker on a field", func() {
+		markedFields[""] = []*fieldInfo{
+			{
+				FieldInfo: markers.FieldInfo{
+					Markers: markers.MarkerValues{
+						"": []interface{}{
+							Descriptor{"status", "Foo", []string{"urn:alm:descriptor:com.tectonic.ui:text"}, nil},
+						},
+					},
+				},
+			},
+		}
+		out = getTypedDescriptors(markedFields, reflect.TypeOf(v1alpha1.StatusDescriptor{}), status)
+		Expect(out).To(HaveLen(1))
+		Expect(out).To(BeEquivalentTo([]interface{}{
+			v1alpha1.StatusDescriptor{
+				DisplayName:  "Foo",
+				XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:text"},
+			},
+		}))
+	})
+	It("returns one spec descriptor for three spec markers and one status marker on a field", func() {
+		markedFields[""] = []*fieldInfo{
+			{
+				FieldInfo: markers.FieldInfo{
+					Markers: markers.MarkerValues{
+						"": []interface{}{
+							Descriptor{"spec", "Foo", nil, nil},
+							Descriptor{"spec", "", nil, intPtr(2)},
+							Descriptor{"spec", "", []string{"urn:alm:descriptor:com.tectonic.ui:text"}, nil},
+							Descriptor{"status", "", []string{"urn:alm:descriptor:com.tectonic.ui:arrayFieldGroup:blah"}, nil},
+						},
+					},
+				},
+				pathSegments: []string{"foo", inlinedTag, "bar", "baz"},
+			},
+		}
+		out = getTypedDescriptors(markedFields, reflect.TypeOf(v1alpha1.SpecDescriptor{}), spec)
+		Expect(out).To(HaveLen(1))
+		Expect(out).To(BeEquivalentTo([]interface{}{
+			v1alpha1.SpecDescriptor{
+				DisplayName:  "Foo",
+				XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:text"},
+				Path:         "foo.bar.baz",
+			},
+		}))
+	})
+	It("returns two spec descriptor for spec markers on two different fields", func() {
+		markedFields[""] = []*fieldInfo{
+			{
+				FieldInfo: markers.FieldInfo{
+					Markers: markers.MarkerValues{
+						"": []interface{}{Descriptor{"spec", "Foo", nil, intPtr(1)}},
+					},
+				},
+				pathSegments: []string{"foo"},
+			},
+			{
+				FieldInfo: markers.FieldInfo{
+					Markers: markers.MarkerValues{
+						"": []interface{}{Descriptor{"spec", "Bar", nil, intPtr(0)}},
+					},
+				},
+				pathSegments: []string{"bar"},
+			},
+		}
+		out = getTypedDescriptors(markedFields, reflect.TypeOf(v1alpha1.SpecDescriptor{}), spec)
+		Expect(out).To(HaveLen(2))
+		Expect(out).To(BeEquivalentTo([]interface{}{
+			v1alpha1.SpecDescriptor{DisplayName: "Bar", Path: "bar"},
+			v1alpha1.SpecDescriptor{DisplayName: "Foo", Path: "foo"},
+		}))
+	})
+	It("returns multiple sorted spec descriptors with all orders set", func() {
+		markedFields, expected := makeMockMarkedFields()
+		out = getTypedDescriptors(markedFields, reflect.TypeOf(v1alpha1.SpecDescriptor{}), spec)
+		Expect(out).To(HaveLen(len(expected)))
+		Expect(out).To(BeEquivalentTo(expected))
+	})
+})
+
+func intPtr(i int) *int { return &i }
+
+// makeMockMarkedFields returns a randomly generated mock marked field set,
+// and the expected sorted set of descriptors.
+func makeMockMarkedFields() (markedFields map[string][]*fieldInfo, expected []interface{}) {
+	descBuckets := make(map[int][]v1alpha1.SpecDescriptor, 100)
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	markedFields = make(map[string][]*fieldInfo, 100)
+	for i := 0; i < 100; i++ {
+		s, err := utils.RandomSuffix()
+		if err != nil {
+			panic(err)
+		}
+		name := strings.Title(s)
+		order := r.Int() % 200 // Very likely to get one conflict.
+		if _, hasName := markedFields[name]; hasName {
+			continue
+		}
+		markedFields[name] = []*fieldInfo{
+			{
+				FieldInfo: markers.FieldInfo{
+					Markers: markers.MarkerValues{
+						"": []interface{}{Descriptor{"spec", name, nil, intPtr(order)}},
+					},
+				},
+				pathSegments: []string{s},
+			},
+		}
+		descBuckets[order] = append(descBuckets[order], v1alpha1.SpecDescriptor{DisplayName: name, Path: s})
+	}
+
+	orders := make([]int, 0, 100)
+	for order := range descBuckets {
+		orders = append(orders, order)
+	}
+	sort.Ints(orders)
+
+	for _, order := range orders {
+		bucket := descBuckets[order]
+		sort.Slice(bucket, func(i, j int) bool { return bucket[i].DisplayName < bucket[j].DisplayName })
+		for _, d := range bucket {
+			expected = append(expected, d)
+		}
+	}
+
+	return markedFields, expected
+}

--- a/internal/generate/clusterserviceversion/bases/definitions/definitions_suite_test.go
+++ b/internal/generate/clusterserviceversion/bases/definitions/definitions_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package definitions
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestGenerator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Definitions Suite")
+}

--- a/internal/generate/clusterserviceversion/bases/definitions/zz_generated.markerhelp.go
+++ b/internal/generate/clusterserviceversion/bases/definitions/zz_generated.markerhelp.go
@@ -38,6 +38,10 @@ func (Description) Help() *markers.DefinitionHelp {
 				Summary: "is the displayName of a CRD description.",
 				Details: "",
 			},
+			"Order": markers.DetailedHelp{
+				Summary: "determines which position in the list this description will take. Markers with Order omitted have the highest Order. If more than one marker has the same Order, the corresponding descriptions will be sorted alphabetically and placed above others with higher Orders.",
+				Details: "",
+			},
 		},
 	}
 }
@@ -60,6 +64,10 @@ func (Descriptor) Help() *markers.DefinitionHelp {
 			},
 			"XDescriptors": markers.DetailedHelp{
 				Summary: "is a list of UI path strings. The marker format is: \"ui:element:foo,ui:element:bar\"",
+				Details: "",
+			},
+			"Order": markers.DetailedHelp{
+				Summary: "determines which position in the list this descriptor will take. Markers with Order omitted have the highest Order. If more than one marker has the same Order, the corresponding descriptors will be sorted alphabetically and placed above others with higher Orders.",
 				Details: "",
 			},
 		},

--- a/website/content/en/docs/building-operators/golang/references/markers.md
+++ b/website/content/en/docs/building-operators/golang/references/markers.md
@@ -25,13 +25,16 @@ Possible type-level markers:
 	- Configures the kind's display name.
 - `+operator-sdk:csv:customresourcedefinitions:resources={{Kind1,v1alpha1,dns-name-1},{Kind2,v1,"dns-name-2"},...}`
 	- Configures the kind's resources.
+- `+operator-sdk:csv:customresourcedefinitions:order=1`
+	- Configures the order of this type in the list. Markers with order omitted have the highest order, i.e. are at the end of the list. If more than one marker has the same order, the corresponding descriptions will be sorted alphabetically and placed above others with higher orders. Pre-existing list elements in the CSV will be appended to the set of other elements in the order corresponding to its index.
 
 Possible field-level markers, all of which must contain the `type=[spec,status]` key-value pair:
 - `+operator-sdk:csv:customresourcedefinitions:type=[spec,status],displayName="some field display name"`
 	- Configures the field's display name.
 - `+operator-sdk:csv:customresourcedefinitions:type=[spec,status],xDescriptors={"urn:alm:descriptor:com.tectonic.ui:podCount","urn:alm:descriptor:io.kubernetes:custom"}`
 	- Configures the field's x-descriptors.
-
+- `+operator-sdk:csv:customresourcedefinitions:type=[spec,status],order=1`
+	- Configures the order of this type in the list. Markers with order omitted have the highest order, i.e. are at the end of the list. If more than one marker has the same order, the corresponding descriptions will be sorted alphabetically and placed above others with higher orders.
 
 Top-level `kind`, `name`, and `version` fields are parsed from API code.
 All `description` fields are parsed from type declaration and `struct` type field comments.


### PR DESCRIPTION
**Description of the change:** 
- internal/generate/clusterserviceversion/bases/definitions: add Order to Description and Descriptor marker types, which are considered when adding elements to .spec.customresourcedefinitions

**Motivation for the change:** This PR adds the 'order=<int>' field to the set of CSV marker definitions on both types and fields, which will order that type or field with all others of the same order in a descending manner. The order of `.spec.customresourcedefinition` elements and their descriptors matters in a CSV, as this order is pushed to consoles.

/kind feature

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
