### PR TITLE
docs: add ubuntu keyserver to installation instructions, remove gpg requirement from release guide

### DIFF
--- a/website/content/en/docs/contribution-guidelines/releasing.md
+++ b/website/content/en/docs/contribution-guidelines/releasing.md
@@ -9,16 +9,16 @@ Replace these versions with the current and new version you are releasing, respe
 
 ## Prerequisites
 
-- [`git`][git]
-- [`gpg`][gpg] v2.0+ and a [GPG key][gpg-key-create].
-- Your GPG key is publicly available in a [public key server][gpg-upload], like https://keyserver.ubuntu.com/.
+- [`git`](https://git-scm.com/downloads)
+- [`make`](https://www.gnu.org/software/make/)
+- [`sed`](https://www.gnu.org/software/sed/)
 
 ##### MacOS users
 
-Install GNU `sed`, `make`, and `gpg` which may not be by default:
+Install GNU `sed` and `make` which may not be by default:
 
 ```sh
-brew install gnu-sed make gnupg
+brew install gnu-sed make
 ```
 
 ## Major and Minor releases
@@ -233,10 +233,6 @@ Create and merge a PR from your branch to `v1.3.x`.
 GitHub releases live under the [`Releases` tab][release-page] in the operator-sdk repo.
 
 
-[git]:https://git-scm.com/downloads
-[gpg]:https://gnupg.org/download/
-[gpg-key-create]:https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/managing-commit-signature-verification
-[gpg-upload]:https://www.gnupg.org/gph/en/manual/x457.html
 [netlify-deploy]:https://docs.netlify.com/site-deploys/overview/#deploy-summary
 [doc-owners]: https://github.com/operator-framework/operator-sdk/blob/master/OWNERS
 [release-page]:https://github.com/operator-framework/operator-sdk/releases

--- a/website/content/en/docs/installation/_index.md
+++ b/website/content/en/docs/installation/_index.md
@@ -42,10 +42,10 @@ curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
 
 #### 2. Verify the downloaded binary
 
-Import the operator-sdk release GPG key:
+Import the operator-sdk release GPG key from `keyserver.ubuntu.com`:
 
 ```sh
-gpg --recv-keys 052996E2A20B5C7E
+gpg --keyserver keyserver.ubuntu.com --recv-keys 052996E2A20B5C7E
 ```
 
 Download the checksums file and its signature, then verify the signature:


### PR DESCRIPTION




<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
- docs: add ubuntu keyserver to installation instructions, remove gpg requirement from release guide

**Motivation for the change:** the default gpg server does not work.

Closes #4435 

/kind documentation

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
