### PR TITLE
fix: (helm) - do not add owner references to resources that contain the Helm keep resource-policy annotation

### DIFF
--- a/changelog/fragments/helm_operator_fix_helm_keep_annotated_delete.yaml
+++ b/changelog/fragments/helm_operator_fix_helm_keep_annotated_delete.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      For Helm-based operators, do not add owner references to resources that contain the Helm annotation: 'helm.sh/resource-policy: keep'.
+    kind: bugfix
+    breaking: false

--- a/internal/helm/client/client.go
+++ b/internal/helm/client/client.go
@@ -165,13 +165,13 @@ func (c *ownerRefInjectingClient) Build(reader io.Reader, validate bool) (kube.R
 }
 
 func containsResourcePolicyKeep(annotations map[string]string) bool {
-	if annotations != nil {
-		resourcePolicyType, ok := annotations[kube.ResourcePolicyAnno]
-		if ok {
-			resourcePolicyType = strings.ToLower(strings.TrimSpace(resourcePolicyType))
-			return resourcePolicyType == kube.KeepPolicy
-		}
+	if annotations == nil {
+		return false
 	}
-
-	return false
+	resourcePolicyType, ok := annotations[kube.ResourcePolicyAnno]
+	if !ok {
+		return false
+	}
+	resourcePolicyType = strings.ToLower(strings.TrimSpace(resourcePolicyType))
+	return resourcePolicyType == kube.KeepPolicy
 }

--- a/internal/helm/client/client_test.go
+++ b/internal/helm/client/client_test.go
@@ -1,0 +1,79 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/kube"
+)
+
+func TestContainsResourcePolicyKeep(t *testing.T) {
+	tests := []struct {
+		input       map[string]string
+		expectedVal bool
+		expectedOut string
+		name        string
+	}{
+		{
+			input: map[string]string{
+				kube.ResourcePolicyAnno: kube.KeepPolicy,
+			},
+			expectedVal: true,
+			name:        "base case true",
+		},
+		{
+			input: map[string]string{
+				"not-" + kube.ResourcePolicyAnno: kube.KeepPolicy,
+			},
+			expectedVal: false,
+			name:        "base case annotation false",
+		},
+		{
+			input: map[string]string{
+				kube.ResourcePolicyAnno: "not-" + kube.KeepPolicy,
+			},
+			expectedVal: false,
+			name:        "base case value false",
+		},
+		{
+			input: map[string]string{
+				kube.ResourcePolicyAnno: strings.ToUpper(kube.KeepPolicy),
+			},
+			expectedVal: true,
+			name:        "true with upper case",
+		},
+		{
+			input: map[string]string{
+				kube.ResourcePolicyAnno: " " + kube.KeepPolicy + "  ",
+			},
+			expectedVal: true,
+			name:        "true with spaces",
+		},
+		{
+			input: map[string]string{
+				kube.ResourcePolicyAnno: " " + strings.ToUpper(kube.KeepPolicy) + "  ",
+			},
+			expectedVal: true,
+			name:        "true with upper case and spaces",
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expectedVal, containsResourcePolicyKeep(test.input), test.name)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

**Description of the change:**
Helm operator: updated the ownerRefInjectingClient to not inject the owner references if it contains the annotation: 
```
  annotations:
    "helm.sh/resource-policy": keep
```
see https://helm.sh/docs/howto/charts_tips_and_tricks/ for more details about the `keep` annotation.

**Motivation for the change:**
For the Helm operator delete CR, namespace scope resources with the Helm keep annotation are being GC'ed by Kubernetes.
This change is to make sure those resources are not owned by the CR so they won't get GC'ed.

Closes: https://github.com/operator-framework/operator-sdk/issues/4378

After this change, I can no longer reproduces the issue described in https://github.com/operator-framework/operator-sdk/issues/4378

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [NA] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
