### PR TITLE
test/e2e-go: fix reconcile check

### DIFF
--- a/test/e2e-go/e2e_go_olm_test.go
+++ b/test/e2e-go/e2e_go_olm_test.go
@@ -30,7 +30,6 @@ var _ = Describe("Integrating Go Projects with OLM", func() {
 	// the pkg manifest after we comment cert-manager options into the kustomization file.
 	// More info: https://olm.operatorframework.io/docs/advanced-tasks/adding-admission-and-conversion-webhooks/#certificate-authority-requirements
 	BeforeEach(func() {
-		reconcileCount++
 		By("commenting cert-manager")
 		err := testutils.ReplaceInFile(
 			filepath.Join(tc.Dir, "config", "default", "kustomization.yaml"),

--- a/test/e2e-go/e2e_go_scorecard_test.go
+++ b/test/e2e-go/e2e_go_scorecard_test.go
@@ -26,7 +26,6 @@ import (
 
 var _ = Describe("Testing Go Projects with Scorecard", func() {
 	Context("with operator-sdk", func() {
-		reconcileCount++
 		const (
 			OLMBundleValidationTest   = "olm-bundle-validation"
 			OLMCRDsHaveValidationTest = "olm-crds-have-validation"

--- a/test/e2e-go/e2e_go_suite_test.go
+++ b/test/e2e-go/e2e_go_suite_test.go
@@ -35,8 +35,7 @@ func TestE2EGo(t *testing.T) {
 }
 
 var (
-	tc             testutils.TestContext
-	reconcileCount = 0
+	tc testutils.TestContext
 )
 
 // BeforeSuite run before any specs are run to perform the required actions for all e2e Go tests.


### PR DESCRIPTION
**Description of the change:** fix go-e2e test

**Motivation for the change:** reconciliation count is a flaky check, while the sample reconciler will update `status.nodes` on successful reconcile

/area testing

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
