### PR TITLE
Pin top level Python dependencies

### DIFF
--- a/changelog/fragments/pin-ansible-2.9.yaml
+++ b/changelog/fragments/pin-ansible-2.9.yaml
@@ -1,0 +1,9 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      (ansible/v1) Pin all top level Python requirements. This fixes a bug that
+      erroneously installed Ansible 2.10.z instead of Ansible 2.9.z.
+
+    kind: "bugfix"
+    breaking: false

--- a/images/ansible-operator/Dockerfile
+++ b/images/ansible-operator/Dockerfile
@@ -17,12 +17,13 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
   && yum -y update \
   && yum install -y libffi-devel openssl-devel python36-devel gcc python3-pip python3-setuptools \
   && pip3 install --no-cache-dir \
-    ipaddress \
     ansible-runner==1.3.4 \
     ansible-runner-http==1.0.0 \
-    openshift~=0.10.0 \
-    ansible~=2.9 \
-    jmespath \
+    ipaddress==1.0.23 \
+    kubernetes==10.1.0 \
+    openshift==0.10.3 \
+    ansible==2.9.15 \
+    jmespath==0.10.0 \
   && yum remove -y gcc libffi-devel openssl-devel python36-devel \
   && yum clean all \
   && rm -rf /var/cache/yum


### PR DESCRIPTION
This rolls back the version of Ansible installed in the Ansible base
image, fixing a syntax error in the Dockerfile. ansible~=2.9 resolves to
Ansible 2.10, but should have been < 2.10.

This does not solve the related concern of helping users set up a local environment, which will be addressed in a followup PR.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [X] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
