### PR TITLE
Add issues template for documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc-report.md
+++ b/.github/ISSUE_TEMPLATE/doc-report.md
@@ -1,0 +1,28 @@
+---
+name: Doc Report
+about: Raise an issue with the documentation.
+title: ''
+labels: kind/documentation
+assignees: ''
+
+---
+
+<!-- Please submit only documentation-related issues with this form, or follow the
+Contribute to Operator SDK guidelines (https://sdk.operatorframework.io/docs/contribution-guidelines/reporting-issues/) to submit a PR. Use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+-->
+
+### What is the URL of the document?
+
+<!-- The URL to help identify the document. -->
+
+### Which section(s) is the issue in?
+
+<!-- The sections(s) within the document that have issue in. -->
+
+### What needs fixing?
+
+<!-- A clear and concise description of what the issue is. -->
+
+#### Additional context
+
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
**Description of the change:**

Add new issue type for documentation. Add its as the type to use from "Create documentation issue" link on the sdk docs.

**Motivation for the change:**

Fixes #4129 
Fixes #4349 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
