### PR TITLE
images/scorecard-test-kuttl: upgrade kuttl to v0.8.0

### DIFF
--- a/changelog/fragments/kuttl-v0.8.0.yaml
+++ b/changelog/fragments/kuttl-v0.8.0.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: >
+      Upgraded the `kudobuilder/kuttl` base image version in the `scorecard-test-kuttl` image to v0.8.0
+    kind: change

--- a/images/scorecard-test-kuttl/Dockerfile
+++ b/images/scorecard-test-kuttl/Dockerfile
@@ -1,5 +1,5 @@
 #FROM docker.io/kudobuilder/kuttl@sha256:c9c5edc27ba6e5e994ffd8cea03368c0d4e274f3c7a00f51c1e360feb573f24e
-FROM kudobuilder/kuttl:v0.7.1
+FROM kudobuilder/kuttl:v0.8.0
 
 ENV HOME=/opt/scorecard-test-kuttl \
     USER_NAME=scorecard-test-kuttl \


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:** upgrade the `kudobuilder/kuttl` base image version in the `scorecard-test-kuttl` image to v0.8.0


**Motivation for the change:** new kuttl release has features/changes required for #4329 

/area dependency


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
