### PR TITLE
internal/plugins: add `manifests` and `scorecard` plugin keys to all projects

### DIFF
--- a/changelog/fragments/phase-2-plugin-keys.yaml
+++ b/changelog/fragments/phase-2-plugin-keys.yaml
@@ -1,14 +1,42 @@
 entries:
   - description: >
-      (ansible/v1, helm/v1, go/v2) Added plugin keys for the `manifests` and `scorecard` phase 2 plugins
-    kind: addition
+      (go/v2) Changed `go` PROJECT plugin object to `manifests` and `scorecard` objects (`.sdk.operatorframework.io` suffix)
+    kind: change
     breaking: false
     migration:
-      header: Add `manifests` and `scorecard` plugin keys to your PROJECT
+      header: (go/v2) Change `go` PROJECT plugin object to `manifests` and `scorecard` objects
       body: >
         The `manifests` and `scorecard` plugins that create OLM and scorecard manifests, respectively,
-        now have plugin keys that direct `create` subcommands to create related files. While not necessary
-        to add, the following plugin configuration objects in the PROJECT file will be useful in the future
+        now have plugin objects that direct `create` subcommands to create related files.
+        While the old `go` plugin configuration object is still supported, these new objects will be useful
+        in the future as configuration options are added to their respective plugins:
+
+        Old:
+        ```yaml
+        version: 3-alpha
+        ...
+        plugins:
+          go.sdk.operatorframework.io/v2-alpha: {}
+        ```
+
+        New:
+        ```yaml
+        version: 3-alpha
+        ...
+        plugins:
+          manifests.sdk.operatorframework.io/v2: {}
+          scorecard.sdk.operatorframework.io/v2: {}
+        ```
+
+  - description: >
+      (ansible/v1, helm/v1) Added plugin objects for the `manifests` and `scorecard` phase 2 plugins
+    kind: addition
+    migration:
+      header: (ansible/v1, helm/v1) Add `manifests` and `scorecard` plugin objects to your PROJECT
+      body: >
+        The `manifests` and `scorecard` plugins that create OLM and scorecard manifests, respectively,
+        now have plugin objects that direct `create` subcommands to create related files. While not necessary
+        to add, these new plugin configuration objects in the PROJECT file will be useful in the future
         as configuration options are added to their respective plugins:
 
         ```yaml
@@ -18,5 +46,3 @@ entries:
           manifests.sdk.operatorframework.io/v2: {}
           scorecard.sdk.operatorframework.io/v2: {}
         ```
-
-        For Go projects, you can replace `go.sdk.operatorframework.io/v2-alpha: {}` line with the above two keys.

--- a/changelog/fragments/phase-2-plugin-keys.yaml
+++ b/changelog/fragments/phase-2-plugin-keys.yaml
@@ -1,0 +1,22 @@
+entries:
+  - description: >
+      (ansible/v1, helm/v1, go/v2) Added plugin keys for the `manifests` and `scorecard` phase 2 plugins
+    kind: addition
+    breaking: false
+    migration:
+      header: Add `manifests` and `scorecard` plugin keys to your PROJECT
+      body: >
+        The `manifests` and `scorecard` plugins that create OLM and scorecard manifests, respectively,
+        now have plugin keys that direct `create` subcommands to create related files. While not necessary
+        to add, the following plugin configuration objects in the PROJECT file will be useful in the future
+        as configuration options are added to their respective plugins:
+
+        ```yaml
+        version: 3-alpha
+        ...
+        plugins:
+          manifests.sdk.operatorframework.io/v2: {}
+          scorecard.sdk.operatorframework.io/v2: {}
+        ```
+
+        For Go projects, you can replace `go.sdk.operatorframework.io/v2-alpha: {}` line with the above two keys.

--- a/internal/plugins/ansible/v1/api.go
+++ b/internal/plugins/ansible/v1/api.go
@@ -26,6 +26,7 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/kubebuilder/cmdutil"
 	"github.com/operator-framework/operator-sdk/internal/plugins/ansible/v1/scaffolds"
 	"github.com/operator-framework/operator-sdk/internal/plugins/manifests"
+	manifestsv2 "github.com/operator-framework/operator-sdk/internal/plugins/manifests/v2"
 )
 
 const (
@@ -118,8 +119,24 @@ func (p *createAPIPSubcommand) Run() error {
 
 // SDK phase 2 plugins.
 func (p *createAPIPSubcommand) runPhase2() error {
-	gvk := p.createOptions.GVK
-	return manifests.RunCreateAPI(p.config, config.GVK{Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind})
+	ogvk := p.createOptions.GVK
+	gvk := config.GVK{Group: ogvk.Group, Version: ogvk.Version, Kind: ogvk.Kind}
+
+	// Initially the ansible/v1 plugin was written to not create a "plugins" config entry
+	// for any phase 2 plugin because they did not have their own keys. Now there are phase 2
+	// plugin keys, so those plugins should be run if keys exist. Otherwise, enact old behavior.
+
+	if manifestsv2.HasPluginConfig(p.config) {
+		if err := manifestsv2.RunCreateAPI(p.config, gvk); err != nil {
+			return err
+		}
+	} else {
+		if err := manifests.RunCreateAPI(p.config, gvk); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (p *createAPIPSubcommand) Validate() error {

--- a/internal/plugins/ansible/v1/init.go
+++ b/internal/plugins/ansible/v1/init.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/operator-framework/operator-sdk/internal/kubebuilder/cmdutil"
 	"github.com/operator-framework/operator-sdk/internal/plugins/ansible/v1/scaffolds"
-	"github.com/operator-framework/operator-sdk/internal/plugins/manifests"
-	"github.com/operator-framework/operator-sdk/internal/plugins/scorecard"
+	manifestsv2 "github.com/operator-framework/operator-sdk/internal/plugins/manifests/v2"
+	scorecardv2 "github.com/operator-framework/operator-sdk/internal/plugins/scorecard/v2"
 )
 
 type initSubcommand struct {
@@ -118,10 +118,10 @@ func (p *initSubcommand) Run() error {
 
 // SDK phase 2 plugins.
 func (p *initSubcommand) runPhase2() error {
-	if err := manifests.RunInit(p.config); err != nil {
+	if err := manifestsv2.RunInit(p.config); err != nil {
 		return err
 	}
-	if err := scorecard.RunInit(p.config); err != nil {
+	if err := scorecardv2.RunInit(p.config); err != nil {
 		return err
 	}
 

--- a/internal/plugins/golang/v2/config.go
+++ b/internal/plugins/golang/v2/config.go
@@ -17,6 +17,7 @@ package v2
 import "sigs.k8s.io/kubebuilder/v2/pkg/model/config"
 
 // Config configures this plugin, and is saved in the project config file.
+// Deprecated: use scorecard and manifests plugin configs directly.
 type Config struct{}
 
 // hasPluginConfig returns true if cfg.Plugins contains an exact match for this plugin's key.

--- a/internal/plugins/golang/v2/init.go
+++ b/internal/plugins/golang/v2/init.go
@@ -15,15 +15,13 @@
 package v2
 
 import (
-	"fmt"
-
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/kubebuilder/v2/pkg/model/config"
 	"sigs.k8s.io/kubebuilder/v2/pkg/plugin"
 
 	"github.com/operator-framework/operator-sdk/internal/plugins/envtest"
-	"github.com/operator-framework/operator-sdk/internal/plugins/manifests"
-	"github.com/operator-framework/operator-sdk/internal/plugins/scorecard"
+	manifestsv2 "github.com/operator-framework/operator-sdk/internal/plugins/manifests/v2"
+	scorecardv2 "github.com/operator-framework/operator-sdk/internal/plugins/scorecard/v2"
 )
 
 type initSubcommand struct {
@@ -52,14 +50,6 @@ func (p *initSubcommand) Run() error {
 		return err
 	}
 
-	// Update plugin config section with this plugin's configuration for v3 projects.
-	if p.config.IsV3() {
-		cfg := Config{}
-		if err := p.config.EncodePluginConfig(pluginConfigKey, cfg); err != nil {
-			return fmt.Errorf("error writing plugin config for %s: %v", pluginConfigKey, err)
-		}
-	}
-
 	return nil
 }
 
@@ -68,10 +58,10 @@ func (p *initSubcommand) runPhase2() error {
 	if err := envtest.RunInit(p.config); err != nil {
 		return err
 	}
-	if err := manifests.RunInit(p.config); err != nil {
+	if err := manifestsv2.RunInit(p.config); err != nil {
 		return err
 	}
-	if err := scorecard.RunInit(p.config); err != nil {
+	if err := scorecardv2.RunInit(p.config); err != nil {
 		return err
 	}
 	return nil

--- a/internal/plugins/helm/v1/init.go
+++ b/internal/plugins/helm/v1/init.go
@@ -28,8 +28,8 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/kubebuilder/cmdutil"
 	"github.com/operator-framework/operator-sdk/internal/plugins/helm/v1/chartutil"
 	"github.com/operator-framework/operator-sdk/internal/plugins/helm/v1/scaffolds"
-	"github.com/operator-framework/operator-sdk/internal/plugins/manifests"
-	"github.com/operator-framework/operator-sdk/internal/plugins/scorecard"
+	manifestsv2 "github.com/operator-framework/operator-sdk/internal/plugins/manifests/v2"
+	scorecardv2 "github.com/operator-framework/operator-sdk/internal/plugins/scorecard/v2"
 )
 
 type initSubcommand struct {
@@ -147,10 +147,10 @@ func (p *initSubcommand) Run() error {
 
 // SDK phase 2 plugins.
 func (p *initSubcommand) runPhase2() error {
-	if err := manifests.RunInit(p.config); err != nil {
+	if err := manifestsv2.RunInit(p.config); err != nil {
 		return err
 	}
-	if err := scorecard.RunInit(p.config); err != nil {
+	if err := scorecardv2.RunInit(p.config); err != nil {
 		return err
 	}
 

--- a/internal/plugins/manifests/v2/plugin.go
+++ b/internal/plugins/manifests/v2/plugin.go
@@ -36,8 +36,8 @@ var (
 // Config configures this plugin, and is saved in the project config file.
 type Config struct{}
 
-// hasPluginConfig returns true if cfg.Plugins contains an exact match for this plugin's key.
-func hasPluginConfig(cfg *config.Config) bool {
+// HasPluginConfig returns true if cfg.Plugins contains an exact match for this plugin's key.
+func HasPluginConfig(cfg *config.Config) bool {
 	if !cfg.IsV3() || len(cfg.Plugins) == 0 {
 		return false
 	}
@@ -63,7 +63,7 @@ func RunInit(cfg *config.Config) error {
 
 // RunCreateAPI runs the manifests SDK phase 2 plugin.
 func RunCreateAPI(cfg *config.Config, gvk config.GVK) error {
-	if !hasPluginConfig(cfg) {
+	if !HasPluginConfig(cfg) {
 		return nil
 	}
 	return manifests.RunCreateAPI(cfg, gvk)

--- a/testdata/ansible/memcached-operator/PROJECT
+++ b/testdata/ansible/memcached-operator/PROJECT
@@ -6,3 +6,6 @@ resources:
   kind: Memcached
   version: v1alpha1
 version: 3-alpha
+plugins:
+  manifests.sdk.operatorframework.io/v2: {}
+  scorecard.sdk.operatorframework.io/v2: {}

--- a/testdata/go/v2/memcached-operator/PROJECT
+++ b/testdata/go/v2/memcached-operator/PROJECT
@@ -8,4 +8,5 @@ resources:
   version: v1alpha1
 version: 3-alpha
 plugins:
-  go.sdk.operatorframework.io/v2-alpha: {}
+  manifests.sdk.operatorframework.io/v2: {}
+  scorecard.sdk.operatorframework.io/v2: {}

--- a/testdata/helm/memcached-operator/PROJECT
+++ b/testdata/helm/memcached-operator/PROJECT
@@ -6,3 +6,6 @@ resources:
   kind: Memcached
   version: v1alpha1
 version: 3-alpha
+plugins:
+  manifests.sdk.operatorframework.io/v2: {}
+  scorecard.sdk.operatorframework.io/v2: {}


### PR DESCRIPTION
**Description of the change:**
- internal/plugins: add `manifests` and `scorecard` plugin keys to ansible/v1, helm/v1, and go/v2 projects on init, and consider these keys when running `create api`

**Motivation for the change:** All phase 2 plugins should have keys in the `plugins` config field. This (backwards-compatible) change makes it so.

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
