### PR TITLE
test/: clean up some e2e setup code

### DIFF
--- a/internal/testutils/utils.go
+++ b/internal/testutils/utils.go
@@ -278,3 +278,15 @@ func (tc TestContext) AllowProjectBeMultiGroup() error {
 	}
 	return nil
 }
+
+// WrapWarnOutput is a one-liner to wrap an error from a command that returns (string, error) in a warning.
+func WrapWarnOutput(_ string, err error) {
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "warning: %s", err)
+	}
+}
+
+// WrapWarn is a one-liner to wrap an error from a command that returns (error) in a warning.
+func WrapWarn(err error) {
+	WrapWarnOutput("", err)
+}


### PR DESCRIPTION
**Description of the change:** clean up some e2e setup code

**Motivation for the change:** fix some potential panics and warn on error instead of not checking error at all


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
