### PR TITLE
Fix panic with "operator-sdk bundle validate" and OCI

### DIFF
--- a/changelog/fragments/fix-bundle-validate-panic.yaml
+++ b/changelog/fragments/fix-bundle-validate-panic.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: Fix panic when "operator-sdk bundle validate" fails
+    kind: bugfix
+    breaking: false

--- a/internal/cmd/operator-sdk/bundle/validate/validate.go
+++ b/internal/cmd/operator-sdk/bundle/validate/validate.go
@@ -111,7 +111,7 @@ func (c bundleValidateCmd) run(logger *log.Entry, bundleRaw string) (res *intern
 			return res, err
 		}
 		defer func() {
-			if err = os.RemoveAll(c.directory); err != nil {
+			if err := os.RemoveAll(c.directory); err != nil {
 				logger.Errorf("Error removing temp bundle dir: %v", err)
 			}
 		}()


### PR DESCRIPTION
**Description of the change:**
I faced an issue with `operator-sdk bundle validate` that is quite easy to reproduce, see the command/result below:

```shell
operator-sdk bundle validate --image-builder docker quay.io/blaqkube/mysql-operator:0.4.0
INFO[0000] Unpacking image layers
INFO[0000] running /usr/bin/docker pull quay.io/blaqkube/mysql-operator:0.4.0
INFO[0001] running docker create
INFO[0001] running docker cp
INFO[0001] running docker rm
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x13b0f86]

goroutine 1 [running]:
github.com/operator-framework/operator-sdk/internal/cmd/operator-sdk/bundle/validate/internal.(*Result).prepare(0x0, 0x15, 0x7fff15fead90)
	internal/cmd/operator-sdk/bundle/validate/internal/result.go:132 +0x26
github.com/operator-framework/operator-sdk/internal/cmd/operator-sdk/bundle/validate/internal.(*Result).PrintWithFormat(0x0, 0x211d7ab, 0x4, 0x6, 0x211d7ab)
	internal/cmd/operator-sdk/bundle/validate/internal/result.go:151 +0x2f
github.com/operator-framework/operator-sdk/internal/cmd/operator-sdk/bundle/validate.NewCmd.func1(0xc00035ab00, 0xc000631dd0, 0x1, 0x3, 0x0, 0x0)
	internal/cmd/operator-sdk/bundle/validate/cmd.go:104 +0x3ca
github.com/spf13/cobra.(*Command).execute(0xc00035ab00, 0xc000631da0, 0x3, 0x3, 0xc00035ab00, 0xc000631da0)
	/home/travis/gopath/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:842 +0x47c
github.com/spf13/cobra.(*Command).ExecuteC(0xc0006642c0, 0x244b180, 0xc0002df878, 0x212b18c)
	/home/travis/gopath/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/home/travis/gopath/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
sigs.k8s.io/kubebuilder/v2/pkg/cli.cli.Run(...)
	/home/travis/gopath/pkg/mod/sigs.k8s.io/kubebuilder/v2@v2.3.2-0.20201214213149-0a807f4e9428/pkg/cli/cli.go:494
github.com/operator-framework/operator-sdk/internal/cmd/operator-sdk/cli.Run(0xc000092058, 0x0)
	internal/cmd/operator-sdk/cli/cli.go:51 +0x38
main.main()
	cmd/operator-sdk/main.go:28 +0x25
```

The reason for the panic is in the `run` method for bundleValidateCmd in the validate package:

- variables are set for return values
- there is a defer to perform some cleaning when exiting the method
- the defer reuse the err variable instead of recreating its own variable

The result of that code is that `err` gets erased by the defer() leading to a panic when trying to access the `result` later in the code of the cmd.

**Motivation for the change:**
bugfix

**Checklist**
If the pull request includes user-facing changes, extra documentation is required:

* [x]  Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
* [ ]  Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
