### PR TITLE
docs/building-operators: clean up and align quickstarts

### DIFF
--- a/website/content/en/docs/building-operators/ansible/_index.md
+++ b/website/content/en/docs/building-operators/ansible/_index.md
@@ -3,5 +3,3 @@ title: Ansible
 weight: 1
 description: Guide to building a Ansible Based Operator using Operator SDK
 ---
-
-Ansible based operators run playbooks and roles to react to changes in tracked Kubernetes resources (usually CRs).

--- a/website/content/en/docs/building-operators/ansible/installation.md
+++ b/website/content/en/docs/building-operators/ansible/installation.md
@@ -1,26 +1,23 @@
 ---
-title: Ansible Operator SDK Installation
+title: Installation Guide
 linkTitle: Installation
 weight: 1
 ---
 
-Follow the steps in the [installation guide][install-guide] to learn how to install the Operator SDK CLI tool.
+## Install `operator-sdk`
+
+Follow the steps in the [installation guide][install-guide] to learn how to install the `operator-sdk` CLI tool.
 
 ## Additional Prerequisites
 
-- [ansible][ansible-tool] version v2.9.0+
-- [ansible-runner][ansible-runner-tool] version v1.1.0+
+- [ansible][ansible] version v2.9.0+
+- [ansible-runner][ansible-runner] version v1.1.0+
 - [ansible-runner-http][ansible-runner-http-plugin] version v1.0.0+
 - [openshift][openshift-module] version v0.11.2+
 
-**Note**: This guide uses [minikube][minikube-tool] version v0.25.0+ as the
-local Kubernetes cluster and [quay.io][quay-link] for the public registry.
 
-
-[ansible-tool]:https://docs.ansible.com/ansible/latest/index.html
-[ansible-runner-tool]:https://ansible-runner.readthedocs.io/en/latest/install.html
+[install-guide]:/docs/installation/
+[ansible]:https://docs.ansible.com/ansible/latest/index.html
+[ansible-runner]:https://ansible-runner.readthedocs.io/en/latest/install.html
 [ansible-runner-http-plugin]:https://github.com/ansible/ansible-runner-http
-[install-guide]: /docs/installation/
-[minikube-tool]:https://github.com/kubernetes/minikube#installation
-[quay-link]:https://quay.io
 [openshift-module]:https://pypi.org/project/openshift/

--- a/website/content/en/docs/building-operators/ansible/migration.md
+++ b/website/content/en/docs/building-operators/ansible/migration.md
@@ -1,23 +1,23 @@
 ---
-title: Migrating Legacy Projects
-linkTitle: Migrating Projects to 1.0.0+
+link: Migrating pre-v1.0.0 Projects
+linkTitle: Migrating pre-v1.0.0 Projects
 weight: 6
-description: Instructions for migrating a Ansible-based project built prior to 1.0.0 to use the new Kubebuilder-style layout.
+description: Instructions for migrating a Ansible-based project built prior to v1.0.0 to use the new Kubebuilder-style layout.
 ---
 
 ## Overview
 
-The motivations for the new layout are related to bringing more flexibility to users and 
+The motivations for the new layout are related to bringing more flexibility to users and
 part of the process to [Integrating Kubebuilder and Operator SDK][integration-doc].
 
 ### What was changed
- 
+
 - The `deploy` directory was replaced with the `config` directory including a new layout of Kubernetes manifests files:
     * CRD manifests in `deploy/crds/` are now in `config/crd/bases`
     * CR manifests in `deploy/crds/` are now in `config/samples`
-    * Controller manifest `deploy/operator.yaml` is now in `config/manager/manager.yaml` 
+    * Controller manifest `deploy/operator.yaml` is now in `config/manager/manager.yaml`
     * RBAC manifests in `deploy` are now in `config/rbac/`
-    
+
 - `build/Dockerfile` is moved to `Dockerfile` in the project root directory
 - The `molecule/` directory is now more aligned to Ansible and the new Layout
 
@@ -32,7 +32,7 @@ Scaffolded projects now use:
 ## How to migrate
 
 The easy migration path is to a project from the scratch and let the tool scaffold the new layout. Then, add your customizations and implementations. See below for an example.
- 
+
 ### Creating a new project
 
 In Kubebuilder-style projects, CRD groups are defined using two different flags
@@ -56,7 +56,7 @@ cd memcached-operator
 operator-sdk init --plugins=ansible --domain=example.com
 ```
 
-Now that we have our new project initialized, we need to recreate each of our APIs. 
+Now that we have our new project initialized, we need to recreate each of our APIs.
 Using our API example from earlier (`cache.example.com`), we'll use `cache` for the
 `--group` flag.
 
@@ -68,14 +68,14 @@ For each API in the existing project, run:
 operator-sdk create api \
     --group=cache \
     --version=v1 \
-    --kind=Memcached 
+    --kind=Memcached
 ```
 
 Running the above command creates an empty `roles/<kind>`. We can copy over the content of our old `roles/<kind>` to the new one.   
- 
+
 ### Migrating your Custom Resource samples
 
-Update the CR manifests in `config/samples` with the values of the CRs in your existing project which are in `deploy/crds/<group>_<version>_<kind>_cr.yaml` In our example 
+Update the CR manifests in `config/samples` with the values of the CRs in your existing project which are in `deploy/crds/<group>_<version>_<kind>_cr.yaml` In our example
 the `config/samples/cache_v1alpha1_memcached.yaml` will look like:
 
 ```yaml
@@ -100,11 +100,11 @@ In our example, we will replace `# FIXME: Specify the role or playbook for this 
 - version: v1alpha1
   group: cache.example.com
   kind: Memcached
-  role: memcached 
+  role: memcached
 # +kubebuilder:scaffold:watch
 ```
 
-**NOTE**: Do not remove the `+kubebuilder:scaffold:watch` [marker][marker]. It allows the tool to update the watches file when new APIs are created. 
+**NOTE**: Do not remove the `+kubebuilder:scaffold:watch` [marker][marker]. It allows the tool to update the watches file when new APIs are created.
 
 ### Migrating your Molecule tests
 
@@ -135,7 +135,7 @@ See that default structure changed from:
 
 ```
 
-To: 
+To:
 
 ```
 ├── default
@@ -155,7 +155,7 @@ To:
     └── molecule.yml
 ```
 
-Ensure that the `provisioner.host_vars.localhost` has the following `host_vars`: 
+Ensure that the `provisioner.host_vars.localhost` has the following `host_vars`:
 
 ```
 ....
@@ -202,36 +202,36 @@ The following rules were used in earlier versions of anisible-operator to automa
 
 ### Configuring your Operator
 
-If your existing project has customizations in `deploy/operator.yaml`, they need to be ported to 
+If your existing project has customizations in `deploy/operator.yaml`, they need to be ported to
 `config/manager/manager.yaml`. If you are passing custom arguments in your deployment, make sure to also update `config/default/auth_proxy_patch.yaml`.
 
-Note that the following environment variables are no longer used. 
+Note that the following environment variables are no longer used.
 
 - `OPERATOR_NAME` is deprecated. It is used to define the name for a leader election config map. Operator authors should begin using `--leader-election-id` instead.
 - `POD_NAME` has been removed. It was used to enable a particular pod to hold the leader election lock when the Ansible operator used the leader for life mechanism. Ansible operator now uses controller-runtime's leader with lease mechanism.
 
-## Exporting metrics 
+## Exporting metrics
 
-If you are using metrics and would like to keep them exported you will need to configure 
-it in the `config/default/kustomization.yaml`. Please see the [metrics][metrics] doc to know how you can perform this setup. 
+If you are using metrics and would like to keep them exported you will need to configure
+it in the `config/default/kustomization.yaml`. Please see the [metrics][metrics] doc to know how you can perform this setup.
 
-The default port used by the metric endpoint binds to was changed from `:8383` to `:8080`. To continue using port `8383`, specify `--metrics-addr=:8383` when you start the operator. 
+The default port used by the metric endpoint binds to was changed from `:8383` to `:8080`. To continue using port `8383`, specify `--metrics-addr=:8383` when you start the operator.
 
 ## Checking the changes
 
-Finally, follow the steps in the section [Build and run the Operator][build-and-run-the-operator] to verify your project is running. 
+Finally, follow the steps in the section [Build and run the Operator][build-and-run-the-operator] to verify your project is running.
 
-Note that, you also can troubleshooting by checking the container logs. 
+Note that, you also can troubleshooting by checking the container logs.
 E.g `$ kubectl logs deployment.apps/memcached-operator-controller-manager -n memcached-operator-system -c manager`  
 
 [quickstart-legacy]: https://v0-19-x.sdk.operatorframework.io/docs/ansible/quickstart/
 [quickstart]: /docs/building-operators/ansible/quickstart
 [integration-doc]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/integrating-kubebuilder-and-osdk.md
 [build-and-run-the-operator]: /docs/building-operators/ansible/tutorial/#deploy-the-operator
-[kustomize]: https://github.com/kubernetes-sigs/kustomize 
-[kube-auth-proxy]: https://github.com/brancz/kube-rbac-proxy 
+[kustomize]: https://github.com/kubernetes-sigs/kustomize
+[kube-auth-proxy]: https://github.com/brancz/kube-rbac-proxy
 [metrics]: https://book.kubebuilder.io/reference/metrics.html?highlight=metr#metrics
 [marker]: https://book.kubebuilder.io/reference/markers.html?highlight=markers#marker-syntax
 [operator-scope]: /docs/building-operators/golang/operator-scope
-[molecule]: https://molecule.readthedocs.io/en/latest/# 
+[molecule]: https://molecule.readthedocs.io/en/latest/#
 [testing-guide]: /docs/building-operators/ansible/testing-guide

--- a/website/content/en/docs/building-operators/ansible/quickstart.md
+++ b/website/content/en/docs/building-operators/ansible/quickstart.md
@@ -2,91 +2,107 @@
 title: Quickstart for Ansible-based Operators
 linkTitle: Quickstart
 weight: 2
-description: A simple set of instructions that demonstrates the basics of setting up and running a Ansible-based operator.
+description: A simple set of instructions to set up and run an Ansible-based operator.
 ---
 
 This guide walks through an example of building a simple memcached-operator powered by [Ansible][ansible-link] using tools and libraries provided by the Operator SDK.
 
 ## Prerequisites
 
-- [Install `operator-sdk`][operator_install] and the [Ansible prequisites][ansible-operator-install] 
-- Access to a Kubernetes v1.16.0+ cluster.
+- Go through the [installation guide][install-guide].
 - User authorized with `cluster-admin` permissions.
 
-## Quickstart Steps
+## Steps
 
-### Create a project
+1. Create a project directory for your project and initialize the project:
 
-Create and change into a directory for your project. Then call `operator-sdk init`
-with the Ansible plugin to initialize the [base project layout][layout-doc]:
+  ```sh
+  mkdir memcached-operator
+  cd memcached-operator
+  operator-sdk init --domain example.com --plugins ansible
+  ```
 
-```sh
-mkdir memcached-operator
-cd memcached-operator
-operator-sdk init --plugins=ansible --domain=example.com
-```
+1. Create a simple Memcached API:
 
-### Create an API
+  ```sh
+  operator-sdk create api --group cache --version v1alpha1 --kind Memcached --generate-role
+  ```
 
-Let's create a new API with a role for it:
+1. Use the built-in Makefile targets to build and push your operator.
+Make sure to define `IMG` when you call `make`:
 
-```sh
-operator-sdk create api --group cache --version v1 --kind Memcached --generate-role 
-```
-
-### Build and push the operator image
-
-Use the built-in Makefile targets to build and push your operator. Make
-sure to define `IMG` when you call `make`:
-
-```sh
-make docker-build docker-push IMG=<some-registry>/<project-name>:<tag>
-```
-
-**NOTE**: To allow the cluster pull the image the repository needs to be
-          set as public or you must configure an image pull secret.
+  ```sh
+  export OPERATOR_IMG="quay.io/example-inc/memcached-operator:v0.0.1"
+  make docker-build docker-push IMG=$OPERATOR_IMG
+  ```
 
 
-### Run the operator
+### OLM deployment
 
-Install the CRD and deploy the project to the cluster. Set `IMG` with
-`make deploy` to use the image you just pushed:
+1. Install [OLM][doc-olm]:
 
-```sh
-make install
-make deploy IMG=<some-registry>/<project-name>:<tag>
-```
+  ```sh
+  operator-sdk olm install
+  ```
 
-### Create a sample custom resource
+1. Bundle your operator and push the bundle image:
 
-Create a sample CR:
-```sh
-kubectl apply -f config/samples/cache_v1_memcached.yaml
-```
+  ```sh
+  make bundle IMG=$OPERATOR_IMG
+  # Note the "-bundle" component in the image name below.
+  export BUNDLE_IMG="quay.io/example-inc/memcached-operator-bundle:v0.0.1"
+  make bundle-build BUNDLE_IMG=$BUNDLE_IMG
+  make docker-push IMG=$BUNDLE_IMG
+  ```
 
-Watch for the CR be reconciled by the operator:
-```sh
-kubectl logs deployment.apps/memcached-operator-controller-manager -n memcached-operator-system -c manager
-```
+1. Run your bundle:
 
-### Clean up
+  ```sh
+  operator-sdk run bundle $BUNDLE_IMG
+  ```
 
-Delete the CR to uninstall memcached:
-```sh
-kubectl delete -f config/samples/cache_v1_memcached.yaml 
-```
+1. Create a sample Memcached custom resource:
 
-Use `make undeploy` to uninstall the operator and its CRDs:
-```sh
-make undeploy
-```
+  ```console
+  $ kubectl apply -f config/samples/cache_v1alpha1_memcached.yaml
+  memcached.cache.example.com/memcached-sample created
+  ```
+
+1. Uninstall the operator:
+
+  ```sh
+  operator-sdk cleanup memcached-operator
+  ```
+
+
+### Direct deployment
+
+1. Deploy your operator:
+
+  ```sh
+  make deploy IMG=$OPERATOR_IMG
+  ```
+
+1. Create a sample Memcached custom resource:
+
+  ```console
+  $ kubectl apply -f config/samples/cache_v1alpha1_memcached.yaml
+  memcached.cache.example.com/memcached-sample created
+  ```
+
+1. Uninstall the operator:
+
+  ```sh
+  make undeploy
+  ```
+
 
 ## Next Steps
 
-Read the [tutorial][tutorial] for an in-depth walkthough of building a Ansible operator.
+Read the [full tutorial][tutorial] for an in-depth walkthough of building a Ansible operator.
 
-[operator_install]: /docs/installation/
-[ansible-operator-install]: /docs/building-operators/ansible/installation
-[layout-doc]:../reference/scaffolding
-[tutorial]: /docs/building-operators/ansible/tutorial/
-[ansible-link]: https://www.ansible.com/ 
+
+[ansible-link]:https://www.ansible.com/
+[install-guide]:/docs/building-operators/ansible/installation
+[doc-olm]:/docs/olm-integration/quickstart-bundle/#enabling-olm
+[tutorial]:/docs/building-operators/ansible/tutorial/

--- a/website/content/en/docs/building-operators/ansible/tutorial.md
+++ b/website/content/en/docs/building-operators/ansible/tutorial.md
@@ -9,8 +9,7 @@ This guide walks through an example of building a simple memcached-operator powe
 
 ## Prerequisites
 
-- [Install `operator-sdk`][operator_install] and the [Ansible prequisites][ansible-operator-install] 
-- Access to a Kubernetes v1.16.0+ cluster.
+- Go through the [installation guide][install-guide].
 - User authorized with `cluster-admin` permissions.
 
 ## Creating an Operator
@@ -24,7 +23,7 @@ In this section we will:
 Begin by generating a new project from a new directory.
 
 ```sh
-$ mkdir memcached-operator 
+$ mkdir memcached-operator
 $ cd memcached-operator
 $ operator-sdk init --plugins=ansible --domain example.com
 ```
@@ -163,7 +162,7 @@ $ make deploy
 ```
 
 We are using the `memcached-operator-system` Namespace, so let's set
-that context. 
+that context.
 
 ```sh
 $ kubectl config set-context --current --namespace=memcached-operator-system
@@ -172,7 +171,7 @@ $ kubectl config set-context --current --namespace=memcached-operator-system
 Verify that the memcached-operator is up and running:
 
 ```sh
-$ kubectl get deployment 
+$ kubectl get deployment
 
 NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 memcached-operator       1         1         1            1           1m
@@ -223,13 +222,10 @@ can also be used with cluster-wide scope. See the [operator scope][operator-scop
 
 OLM will manage creation of most if not all resources required to run your operator, using a bit of setup from other operator-sdk commands. Check out the [OLM integration guide][quickstart-bundle].
 
-[ansible-operator-install]: /docs/building-operators/ansible/installation
-[ansible-developer-tips]: /docs/building-operators/ansible/development-tips/
-[ansible-watches]: /docs/building-operators/ansible/reference/watches
-[custom-resources]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
+[install-guide]:/docs/building-operators/ansible/installation
+[ansible-developer-tips]:/docs/building-operators/ansible/development-tips/
+[ansible-watches]:/docs/building-operators/ansible/reference/watches
+[custom-resources]:https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
 [operator-scope]:https://v0-19-x.sdk.operatorframework.io/docs/legacy-common/operator-scope/
-[layout-doc]:../reference/scaffolding
-[docker-tool]:https://docs.docker.com/install/
-[kubectl-tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
-[quickstart-bundle]: /docs/olm-integration/quickstart-bundle/
-[operator_install]: /docs/installation/
+[layout-doc]:/docs/building-operators/ansible/reference/scaffolding
+[quickstart-bundle]:/docs/olm-integration/quickstart-bundle/

--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -1,8 +1,8 @@
 ---
-title: Migrating Legacy Projects
-linkTitle: Migrating Projects to 1.0.0+
+link: Migrating pre-v1.0.0 Projects
+linkTitle: Migrating pre-v1.0.0 Projects
 weight: 200
-description: Instructions for migrating a legacy Go-based project to use the new Kubebuilder-style layout.
+description: Instructions for migrating a Go-based project built prior to v1.0.0 to use the new Kubebuilder-style layout.
 ---
 
 ## Overview

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -461,12 +461,7 @@ The following guides build off the operator created in this example, adding adva
 
 Also see the [advanced topics][advanced_topics] doc for more use cases and under the hood details.
 
-[operator_install]: https://sdk.operatorframework.io/docs/installation/install-operator-sdk/
-[go_tool]:https://golang.org/dl/
-[docker_tool]:https://docs.docker.com/install/
-[kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
-[kustomize_tool]: https://sigs.k8s.io/kustomize/docs/INSTALL.md
-
+[install-guide]:/docs/building-operators/golang/installation
 [enqueue_requests_from_map_func]: https://godoc.org/sigs.k8s.io/controller-runtime/pkg/handler#EnqueueRequestsFromMapFunc
 [event_handler_godocs]: https://godoc.org/sigs.k8s.io/controller-runtime/pkg/handler#hdr-EventHandlers
 [event_filtering]:/docs/building-operators/golang/references/event-filtering/
@@ -474,18 +469,14 @@ Also see the [advanced topics][advanced_topics] doc for more use cases and under
 [controller_godocs]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/controller
 [operator_scope]:/docs/building-operators/golang/operator-scope/
 [kubebuilder_layout_doc]:https://book.kubebuilder.io/cronjob-tutorial/basic-project.html
-[homebrew_tool]:https://brew.sh/
 [go_mod_wiki]: https://github.com/golang/go/wiki/Modules
-[go_vendoring]: https://blog.gopheracademy.com/advent-2015/vendor-folder/
 [doc_client_api]:/docs/building-operators/golang/references/client/
 [manager_go_doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/manager#Manager
-[controller-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg#hdr-Controller
 [request-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Request
 [result_go_doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Result
 [multi-namespaced-cache-builder]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder
 [cli-run-olm]: /docs/olm-integration/cli-overview
 [kubebuilder_entrypoint_doc]: https://book.kubebuilder.io/cronjob-tutorial/empty-main.html
-
 [api_terms_doc]: https://book.kubebuilder.io/cronjob-tutorial/gvks.html
 [kb_controller_doc]: https://book.kubebuilder.io/cronjob-tutorial/controller-overview.html
 [kb_api_doc]: https://book.kubebuilder.io/cronjob-tutorial/new-api.html
@@ -494,7 +485,6 @@ Also see the [advanced topics][advanced_topics] doc for more use cases and under
 [generating-crd]: https://book.kubebuilder.io/reference/generating-crd.html
 [markers]: https://book.kubebuilder.io/reference/markers.html
 [crd-markers]: https://book.kubebuilder.io/reference/markers/crd-validation.html
-[rbac-markers]: https://book.kubebuilder.io/reference/markers/rbac.html
 [memcached_controller]: https://github.com/operator-framework/operator-sdk/blob/v1.2.0/testdata/go/memcached-operator/controllers/memcached_controller.go
 [builder_godocs]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/builder#example-Builder
 [legacy_quickstart_doc]:https://v0-19-x.sdk.operatorframework.io/docs/golang/legacy/quickstart/
@@ -503,7 +493,6 @@ Also see the [advanced topics][advanced_topics] doc for more use cases and under
 [create_a_webhook]: https://book.kubebuilder.io/cronjob-tutorial/webhook-implementation.html
 [status_marker]: https://book.kubebuilder.io/reference/generating-crd.html#status
 [status_subresource]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource
-[API-groups]:https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups
 [legacy_CLI]:https://v0-19-x.sdk.operatorframework.io/docs/cli/
 [env-test-setup]: /docs/building-operators/golang/references/envtest-setup
 [role-based-access-control]: https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#iam-rolebinding-bootstrap

--- a/website/content/en/docs/building-operators/helm/installation.md
+++ b/website/content/en/docs/building-operators/helm/installation.md
@@ -8,19 +8,13 @@ weight: 1
 
 Follow the steps in the [installation guide][install-guide] to learn how to install the `operator-sdk` CLI tool.
 
-## Additional Prerequisites
+### Additional Prerequisites
 
-- [git][git_tool]
-- [go][go_tool] version v1.13+.
-- [mercurial][mercurial_tool] version 3.9+
 - [docker][docker_tool] version 17.03+.
 - [kubectl][kubectl_tool] version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster (v1.16.0+ if using `apiextensions.k8s.io/v1` CRDs).
 
 
 [install-guide]:/docs/installation/
-[git_tool]:https://git-scm.com/downloads
-[go_tool]:https://golang.org/dl/
 [docker_tool]:https://docs.docker.com/install/
-[mercurial_tool]:https://www.mercurial-scm.org/downloads
 [kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/

--- a/website/content/en/docs/building-operators/helm/migration.md
+++ b/website/content/en/docs/building-operators/helm/migration.md
@@ -1,23 +1,23 @@
 ---
-title: Migrating Helm-based Legacy Projects
-linkTitle: Migrating Legacy Projects
+link: Migrating pre-v1.0.0 Projects
+linkTitle: Migrating pre-v1.0.0 Projects
 weight: 300
-description: Instructions for migrating a legacy Helm-based project to use the new Kubebuilder-style layout.
+description: Instructions for migrating a Helm-based project built prior to v1.0.0 to use the new Kubebuilder-style layout.
 ---
 
 ## Overview
 
-The motivations for the new layout are related to bringing more flexibility to users and 
+The motivations for the new layout are related to bringing more flexibility to users and
 part of the process to [Integrating Kubebuilder and Operator SDK][integration-doc].
 
 ### What was changed
- 
+
 - The `deploy` directory was replaced with the `config` directory including a new layout of Kubernetes manifests files:
     * CRD manifests in `deploy/crds/` are now in `config/crd/bases`
     * CR manifests in `deploy/crds/` are now in `config/samples`
-    * Controller manifest `deploy/operator.yaml` is now in `config/manager/manager.yaml` 
+    * Controller manifest `deploy/operator.yaml` is now in `config/manager/manager.yaml`
     * RBAC manifests in `deploy` are now in `config/rbac/`
-    
+
 - `build/Dockerfile` is moved to `Dockerfile` in the project root directory
 
 ### What is new
@@ -30,9 +30,9 @@ Projects are now scaffold using:
 
 ## How to migrate
 
-The easy migration path is to create a new project from the scratch and let the tool scaffold the files properly and then, 
-just replace with your customizations and implementations. Following an example. 
- 
+The easy migration path is to create a new project from the scratch and let the tool scaffold the files properly and then,
+just replace with your customizations and implementations. Following an example.
+
 ### Creating a new project
 
 In Kubebuilder-style projects, CRD groups are defined using two different flags
@@ -88,7 +88,7 @@ Check if you have custom options in the `watches.yaml` file of your existing pro
 # +kubebuilder:scaffold:watch
 ```
 
-**NOTE**: Do not remove the `+kubebuilder:scaffold:watch` [marker][marker]. It allows the tool to update the watches file when new APIs are created. 
+**NOTE**: Do not remove the `+kubebuilder:scaffold:watch` [marker][marker]. It allows the tool to update the watches file when new APIs are created.
 
 ### Checking the Permissions (RBAC)
 
@@ -120,29 +120,29 @@ The following rules were used in earlier versions of helm-operator to automatica
 
 ### Configuring your Operator
 
-If your existing project has customizations in `deploy/operator.yaml`, they need to be ported to 
+If your existing project has customizations in `deploy/operator.yaml`, they need to be ported to
 `config/manager/manager.yaml`. If you are passing custom arguments in your deployment, make sure to also update `config/default/auth_proxy_patch.yaml`.
 
-Note that the following environment variables are no longer used. 
+Note that the following environment variables are no longer used.
 
 - `OPERATOR_NAME` is deprecated. It is used to define the name for a leader election config map. Operator authors should begin using `--leader-election-id` instead.
 - `POD_NAME` was used to enable a particular pod to hold the leader election lock when the Helm operator used the leader for life mechanism. Helm operator now uses controller-runtime's leader with lease mechanism, and `POD_NAME` is no longer necessary.
 
-## Exporting metrics 
+## Exporting metrics
 
-If you are using metrics and would like to keep them exported you will need to configure 
-it in the `config/default/kustomization.yaml`. Please see the [metrics][metrics] doc to know how you can perform this setup. 
+If you are using metrics and would like to keep them exported you will need to configure
+it in the `config/default/kustomization.yaml`. Please see the [metrics][metrics] doc to know how you can perform this setup.
 
-The default port used by the metric endpoint binds to was changed from `:8383` to `:8080`. To continue using port `8383`, specify `--metrics-addr=:8383` when you start the operator. 
+The default port used by the metric endpoint binds to was changed from `:8383` to `:8080`. To continue using port `8383`, specify `--metrics-addr=:8383` when you start the operator.
 
 ## Checking the changes
 
-Finally, follow the steps in the section [Build and run the operator][build-and-run-the-operator] to verify your project is running. 
+Finally, follow the steps in the section [Build and run the operator][build-and-run-the-operator] to verify your project is running.
 
 [quickstart]: /docs/building-operators/helm/quickstart
 [integration-doc]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/integrating-kubebuilder-and-osdk.md
 [build-and-run-the-operator]: /docs/building-operators/helm/tutorial#build-and-run-the-operator
-[kustomize]: https://github.com/kubernetes-sigs/kustomize 
-[kube-auth-proxy]: https://github.com/brancz/kube-rbac-proxy 
+[kustomize]: https://github.com/kubernetes-sigs/kustomize
+[kube-auth-proxy]: https://github.com/brancz/kube-rbac-proxy
 [metrics]: https://book.kubebuilder.io/reference/metrics.html?highlight=metr#metrics
 [marker]: https://book.kubebuilder.io/reference/markers.html?highlight=markers#marker-syntax

--- a/website/content/en/docs/building-operators/helm/tutorial.md
+++ b/website/content/en/docs/building-operators/helm/tutorial.md
@@ -11,8 +11,7 @@ This guide walks through an example of building a simple nginx-operator powered 
 
 ## Prerequisites
 
-- [Install `operator-sdk`][operator_install] and its prequisites.
-- Access to a Kubernetes v1.16.0+ cluster.
+- Go through the [installation guide][install-guide].
 - User authorized with `cluster-admin` permissions.
 
 ## Create a new project
@@ -50,7 +49,7 @@ If `--helm-chart` is specified, the `--group`, `--version`, and `--kind` flags b
 | kind |  deduce from the specified chart |
 | version | v1alpha1 |
 
-If `--helm-chart` is a local chart archive (e.g `example-chart-1.2.0.tgz`) or directory, 
+If `--helm-chart` is a local chart archive (e.g `example-chart-1.2.0.tgz`) or directory,
 it will be validated and unpacked or copied into the project.
 
 Otherwise, the SDK will attempt to fetch the specified helm chart from a remote repository.
@@ -195,7 +194,7 @@ make deploy IMG=$IMG
 
 Verify that the nginx-operator is up and running:
 
-```sh
+```console
 $ kubectl get deployment -n nginx-operator-system
 NAME                                DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 nginx-operator-controller-manager   1/1       1         1            1           77s
@@ -224,7 +223,7 @@ kubectl apply -f config/samples/example_v1alpha1_nginx.yaml
 
 Ensure that the nginx-operator creates the deployment for the CR:
 
-```sh
+```console
 $ kubectl get deployment
 NAME           READY   UP-TO-DATE   AVAILABLE   AGE
 nginx-sample   2/2     2            2           2m13s
@@ -232,15 +231,16 @@ nginx-sample   2/2     2            2           2m13s
 
 Check the pods to confirm 2 replicas were created:
 
-```sh
+```console
 $ kubectl get pods
 NAME                                                   READY   STATUS    RESTARTS   AGE
 nginx-sample-c786bfdcf-4g6md                           1/1     Running   0          81s
 nginx-sample-c786bfdcf-6bhmx                           1/1     Running   0          81s
+```
 
 Check that the service port is set to `8080`:
 
-```sh
+```console
 $ kubectl get service
 NAME                                      TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
 nginx-sample                              ClusterIP   10.96.26.3   <none>        8080/TCP   1m
@@ -251,7 +251,7 @@ nginx-sample                              ClusterIP   10.96.26.3   <none>       
 Change the `spec.replicaCount` field from 2 to 3, remove the `spec.service`
 field:
 
-```sh
+```console
 $ cat config/samples/example_v1alpha1_nginx.yaml
 apiVersion: example.com/v1alpha1
 kind: Nginx
@@ -269,7 +269,7 @@ kubectl apply -f config/samples/example_v1alpha1_nginx.yaml
 
 Confirm that the operator changes the deployment size:
 
-```sh
+```console
 $ kubectl get deployment
 NAME                                           DESIRED   CURRENT   UP-TO-DATE     AGE
 nginx-sample                                   3/3       3            3           7m29s
@@ -277,7 +277,7 @@ nginx-sample                                   3/3       3            3         
 
 Check that the service port is set to the default (`80`):
 
-```sh
+```console
 $ kubectl get service
 NAME                                      TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)  AGE
 nginx-sample                              ClusterIP   10.96.152.76    <none>        80/TCP   7m54s
@@ -294,7 +294,7 @@ kubectl logs deployment.apps/nginx-operator-controller-manager  -n nginx-operato
 Use the following command to check the CR status and events.
 
 ```sh
-kubectl describe nginxes.example.com 
+kubectl describe nginxes.example.com
 ```
 
 ### Cleanup
@@ -308,11 +308,11 @@ make undeploy
 **NOTE** Additional CR/CRD's can be added to the project by running, for example, the command :`operator-sdk create api --group=example --version=v1alpha1 --kind=AppService`
 
 <!--
-todo(camilamacedo86): https://github.com/operator-framework/operator-sdk/issues/3447 
+todo(camilamacedo86): https://github.com/operator-framework/operator-sdk/issues/3447
 -->
+[install-guide]:/docs/building-operators/helm/installation
 [operator-scope]: /docs/building-operators/golang/operator-scope
 [layout-doc]: /docs/building-operators/helm/reference/project_layout/
 [helm-charts]:https://helm.sh/docs/topics/charts/
 [helm-values]:https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing
 [helm-official]:https://helm.sh/docs/
-[operator_install]: /docs/installation/


### PR DESCRIPTION
**Description of the change:** unify all quickstarts 

**Motivation for the change:** the quickstarts have drifted when they should be closely aligned

/kind documentation

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
