### PR TITLE
upgrade Python to v 3.8

### DIFF
--- a/changelog/fragments/upgrade-python-on-ansible-operator.yaml
+++ b/changelog/fragments/upgrade-python-on-ansible-operator.yaml
@@ -1,0 +1,11 @@
+entries:
+  - description: >
+      For Ansible-based operators, the Python version has been updated
+      to a newer version, from 3.6 to 3.8 to take advantage of performance
+      improvements, language additions, security updates and generally
+      better availability for local development.
+
+    kind: change
+
+    # Is this a breaking change?
+    breaking: false

--- a/images/ansible-operator/Dockerfile
+++ b/images/ansible-operator/Dockerfile
@@ -15,7 +15,7 @@ ENV HOME=/opt/ansible \
 # yum clean all && rm -rf /var/yum/cache/* first
 RUN yum clean all && rm -rf /var/cache/yum/* \
   && yum -y update \
-  && yum install -y libffi-devel openssl-devel python36-devel gcc python3-pip python3-setuptools \
+  && yum install -y libffi-devel openssl-devel python38-devel gcc python38-pip python38-setuptools \
   && pip3 install --no-cache-dir \
     ansible-runner==1.3.4 \
     ansible-runner-http==1.0.0 \
@@ -24,7 +24,7 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
     openshift==0.10.3 \
     ansible==2.9.15 \
     jmespath==0.10.0 \
-  && yum remove -y gcc libffi-devel openssl-devel python36-devel \
+  && yum remove -y gcc libffi-devel openssl-devel python38-devel \
   && yum clean all \
   && rm -rf /var/cache/yum
 

--- a/website/content/en/docs/building-operators/ansible/installation.md
+++ b/website/content/en/docs/building-operators/ansible/installation.md
@@ -9,7 +9,7 @@ weight: 1
 Follow the steps in the [installation guide][install-guide] to learn how to install the `operator-sdk` CLI tool.
 
 ## Additional Prerequisites
-
+- [python][python] version 3.8.6+
 - [ansible][ansible] version v2.9.0+
 - [ansible-runner][ansible-runner] version v1.1.0+
 - [ansible-runner-http][ansible-runner-http-plugin] version v1.0.0+
@@ -17,6 +17,7 @@ Follow the steps in the [installation guide][install-guide] to learn how to inst
 
 
 [install-guide]:/docs/installation/
+[python]:https://www.python.org/downloads/
 [ansible]:https://docs.ansible.com/ansible/latest/index.html
 [ansible-runner]:https://ansible-runner.readthedocs.io/en/latest/install.html
 [ansible-runner-http-plugin]:https://github.com/ansible/ansible-runner-http


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Upgrade Python to version 3.8 to facilitate local development (i.e. without having to resort to deadsnakes repos and suchlikes) and benefit from performance enhancements in more recent versions of Python (with 3.6 functionally mothballed now)

**Motivation for the change:**
The Ansible operator uses an outdated version of Python that hampers local development and reproducible builds as it requires you to keep around an old version of Python. Since many recent distros don't ship Python 3.6 in their standard packaging repositories anymore, this requires a manual install, or alternate package repositories.

*Note*: this is a first pull request to start addressing the issues mentioned in #4237 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
