### PR TITLE
Bug 1921458: `run bundle-upgrade` should handle error gracefully when a previous operator version doesn't exist

### DIFF
--- a/changelog/fragments/bugfix-run-bundle-upgrade.yaml
+++ b/changelog/fragments/bugfix-run-bundle-upgrade.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: >
+      `run bundle-upgrade` handles error gracefully when a previous operator version doesn't exist
+    kind: bugfix

--- a/internal/olm/operator/registry/operator_installer.go
+++ b/internal/olm/operator/registry/operator_installer.go
@@ -16,6 +16,7 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -106,6 +107,11 @@ func (o OperatorInstaller) UpgradeOperator(ctx context.Context) (*v1alpha1.Clust
 	}
 	if err := o.cfg.Client.List(ctx, subList, &options); err != nil {
 		return nil, fmt.Errorf("error getting list of subscriptions: %v", err)
+	}
+
+	// If there are no subscriptions found, then the previous operator version doesn't exist, so return error
+	if len(subList.Items) == 0 {
+		return nil, errors.New("no existing operator found in the cluster to upgrade")
 	}
 
 	var subscription *v1alpha1.Subscription


### PR DESCRIPTION
**Description of the change:**
`run bundle-upgrade` command handles error instead of throwing a panic, when a previous version of the operator bundle doesn't exist in the cluster 

**Motivation for the change:**
```
Without installing etcd operator, 
# operator-sdk run bundle-upgrade quay.io/olmqe/etcd-bundle:0.9.2-share

Result:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1978d29]
```

Expected behavior: The command should check that the etcd operator doesn't exist in the cluster and handle the error gracefully instead of throwing a panic.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
