### PR TITLE
change: (helm) - if the release is not installed but status.DeployedRelease is populated, skip the rollback(uninstall) if the install errors

### DIFF
--- a/changelog/fragments/helm_operator_install_rollback_change.yaml
+++ b/changelog/fragments/helm_operator_install_rollback_change.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      For Helm-based operators, if the release is not installed but status.DeployedRelease is populated, skip the rollback(uninstall) if the install errors.
+    kind: "change"
+    breaking: false


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

**Description of the change:**
If all the Helm release records are deleted, then the Helm operator will try to install the release again. In that case, if the install errors, then don't perform the uninstall rollback because it might lead to unintended data loss.

**Motivation for the change:**
In some rare cases, the Helm operator is performing an unintended Helm uninstall which can cause data loss. This change is to ensure that the Helm uninstall doesn't happen in those cases.

Closes: https://github.com/operator-framework/operator-sdk/issues/4296

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
