### PR TITLE
*: Replace 'docker build . -t ${IMG}' with '-t ${IMG} .'

### DIFF
--- a/changelog/fragments/reorder-docker-args.yaml
+++ b/changelog/fragments/reorder-docker-args.yaml
@@ -1,0 +1,28 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      (ansible/v1, helm/v1) Post-fixed positional directory argument `.` in `docker-build` make target to align with `podman`
+    kind: "change"
+    breaking: false
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: Move positional directory argument `.` in `docker-build` make target
+      body: >
+        The directory argument `.` in the `docker-build` make target was moved to the
+        last positional argument to align with `podman`'s expectations, making substitution
+        cleaner. In your `Makefile`, change:
+
+            docker build . -t ${IMG}
+
+        to
+             docker build -t ${IMG} .
+
+        Alternatively, you could replace it programmatically
+
+        ```sh
+        sed -i 's/docker build . -t ${IMG}/docker build -t ${IMG} ./' $(git grep -l 'docker.*build \. ')
+        ```
+

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
@@ -93,7 +93,7 @@ undeploy: kustomize
 
 # Build the docker image
 docker-build:
-	docker build . -t ${IMG}
+	docker build -t ${IMG} .
 
 # Push the docker image
 docker-push:

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/makefile.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/makefile.go
@@ -93,7 +93,7 @@ undeploy: kustomize
 
 # Build the docker image
 docker-build:
-	docker build . -t ${IMG}
+	docker build -t ${IMG} .
 
 # Push the docker image
 docker-push:

--- a/testdata/ansible/memcached-operator/Makefile
+++ b/testdata/ansible/memcached-operator/Makefile
@@ -56,7 +56,7 @@ undeploy: kustomize
 
 # Build the docker image
 docker-build:
-	docker build . -t ${IMG}
+	docker build -t ${IMG} .
 
 # Push the docker image
 docker-push:

--- a/testdata/helm/memcached-operator/Makefile
+++ b/testdata/helm/memcached-operator/Makefile
@@ -56,7 +56,7 @@ undeploy: kustomize
 
 # Build the docker image
 docker-build:
-	docker build . -t ${IMG}
+	docker build -t ${IMG} .
 
 # Push the docker image
 docker-push:


### PR DESCRIPTION
Because folks may have `docker` aliased to `podman`, and Podman prefers options before positional arguments:

```console
$ podman build --help | grep CONTEXT-DIRECTORY
   podman build [command options] CONTEXT-DIRECTORY | URL
```
Supersedes PR #4226 

Co-authored-by: W. Trevor King <wking@tremily.us>
Signed-off-by: jesus m. rodriguez <jmrodri@gmail.com>

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
