### PR TITLE
*: replace defunct coreos.com/operators/ with kubernetes.io link

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,5 +69,5 @@ Operator SDK is under Apache 2.0 license. See the [LICENSE][license_file] file f
 [license_file]:./LICENSE
 [of-home]: https://github.com/operator-framework
 [of-blog]: https://coreos.com/blog/introducing-operator-framework
-[operator-link]: https://coreos.com/operators/
+[operator-link]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 [sdk-docs]: https://sdk.operatorframework.io

--- a/website/content/en/_index.html
+++ b/website/content/en/_index.html
@@ -10,7 +10,7 @@ title = "Operator SDK"
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/operator-framework/operator-sdk/">
 		Source <i class="fab fa-github ml-2 "></i>
 	</a>
-	<p class="lead mt-5"><a href=https://coreos.com/operators/>Operators 🔗</a>
+	<p class="lead mt-5"><a href=https://kubernetes.io/docs/concepts/extend-kubernetes/operator/>Operators 🔗</a>
 		are used to manage complex stateful applications on top of Kubernetes. The
 		Operator SDK makes it easier to create them by providing high level APIs,
 		useful abstractions, and project scaffolding.

--- a/website/content/en/docs/overview/_index.md
+++ b/website/content/en/docs/overview/_index.md
@@ -6,7 +6,7 @@ description: >
     What is Operator SDK? Why should I use it?
 ---
 
-## What is Operator SDK and why should I use it? 
+## What is Operator SDK and why should I use it?
 
 This project is a component of the [Operator Framework][of-home], an open source toolkit to manage Kubernetes native applications, called Operators, in an effective, automated, and scalable way. Read more in the [introduction blog post][of-blog].
 
@@ -91,7 +91,7 @@ Operator SDK is under Apache 2.0 license. See the [LICENSE][license_file] file f
 [license_file]:https://github.com/operator-framework/operator-sdk/blob/master/LICENSE
 [of-blog]: https://coreos.com/blog/introducing-operator-framework
 [of-home]: https://github.com/operator-framework
-[operator_link]: https://coreos.com/operators/
+[operator_link]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 [proposals_docs]: https://github.com/operator-framework/operator-sdk/tree/master/proposals
 [testdata_samples]: https://github.com/operator-framework/operator-sdk/tree/master/testdata
 [sdk_cli_ref]: /docs/cli/


### PR DESCRIPTION
**Description of the change:** remove old link

**Motivation for the change:** use upstream docs

/kind documentation

Closes #3801

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
