### PR TITLE
`run bundle{-upgrade}`: validate `--mode` before running a bundle

### DIFF
--- a/changelog/fragments/bugfix-validate-add-mode.yaml
+++ b/changelog/fragments/bugfix-validate-add-mode.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      `run bundle` and `run bundle-upgrade` now validate the value passed to the hidden flag `--mode` before
+      running a bundle.
+    kind: bugfix

--- a/internal/olm/operator/registry/index/bundle_add_mode.go
+++ b/internal/olm/operator/registry/index/bundle_add_mode.go
@@ -1,0 +1,41 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import "fmt"
+
+// BundleAddMode is the mode to add a bundle to an index.
+type BundleAddMode string
+
+const (
+	// SemverBundleAddMode - bundle add mode for semver
+	SemverBundleAddMode BundleAddMode = "semver"
+	// ReplacesBundleAddMode - bundle add mode for replaces
+	ReplacesBundleAddMode BundleAddMode = "replaces"
+)
+
+var modes = []BundleAddMode{SemverBundleAddMode, ReplacesBundleAddMode}
+
+func (m BundleAddMode) Validate() error {
+	switch m {
+	case SemverBundleAddMode, ReplacesBundleAddMode:
+	case "":
+		return fmt.Errorf("bundle add mode cannot be empty, must be one of: %+q", modes)
+	default:
+		return fmt.Errorf("bundle add mode %q does not exist, must be one of: %+q", m, modes)
+	}
+
+	return nil
+}

--- a/internal/olm/operator/registry/index/registry_pod.go
+++ b/internal/olm/operator/registry/index/registry_pod.go
@@ -35,15 +35,6 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
 )
 
-// BundleAddMode - type of BundleAddMode in RegistryPod struct
-type BundleAddMode = string
-
-const (
-	// SemverBundleAddMode - bundle add mode for semver
-	SemverBundleAddMode BundleAddMode = "semver"
-	// ReplacesBundleAddMode - bundle add mode for replaces
-	ReplacesBundleAddMode BundleAddMode = "replaces"
-)
 const (
 	// DefaultIndexImage is the index base image used if none is specified. It contains no bundles.
 	DefaultIndexImage = "quay.io/operator-framework/upstream-opm-builder:latest"
@@ -175,12 +166,8 @@ func (rp *RegistryPod) validate() error {
 		if item.ImageTag == "" {
 			return errors.New("bundle image cannot be empty")
 		}
-		if item.AddMode == "" {
-			return fmt.Errorf("bundle add mode for %q cannot be empty", item.ImageTag)
-		}
-		if item.AddMode != SemverBundleAddMode && item.AddMode != ReplacesBundleAddMode {
-			return fmt.Errorf("invalid bundle mode %q: must be one of [%q, %q]",
-				item.AddMode, ReplacesBundleAddMode, SemverBundleAddMode)
+		if err := item.AddMode.Validate(); err != nil {
+			return fmt.Errorf("invalid bundle add mode: %v", err)
 		}
 	}
 

--- a/internal/olm/operator/registry/index/registry_pod_test.go
+++ b/internal/olm/operator/registry/index/registry_pod_test.go
@@ -138,7 +138,7 @@ var _ = Describe("RegistryPod", func() {
 			})
 
 			It("should not accept any other bundle add mode other than semver or replaces", func() {
-				expectedErr := "invalid bundle mode"
+				expectedErr := `bundle add mode "invalid" does not exist`
 				rp := &RegistryPod{
 					BundleItems: []BundleItem{{ImageTag: "quay.io/example/example-operator-bundle:0.2.0", AddMode: "invalid"}},
 				}


### PR DESCRIPTION
**Description of the change:**
- internal/olm/operator: validate BundleAddMode before running a bundle image

**Motivation for the change:** values should be validated before the heavy lifting of these commands occurs (pulling/unpacking a bundle)

/kind bug

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
