### PR TITLE
Add github action to rerun tests on PRs

### DIFF
--- a/.github/workflows/rerun-tests.yml
+++ b/.github/workflows/rerun-tests.yml
@@ -1,0 +1,31 @@
+name: rerun_tests
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rerun_tests:
+    if:  ${{ contains(github.event.comment.body, '/rerun-tests') && github.event.issue.pull_request }}
+    runs-on: ubuntu-18.04
+    steps:
+      - run: |
+          PR=${{ github.event.issue.pull_request.url}}
+          PR_SHA="$(curl $PR | jq '.head.sha')"
+          
+          WORKFLOW_RUN_NUMBER="$(curl --oauth2-bearer $GITHUB_TOKEN https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/integration.yml/runs?event=pull_request | jq '.workflow_runs[] | select(.head_sha=='$PR_SHA')' | jq '.id')"
+          curl -u estroz:$ACTION_ADMIN_TOKEN -X POST https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_NUMBER/rerun
+         
+          WORKFLOW_RUN_NUMBER="$(curl --oauth2-bearer $GITHUB_TOKEN https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/test-ansible.yml/runs?event=pull_request | jq '.workflow_runs[] | select(.head_sha=='$PR_SHA')' | jq '.id')"
+          curl -u estroz:$ACTION_ADMIN_TOKEN -X POST https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_NUMBER/rerun
+          
+          WORKFLOW_RUN_NUMBER="$(curl --oauth2-bearer $GITHUB_TOKEN https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/test-go.yml/runs?event=pull_request | jq '.workflow_runs[] | select(.head_sha=='$PR_SHA')' | jq '.id')"
+          curl -u estroz:$ACTION_ADMIN_TOKEN -X POST https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_NUMBER/rerun
+        
+          WORKFLOW_RUN_NUMBER="$(curl --oauth2-bearer $GITHUB_TOKEN https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/test-helm.yml/runs?event=pull_request | jq '.workflow_runs[] | select(.head_sha=='$PR_SHA')' | jq '.id')"
+          curl -u estroz:$ACTION_ADMIN_TOKEN -X POST https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_NUMBER/rerun
+          
+          WORKFLOW_RUN_NUMBER="$(curl --oauth2-bearer $GITHUB_TOKEN https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/test-sanity.yml/runs?event=pull_request | jq '.workflow_runs[] | select(.head_sha=='$PR_SHA')' | jq '.id')"
+          curl -u estroz:$ACTION_ADMIN_TOKEN -X POST https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/$WORKFLOW_RUN_NUMBER/rerun
+        env:
+           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' 
+           ACTION_ADMIN_TOKEN: '${{ secrets.ACTION_ADMIN_TOKEN }}'


### PR DESCRIPTION
This adds a github action to rerun the tests on a PR whenever anyone adds a comment that contains the string '/rerun-tests'.

Couple of caveats:

1. This requires someone who is a repo admin's token be added to the repo with repo and workflow permissions. I used @estroz as the basis for the PR, but can change it to someone else if need be. I couldn't figure out how to do it in a person-agnostic fashion, because github doesn't let you trigger github actions from inside a github action (yet), so I had to go in manually through the github API.

2. The way Issue (which is what PRs actually are) and Workflow_Run objects are associated in the github API is kind of wonky. I have to get the list of all workflow runs and filter it based on the head SHA of the PR branch. This will break if you open multiple PRs of the same commits. The github action will still run, but the POSTS will be thrown at some incorrectly constructed URL which won't do anything. It sounds like github might add more functionality to this bit in the future though. 