### PR TITLE
docs/upgrading-sdk-version: note v0.19.0 migration guide as well as latest

### DIFF
--- a/website/content/en/docs/upgrading-sdk-version/v0.19.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v0.19.0.md
@@ -22,8 +22,12 @@ _See [#3265](https://github.com/operator-framework/operator-sdk/pull/3265) for m
 
 ## Migrating Go projects to the new Kubebuilder aligned project layout
 
-See the [migration guide][migration-guide] that walks through an example of how
-to migrate a Go based operator project from the old layout to the new layout.
+See the [v0.19.0 project migration guide][migration-guide-v0.19.0] that walks through an example of how
+to migrate a Go based operator project from the old layout to the v0.19.0 layout. Migrating to v0.19.0
+before v1.0.0 is practical if you plan to migrate your project between one minor version at a time.
+
+If you wish to migrate directly from the old layout to the latest v1.0.0+ layout, see
+the [latest migration guide][migration-guide].
 
 _See [#3190](https://github.com/operator-framework/operator-sdk/pull/3190) for more details._
 
@@ -48,3 +52,4 @@ to use `UpgradeError` instead of `UpdateError`.
 _See [#3269](https://github.com/operator-framework/operator-sdk/pull/3269) for more details._
 
 [migration-guide]: /docs/building-operators/golang/migration/
+[migration-guide-v0.19.0]: https://v0-19-x.sdk.operatorframework.io/docs/golang/project_migration_guide/


### PR DESCRIPTION
**Description of the change:**
- docs/upgrading-sdk-version/v0.19.0.md: add link to and note about v0.19.x migration guide

**Motivation for the change:** it is confusing to see two different migration guides when migrating a Go project to v0.19.0, one of which is specifically for v0.19.0 and the other for v1.x (latest).

/kind documentation

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>
