### PR TITLE
generate: respect project version when getting package name

### DIFF
--- a/changelog/fragments/bugfix-generate-no-project-name.yaml
+++ b/changelog/fragments/bugfix-generate-no-project-name.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: >
+      Project version now determines how package name is retrieved for a project
+    kind: bugfix

--- a/internal/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/internal/cmd/operator-sdk/generate/bundle/bundle.go
@@ -105,21 +105,9 @@ https://github.com/operator-framework/operator-registry/#manifest-format
 const defaultRootDir = "bundle"
 
 // setDefaults sets defaults useful to all modes of this subcommand.
-func (c *bundleCmd) setDefaults() error {
-	if projutil.HasProjectFile() {
-		cfg, err := projutil.ReadConfig()
-		if err != nil {
-			return err
-		}
-		if c.packageName == "" {
-			c.packageName = cfg.ProjectName
-		}
-		c.layout = projutil.GetProjectLayout(cfg)
-	} else {
-		if c.packageName == "" {
-			return fmt.Errorf("package name is required if PROJECT config file is not present")
-		}
-		c.layout = "unknown"
+func (c *bundleCmd) setDefaults() (err error) {
+	if c.packageName, c.layout, err = genutil.GetPackageNameAndLayout(c.packageName); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
+++ b/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
@@ -26,7 +26,6 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/generate/clusterserviceversion/bases"
 	"github.com/operator-framework/operator-sdk/internal/generate/collector"
 	genpkg "github.com/operator-framework/operator-sdk/internal/generate/packagemanifest"
-	"github.com/operator-framework/operator-sdk/internal/util/projutil"
 )
 
 const (
@@ -78,21 +77,9 @@ https://github.com/operator-framework/operator-registry/#manifest-format
 const defaultRootDir = "packagemanifests"
 
 // setDefaults sets command defaults.
-func (c *packagemanifestsCmd) setDefaults() error {
-	if projutil.HasProjectFile() {
-		cfg, err := projutil.ReadConfig()
-		if err != nil {
-			return err
-		}
-		if c.packageName == "" {
-			c.packageName = cfg.ProjectName
-		}
-		c.layout = projutil.GetProjectLayout(cfg)
-	} else {
-		if c.packageName == "" {
-			return fmt.Errorf("package name is required if PROJECT config file is not present")
-		}
-		c.layout = "unknown"
+func (c *packagemanifestsCmd) setDefaults() (err error) {
+	if c.packageName, c.layout, err = genutil.GetPackageNameAndLayout(c.packageName); err != nil {
+		return err
 	}
 
 	if c.inputDir == "" {
@@ -103,6 +90,7 @@ func (c *packagemanifestsCmd) setDefaults() error {
 			c.outputDir = defaultRootDir
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
**Description of the change:**
- internal/cmd/operator-sdk/generate: respect project version when getting package name

**Motivation for the change:** project version determines how package name is retrieved for a project (dir name vs. config's `projectName` field).

/kind bug

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
