### PR TITLE
e2e/integration: fix flaky OLM integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,6 @@ e2e_targets := test-e2e $(e2e_tests)
 
 .PHONY: test-e2e-setup
 export KIND_CLUSTER := operator-sdk-e2e
-export KUBECONFIG := $(HOME)/.kube/kind-$(KIND_CLUSTER).config
 export KUBEBUILDER_ASSETS := $(PWD)/$(TOOLS_DIR)
 test-e2e-setup: build
 	$(SCRIPTS_DIR)/fetch kind 0.9.0

--- a/internal/olm/operator/uninstall.go
+++ b/internal/olm/operator/uninstall.go
@@ -83,7 +83,6 @@ func (u *Uninstall) Run(ctx context.Context) error {
 	}
 
 	catsrc := &v1alpha1.CatalogSource{}
-	catsrc.SetGroupVersionKind(v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CatalogSourceKind))
 	if sub != nil {
 		catsrcKey := types.NamespacedName{
 			Namespace: sub.Spec.CatalogSourceNamespace,
@@ -129,6 +128,7 @@ func (u *Uninstall) Run(ctx context.Context) error {
 	// Delete the catalog source. This assumes that all underlying resources related
 	// to this catalog source have an owner reference to this catalog source so that
 	// they are automatically garbage-collected.
+	catsrc.SetGroupVersionKind(v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CatalogSourceKind))
 	if err := u.deleteObjects(ctx, true, catsrc); err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description of the change:**
- Makefile: remove atypical KUBECONFIG
- internal/olm/operator/uninstall.go: set CatalogSource GVK before deleting
- test/integration/operator_olm_test.go: ensure cleanup after each run

**Motivation for the change:** flaky test


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
