### PR TITLE
.github/workflows: add rerun-actions action to rerun other actions by comment

### DIFF
--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -1,0 +1,14 @@
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rerun_tests:
+    name: rerun_pr_tests
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: estroz/rerun-actions@v0.3.0
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        comment_id: ${{ github.event.comment.id }}


### PR DESCRIPTION
**Description of the change:** rerun failed actions with `/test <action name>` or all failed actions with `/retest` (same commands as prow)

**Motivation for the change:** closes #3712 

See [test PR](https://github.com/estroz/operator-sdk/pull/14) and corresponding [actions runs](https://github.com/estroz/operator-sdk/runs/1581202133?check_suite_focus=true).


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
