### PR TITLE
hack/ci: remove workflows dir from docs-only check

### DIFF
--- a/hack/ci/check-doc-only-update.sh
+++ b/hack/ci/check-doc-only-update.sh
@@ -22,7 +22,6 @@ DOC_PATTERNS=(
   "^(MAINTAINERS)"
   "^(SECURITY)"
   "^(LICENSE)"
-  "^(\.github/workflows/)"
 )
 
 if ! git diff --name-only $1 | grep -qvE "$(IFS="|"; echo "${DOC_PATTERNS[*]}")"; then


### PR DESCRIPTION


<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
- hack/ci: remove workflows dir from docs-only check

**Motivation for the change:** workflow changes should be fully tested


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
