### PR TITLE
feat: rename the default channel scaffold for the builds to follow the convection

### DIFF
--- a/changelog/fragments/bundle_name_channel_convection.yaml
+++ b/changelog/fragments/bundle_name_channel_convection.yaml
@@ -18,5 +18,5 @@ entries:
         By using the make target `make bundle` or the command `operator-sdk generate bundle` the default channel name configured
         for the bundle was `alpha` and for now on, SDK will use `preview` as default the channel name instead.
 
-        To update the channel name used in the bundle of your project to use the new default value run `make bundle`.
+        To update the project bundle's channel name to the new default, run `make bundle`.
         To know more about the OLM channel name see: https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/channel-naming.md#naming

--- a/changelog/fragments/bundle_name_channel_convection.yaml
+++ b/changelog/fragments/bundle_name_channel_convection.yaml
@@ -16,7 +16,7 @@ entries:
       body: >
         Channel names are used to imply what form of upgrade you want to offer for your operator which is integrated with OLM.
         By using the make target `make bundle` or the command `operator-sdk generate bundle` the default channel name configured
-        for the bundle was `alpha` and for now on, SDK will use `preview` as default the channel name instead.
+        for the bundle was `alpha` and from now on, SDK will use `preview` as default the channel name instead.
 
         To update the project bundle's channel name to the new default, run `make bundle`.
         To know more about the OLM channel name see: https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/channel-naming.md#naming

--- a/changelog/fragments/bundle_name_channel_convection.yaml
+++ b/changelog/fragments/bundle_name_channel_convection.yaml
@@ -1,0 +1,22 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Use `preview` as default channel name value instead of `alpha` for OLM bundles.
+
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: (Optional) Update OLM bundle channel name
+      body: >
+        Channel names are used to imply what form of upgrade you want to offer for your operator which is integrated with OLM.
+        By using the make target `make bundle` or the command `operator-sdk generate bundle` the default channel name configured
+        for the bundle was `alpha` and for now on, SDK will use `preview` as default the channel name instead.
+
+        To update the channel name used in the bundle of your project to use the new default value run `make bundle`.
+        To know more about the OLM channel name see: https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/channel-naming.md#naming

--- a/internal/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/generate/bundle/cmd.go
@@ -118,7 +118,7 @@ func (c *bundleCmd) addFlagsTo(fs *pflag.FlagSet) {
 	fs.StringVar(&c.deployDir, "deploy-dir", "", "Root directory for operator manifests such as "+
 		"Deployments and RBAC, ex. 'deploy'. This directory is different from that passed to --input-dir")
 	fs.StringVar(&c.crdsDir, "crds-dir", "", "Root directory for CustomResoureDefinition manifests")
-	fs.StringVar(&c.channels, "channels", "alpha", "A comma-separated list of channels the bundle belongs to")
+	fs.StringVar(&c.channels, "channels", "preview", "A comma-separated list of channels the bundle belongs to")
 	fs.StringVar(&c.defaultChannel, "default-channel", "", "The default channel for the bundle")
 	fs.BoolVar(&c.overwrite, "overwrite", true, "Overwrite the bundle's metadata and Dockerfile if they exist")
 	fs.BoolVarP(&c.quiet, "quiet", "q", false, "Run in quiet mode")

--- a/internal/generate/clusterserviceversion/bases/clusterserviceversion.go
+++ b/internal/generate/clusterserviceversion/bases/clusterserviceversion.go
@@ -113,7 +113,7 @@ func (b *ClusterServiceVersion) setDefaults() {
 		b.Description = b.DisplayName + " description. TODO."
 	}
 	if b.Maturity == "" {
-		b.Maturity = "alpha"
+		b.Maturity = "preview"
 	}
 	if b.Capabilities == "" {
 		b.Capabilities = "Basic Install"

--- a/internal/generate/packagemanifest/packagemanifest.go
+++ b/internal/generate/packagemanifest/packagemanifest.go
@@ -143,8 +143,8 @@ func (g *Generator) generate() (*apimanifests.PackageManifest, error) {
 			base.DefaultChannelName = g.ChannelName
 		}
 	} else if len(base.Channels) == 0 {
-		setChannels(base, "alpha", csvName)
-		base.DefaultChannelName = "alpha"
+		setChannels(base, "preview", csvName)
+		base.DefaultChannelName = "preview"
 	}
 
 	if err = validatePackageManifest(base); err != nil {

--- a/internal/generate/packagemanifest/packagemanifest_test.go
+++ b/internal/generate/packagemanifest/packagemanifest_test.go
@@ -39,8 +39,8 @@ func TestGenerator(t *testing.T) {
 const (
 	pkgManDefaultContent = `channels:
   - currentCSV: memcached-operator.v0.0.1
-    name: alpha
-defaultChannel: alpha
+    name: preview
+defaultChannel: preview
 packageName: memcached-operator
 `
 

--- a/internal/generate/packagemanifest/packagemanifest_test.go
+++ b/internal/generate/packagemanifest/packagemanifest_test.go
@@ -188,16 +188,16 @@ var _ = Describe("Generating a PackageManifest", func() {
 				g = Generator{
 					OperatorName: operatorName,
 					Version:      "0.0.2",
-					ChannelName:  "alpha",
+					ChannelName:  "preview",
 					getBase:      makeBaseGetter(pkgManDefaultContent),
 				}
 				pkg, err := g.generate()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pkg).To(Equal(&apimanifests.PackageManifest{
 					Channels: []apimanifests.PackageChannel{
-						{Name: "alpha", CurrentCSVName: genutil.MakeCSVName(operatorName, "0.0.2")},
+						{Name: "preview", CurrentCSVName: genutil.MakeCSVName(operatorName, "0.0.2")},
 					},
-					DefaultChannelName: "alpha",
+					DefaultChannelName: "preview",
 					PackageName:        operatorName,
 				}))
 			})
@@ -212,10 +212,10 @@ var _ = Describe("Generating a PackageManifest", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pkg).To(Equal(&apimanifests.PackageManifest{
 					Channels: []apimanifests.PackageChannel{
-						{Name: "alpha", CurrentCSVName: genutil.MakeCSVName(operatorName, version)},
+						{Name: "preview", CurrentCSVName: genutil.MakeCSVName(operatorName, version)},
 						{Name: "stable", CurrentCSVName: genutil.MakeCSVName(operatorName, "0.0.2")},
 					},
-					DefaultChannelName: "alpha",
+					DefaultChannelName: "preview",
 					PackageName:        operatorName,
 				}))
 			})
@@ -231,7 +231,7 @@ var _ = Describe("Generating a PackageManifest", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pkg).To(Equal(&apimanifests.PackageManifest{
 					Channels: []apimanifests.PackageChannel{
-						{Name: "alpha", CurrentCSVName: genutil.MakeCSVName(operatorName, version)},
+						{Name: "preview", CurrentCSVName: genutil.MakeCSVName(operatorName, version)},
 						{Name: "stable", CurrentCSVName: genutil.MakeCSVName(operatorName, "0.0.2")},
 					},
 					DefaultChannelName: "stable",

--- a/internal/generate/testdata/memcached-operator.package.yaml
+++ b/internal/generate/testdata/memcached-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
 - currentCSV: memcached-operator.v0.0.1
-  name: alpha
-defaultChannel: alpha
+  name: preview
+defaultChannel: preview
 packageName: memcached-operator

--- a/test/integration/packagemanifests_test.go
+++ b/test/integration/packagemanifests_test.go
@@ -68,7 +68,7 @@ var _ = Describe("run packagemanifests", func() {
 
 	It("should successfully deploy the second of two operator versions", func() {
 		versions := []string{"0.0.1", "0.2.0"}
-		channels := []string{"alpha", "stable"}
+		channels := []string{"preview", "stable"}
 		for i, version := range versions {
 			imageTag := fmt.Sprintf("integration/%s:%s", tc.ProjectName, version)
 			By("building the manager image " + imageTag)

--- a/testdata/ansible/memcached-operator/bundle.Dockerfile
+++ b/testdata/ansible/memcached-operator/bundle.Dockerfile
@@ -4,7 +4,7 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=memcached-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channels.v1=preview
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 COPY bundle/manifests /manifests/

--- a/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -179,7 +179,7 @@ spec:
   maintainers:
   - email: your@email.com
     name: Maintainer Name
-  maturity: alpha
+  maturity: preview
   provider:
     name: Provider Name
     url: https://your.domain

--- a/testdata/ansible/memcached-operator/bundle/metadata/annotations.yaml
+++ b/testdata/ansible/memcached-operator/bundle/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channels.v1: preview
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/testdata/ansible/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/ansible/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ spec:
   maintainers:
   - email: your@email.com
     name: Maintainer Name
-  maturity: alpha
+  maturity: preview
   provider:
     name: Provider Name
     url: https://your.domain

--- a/testdata/go/v2/memcached-operator/bundle.Dockerfile
+++ b/testdata/go/v2/memcached-operator/bundle.Dockerfile
@@ -4,7 +4,7 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=memcached-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channels.v1=preview
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 COPY bundle/manifests /manifests/

--- a/testdata/go/v2/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v2/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -195,7 +195,7 @@ spec:
   maintainers:
   - email: your@email.com
     name: Maintainer Name
-  maturity: alpha
+  maturity: preview
   provider:
     name: Provider Name
     url: https://your.domain

--- a/testdata/go/v2/memcached-operator/bundle/metadata/annotations.yaml
+++ b/testdata/go/v2/memcached-operator/bundle/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channels.v1: preview
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/testdata/go/v2/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v2/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ spec:
   maintainers:
   - email: your@email.com
     name: Maintainer Name
-  maturity: alpha
+  maturity: preview
   provider:
     name: Provider Name
     url: https://your.domain

--- a/testdata/go/v3/memcached-operator/bundle.Dockerfile
+++ b/testdata/go/v3/memcached-operator/bundle.Dockerfile
@@ -4,7 +4,7 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=memcached-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channels.v1=preview
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 COPY bundle/manifests /manifests/

--- a/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -206,7 +206,7 @@ spec:
   maintainers:
   - email: your@email.com
     name: Maintainer Name
-  maturity: alpha
+  maturity: preview
   provider:
     name: Provider Name
     url: https://your.domain

--- a/testdata/go/v3/memcached-operator/bundle/metadata/annotations.yaml
+++ b/testdata/go/v3/memcached-operator/bundle/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channels.v1: preview
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/testdata/go/v3/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v3/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ spec:
   maintainers:
   - email: your@email.com
     name: Maintainer Name
-  maturity: alpha
+  maturity: preview
   provider:
     name: Provider Name
     url: https://your.domain

--- a/testdata/helm/memcached-operator/bundle.Dockerfile
+++ b/testdata/helm/memcached-operator/bundle.Dockerfile
@@ -4,7 +4,7 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=memcached-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channels.v1=preview
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 COPY bundle/manifests /manifests/

--- a/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -270,7 +270,7 @@ spec:
   maintainers:
   - email: your@email.com
     name: Maintainer Name
-  maturity: alpha
+  maturity: preview
   provider:
     name: Provider Name
     url: https://your.domain

--- a/testdata/helm/memcached-operator/bundle/metadata/annotations.yaml
+++ b/testdata/helm/memcached-operator/bundle/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channels.v1: preview
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/testdata/helm/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/helm/memcached-operator/config/manifests/bases/memcached-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ spec:
   maintainers:
   - email: your@email.com
     name: Maintainer Name
-  maturity: alpha
+  maturity: preview
   provider:
     name: Provider Name
     url: https://your.domain

--- a/website/content/en/docs/cli/operator-sdk_generate_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_bundle.md
@@ -79,7 +79,7 @@ operator-sdk generate bundle [flags]
 ### Options
 
 ```
-      --channels string          A comma-separated list of channels the bundle belongs to (default "alpha")
+      --channels string          A comma-separated list of channels the bundle belongs to (default "preview")
       --crds-dir string          Root directory for CustomResoureDefinition manifests
       --default-channel string   The default channel for the bundle
       --deploy-dir string        Root directory for operator manifests such as Deployments and RBAC, ex. 'deploy'. This directory is different from that passed to --input-dir


### PR DESCRIPTION
**Description**
Use `preview` as default channel name value instead of `alpha` for OLM bundles.

**Motivation**
Encourage users to adopted its conventional. See; https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/channel-naming.md#naming


