### PR TITLE
Updates to the tutorial docs

### DIFF
--- a/website/content/en/docs/building-operators/ansible/quickstart.md
+++ b/website/content/en/docs/building-operators/ansible/quickstart.md
@@ -36,7 +36,6 @@ Make sure to define `IMG` when you call `make`:
   make docker-build docker-push IMG=$OPERATOR_IMG
   ```
 
-
 ### OLM deployment
 
 1. Install [OLM][doc-olm]:

--- a/website/content/en/docs/building-operators/ansible/tutorial.md
+++ b/website/content/en/docs/building-operators/ansible/tutorial.md
@@ -235,7 +235,6 @@ Ensure that the memcached operator creates the deployment for the sample CR with
 ```console
 $ kubectl get deployment
 NAME                                    READY   UP-TO-DATE   AVAILABLE   AGE
-memcached-operator-controller-manager   1/1     1            1           8m
 memcached-sample                        3/3     3            3           1m
 ```
 
@@ -284,7 +283,6 @@ Confirm that the operator changes the deployment size:
 ```console
 $ kubectl get deployment
 NAME                                    READY   UP-TO-DATE   AVAILABLE   AGE
-memcached-operator-controller-manager   1/1     1            1           10m
 memcached-sample                        5/5     5            5           3m
 ```
 

--- a/website/content/en/docs/building-operators/golang/quickstart.md
+++ b/website/content/en/docs/building-operators/golang/quickstart.md
@@ -10,7 +10,7 @@ This guide walks through an example of building a simple memcached-operator usin
 ## Prerequisites
 
 - Go through the [installation guide][install-guide].
-- User authorized with `cluster-admin` permissions
+- User authorized with `cluster-admin` permissions.
 
 ## Steps
 
@@ -37,6 +37,12 @@ Make sure to define `IMG` when you call `make`:
   make docker-build docker-push IMG=$OPERATOR_IMG
   ```
 
+**Note**: If using an OS which does not point `sh` to the `bash` shell (Ubuntu for example) then you should add the following line to the `Makefile`:
+
+`SHELL := /bin/bash`
+
+This will fix potential issues when the `docker-build` target runs the controller test suite. Issues maybe similar to following error:
+`failed to start the controlplane. retried 5 times: fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory occurred`
 
 ### OLM deployment
 

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -10,9 +10,9 @@ please [migrate][migration-guide], or consult the [legacy docs][legacy-quickstar
 
 ## Prerequisites
 
-- [Install operator-sdk][operator_install] and its prequisites.
+- Go through the [installation guide][install-guide].
 - Access to a Kubernetes v1.11.3+ cluster (v1.16.0+ if using `apiextensions.k8s.io/v1` CRDs).
-- User logged with admin permission. See [how to grant yourself cluster-admin privileges or be logged in as admin][role-based-access-control]
+- User authorized with `cluster-admin` permissions.
 
 ## Create a new project
 
@@ -314,6 +314,13 @@ make docker-build docker-push IMG=quay.io/$USERNAME/memcached-operator:v0.0.1
 **Note**: The name and tag of the image (`IMG=<some-registry>/<project-name>:tag`) in both the commands can also be set in the Makefile.
 Modify the line which has `IMG ?= controller:latest` to set your desired default image name.
 
+**Note**: If using an OS which does not point `sh` to the `bash` shell (Ubuntu for example) then you should add the following line to the `Makefile`:
+
+`SHELL := /bin/bash`
+
+This will fix potential issues when the `docker-build` target runs the controller test suite. Issues maybe similar to following error:
+`failed to start the controlplane. retried 5 times: fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory occurred`
+
 #### Deploy the operator
 
 By default, a new namespace is created with name `<project-name>-system`, i.e. memcached-operator-system and will be used for the deployment.
@@ -386,7 +393,6 @@ Ensure that the memcached operator creates the deployment for the sample CR with
 ```console
 $ kubectl get deployment
 NAME                                    READY   UP-TO-DATE   AVAILABLE   AGE
-memcached-operator-controller-manager   1/1     1            1           8m
 memcached-sample                        3/3     3            3           1m
 ```
 
@@ -435,7 +441,6 @@ Confirm that the operator changes the deployment size:
 ```console
 $ kubectl get deployment
 NAME                                    READY   UP-TO-DATE   AVAILABLE   AGE
-memcached-operator-controller-manager   1/1     1            1           10m
 memcached-sample                        5/5     5            5           3m
 ```
 


### PR DESCRIPTION
**Description of the change:**
While using the operator-sdk docs, I encountered the following issues:
- Link in https://sdk.operatorframework.io/docs/building-operators/golang/tutorial/#prerequisites for install is incorrect. It should be https://sdk.operatorframework.io/docs/building-operators/golang/installation/
- Error when run: `make docker-build IMG=hub.docker.com/$USERNAME/memcached-operator:v0.0.1` in https://sdk.operatorframework.io/docs/building-operators/golang/tutorial/#build-and-push-the-image:

```
[...]
Failure [0.005 seconds]
[BeforeSuite] BeforeSuite 
/home/marty/projects/memcached-operator/controllers/suite_test.go:52

  Unexpected error:
      <*fmt.wrapError | 0xc0003d0ac0>: {
          msg: "failed to start the controlplane. retried 5 times: fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory",
          err: {
              Op: "fork/exec",
              Path: "/usr/local/kubebuilder/bin/etcd",
              Err: 0x2,
          },
      }
      failed to start the controlplane. retried 5 times: fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory
  occurred

  /home/marty/projects/memcached-operator/controllers/suite_test.go:62
```

~~Installing `kubebuilder` fixes the issue.~~ Ref: Issue#4203.

- In https://sdk.operatorframework.io/docs/building-operators/golang/tutorial/#create-a-memcached-cr:

`kubectl get deployment` command should not display `memcached-operator-controller-manager` as it is not in the default namespace

**Motivation for the change:**
Improve the docs.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
