### PR TITLE
fix: (helm) - use atomic flag for install/upgrade instead of the workaround rollback

### DIFF
--- a/internal/helm/controller/reconcile.go
+++ b/internal/helm/controller/reconcile.go
@@ -175,7 +175,7 @@ func (r HelmOperatorReconciler) Reconcile(ctx context.Context, request reconcile
 			r.EventRecorder.Eventf(o, "Warning", "OverrideValuesInUse",
 				"Chart value %q overridden to %q by operator's watches.yaml", k, v)
 		}
-		installedRelease, err := manager.InstallRelease(ctx)
+		installedRelease, err := manager.InstallRelease(ctx, release.AtomicInstall())
 		if err != nil {
 			log.Error(err, "Release failed")
 			status.SetCondition(types.HelmAppCondition{
@@ -241,7 +241,7 @@ func (r HelmOperatorReconciler) Reconcile(ctx context.Context, request reconcile
 				"Chart value %q overridden to %q by operator's watches.yaml", k, v)
 		}
 		force := hasHelmUpgradeForceAnnotation(o)
-		previousRelease, upgradedRelease, err := manager.UpgradeRelease(ctx, release.ForceUpgrade(force))
+		previousRelease, upgradedRelease, err := manager.UpgradeRelease(ctx, release.AtomicUpgrade(), release.ForceUpgrade(force))
 		if err != nil {
 			log.Error(err, "Release failed")
 			status.SetCondition(types.HelmAppCondition{


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

**Description of the change:**
Related to https://github.com/operator-framework/operator-sdk/issues/4285

In helm operator, the install and upgrade still has workaround for dealing with failures.
There is now an `atomic` flag that can be used to replace those workaround.

**Motivation for the change:**
Use helm atomic instead of manually perform the rollback.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
not a user-facing change
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
no relevant section in doc.
