### PR TITLE
bugfix for `run bundle-upgrade`: handle subscription that matches package name not being found

### DIFF
--- a/internal/olm/operator/registry/operator_installer.go
+++ b/internal/olm/operator/registry/operator_installer.go
@@ -123,6 +123,10 @@ func (o OperatorInstaller) UpgradeOperator(ctx context.Context) (*v1alpha1.Clust
 		}
 	}
 
+	if subscription == nil {
+		return nil, fmt.Errorf("subscription for package %q not found", o.PackageName)
+	}
+
 	log.Infof("Found existing subscription with name %s and namespace %s", subscription.Name, subscription.Namespace)
 
 	// Get existing catalog source from the subsription


### PR DESCRIPTION
**Description of the change:**
If subscription doesn't match any existing package name, then return error instead of panic. 

**Motivation for the change:**
Improve error handling for `run bundle-upgrade` command

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
