### PR TITLE
fix: change step in hack/tests/integration.sh to allow it be executed  from osx

### DIFF
--- a/hack/tests/integration.sh
+++ b/hack/tests/integration.sh
@@ -5,9 +5,12 @@ set -eu
 source hack/lib/common.sh
 source hack/lib/image_lib.sh
 
-TMPDIR="$(mktemp -d -p /tmp memcached-operator-XXXX)"
+TMPDIR="$(mktemp -d)"
 trap_add 'rm -rf $TMPDIR' EXIT
 pushd "$TMPDIR"
+cd $TMPDIR
+mkdir memcached-operator-XXXX
+cd memcached-operator-XXXX
 
 header_text "Initializing test project"
 


### PR DESCRIPTION
**Description of the change:**

Replace the command `mktemp -d -p /tmp memcached-operator-XXXX)` that does not work in OSX. 

**Motivation for the change:**

Allow the tests to be executed from Linux and mac. 
