### PR TITLE
e2e-intgration-tests: keep using OLM version 0.15.1

### DIFF
--- a/hack/tests/integration.sh
+++ b/hack/tests/integration.sh
@@ -24,10 +24,11 @@ load_image_if_kind "$OSDK_INTEGRATION_IMAGE"
 
 popd
 
+# todo: upgrade to use the 0.17.0 when the issue  https://github.com/operator-framework/operator-sdk/issues/4284 be solved
 # Install OLM on the cluster if not installed.
 olm_latest_exists=0
 if ! operator-sdk olm status > /dev/null 2>&1; then
-  operator-sdk olm install --version=0.17.0
+  operator-sdk olm install --version=0.15.1
   olm_latest_exists=1
 fi
 
@@ -38,7 +39,8 @@ go test -v ./test/integration
 
 header_text "Integration tests succeeded"
 
+# todo: upgrade to use the 0.17.0 when the issue  https://github.com/operator-framework/operator-sdk/issues/4284 be solved
 # Uninstall OLM if it was installed for test purposes.
 if eval "(( $olm_latest_exists ))"; then
-  operator-sdk olm uninstall --version=0.17.0
+  operator-sdk olm uninstall --version=0.15.1
 fi


### PR DESCRIPTION
Downgrade the OLM version used ONLY for the integration tests. Note that the tests were not updated to use the OLM bindata 0.16 when it was added and after the merge of https://github.com/operator-framework/operator-sdk/pull/4242, besides it pass in the tests (https://github.com/operator-framework/operator-sdk/runs/1501864624), we could identify that all follow-up prs starts to fail in the integration tests. Then, since 

- ALL tests have not really been done with the latest version ( 0.16 previously )
- On master, all other tests work with 0.17.0
    

Shows fine we just downgrade this one to unblock the CI until we are able to identify the root cause and fix it which indeed can be in the OLM side. See the:  https://github.com/operator-framework/operator-sdk/issues/4284

