### PR TITLE
Fix a tiny typo in Ansible tutorial.

### DIFF
--- a/website/content/en/docs/building-operators/ansible/tutorial.md
+++ b/website/content/en/docs/building-operators/ansible/tutorial.md
@@ -52,7 +52,7 @@ See [scaffolded files reference][layout-doc] and [watches reference][ansible-wat
 
 Now we need to provide the reconcile logic, in the form of an Ansible
 Role, which will run every time a `Memcached` resource is created,
-updated, or delete.
+updated, or deleted.
 
 Update `roles/memcached/tasks/main.yml`:
 


### PR DESCRIPTION
**Description of the change:**

Fixes a tiny typo I found while reading through the Ansible Operator SDK tutorial.

**Motivation for the change:**

I don't like typos.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
