### PR TITLE
ansible/v1: add new marker to add the name of the molecule task

### DIFF
--- a/changelog/fragments/new-marker-ansible
+++ b/changelog/fragments/new-marker-ansible
@@ -1,0 +1,43 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For Ansible-based operators, add new marker to add the name of the molecule task in failure cases.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: (Optional) For Ansible-based operators, raise the name of the molecule task in failure cases.
+      body: >
+        Add the variable `name: '{{ ansible_failed_task.name }}'` to the `Re-emit failure` in the `molecule/default/verify.yml` file which would like:
+
+        ```yml
+        - name: Re-emit failure
+          vars:
+            failed_task:
+              name: '{{ ansible_failed_task.name }}'
+              result: '{{ "{{ ansible_failed_result }}" }}'
+            fail:
+              msg: '{{ "{{ failed_task }}" }}'
+        ```

--- a/internal/plugins/ansible/v1/scaffolds/api.go
+++ b/internal/plugins/ansible/v1/scaffolds/api.go
@@ -104,6 +104,7 @@ func (s *apiScaffolder) scaffold() error {
 		&samples.CR{},
 		&templates.WatchesUpdater{GeneratePlaybook: s.opts.GeneratePlaybook, GenerateRole: s.opts.GenerateRole, PlaybooksDir: constants.PlaybooksDir},
 		&mdefault.ResourceTest{},
+		&mdefault.VerifyUpdater{WireResource: true},
 	)
 	if s.opts.GenerateRole {
 		createAPITemplates = append(createAPITemplates,


### PR DESCRIPTION
**Description of the change:**
For Ansible-based operators, add a new marker to add the name of the molecule task in failure cases.

**Motivation for the change:**
https://github.com/operator-framework/operator-sdk/issues/4311

**Blocked by**
- Upstream PR get merged: https://github.com/kubernetes-sigs/kubebuilder/pull/1907
- SDK repo be updated with the new commit and these change
