### PR TITLE
*: make go/v3 the default plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@
 # Build artifacts
 /build
 /dist
-/tools/bin
-/images/*/bin
+**/bin/
+
+# Test artifacts
+**/testbin/
 
 # CI GPG keyring
 /.ci/gpg/keyring
@@ -15,12 +17,6 @@ website/public/
 website/resources/
 website/node_modules/
 website/tech-doc-hugo
-
-# Ensure that will not commit the bin gen in the go sample
-testdata/go/v2/memcached-operator/bin/*
-testdata/go/v3/memcached-operator/bin/*
-testdata/ansible/memcached-operator/bin/*
-testdata/helm/memcached-operator/bin/*
 
 # Ignore molecule samples testdata if it be generated in the testdata/ diretory
 testdata/ansible/memcached-molecule-operator

--- a/changelog/fragments/go-v3-default.yaml
+++ b/changelog/fragments/go-v3-default.yaml
@@ -1,0 +1,28 @@
+entries:
+  - description: >
+      Go CLI plugin go/v3 is now the default.
+    kind: change
+    breaking: false
+    migration:
+      header: Upgrade your Go project from "go.kubebuilder.io/v2" to "go.kubebuilder.io/v3"
+      body: >
+        The newly released go/v3 plugin has many new features and (breaking) changes
+        incompatible with projects created by go/v2. You are not required to upgrade
+        and your go/v2 project will continue to work with new operator-sdk versions.
+        If you wish to upgrade, check out the upstream
+        [migration guide](https://master.book.kubebuilder.io/migration/plugin/plugins.html).
+
+        Additionally, if using project version "3-alpha", you must update your "plugins" config field:
+
+        Old:
+        ```yaml
+        plugins:
+          go.sdk.operatorframework.io/v2-alpha: {}
+        ```
+
+        New:
+        ```yaml
+        plugins:
+          manifests.sdk.operatorframework.io/v2: {}
+          scorecard.sdk.operatorframework.io/v2: {}
+        ```

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/controller-runtime v0.7.0
 	sigs.k8s.io/controller-tools v0.4.1
-	sigs.k8s.io/kubebuilder/v2 v2.3.2-0.20201211222127-503ba3b7e4ad
+	sigs.k8s.io/kubebuilder/v2 v2.3.2-0.20201214213149-0a807f4e9428
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1354,8 +1354,8 @@ sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPh
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
 sigs.k8s.io/controller-tools v0.4.1 h1:VkuV0MxlRPmRu5iTgBZU4UxUX2LiR99n3sdQGRxZF4w=
 sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
-sigs.k8s.io/kubebuilder/v2 v2.3.2-0.20201211222127-503ba3b7e4ad h1:QCCQLxLLZsNKgp49jG0rErcSz9oa/4J5WU7lnaEA99A=
-sigs.k8s.io/kubebuilder/v2 v2.3.2-0.20201211222127-503ba3b7e4ad/go.mod h1:J/D/179LBZhQOhRvmMRNbje/Bk+PjbN0/fzUupmO7+U=
+sigs.k8s.io/kubebuilder/v2 v2.3.2-0.20201214213149-0a807f4e9428 h1:VUvP/g8pDUdqBHgKPoSX6WA/ZH1Y1+FBOk7khgyTLJw=
+sigs.k8s.io/kubebuilder/v2 v2.3.2-0.20201214213149-0a807f4e9428/go.mod h1:J/D/179LBZhQOhRvmMRNbje/Bk+PjbN0/fzUupmO7+U=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
@@ -61,8 +61,7 @@ func (mh *MemcachedGoWithWebhooks) Run() {
 	err := mh.ctx.Init(
 		// TODO(estroz): change this to 3 when stabilized.
 		"--project-version", "3-alpha",
-		// TODO(estroz): change this to go/v3 when stabilized.
-		"--plugins", "go/v3-alpha",
+		"--plugins", "go/v3",
 		"--repo", "github.com/example/memcached-operator",
 		"--domain",
 		mh.ctx.Domain)

--- a/internal/cmd/operator-sdk/cli/cli.go
+++ b/internal/cmd/operator-sdk/cli/cli.go
@@ -66,8 +66,7 @@ func GetPluginsCLIAndRoot() (cli.CLI, *cobra.Command) {
 			&ansiblev1.Plugin{},
 		),
 		cli.WithDefaultPlugins(config.Version2, &golangv2.Plugin{}),
-		// TODO(estroz): make go/v3-alpha plugin the default once stabilized.
-		cli.WithDefaultPlugins(config.Version3Alpha, &golangv2.Plugin{}),
+		cli.WithDefaultPlugins(config.Version3Alpha, &golangv3.Plugin{}),
 		cli.WithExtraCommands(commands...),
 	)
 	if err != nil {

--- a/internal/generate/testdata/go/PROJECT
+++ b/internal/generate/testdata/go/PROJECT
@@ -1,5 +1,4 @@
 domain: example.com
-layout: go.kubebuilder.io/v2
 projectName: memcached-operator
 repo: github.com/example/memcached-operator
 resources:
@@ -7,5 +6,3 @@ resources:
   kind: Memcached
   version: v1alpha1
 version: 3-alpha
-plugins:
-  go.sdk.operatorframework.io/v2-alpha: {}

--- a/test/e2e-go/e2e_go_suite_test.go
+++ b/test/e2e-go/e2e_go_suite_test.go
@@ -55,7 +55,7 @@ var _ = BeforeSuite(func() {
 	tc.Kubectl.Namespace = fmt.Sprintf("%s-system", tc.ProjectName)
 
 	By("copying sample to a temporary e2e directory")
-	Expect(exec.Command("cp", "-r", "../../testdata/go/v2/memcached-operator", tc.Dir).Run()).To(Succeed())
+	Expect(exec.Command("cp", "-r", "../../testdata/go/v3/memcached-operator", tc.Dir).Run()).To(Succeed())
 
 	By("fetching the current-context")
 	tc.Kubectx, err = tc.Kubectl.Command("config", "current-context")
@@ -98,14 +98,14 @@ var _ = BeforeSuite(func() {
 	}
 
 	By("installing cert manager bundle")
-	Expect(tc.InstallCertManager(true)).To(Succeed())
+	Expect(tc.InstallCertManager(false)).To(Succeed())
 })
 
 // AfterSuite run after all the specs have run, regardless of whether any tests have failed to ensures that
 // all be cleaned up
 var _ = AfterSuite(func() {
 	By("uninstall cert manager bundle")
-	tc.UninstallCertManager(true)
+	tc.UninstallCertManager(false)
 
 	By("uninstalling prerequisites")
 	tc.UninstallPrerequisites()

--- a/testdata/go/v3/memcached-operator/PROJECT
+++ b/testdata/go/v3/memcached-operator/PROJECT
@@ -1,5 +1,5 @@
 domain: example.com
-layout: go.kubebuilder.io/v3-alpha
+layout: go.kubebuilder.io/v3
 projectName: memcached-operator
 repo: github.com/example/memcached-operator
 resources:

--- a/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -128,7 +128,7 @@ spec:
                 image: quay.io/example/memcached-operator:v0.0.1
                 livenessProbe:
                   httpGet:
-                    path: /readyz
+                    path: /healthz
                     port: 8081
                   initialDelaySeconds: 15
                   periodSeconds: 20
@@ -139,7 +139,7 @@ spec:
                   protocol: TCP
                 readinessProbe:
                   httpGet:
-                    path: /healthz
+                    path: /readyz
                     port: 8081
                   initialDelaySeconds: 5
                   periodSeconds: 10

--- a/testdata/go/v3/memcached-operator/config/manager/manager.yaml
+++ b/testdata/go/v3/memcached-operator/config/manager/manager.yaml
@@ -35,13 +35,13 @@ spec:
           allowPrivilegeEscalation: false
         livenessProbe:
           httpGet:
-            path: /readyz
+            path: /healthz
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -65,7 +65,7 @@ Before creating an API and controller, consider if your operator requires multip
 
 ```YAML
 domain: example.com
-layout: go.kubebuilder.io/v2
+layout: go.kubebuilder.io/v3
 multigroup: true
 ...
 ```

--- a/website/content/en/docs/cli/operator-sdk_init.md
+++ b/website/content/en/docs/cli/operator-sdk_init.md
@@ -37,12 +37,13 @@ operator-sdk init [flags]
 ### Options
 
 ```
+      --component-config         create a versioned ComponentConfig file, may be 'true' or 'false'
       --domain string            domain for groups (default "my.domain")
       --fetch-deps               ensure dependencies are downloaded (default true)
   -h, --help                     help for init
       --license string           license to use to boilerplate, may be one of 'apache2', 'none' (default "apache2")
       --owner string             owner to add to the copyright
-      --plugins strings          Name and optionally version of the plugin to initialize the project with. Available plugins: ("ansible.sdk.operatorframework.io/v1", "go.kubebuilder.io/v2", "go.kubebuilder.io/v3-alpha", "helm.sdk.operatorframework.io/v1")
+      --plugins strings          Name and optionally version of the plugin to initialize the project with. Available plugins: ("ansible.sdk.operatorframework.io/v1", "go.kubebuilder.io/v2", "go.kubebuilder.io/v3", "helm.sdk.operatorframework.io/v1")
       --project-name string      name of this project
       --project-version string   project version, possible values: ("2", "3-alpha") (default "3-alpha")
       --repo string              name to use for go module (e.g., github.com/user/repo), defaults to the go package of the current working directory.


### PR DESCRIPTION
**Description of the change:**
- hack/generate/samples: update webhook marker and a few other nits
- internal/cmd/operator-sdk/cli: make go/v3 the default

**Motivation for the change:** now that go/v3 is stable, it can be the default plugin. This is not a breaking change because go/v2 is still supported.


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
