### PR TITLE
docs/building-operators: update and align tutorials

### DIFF
--- a/internal/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/internal/cmd/operator-sdk/generate/bundle/bundle.go
@@ -57,7 +57,7 @@ https://github.com/operator-framework/operator-registry/#manifest-format
 	examples = `
   # Generate bundle files and build your bundle image with these 'make' recipes:
   $ make bundle
-  $ export USERNAME=<your registry username>
+  $ export USERNAME=<quay-namespace>
   $ export BUNDLE_IMG=quay.io/$USERNAME/memcached-operator-bundle:v0.0.1
   $ make bundle-build BUNDLE_IMG=$BUNDLE_IMG
 

--- a/website/content/en/docs/building-operators/ansible/migration.md
+++ b/website/content/en/docs/building-operators/ansible/migration.md
@@ -178,7 +178,12 @@ In your new project, roles are automatically generated in `config/rbac/role.yaml
 If you modified these permissions manually in `deploy/role.yaml` in your existing
 project, you need to re-apply them in `config/rbac/role.yaml`.
 
-New projects are configured to watch all namespaces by default, so they need a `ClusterRole` to have the necessary permissions. Ensure that `config/rbac/role.yaml` remains a `ClusterRole` if you want to retain the default behavior of the new project conventions. For further information refer to the [operator scope][operator-scope] documentation.  
+<!--
+todo(camilamacedo86): Create an Ansible operator scope document.
+https://github.com/operator-framework/operator-sdk/issues/3447
+-->
+
+New projects are configured to watch all namespaces by default, so they need a `ClusterRole` to have the necessary permissions. Ensure that `config/rbac/role.yaml` remains a `ClusterRole` if you want to retain the default behavior of the new project conventions.
 
 The following rules were used in earlier versions of anisible-operator to automatically create and manage services and `servicemonitors` for metrics collection. If your operator's don't require these rules, they can safely be left out of the new `config/rbac/role.yaml` file:
 
@@ -219,7 +224,7 @@ The default port used by the metric endpoint binds to was changed from `:8383` t
 
 ## Checking the changes
 
-Finally, follow the steps in the section [Build and run the Operator][build-and-run-the-operator] to verify your project is running.
+Finally, follow the steps in the ["run the Operator"][run-the-operator] section to verify your project is running.
 
 Note that, you also can troubleshooting by checking the container logs.
 E.g `$ kubectl logs deployment.apps/memcached-operator-controller-manager -n memcached-operator-system -c manager`  
@@ -227,11 +232,10 @@ E.g `$ kubectl logs deployment.apps/memcached-operator-controller-manager -n mem
 [quickstart-legacy]: https://v0-19-x.sdk.operatorframework.io/docs/ansible/quickstart/
 [quickstart]: /docs/building-operators/ansible/quickstart
 [integration-doc]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/integrating-kubebuilder-and-osdk.md
-[build-and-run-the-operator]: /docs/building-operators/ansible/tutorial/#deploy-the-operator
+[run-the-operator]: /docs/building-operators/ansible/tutorial/#run-the-operator
 [kustomize]: https://github.com/kubernetes-sigs/kustomize
 [kube-auth-proxy]: https://github.com/brancz/kube-rbac-proxy
 [metrics]: https://book.kubebuilder.io/reference/metrics.html?highlight=metr#metrics
 [marker]: https://book.kubebuilder.io/reference/markers.html?highlight=markers#marker-syntax
-[operator-scope]: /docs/building-operators/golang/operator-scope
 [molecule]: https://molecule.readthedocs.io/en/latest/#
 [testing-guide]: /docs/building-operators/ansible/testing-guide

--- a/website/content/en/docs/building-operators/golang/quickstart.md
+++ b/website/content/en/docs/building-operators/golang/quickstart.md
@@ -32,7 +32,8 @@ This guide walks through an example of building a simple memcached-operator usin
 Make sure to define `IMG` when you call `make`:
 
   ```sh
-  export OPERATOR_IMG="quay.io/example-inc/memcached-operator:v0.0.1"
+  export USERNAME=<quay-namespace>
+  export OPERATOR_IMG="quay.io/$USERNAME/memcached-operator:v0.0.1"
   make docker-build docker-push IMG=$OPERATOR_IMG
   ```
 
@@ -50,7 +51,7 @@ Make sure to define `IMG` when you call `make`:
   ```sh
   make bundle IMG=$OPERATOR_IMG
   # Note the "-bundle" component in the image name below.
-  export BUNDLE_IMG="quay.io/example-inc/memcached-operator-bundle:v0.0.1"
+  export BUNDLE_IMG="quay.io/$USERNAME/memcached-operator-bundle:v0.0.1"
   make bundle-build BUNDLE_IMG=$BUNDLE_IMG
   make docker-push IMG=$BUNDLE_IMG
   ```

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -1,11 +1,12 @@
 ---
-title: Golang Based Operator Tutorial
+title: Golang Operator Tutorial
 linkTitle: Tutorial
 weight: 30
-description: This guide walks through an example of building a simple memcached-operator using the operator-sdk CLI tool and controller-runtime library API.
+description: An in-depth walkthough of building and running a Go-based operator.
 ---
 
-**NOTE:** For the SDK versions prior to `v0.19.0` please consult the [legacy docs][legacy_quickstart_doc] for the [legacy CLI][legacy_CLI] and project.
+**NOTE:** If your project was created with an `operator-sdk` version prior to `v1.0.0`
+please [migrate][migration-guide], or consult the [legacy docs][legacy-quickstart-doc].
 
 ## Prerequisites
 
@@ -18,11 +19,11 @@ description: This guide walks through an example of building a simple memcached-
 Use the CLI to create a new memcached-operator project:
 
 ```sh
-$ mkdir -p $HOME/projects/memcached-operator
-$ cd $HOME/projects/memcached-operator
+mkdir -p $HOME/projects/memcached-operator
+cd $HOME/projects/memcached-operator
 # we'll use a domain of example.com
 # so all API groups will be <group>.example.com
-$ operator-sdk init --domain=example.com --repo=github.com/example-inc/memcached-operator
+operator-sdk init --domain example.com --repo github.com/example-inc/memcached-operator
 ```
 
 To learn about the project directory structure, see [Kubebuilder project layout][kubebuilder_layout_doc] doc.
@@ -32,6 +33,7 @@ To learn about the project directory structure, see [Kubebuilder project layout]
 `operator-sdk init` generates a `go.mod` file to be used with [Go modules][go_mod_wiki]. The `--repo=<path>` flag is required when creating a project outside of `$GOPATH/src`, as scaffolded files require a valid module path. Ensure you [activate module support][activate_modules] by running `export GO111MODULE=on` before using the SDK.
 
 ### Manager
+
 The main program for the operator `main.go` initializes and runs the [Manager][manager_go_doc].
 
 See the [Kubebuilder entrypoint doc][kubebuilder_entrypoint_doc] for more details on how the manager registers the Scheme for the custom resource API defintions, and sets up and runs controllers and webhooks.
@@ -61,7 +63,7 @@ Read the [operator scope][operator_scope] documentation on how to run your opera
 
 ### Multi-Group APIs
 
-Before creating an API and controller, consider if your operator requires multiple API [groups][api-groups]. Then to change the layout of your project to support multi-group run the command `operator-sdk edit --multigroup=true`. It will update the `PROJECT` file which should look like the following:
+Before creating an API and controller, consider if your operator requires multiple API [groups][api-groups]. Then to change the layout of your project to support multi-group run the command `operator-sdk edit --multigroup`. It will update the `PROJECT` file which should look like the following:
 
 ```YAML
 domain: example.com
@@ -79,11 +81,7 @@ Create a new Custom Resource Definition(CRD) API with group `cache` version `v1a
 When prompted, enter yes `y` for creating both the resource and controller.
 
 ```console
-$ operator-sdk create api --group=cache --version=v1alpha1 --kind=Memcached
-Create Resource [y/n]
-y
-Create Controller [y/n]
-y
+$ operator-sdk create api --group cache --version v1alpha1 --kind Memcached --resource --controller
 Writing scaffold for you to edit...
 api/v1alpha1/memcached_types.go
 controllers/memcached_controller.go
@@ -132,7 +130,7 @@ type Memcached struct {
 After modifying the `*_types.go` file always run the following command to update the generated code for that resource type:
 
 ```sh
-$ make generate
+make generate
 ```
 
 The above makefile target will invoke the [controller-gen][controller_tools] utility to update the `api/v1alpha1/zz_generated.deepcopy.go` file to ensure our API's Go type definitons implement the `runtime.Object` interface that all Kind types must implement.
@@ -141,8 +139,8 @@ The above makefile target will invoke the [controller-gen][controller_tools] uti
 
 Once the API is defined with spec/status fields and CRD validation markers, the CRD manifests can be generated and updated with the following command:
 
-```console
-$ make manifests
+```sh
+make manifests
 ```
 
 This makefile target will invoke controller-gen to generate the CRD manifests at `config/crd/bases/cache.example.com_memcacheds.yaml`.
@@ -166,7 +164,7 @@ The example controller executes the following reconciliation logic for each Memc
 - Ensure that the Deployment size is the same as specified by the Memcached CR spec
 - Update the Memcached CR status using the status writer with the names of the memcached pods
 
-The next two subsections explain how the controller watches resources and how the reconcile loop is triggered. Skip to the [Build](#build-and-run-the-operator) section to see how to build and run the operator.
+The next two subsections explain how the controller watches resources and how the reconcile loop is triggered. Skip to the ["run the Operator"](#run-the-operator) section to see how to build and run the operator.
 
 #### Resources watched by the Controller
 
@@ -199,15 +197,13 @@ There are a number of other useful configurations that can be made when initialz
 
 - Set the max number of concurrent Reconciles for the controller via the [`MaxConcurrentReconciles`][controller_options]  option. Defaults to 1.
   ```Go
-    func (r *MemcachedReconciler) SetupWithManager(mgr ctrl.Manager) error {
-        return ctrl.NewControllerManagedBy(mgr).
-            For(&cachev1alpha1.Memcached{}).
-            Owns(&appsv1.Deployment{}).
-            WithOptions(controller.Options{
-                MaxConcurrentReconciles: 2,
-            }).
-            Complete(r)
-    }
+  func (r *MemcachedReconciler) SetupWithManager(mgr ctrl.Manager) error {
+    return ctrl.NewControllerManagedBy(mgr).
+      For(&cachev1alpha1.Memcached{}).
+      Owns(&appsv1.Deployment{}).
+      WithOptions(controller.Options{MaxConcurrentReconciles: 2}).
+      Complete(r)
+  }
   ```
 - Filter watch events using [predicates][event_filtering]
 - Choose the type of [EventHandler][event_handler_godocs] to change how a watch event will translate to reconcile requests for the reconcile loop. For operator relationships that are more complex than primary and secondary resources, the [`EnqueueRequestsFromMapFunc`][enqueue_requests_from_map_func] handler can be used to transform a watch event into an arbitrary set of reconcile requests.
@@ -275,34 +271,23 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 The `ClusterRole` manifest at `config/rbac/role.yaml` is generated from the above markers via controller-gen with the following command:
 
 ```sh
-$ make manifests
+make manifests
 ```
 
-## Build and run the operator
+## Run the Operator
 
-Before running the operator, the CRD must be registered with the Kubernetes apiserver:
-
-```sh
-$ make install
-```
-
-Once this is done, there are two ways to run the operator:
+There are three ways to run the operator:
 
 - As Go program outside a cluster
 - As a Deployment inside a Kubernetes cluster
-
-## Configuring your test environment
-
-Projects are scaffolded with unit tests that utilize the [envtest](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/envtest)
-library, which requires certain Kubernetes server binaries be present locally.
-Installation instructions can be found [here][env-test-setup].
+- Managed by the [Operator Lifecycle Manager (OLM)][doc-olm] in [bundle][quickstart-bundle] format
 
 ### 1. Run locally outside the cluster
 
-To run the operator locally execute the following command:
+Execute the following command, which install your CRDs and run the manager locally:
 
 ```sh
-$ make run ENABLE_WEBHOOKS=false
+make install run ENABLE_WEBHOOKS=false
 ```
 
 ### 2. Run as a Deployment inside the cluster
@@ -319,21 +304,15 @@ Make sure to modify the `IMG` arg in the example below to reference a container 
 you have access to. You can obtain an account for storing containers at
 repository sites such quay.io or hub.docker.com. This example uses quay.
 
-Build the image:
-```sh
-$ export USERNAME=<quay-username>
-
-$ make docker-build IMG=quay.io/$USERNAME/memcached-operator:v0.0.1
-```
-
-Push the image to a repository:
+Build and push the image:
 
 ```sh
-$ make docker-push IMG=quay.io/$USERNAME/memcached-operator:v0.0.1
+export USERNAME=<quay-namespace>
+make docker-build docker-push IMG=quay.io/$USERNAME/memcached-operator:v0.0.1
 ```
 
-**Note**:
-The name and tag of the image (`IMG=<some-registry>/<project-name>:tag`) in both the commands can also be set in the Makefile. Modify the line which has `IMG ?= controller:latest` to set your desired default image name.
+**Note**: The name and tag of the image (`IMG=<some-registry>/<project-name>:tag`) in both the commands can also be set in the Makefile.
+Modify the line which has `IMG ?= controller:latest` to set your desired default image name.
 
 #### Deploy the operator
 
@@ -342,7 +321,7 @@ By default, a new namespace is created with name `<project-name>-system`, i.e. m
 Run the following to deploy the operator. This will also install the RBAC manifests from `config/rbac`.
 
 ```sh
-$ make deploy IMG=quay.io/$USERNAME/memcached-operator:v0.0.1
+make deploy IMG=quay.io/$USERNAME/memcached-operator:v0.0.1
 ```
 
 *NOTE* If you have enabled webhooks in your deployments, you will need to have cert-manager already installed
@@ -356,9 +335,32 @@ NAME                                    READY   UP-TO-DATE   AVAILABLE   AGE
 memcached-operator-controller-manager   1/1     1            1           8m
 ```
 
-### 3. Deploy your Operator with the Operator Lifecycle Manager (OLM)
+### 3. Deploy your Operator with OLM
 
-OLM will manage creation of most if not all resources required to run your operator, using a bit of setup from other `operator-sdk` commands. Check out the [docs][cli-run-olm] for more information.
+First, install [OLM][doc-olm]:
+
+```sh
+operator-sdk olm install
+```
+
+Then bundle your operator and push the bundle image:
+
+```sh
+make bundle IMG=$OPERATOR_IMG
+# Note the "-bundle" component in the image name below.
+export BUNDLE_IMG="quay.io/$USERNAME/memcached-operator-bundle:v0.0.1"
+make bundle-build BUNDLE_IMG=$BUNDLE_IMG
+make docker-push IMG=$BUNDLE_IMG
+```
+
+Finally, run your bundle:
+
+```sh
+operator-sdk run bundle $BUNDLE_IMG
+```
+
+Check out the [docs][quickstart-bundle] for a deep dive into `operator-sdk`'s OLM integration.
+
 
 ## Create a Memcached CR
 
@@ -376,7 +378,7 @@ spec:
 Create the CR:
 
 ```sh
-$ kubectl apply -f config/samples/cache_v1alpha1_memcached.yaml
+kubectl apply -f config/samples/cache_v1alpha1_memcached.yaml
 ```
 
 Ensure that the memcached operator creates the deployment for the sample CR with the correct size:
@@ -425,7 +427,7 @@ status:
 Update `config/samples/cache_v1alpha1_memcached.yaml` to change the `spec.size` field in the Memcached CR from 3 to 5:
 
 ```sh
-$ kubectl patch memcached memcached-sample -p '{"spec":{"size": 5}}' --type=merge
+kubectl patch memcached memcached-sample -p '{"spec":{"size": 5}}' --type=merge
 ```
 
 Confirm that the operator changes the deployment size:
@@ -439,18 +441,10 @@ memcached-sample                        5/5     5            5           3m
 
 ### Cleanup
 
-A new target can be added into the Makefile for cleaning up the resources that have been created along this tutorial:
-
-```make
-# Undeploy controller from the configured Kubernetes cluster
-undeploy:
-	$(KUSTOMIZE) build config/default | kubectl delete -f -
-```
-
-Once that's done the simple command below will delete all the resources:
+Call the following to delete all deployed resources:
 
 ```sh
-$ make undeploy
+make undeploy
 ```
 
 ## Further steps
@@ -461,6 +455,9 @@ The following guides build off the operator created in this example, adding adva
 
 Also see the [advanced topics][advanced_topics] doc for more use cases and under the hood details.
 
+
+[legacy-quickstart-doc]:https://v0-19-x.sdk.operatorframework.io/docs/golang/legacy/quickstart/
+[migration-guide]:/docs/building-operators/golang/migration
 [install-guide]:/docs/building-operators/golang/installation
 [enqueue_requests_from_map_func]: https://godoc.org/sigs.k8s.io/controller-runtime/pkg/handler#EnqueueRequestsFromMapFunc
 [event_handler_godocs]: https://godoc.org/sigs.k8s.io/controller-runtime/pkg/handler#hdr-EventHandlers
@@ -475,7 +472,6 @@ Also see the [advanced topics][advanced_topics] doc for more use cases and under
 [request-go-doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Request
 [result_go_doc]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Result
 [multi-namespaced-cache-builder]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder
-[cli-run-olm]: /docs/olm-integration/cli-overview
 [kubebuilder_entrypoint_doc]: https://book.kubebuilder.io/cronjob-tutorial/empty-main.html
 [api_terms_doc]: https://book.kubebuilder.io/cronjob-tutorial/gvks.html
 [kb_controller_doc]: https://book.kubebuilder.io/cronjob-tutorial/controller-overview.html
@@ -487,13 +483,13 @@ Also see the [advanced topics][advanced_topics] doc for more use cases and under
 [crd-markers]: https://book.kubebuilder.io/reference/markers/crd-validation.html
 [memcached_controller]: https://github.com/operator-framework/operator-sdk/blob/v1.2.0/testdata/go/memcached-operator/controllers/memcached_controller.go
 [builder_godocs]: https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/builder#example-Builder
-[legacy_quickstart_doc]:https://v0-19-x.sdk.operatorframework.io/docs/golang/legacy/quickstart/
 [activate_modules]: https://github.com/golang/go/wiki/Modules#how-to-install-and-activate-module-support
 [advanced_topics]: /docs/building-operators/golang/advanced-topics/
 [create_a_webhook]: https://book.kubebuilder.io/cronjob-tutorial/webhook-implementation.html
 [status_marker]: https://book.kubebuilder.io/reference/generating-crd.html#status
 [status_subresource]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource
-[legacy_CLI]:https://v0-19-x.sdk.operatorframework.io/docs/cli/
 [env-test-setup]: /docs/building-operators/golang/references/envtest-setup
 [role-based-access-control]: https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#iam-rolebinding-bootstrap
 [multigroup-kubebuilder-doc]: https://book.kubebuilder.io/migration/multi-group.html
+[quickstart-bundle]:/docs/olm-integration/quickstart-bundle
+[doc-olm]:/docs/olm-integration/quickstart-bundle/#enabling-olm

--- a/website/content/en/docs/building-operators/helm/migration.md
+++ b/website/content/en/docs/building-operators/helm/migration.md
@@ -96,7 +96,12 @@ In your new project, roles are automatically generated in `config/rbac/role.yaml
 If you modified these permissions manually in `deploy/role.yaml` in your existing
 project, you need to re-apply them in `config/rbac/role.yaml`.
 
-New projects are configured to watch all namespaces by default, so they need a `ClusterRole` to have the necessary permissions. Ensure that `config/rbac/role.yaml` remains a `ClusterRole` if you want to retain the default behavior of the new project conventions. For further information refer to the [operator scope][operator-scope] documentation.  
+New projects are configured to watch all namespaces by default, so they need a `ClusterRole` to have the necessary permissions. Ensure that `config/rbac/role.yaml` remains a `ClusterRole` if you want to retain the default behavior of the new project conventions.
+
+<!--
+todo(camilamacedo86): Create an Ansible operator scope document.
+https://github.com/operator-framework/operator-sdk/issues/3447
+-->
 
 The following rules were used in earlier versions of helm-operator to automatically create and manage services and servicemonitors for metrics collection. If your operator's charts don't require these rules, they can safely be left out of the new `config/rbac/role.yaml` file:
 
@@ -137,11 +142,11 @@ The default port used by the metric endpoint binds to was changed from `:8383` t
 
 ## Checking the changes
 
-Finally, follow the steps in the section [Build and run the operator][build-and-run-the-operator] to verify your project is running.
+Finally, follow the steps in the ["run the Operator"][run-the-operator] section to verify your project is running.
 
 [quickstart]: /docs/building-operators/helm/quickstart
 [integration-doc]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/integrating-kubebuilder-and-osdk.md
-[build-and-run-the-operator]: /docs/building-operators/helm/tutorial#build-and-run-the-operator
+[run-the-operator]: /docs/building-operators/helm/tutorial#run-the-operator
 [kustomize]: https://github.com/kubernetes-sigs/kustomize
 [kube-auth-proxy]: https://github.com/brancz/kube-rbac-proxy
 [metrics]: https://book.kubebuilder.io/reference/metrics.html?highlight=metr#metrics

--- a/website/content/en/docs/cli/operator-sdk_generate_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_bundle.md
@@ -32,7 +32,7 @@ operator-sdk generate bundle [flags]
 
   # Generate bundle files and build your bundle image with these 'make' recipes:
   $ make bundle
-  $ export USERNAME=<your registry username>
+  $ export USERNAME=<quay-namespace>
   $ export BUNDLE_IMG=quay.io/$USERNAME/memcached-operator-bundle:v0.0.1
   $ make bundle-build BUNDLE_IMG=$BUNDLE_IMG
 


### PR DESCRIPTION
**Description of the change:** unify all tutorials 

**Motivation for the change:** the tutorials have drifted when they should be closely aligned

/kind documentation

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
