### PR TITLE
Handle operator bundle upgrade from traditional operator installation

### DIFF
--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -17,6 +17,7 @@ package registry
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -74,7 +75,7 @@ func (c IndexImageCatalogCreator) CreateCatalog(ctx context.Context, name string
 	}
 
 	newItems := []index.BundleItem{{ImageTag: c.BundleImage, AddMode: c.BundleAddMode}}
-	if err := c.createAnnotatedRegistry(ctx, cs, newItems, updateFeildsNoOp); err != nil {
+	if err := c.createAnnotatedRegistry(ctx, cs, newItems, updateFieldsNoOp); err != nil {
 		return nil, fmt.Errorf("error creating registry pod: %v", err)
 	}
 
@@ -91,6 +92,28 @@ func (c IndexImageCatalogCreator) UpdateCatalog(ctx context.Context, cs *v1alpha
 		}
 		prevRegistryPodName = annotations[registryPodNameAnnotation]
 	}
+
+	existingItems, err := getExistingBundleItems(cs.GetAnnotations())
+	if err != nil {
+		return fmt.Errorf("error getting existing bundles from CatalogSource %s annotations: %v", cs.GetName(), err)
+	}
+	annotationsNotFound := len(existingItems) == 0
+
+	if annotationsNotFound && cs.Spec.Image != "" {
+		// if no annotations exist and image reference exists, set it to index image
+		c.IndexImage = cs.Spec.Image
+	} else if annotationsNotFound && cs.Spec.Image == "" {
+		// if no annotations exist and image reference is empty, error out
+		return errors.New("annotations and catalog source image reference don't exist")
+	}
+
+	updateFields := func(*v1alpha1.CatalogSource) {
+		// set `spec.Image` field to empty as we set the address in
+		// catalog source to registry pod IP
+		cs.Spec.Image = ""
+
+	}
+
 	// Default add mode here since it depends on an existing annotation.
 	if c.BundleAddMode == "" {
 		if c.IndexImage == index.DefaultIndexImage {
@@ -100,22 +123,9 @@ func (c IndexImageCatalogCreator) UpdateCatalog(ctx context.Context, cs *v1alpha
 		}
 	}
 
-	existingItems, err := getExistingBundleItems(cs.GetAnnotations())
-	if err != nil {
-		return fmt.Errorf("error getting existing bundles from CatalogSource %s annotations: %v", cs.GetName(), err)
-	}
-	imageReferenceExists := len(existingItems) == 0
-
 	newItem := index.BundleItem{ImageTag: c.BundleImage, AddMode: c.BundleAddMode}
 	existingItems = append(existingItems, newItem)
 
-	updateFields := func(*v1alpha1.CatalogSource) {
-		// set `spec.Image` field to empty as we will be setting the address field in
-		// catalog source to point to the new new registry pod
-		if imageReferenceExists {
-			cs.Spec.Image = ""
-		}
-	}
 	if err := c.createAnnotatedRegistry(ctx, cs, existingItems, updateFields); err != nil {
 		return fmt.Errorf("error creating registry pod: %v", err)
 	}
@@ -135,7 +145,6 @@ func (c IndexImageCatalogCreator) UpdateCatalog(ctx context.Context, cs *v1alpha
 // from items and that pod, then applies updateFields.
 func (c IndexImageCatalogCreator) createAnnotatedRegistry(ctx context.Context, cs *v1alpha1.CatalogSource,
 	items []index.BundleItem, updateFields func(*v1alpha1.CatalogSource)) (err error) {
-
 	// Initialize and create registry pod
 	registryPod := index.RegistryPod{
 		BundleItems: items,
@@ -182,7 +191,7 @@ func (c IndexImageCatalogCreator) createAnnotatedRegistry(ctx context.Context, c
 }
 
 // Use if no extra updates need to be made to an annotated CatalogSource.
-func updateFeildsNoOp(*v1alpha1.CatalogSource) {}
+func updateFieldsNoOp(*v1alpha1.CatalogSource) {}
 
 // getDBPath returns the database path from the index image's labels.
 func (c IndexImageCatalogCreator) getDBPath(ctx context.Context) (string, error) {

--- a/internal/olm/operator/registry/operator_installer.go
+++ b/internal/olm/operator/registry/operator_installer.go
@@ -119,19 +119,6 @@ func (o OperatorInstaller) UpgradeOperator(ctx context.Context) (*v1alpha1.Clust
 
 	log.Infof("Found existing subscription with name %s and namespace %s", subscription.Name, subscription.Namespace)
 
-	// todo: attempt #1 to trigger install plan for the subscription and
-	// to make it detect catalog changes, as per OLM suggestion
-	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		// set the startingCSV to empty
-		subscription.Spec.StartingCSV = ""
-		if err := o.cfg.Client.Update(ctx, subscription); err != nil {
-			return fmt.Errorf("error updating subscription: %v", err)
-		}
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-
 	// Get existing catalog source from the subsription
 	catsrcKey := types.NamespacedName{
 		Namespace: subscription.Spec.CatalogSourceNamespace,


### PR DESCRIPTION
**Description of the change:**
Handle operator bundle upgrade from traditional operator installation without executing `run bundle` command to deploy the operator bundle.

**Motivation for the change:**
Supporting a use-case where an operator bundle was deployed onto the cluster without executing `run bundle`, and still being able to perform upgrades to it thereafter, through `run bundle-upgrade` command.

/cc @joelanford @estroz @jmrodri
