### PR TITLE
olm/operator: fix issue in wrapping error

### DIFF
--- a/internal/olm/operator/registry/operator_installer.go
+++ b/internal/olm/operator/registry/operator_installer.go
@@ -335,7 +335,7 @@ func (o OperatorInstaller) approveInstallPlan(ctx context.Context, sub *v1alpha1
 		// approve the install plan by setting Approved to true
 		ip.Spec.Approved = true
 		if err := o.cfg.Client.Update(ctx, &ip); err != nil {
-			return fmt.Errorf("error approving install plan: %v", err)
+			return fmt.Errorf("error approving install plan: %w", err)
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Randomly `run packagemanifests` fails with the below error:
```
Failed to run packagemanifests: error approving install plan: Operation cannot be fulfilled on installplans.operators.coreos.com \"install-jp28s\": the object has been modified; please apply your changes to the latest version and try again
```

The reason is the way error wrapping while calling the
`retry.RetryOnConflict()`. Using '%w' for formatting the error keeps the
original error type unlike '%v'.


**Motivation for the change:**

FIXES #4308

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
