### PR TITLE
generate: fix "invalid CSV name" bug

### DIFF
--- a/changelog/fragments/csv-base-name-bugfix.yaml
+++ b/changelog/fragments/csv-base-name-bugfix.yaml
@@ -1,0 +1,6 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      `generate kustomize manifests` will (re)generate a base `ClusterServiceVersion` manifest with a valid name.
+    kind: bugfix

--- a/internal/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/generate/bundle/cmd.go
@@ -80,11 +80,6 @@ func NewCmd() *cobra.Command {
 					return fmt.Errorf("invalid command options: %v", err)
 				}
 			}
-			if c.metadata {
-				if err := c.validateMetadata(); err != nil {
-					return fmt.Errorf("invalid command options: %v", err)
-				}
-			}
 
 			// Run command logic.
 			if c.manifests {

--- a/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
+++ b/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
@@ -178,11 +178,13 @@ func (c packagemanifestsCmd) run() error {
 	// If no CSV is passed via stdin, an on-disk base is expected at basePath.
 	if len(col.ClusterServiceVersions) == 0 {
 		basePath := filepath.Join(c.kustomizeDir, "bases", c.packageName+".clusterserviceversion.yaml")
-		base, err := bases.ClusterServiceVersion{BasePath: basePath}.GetBase()
-		if err != nil {
-			return fmt.Errorf("error reading CSV base: %v", err)
+		if genutil.IsExist(basePath) {
+			base, err := bases.ClusterServiceVersion{BasePath: basePath}.GetBase()
+			if err != nil {
+				return fmt.Errorf("error reading CSV base: %v", err)
+			}
+			col.ClusterServiceVersions = append(col.ClusterServiceVersions, *base)
 		}
-		col.ClusterServiceVersions = append(col.ClusterServiceVersions, *base)
 	}
 
 	var opts []gencsv.Option

--- a/internal/generate/clusterserviceversion/bases/metadata_test.go
+++ b/internal/generate/clusterserviceversion/bases/metadata_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Metadata", func() {
 	It("populates a CSV with existing values", func() {
 		b := ClusterServiceVersion{OperatorName: "test-operator"}
 		b.setDefaults()
-		csv := b.makeNewBase()
+		csv := b.newBase()
 
 		meta.apply(csv)
 

--- a/internal/generate/clusterserviceversion/clusterserviceversion_test.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_test.go
@@ -30,6 +30,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/yaml"
 
+	"github.com/operator-framework/operator-sdk/internal/generate/clusterserviceversion/bases"
 	"github.com/operator-framework/operator-sdk/internal/generate/collector"
 	genutil "github.com/operator-framework/operator-sdk/internal/generate/internal"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
@@ -164,7 +165,22 @@ var _ = Describe("Generating a ClusterServiceVersion", func() {
 		})
 
 		Context("to create a new ClusterServiceVersion", func() {
-			It("should return a valid object", func() {
+			It("should return a default object when no base is supplied", func() {
+				col.ClusterServiceVersions = nil
+				g = Generator{
+					OperatorName: operatorName,
+					Version:      zeroZeroOne,
+					Collector:    col,
+				}
+				csv, err := g.generate()
+				Expect(err).ToNot(HaveOccurred())
+				col.ClusterServiceVersions = []v1alpha1.ClusterServiceVersion{*(bases.New(operatorName))}
+				csvExp, err := g.generate()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(csv).To(Equal(csvExp))
+			})
+
+			It("should return a default object", func() {
 				col.ClusterServiceVersions = []v1alpha1.ClusterServiceVersion{*baseCSV}
 				g = Generator{
 					OperatorName: operatorName,
@@ -251,18 +267,6 @@ var _ = Describe("Generating a ClusterServiceVersion", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(csv).To(Equal(upgradeCSV(newCSVUIMeta, g.OperatorName, g.Version)))
 			})
-		})
-	})
-
-	Context("with incorrect configuration", func() {
-		It("should return an error when a base CSV has an invalid name", func() {
-			col.ClusterServiceVersions = []v1alpha1.ClusterServiceVersion{*baseCSV}
-			g = Generator{
-				OperatorName: operatorName,
-				Collector:    col,
-			}
-			_, err := g.generate()
-			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/internal/generate/testdata/clusterserviceversions/bases/memcached-operator.clusterserviceversion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/bases/memcached-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: memcached-operator.vX.Y.Z
+  name: memcached-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/internal/generate/testdata/clusterserviceversions/bases/with-ui-metadata.clusterserviceversion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/bases/with-ui-metadata.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-  name: memcached-operator.vX.Y.Z
+  name: memcached-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/testdata/ansible/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/ansible/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-  name: memcached-operator.vX.Y.Z
+  name: memcached-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/testdata/go/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-  name: memcached-operator.vX.Y.Z
+  name: memcached-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/testdata/helm/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/helm/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-  name: memcached-operator.vX.Y.Z
+  name: memcached-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}


### PR DESCRIPTION
**Description of the change:** 
- internal/generate/clusterserviceversion: use an empty base if no CSVs are in the collector
- internal/generate/clusterserviceversion/bases: auto-migrate base name
- docs/olm-integration: document updated behavior

**Motivation for the change:** This commit fixes a bug caused by an invalid CSV name being generated. `operator-sdk generate kustomize manifests` will auto-migrate a base CSV's name to `<package name>.v<version>` if it ends in `.vX.Y.Z`. `operator-sdk generate <bundle|packagemanifests` will always persist base CSV metadata unless `--version` or `--from-version` are set.

/kind bug

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
