### PR TITLE
generate: make CSV generator for Go GVKs package-aware

### DIFF
--- a/changelog/fragments/csv-gen-package-aware.yaml
+++ b/changelog/fragments/csv-gen-package-aware.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      For Go-based projects, `generate <bundle|packagemanifests>` subcommands now consider package and type names
+      when parsing Go API types files to generate a CSV's `owned.customresourcedefinitions`, such that types in
+      different packages and files will not overwrite each other.
+    kind: bugfix

--- a/internal/generate/clusterserviceversion/bases/definitions/ast.go
+++ b/internal/generate/clusterserviceversion/bases/definitions/ast.go
@@ -18,15 +18,90 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
+	"strconv"
 	"strings"
 
+	"sigs.k8s.io/controller-tools/pkg/crd"
+	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
 
-// getMarkedChildrenOfField collects all marked fields from type declarations starting at root in depth-first order.
-func (g generator) getMarkedChildrenOfField(root markers.FieldInfo) (map[string][]*fieldInfo, error) {
+// importIdents maps import identifiers to a list of corresponding path and file containing that path.
+// For example, consider the set of 2 files, one containing 'import foo "my/foo"' and the other 'import foo "your/foo"'.
+// Then the map would be: map["foo"][]struct{{f: (file 1), path: "my/foo"},{f: (file 2), path: "your/foo"}}.
+type importIdents map[string][]struct {
+	f    *ast.File
+	path string
+}
+
+// newImportIdents creates an importIdents from all imports in pkg.
+func newImportIdents(pkg *loader.Package) (importIdents, error) {
+	importIDs := make(map[string][]struct {
+		f    *ast.File
+		path string
+	})
+	for _, file := range pkg.Syntax {
+		for _, impSpec := range file.Imports {
+			val, err := strconv.Unquote(impSpec.Path.Value)
+			if err != nil {
+				return nil, err
+			}
+			// Most imports are not locally named, so the real package name should be used.
+			var impName string
+			if imp, hasImp := pkg.Imports()[val]; hasImp {
+				impName = imp.Name
+			}
+			// impSpec.Name will not be empty for locally named imports
+			if impSpec.Name != nil {
+				impName = impSpec.Name.Name
+			}
+			importIDs[impName] = append(importIDs[impName], struct {
+				f    *ast.File
+				path string
+			}{file, val})
+		}
+	}
+	return importIDs, nil
+}
+
+// findPackagePathForSelExpr returns the package path corresponding to the package name used in expr if it exists in im.
+func (im importIdents) findPackagePathForSelExpr(expr *ast.SelectorExpr) (pkgPath string) {
+	// X contains the name being selected from.
+	xIdent, isIdent := expr.X.(*ast.Ident)
+	if !isIdent {
+		return ""
+	}
+	// Imports for all import statements where local import name == name being selected from.
+	imports, hasImports := im[xIdent.String()]
+	if !hasImports {
+		return ""
+	}
+
+	// Short-circuit if only one import.
+	if len(imports) == 1 {
+		return imports[0].path
+	}
+
+	// If multiple files contain the same local import name, check to see which file contains the selector expression.
+	for _, imp := range imports {
+		if imp.f.Pos() <= expr.Pos() && imp.f.End() >= expr.End() {
+			return imp.path
+		}
+	}
+	return ""
+}
+
+// getMarkedChildrenOfField collects all marked fields from type declarations starting at rootField in depth-first order.
+func (g generator) getMarkedChildrenOfField(rootPkg *loader.Package, rootField markers.FieldInfo) (map[string][]*fieldInfo, error) {
+	// Gather all types and imports needed to build the BFS tree.
+	rootPkg.NeedTypesInfo()
+	importIDs, err := newImportIdents(rootPkg)
+	if err != nil {
+		return nil, err
+	}
+
 	// ast.Inspect will not traverse into fields, so iteratively collect them and to check for markers.
-	nextFields := []*fieldInfo{{FieldInfo: root}}
+	nextFields := []*fieldInfo{{FieldInfo: rootField}}
 	markedFields := map[string][]*fieldInfo{}
 	for len(nextFields) > 0 {
 		fields := []*fieldInfo{}
@@ -36,49 +111,65 @@ func (g generator) getMarkedChildrenOfField(root markers.FieldInfo) (map[string]
 				if n == nil {
 					return true
 				}
-				switch expr := n.(type) {
+
+				var info *markers.TypeInfo
+				var hasInfo bool
+				switch nt := n.(type) {
+				case *ast.SelectorExpr:
+					// Case of a type definition in an imported package.
+
+					pkgPath := importIDs.findPackagePathForSelExpr(nt)
+					if pkgPath == "" {
+						// Found no reference to pkgPath in any file.
+						return true
+					}
+					if pkg, hasImport := rootPkg.Imports()[loader.NonVendorPath(pkgPath)]; hasImport {
+						// Check if the field's type exists in the known types.
+						info, hasInfo = g.types[crd.TypeIdent{Package: pkg, Name: nt.Sel.Name}]
+					}
 				case *ast.Ident:
+					// Case of a local type definition.
+
 					// Only look at type names.
-					if expr.Obj == nil || expr.Obj.Kind != ast.Typ {
-						return true
-					}
-					// Check if the field's type exists in the known types.
-					info, hasInfo := g.types[expr.Name]
-					if !hasInfo {
-						return true
-					}
-					// Add all child fields to the list to search next.
-					for _, finfo := range info.Fields {
-						segment, err := getPathSegmentForField(finfo)
-						if err != nil {
-							errs = append(errs, fmt.Errorf("error getting path from type %s field %s: %v",
-								info.Name, finfo.Name, err),
-							)
-							return true
-						}
-						// Add extra information to the segment if it comes from a certain field type.
-						switch finfo.RawField.Type.(type) {
-						case (*ast.ArrayType):
-							// arrayFieldGroup case.
-							if segment != ignoredTag && segment != inlinedTag {
-								segment += "[0]"
-							}
-						}
-						// Create a new set of path segments using the parent's segments
-						// and add the field to the next fields to search.
-						parentSegments := make([]string, len(field.pathSegments), len(field.pathSegments)+1)
-						copy(parentSegments, field.pathSegments)
-						f := &fieldInfo{
-							FieldInfo:    finfo,
-							pathSegments: append(parentSegments, segment),
-						}
-						fields = append(fields, f)
-						// Marked fields get collected for the caller to parse.
-						if len(finfo.Markers) != 0 {
-							markedFields[info.Name] = append(markedFields[info.Name], f)
-						}
+					if nt.Obj != nil && nt.Obj.Kind == ast.Typ {
+						// Check if the field's type exists in the known types.
+						info, hasInfo = g.types[crd.TypeIdent{Package: rootPkg, Name: nt.Name}]
 					}
 				}
+				if !hasInfo {
+					return true
+				}
+
+				// Add all child fields to the list to search next.
+				for _, finfo := range info.Fields {
+					segment, err := getPathSegmentForField(finfo)
+					if err != nil {
+						errs = append(errs, fmt.Errorf("error getting path from type %s field %s: %v", info.Name, finfo.Name, err))
+						return true
+					}
+					// Add extra information to the segment if it comes from a certain field type.
+					switch finfo.RawField.Type.(type) {
+					case *ast.ArrayType:
+						// arrayFieldGroup case.
+						if segment != ignoredTag && segment != inlinedTag {
+							segment += "[0]"
+						}
+					}
+					// Create a new set of path segments using the parent's segments
+					// and add the field to the next fields to search.
+					parentSegments := make([]string, len(field.pathSegments), len(field.pathSegments)+1)
+					copy(parentSegments, field.pathSegments)
+					f := &fieldInfo{
+						FieldInfo:    finfo,
+						pathSegments: append(parentSegments, segment),
+					}
+					fields = append(fields, f)
+					// Marked fields get collected for the caller to parse.
+					if len(finfo.Markers) != 0 {
+						markedFields[info.Name] = append(markedFields[info.Name], f)
+					}
+				}
+
 				return true
 			})
 			if err := fmtParseErrors(errs); err != nil {

--- a/internal/generate/clusterserviceversion/bases/definitions/markers.go
+++ b/internal/generate/clusterserviceversion/bases/definitions/markers.go
@@ -37,17 +37,20 @@ const (
 	crdMarkerName = csvPrefix + ":customresourcedefinitions"
 )
 
-// +operator-sdk:csv:customresourcedefinitions:displayName="string",resources={ {kind,version,name} , ... }
-var typeDefinition = markers.Must(markers.MakeDefinition(crdMarkerName, markers.DescribesType, Description{}))
-
-// +operator-sdk:csv:customresourcedefinitions:type=<spec|status>,displayName="name",xDescriptors="ui:elements:foo:bar"
-var fieldDefinition = markers.Must(markers.MakeDefinition(crdMarkerName, markers.DescribesField, Descriptor{}))
-
-// See https://github.com/kubernetes-sigs/controller-tools/blob/92e95c1/pkg/crd/markers/crd.go#L40
-var crdResourceDefinition = markers.Must(markers.MakeDefinition("kubebuilder:resource", markers.DescribesType, crdmarkers.Resource{}))
+var (
+	// +operator-sdk:csv:customresourcedefinitions:displayName="string",resources={ {kind,version,name} , ... }
+	typeDefinition = markers.Must(markers.MakeDefinition(crdMarkerName, markers.DescribesType, Description{}))
+	// +operator-sdk:csv:customresourcedefinitions:type=<spec|status>,displayName="name",xDescriptors="ui:elements:foo:bar"
+	fieldDefinition = markers.Must(markers.MakeDefinition(crdMarkerName, markers.DescribesField, Descriptor{}))
+)
 
 // registerMarkers adds type and field marker definitions to a registry.
 func registerMarkers(into *markers.Registry) error {
+	// External definitions.
+	if err := crdmarkers.Register(into); err != nil {
+		return fmt.Errorf("error registering external marker definition: %v", err)
+	}
+
 	if err := into.Register(typeDefinition); err != nil {
 		return fmt.Errorf("error registering type definition: %v", err)
 	}
@@ -57,11 +60,6 @@ func registerMarkers(into *markers.Registry) error {
 	}
 	into.AddHelp(fieldDefinition, Descriptor{}.Help())
 
-	// External definitions.
-	if err := into.Register(crdResourceDefinition); err != nil {
-		return fmt.Errorf("error registering CRD resource definition: %v", err)
-	}
-	into.AddHelp(crdResourceDefinition, crdmarkers.Resource{}.Help())
 	return nil
 }
 

--- a/internal/generate/testdata/go/api/shared/doc.go
+++ b/internal/generate/testdata/go/api/shared/doc.go
@@ -1,0 +1,15 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared

--- a/internal/generate/testdata/go/api/shared/memcached_types.go
+++ b/internal/generate/testdata/go/api/shared/memcached_types.go
@@ -1,0 +1,25 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// UsefulType is a type shared between APIs.
+type UsefulType struct {
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	Containers []v1.Container `json:"containers"`
+}

--- a/internal/generate/testdata/go/api/v1alpha1/memcached_types.go
+++ b/internal/generate/testdata/go/api/v1alpha1/memcached_types.go
@@ -16,6 +16,8 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/operator-framework/operator-sdk/internal/generate/testdata/go/api/shared"
 )
 
 // MemcachedSpec defines the desired state of Memcached
@@ -27,6 +29,9 @@ type MemcachedSpec struct {
 	// List of Providers
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Providers"
 	Providers []Provider `json:"providers,omitempty"`
+
+	// A useful shared type.
+	Useful shared.UsefulType `json:",inline"`
 }
 
 // Provider represents the container for a single provider

--- a/internal/generate/testdata/go/api/v1alpha2/dummy_types.go
+++ b/internal/generate/testdata/go/api/v1alpha2/dummy_types.go
@@ -15,7 +15,11 @@
 package v1alpha2
 
 import (
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	// Has the same name as a different import in memcached_types.go to test duplicate package names.
+	foo "github.com/operator-framework/operator-sdk/internal/generate/testdata/go/api/shared"
 )
 
 // +k8s:deepcopy-gen=false
@@ -47,6 +51,10 @@ type DummySpec struct {
 	// Should be in spec, but should not have array index in path
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Wheels",xDescriptors="urn:alm:descriptor:com.tectonic.ui:text"
 	Wheels []Wheel `json:"wheels"`
+	// A useful shared type.
+	Useful foo.UsefulType `json:"useful"`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	SideCar v1.Container `json:"sideCar"`
 }
 
 // +k8s:deepcopy-gen=false

--- a/internal/generate/testdata/go/api/v1alpha2/memcached_types.go
+++ b/internal/generate/testdata/go/api/v1alpha2/memcached_types.go
@@ -15,7 +15,8 @@
 package v1alpha2
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	// Has the same name as a different import in dummy_types.go to test duplicate package names.
+	foo "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MemcachedSpec defines the desired state of Memcached
@@ -40,8 +41,8 @@ type MemcachedStatus struct {
 // +kubebuilder:storageversion
 // +operator-sdk:csv:customresourcedefinitions:displayName="Memcached App"
 type Memcached struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	foo.TypeMeta   `json:",inline"`
+	foo.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   MemcachedSpec   `json:"spec,omitempty"`
 	Status MemcachedStatus `json:"status,omitempty"`
@@ -51,7 +52,7 @@ type Memcached struct {
 
 // MemcachedList contains a list of Memcached
 type MemcachedList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []Memcached `json:"items"`
+	foo.TypeMeta `json:",inline"`
+	foo.ListMeta `json:"metadata,omitempty"`
+	Items        []Memcached `json:"items"`
 }


### PR DESCRIPTION
**Description of the change:**
- internal/generatel/clusterserviceversion/bases/definitions: make the owned CRD generator package- and type-aware so multiple packages containing the same type names can be used.

**Motivation for the change:** currently the CSV generator indexes types in the struct-field hierarchy by type name only, which is potentially not unique between packages. This PR makes the generator package-aware.

Closes #4409
Closes #3744 

/kind bug

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
