### PR TITLE
bundle: use existing permissions if any instead of overwriting

### DIFF
--- a/changelog/fragments/bundle-append-permissions.yaml
+++ b/changelog/fragments/bundle-append-permissions.yaml
@@ -1,0 +1,7 @@
+entries:
+  - description: >
+      Bundle generation: if input CSV already has install.spec.clusterPermissions or install.spec.permissions, do not overwrite but append to existing entries.
+
+    kind: "change"
+
+    breaking: false

--- a/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
@@ -124,7 +124,7 @@ func applyRoles(c *collector.Manifests, strategy *operatorsv1alpha1.StrategyDeta
 			perms = append(perms, perm)
 		}
 	}
-	strategy.Permissions = perms
+	strategy.Permissions = append(perms, strategy.Permissions...)
 }
 
 // applyClusterRoles applies ClusterRoles to strategy's clusterPermissions field by combining ClusterRoles
@@ -168,7 +168,7 @@ func applyClusterRoles(c *collector.Manifests, strategy *operatorsv1alpha1.Strat
 			perms = append(perms, perm)
 		}
 	}
-	strategy.ClusterPermissions = perms
+	strategy.ClusterPermissions = append(perms, strategy.ClusterPermissions...)
 }
 
 // applyDeployments updates strategy's deployments with the Deployments


### PR DESCRIPTION
**Description of the change:**

If input CSV already has `install.spec.clusterPermissions` or `install.spec.permissions`, do not overwrite but append to existing entries.

**Motivation for the change:**

This is useful in some use cases on OpenShift, where operator (in our case, Datadog Operator) runs with `restricted` SCC while operator-managed workload (in our case, Datadog Agent) needs to run with `hostaccess` or `privileged` SCC. In this scenario, we need the OLM to create a dedicated SA for us as operator won't be able to do it.

Enabling this avoids to manually patch CSV after generation.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
