### PR TITLE
helm/samples: customize config/sample to allow it runs in OCP with default config

### DIFF
--- a/hack/generate/samples/internal/helm/memcached.go
+++ b/hack/generate/samples/internal/helm/memcached.go
@@ -82,6 +82,11 @@ func (mh *MemcachedHelm) Run() {
 	pkg.CheckError("scaffolding apis", err)
 
 	log.Infof("customizing the sample")
+	err = testutils.ReplaceInFile(
+		filepath.Join(mh.ctx.Dir, "config", "samples", "cache_v1alpha1_memcached.yaml"),
+		"securityContext:\n    enabled: true", "securityContext:\n    enabled: false")
+	pkg.CheckError("customizing the sample", err)
+	
 	log.Infof("enabling prometheus metrics")
 	err = testutils.UncommentCode(
 		filepath.Join(mh.ctx.Dir, "config", "default", "kustomization.yaml"),

--- a/hack/generate/samples/internal/helm/memcached.go
+++ b/hack/generate/samples/internal/helm/memcached.go
@@ -86,7 +86,7 @@ func (mh *MemcachedHelm) Run() {
 		filepath.Join(mh.ctx.Dir, "config", "samples", "cache_v1alpha1_memcached.yaml"),
 		"securityContext:\n    enabled: true", "securityContext:\n    enabled: false")
 	pkg.CheckError("customizing the sample", err)
-	
+
 	log.Infof("enabling prometheus metrics")
 	err = testutils.UncommentCode(
 		filepath.Join(mh.ctx.Dir, "config", "default", "kustomization.yaml"),

--- a/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -43,7 +43,7 @@ metadata:
               }
             },
             "securityContext": {
-              "enabled": true,
+              "enabled": false,
               "fsGroup": 1001,
               "runAsUser": 1001
             },

--- a/testdata/helm/memcached-operator/config/samples/cache_v1alpha1_memcached.yaml
+++ b/testdata/helm/memcached-operator/config/samples/cache_v1alpha1_memcached.yaml
@@ -31,7 +31,7 @@ spec:
       cpu: 50m
       memory: 64Mi
   securityContext:
-    enabled: true
+    enabled: false
     fsGroup: 1001
     runAsUser: 1001
   serviceAnnotations: {}


### PR DESCRIPTION
**Description**
Disable `securityContext` config for Helm sample 

**Motivation**
Allow sample runs in OCP without: 

```
 Warning  FailedCreate  2m (x18 over 10m)  statefulset-controller  create Pod memcached-sample-0 in StatefulSet memcached-sample failed error: pods "memcached-sample-0" is forbidden: unable to validate against any security context constraint: [provider restricted: .spec.securityContext.fsGroup: Invalid value: []int64{1001}: 1001 is not an allowed group spec.containers[0].securityContext.runAsUser: Invalid value: 1001: must be in the ranges: [1000630000, 1000639999]]
```
- Make easier the downstream process by addressing the same fix done in https://github.com/openshift/ocp-release-operator-sdk/pull/84/files#diff-62df55fca2d17f047db431766e3962fa139afff08331dedf0863ec9d86dd7011R9
