### PR TITLE
Prerequisite: install kubebuilder

### DIFF
--- a/website/content/en/docs/building-operators/golang/quickstart.md
+++ b/website/content/en/docs/building-operators/golang/quickstart.md
@@ -11,6 +11,7 @@ This guide walks through an example of building a simple memcached-operator usin
 
 - Go through the [installation guide][install-guide].
 - User authorized with `cluster-admin` permissions.
+- [Install kubebuilder](https://book.kubebuilder.io/quick-start.html#installation)
 
 ## Steps
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Add 'install kubebuilder' to list of prerequisites.

**Motivation for the change:**
I see that there is assumption that kubebuilder is installed.  
The command
```
make docker-build docker-push IMG=<some-registry>/<project-name>:<tag>
```
will fail with error 
```failed to start the controlplane. retried 5 times: fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory```
otherwise.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
