### PR TITLE
change: (helm) - keep attempting to helm uninstall even if the first helm uninstall was not successful

### DIFF
--- a/changelog/fragments/helm_operator_uninstall_error_handling_change.yaml
+++ b/changelog/fragments/helm_operator_uninstall_error_handling_change.yaml
@@ -1,0 +1,14 @@
+entries:
+  - description: >
+      For Helm-based operators delete resource, if the Helm uninstall completed with error, then keep trying to uninstall until there is no error on the Helm uninstall.
+
+    kind: "change"
+
+    breaking: true
+
+    migration:
+      header: For Helm-based operators delete resource, the finalizer will not be removed until the Helm uninstall is completed without error.
+      body: >
+        In the prior releases, Helm-based operators delete resource will remove it's finalizer even if the Helm uninstallation completed with error.
+        With this change, Helm-based operators will keep attempting to perform Helm uninstall until it completes without error.
+        Only then, will the finalizer be removed.


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

**Description of the change:**
For Helm-based operators delete resource, if the Helm uninstall completed with error, then keep trying to uninstall until there is no error on the Helm uninstall.

**Motivation for the change:**
For the Helm client, the `helm uninstall` command removes the release record even if the uninstall completed with error(s). This is fine behaviour for regular CLI execution because a user is informed that there was an error with the uninstall and the user will perform the proper recovery procedures.

However, this is problematic with the current implementation of the Helm operator. The Helm uninstall might have error and not deleted anything but since the release record is removed, the Helm operator thinks the release is gone and proceed to remove it's finalizer. So unless the user double check the log, the uninstall error is hidden away. See https://github.com/operator-framework/operator-sdk/issues/3407#issuecomment-658178273

This change is to enhance the behaviour of the Helm operator uninstall scenario, where the error will persist on the resource status for user to debug. 

 Closes: https://github.com/operator-framework/operator-sdk/issues/3407

_before this change:_
```
# resource is gone from k8s, only in the log, we can see there was an error
{"level":"error","ts":1608568023.8352385,"logger":"controller-runtime.manager.controller.nginx-controller","msg":"Reconciler error","name":"nginx-sample","namespace":"default","error":"uninstallation completed with 1 error(s): ....
{"level":"info","ts":1608568023.8640625,"logger":"helm.controller","msg":"Release not found, removing finalizer","namespace":"default","name":"nginx-sample","apiVersion":"example.com/v1alpha1","kind":"Nginx","release":"nginx-sample"}
```

_after this change:_
```
$ oc get nginx/nginx-sample -o yaml 
...
  - lastTransitionTime: "2020-12-21T19:40:48Z"
    message: 'uninstallation completed with 1 error(s): ...
    reason: UninstallError
    status: "True"
    type: ReleaseFailed
...

# continuously attempt uninstall until the problem is fixed.
# when the problem is fixed, the log will show:

{"level":"info","ts":1608580477.2366333,"logger":"helm.controller","msg":"Uninstalled release","namespace":"default","name":"nginx-sample","apiVersion":"example.com/v1alpha1","kind":"Nginx","release":"nginx-sample"}
----
-# Source: nginx/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
```

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
