### PR TITLE
fix: Fix wrong level of error raised for bundle validation using  when bundle has not a  by upgrading  version used to

### DIFF
--- a/changelog/fragments/fix-icon-operatorhub-check.yaml
+++ b/changelog/fragments/fix-icon-operatorhub-check.yaml
@@ -1,0 +1,6 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: Fix wrong level of error raised for bundle validation using `--select-optional name=operatorhub` when bundle has not a `spec.icon` by upgrading `github.com/operator-framework/api` version used to `v0.5.3`
+    kind: bugfix
+    breaking: false

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/markbates/inflect v1.0.4
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
-	github.com/operator-framework/api v0.5.2
+	github.com/operator-framework/api v0.5.3
 	github.com/operator-framework/operator-lib v0.4.0
 	github.com/operator-framework/operator-registry v1.15.3
 	github.com/prometheus/client_golang v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -754,6 +754,8 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/operator-framework/api v0.3.22/go.mod h1:GVNiB6AQucwdZz3ZFXNv9HtcLOzcFnr6O/QldzKG93g=
 github.com/operator-framework/api v0.5.2 h1:NLgOoi70+iyz4vVJeeJUKaFT8wZaCbCHzS1eExCqX7A=
 github.com/operator-framework/api v0.5.2/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
+github.com/operator-framework/api v0.5.3 h1:1RDw2FbuEDtSC7ONKLKgAxtq+iRsV7rRTumD4RLQfSI=
+github.com/operator-framework/api v0.5.3/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
 github.com/operator-framework/operator-lib v0.4.0 h1:g7tGRo+FikHgFZDmRdHkOxyTv3sViI+Ujiqbfd9Tfsk=
 github.com/operator-framework/operator-lib v0.4.0/go.mod h1:kOjV7h01DCSw3RZAqYdHyHyVwuJL8hvG53tSZoDZfsQ=
 github.com/operator-framework/operator-registry v1.15.3 h1:C+u+zjDh6yQAKN+DbUvPeLjojZtJftvp/J28rRqiWWU=


### PR DESCRIPTION
**Description of the change:**
- Upgrade the api version used to get the fix: https://github.com/operator-framework/api/releases/tag/v0.5.3

**Motivation for the change:**
The bundle validation with `--select-optional name=operatorhub` is returning error instead of waring when the bundle has not a spec.icon set which is affecting the pipeline. 

