### PR TITLE
olm/operator: do not tamper error type returned by the apiserver

### DIFF
--- a/internal/olm/operator/registry/operator_installer.go
+++ b/internal/olm/operator/registry/operator_installer.go
@@ -328,10 +328,7 @@ func (o OperatorInstaller) approveInstallPlan(ctx context.Context, sub *v1alpha1
 		}
 		// approve the install plan by setting Approved to true
 		ip.Spec.Approved = true
-		if err := o.cfg.Client.Update(ctx, &ip); err != nil {
-			return fmt.Errorf("error approving install plan: %w", err)
-		}
-		return nil
+		return o.cfg.Client.Update(ctx, &ip)
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
PR #4309 does not fully fix the issue #4308 and `run packagemanifests`
randomly fails with below error:

```
Failed to run packagemanifests: error approving install plan: Operation cannot be fulfilled on installplans.operators.coreos.com \"install-jp28s\": the object has been modified; please apply your changes to the latest version and try again
```

`retry.RetryOnConflict()` uses `k8serrors.IsConflict()` to determine if
the error occurred was a conflict error. IsConflict() checks if the
'type' of the error is `StatusError`. Wrapping the error returned by the
Update() call will changed the 'type' to 'wrapError'. Hence do not wrap
the error return from Update().


**Motivation for the change:**
FIXES #4308


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
