### PR TITLE
fix: (helm) - prevent a possible nil pointer in the helm uninstall

### DIFF
--- a/internal/helm/controller/reconcile.go
+++ b/internal/helm/controller/reconcile.go
@@ -119,7 +119,7 @@ func (r HelmOperatorReconciler) Reconcile(ctx context.Context, request reconcile
 			log.Info("Release not found, removing finalizer")
 		} else {
 			log.Info("Uninstalled release")
-			if log.V(0).Enabled() {
+			if log.V(0).Enabled() && uninstalledRelease != nil {
 				fmt.Println(diff.Generate(uninstalledRelease.Manifest, ""))
 			}
 			status.SetCondition(types.HelmAppCondition{

--- a/internal/helm/release/manager.go
+++ b/internal/helm/release/manager.go
@@ -370,5 +370,8 @@ func (m manager) UninstallRelease(ctx context.Context, opts ...UninstallOption) 
 		}
 	}
 	uninstallResponse, err := uninstall.Run(m.releaseName)
+	if uninstallResponse == nil {
+		return nil, err
+	}
 	return uninstallResponse.Release, err
 }


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

**Description of the change:**
It's possible to run into a nil pointer error during a helm uninstall

**Motivation for the change:**
Prevent the nil pointer error from happening.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:

- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
_its not a user-facing changes._
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
_no doc updates required._
