### PR TITLE
OLM client: Wait till the deployment appear

### DIFF
--- a/internal/olm/client/client.go
+++ b/internal/olm/client/client.go
@@ -159,6 +159,7 @@ func getName(namespace, name string) string {
 }
 
 func (c Client) DoRolloutWait(ctx context.Context, key types.NamespacedName) error {
+	onceNotFound := sync.Once{}
 	onceReplicasUpdated := sync.Once{}
 	oncePendingTermination := sync.Once{}
 	onceNotAvailable := sync.Once{}
@@ -168,6 +169,12 @@ func (c Client) DoRolloutWait(ctx context.Context, key types.NamespacedName) err
 		deployment := appsv1.Deployment{}
 		err := c.KubeClient.Get(ctx, key, &deployment)
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				onceNotFound.Do(func() {
+					log.Printf("  Waiting for Deployment %q to appear", key)
+				})
+				return false, nil
+			}
 			return false, err
 		}
 		if deployment.Generation <= deployment.Status.ObservedGeneration {


### PR DESCRIPTION
**Description of the change:**

Sometimes OLM installation fails with the below error:
```
INFO[0028] Waiting for deployment/packageserver rollout to complete
FATA[0028] Failed to install OLM version "latest": deployment/packageserver failed to rollout: deployments.apps "packageserver" not found
```

The reason might be that the deployment object we are waiting for is not
yet registered with the API server. So, do not treat this as an error
and continue the polling.

FIXES: #4293

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->


**Motivation for the change:**
Observed OLM installation failed occasionally.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
