### PR TITLE
*: format finalizers correctly

### DIFF
--- a/changelog/fragments/change-finalizer-format.yaml
+++ b/changelog/fragments/change-finalizer-format.yaml
@@ -1,0 +1,12 @@
+entries:
+  - description: >
+      Changed the suggested finalizer format to `<qualified-group>/<finalizer-name>`
+    kind: change
+    migration:
+      header: Change your operator's finalizer names
+      body: >
+        The finalizer name format suggested by [Kubernetes docs](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers)
+        is `<qualified-group>/<finalizer-name>`, while the format previously documented by Operator SDK docs was
+        `<finalizer-name>.<qualified-group>`. If your operator uses any finalizers with names matching the incorrect format,
+        change them to match the official format.
+        For example, `finalizer.cache.example.com` should be changed to `cache.example.com/finalizer`.

--- a/hack/generate/samples/internal/ansible/constants.go
+++ b/hack/generate/samples/internal/ansible/constants.go
@@ -355,7 +355,7 @@ const taskToDeleteConfigMap = `- name: delete configmap for test
 
 const memcachedWatchCustomizations = `playbook: playbooks/memcached.yml
   finalizer:
-    name: finalizer.cache.example.com
+    name: cache.example.com/finalizer
     role: memfin
   blacklist:
     - group: ""

--- a/internal/ansible/controller/reconcile_test.go
+++ b/internal/ansible/controller/reconcile_test.go
@@ -258,7 +258,7 @@ func TestReconcile(t *testing.T) {
 						Created: eventapi.EventTime{Time: eventTime},
 					},
 				},
-				Finalizer: "testing.io",
+				Finalizer: "testing.io/finalizer",
 			},
 			Client: fakeclient.NewClientBuilder().WithObjects(&unstructured.Unstructured{
 				Object: map[string]interface{}{
@@ -292,7 +292,7 @@ func TestReconcile(t *testing.T) {
 							controller.ReconcilePeriodAnnotation: "3s",
 						},
 						"finalizers": []interface{}{
-							"testing.io",
+							"testing.io/finalizer",
 						},
 					},
 					"apiVersion": "operator-sdk/v1beta1",
@@ -329,7 +329,7 @@ func TestReconcile(t *testing.T) {
 						Created: eventapi.EventTime{Time: eventTime},
 					},
 				},
-				Finalizer: "testing.io",
+				Finalizer: "testing.io/finalizer",
 			},
 			Client: fakeclient.NewClientBuilder().WithObjects(&unstructured.Unstructured{
 				Object: map[string]interface{}{
@@ -366,7 +366,7 @@ func TestReconcile(t *testing.T) {
 						Created: eventapi.EventTime{Time: eventTime},
 					},
 				},
-				Finalizer: "testing.io",
+				Finalizer: "testing.io/finalizer",
 			},
 			Client: fakeclient.NewClientBuilder().WithObjects(&unstructured.Unstructured{
 				Object: map[string]interface{}{
@@ -374,7 +374,7 @@ func TestReconcile(t *testing.T) {
 						"name":      "reconcile",
 						"namespace": "default",
 						"finalizers": []interface{}{
-							"testing.io",
+							"testing.io/finalizer",
 						},
 						"deletionTimestamp": eventTime.Format(time.RFC3339),
 					},

--- a/internal/ansible/runner/runner_test.go
+++ b/internal/ansible/runner/runner_test.go
@@ -93,7 +93,7 @@ func TestNew(t *testing.T) {
 			},
 			playbook: validPlaybook,
 			finalizer: &watches.Finalizer{
-				Name:     "example.finalizer.com",
+				Name:     "operator.example.com/finalizer",
 				Playbook: validPlaybook,
 			},
 		},
@@ -106,7 +106,7 @@ func TestNew(t *testing.T) {
 			},
 			role: validRole,
 			finalizer: &watches.Finalizer{
-				Name: "example.finalizer.com",
+				Name: "operator.example.com/finalizer",
 				Role: validRole,
 			},
 		},
@@ -119,7 +119,7 @@ func TestNew(t *testing.T) {
 			},
 			playbook: validPlaybook,
 			finalizer: &watches.Finalizer{
-				Name: "example.finalizer.com",
+				Name: "operator.example.com/finalizer",
 				Vars: map[string]interface{}{
 					"state": "absent",
 				},
@@ -137,7 +137,7 @@ func TestNew(t *testing.T) {
 				"type": "this",
 			},
 			finalizer: &watches.Finalizer{
-				Name: "example.finalizer.com",
+				Name: "operator.example.com/finalizer",
 				Vars: map[string]interface{}{
 					"state": "absent",
 				},

--- a/internal/ansible/watches/testdata/duplicate_gvk.yaml
+++ b/internal/ansible/watches/testdata/duplicate_gvk.yaml
@@ -4,7 +4,7 @@
   kind: Database
   playbook: playbook.yaml
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     vars:
       sentinel: finalizer_running
 - version: v1alpha1
@@ -12,6 +12,6 @@
   kind: Database
   playbook: playbook.yaml
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     vars:
       sentinel: finalizer_running

--- a/internal/ansible/watches/testdata/invalid.yaml
+++ b/internal/ansible/watches/testdata/invalid.yaml
@@ -4,6 +4,6 @@ version: v1alpha1
   kind: Database
   playbook: playbook.yaml
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     vars:
       sentinel: finalizer_running

--- a/internal/ansible/watches/testdata/invalid_finalizer_no_vars.yaml
+++ b/internal/ansible/watches/testdata/invalid_finalizer_no_vars.yaml
@@ -4,4 +4,4 @@
   kind: Database
   playbook: playbook.yaml
   finalizer:
-    name: foo.app.example.com
+    name: foo.app.example.com/finalizer

--- a/internal/ansible/watches/testdata/invalid_finalizer_playbook_path.yaml
+++ b/internal/ansible/watches/testdata/invalid_finalizer_playbook_path.yaml
@@ -4,7 +4,7 @@
   kind: Database
   playbook: playbook.yaml
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     playbook: playbook.yaml
     vars:
       sentinel: finalizer_running

--- a/internal/ansible/watches/testdata/invalid_finalizer_role_path.yaml
+++ b/internal/ansible/watches/testdata/invalid_finalizer_role_path.yaml
@@ -4,7 +4,7 @@
   kind: Database
   playbook: playbook.yaml
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     role: ansible/role
     vars:
       sentinel: finalizer_running

--- a/internal/ansible/watches/testdata/invalid_playbook_path.yaml
+++ b/internal/ansible/watches/testdata/invalid_playbook_path.yaml
@@ -4,6 +4,6 @@
   kind: Database
   playbook: invalid/playbook.yaml
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     vars:
       sentinel: finalizer_running

--- a/internal/ansible/watches/testdata/invalid_role_path.yaml
+++ b/internal/ansible/watches/testdata/invalid_role_path.yaml
@@ -4,6 +4,6 @@
   kind: Database
   role: opt/ansible/playbook.yaml
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     vars:
       sentinel: finalizer_running

--- a/internal/ansible/watches/testdata/valid.yaml.tmpl
+++ b/internal/ansible/watches/testdata/valid.yaml.tmpl
@@ -9,7 +9,7 @@
   kind: Playbook
   playbook: {{ .ValidPlaybook }}
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     role: {{ .ValidRole }}
     vars:
       sentinel: finalizer_running
@@ -43,7 +43,7 @@
   kind: Role
   role: {{ .ValidRole }}
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     playbook: {{ .ValidPlaybook }}
     vars:
       sentinel: finalizer_running
@@ -52,7 +52,7 @@
   kind: FinalizerRole
   role: {{ .ValidRole }}
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     vars:
       sentinel: finalizer_running
 - version: v1alpha1

--- a/internal/ansible/watches/watches_test.go
+++ b/internal/ansible/watches/watches_test.go
@@ -160,7 +160,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			SnakeCaseParameters:         false,
 			WatchClusterScopedResources: false,
 			Finalizer: &Finalizer{
-				Name: "finalizer.app.example.com",
+				Name: "app.example.com/finalizer",
 				Role: validTemplate.ValidRole,
 				Vars: map[string]interface{}{"sentinel": "finalizer_running"},
 			},
@@ -223,7 +223,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			Role:         validTemplate.ValidRole,
 			ManageStatus: true,
 			Finalizer: &Finalizer{
-				Name:     "finalizer.app.example.com",
+				Name:     "app.example.com/finalizer",
 				Playbook: validTemplate.ValidPlaybook,
 				Vars:     map[string]interface{}{"sentinel": "finalizer_running"},
 			},
@@ -237,7 +237,7 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			Role:         validTemplate.ValidRole,
 			ManageStatus: true,
 			Finalizer: &Finalizer{
-				Name: "finalizer.app.example.com",
+				Name: "app.example.com/finalizer",
 				Vars: map[string]interface{}{"sentinel": "finalizer_running"},
 			},
 		},

--- a/test/e2e-ansible/e2e_ansible_suite_test.go
+++ b/test/e2e-ansible/e2e_ansible_suite_test.go
@@ -190,7 +190,7 @@ const taskToDeleteConfigMap = `- name: delete configmap for test
 
 const memcachedWatchCustomizations = `playbook: playbooks/memcached.yml
   finalizer:
-    name: finalizer.cache.example.com
+    name: cache.example.com/finalizer
     role: memfin
   blacklist:
     - group: ""

--- a/website/content/en/docs/building-operators/ansible/reference/finalizers.md
+++ b/website/content/en/docs/building-operators/ansible/reference/finalizers.md
@@ -9,7 +9,7 @@ created during reconciliation when a managed resource is marked for deletion. Th
 behavior is usually sufficient for applications that exist only in Kubernetes, but
 sometimes it is necessary to perform more complex operations (for example, when
 your action performed against a third party API needs to be undone). These more
-complex cases can still be handled by Ansible Operator, through the use of a finalizer.
+complex cases can still be handled by Ansible Operator, through the use of a [finalizer][doc-crd-finalizers].
 
 Finalizers allow controllers (such as an Ansible Operator) to implement asynchronous pre-delete hooks.
 This allows custom logic to run after a resource has been marked for deletion, but
@@ -20,18 +20,19 @@ define the mapping from your finalizer to a playbook or role by simply setting t
 your top-level playbook or role with different variables set. The `watches.yaml`
 finalizer configuration accepts the following options:
 
-See [Ansible watches documentation][ansible-watches] for more
-information.
+See [Ansible watches documentation][ansible-watches] for more information.
 
 
 #### name
+
 `name` is required.
 
 This is the name of the finalizer. This is basically an arbitrary string, the existence
 of any finalizer string on a resource will prevent that resource from being deleted until
 the finalizer is removed. Ansible Operator will remove this string from the list of
 finalizers on successful execution of the specified role or playbook. A typical finalizer
-will be `finalizer.<group>`, where `<group>` is the group of the resource being managed.
+will be `<qualified-group>/finalizer`, where `<qualified-group>` is the fully qualified group
+of the resource being managed.
 
 #### playbook
 
@@ -71,7 +72,7 @@ Here are a few examples of `watches.yaml` files that specify a finalizer:
   kind: Database
   playbook: /opt/ansible/playbook.yml
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     vars:
       state: absent
 ```
@@ -87,7 +88,7 @@ the author can check this value and perform whatever cleanup is necessary.
   kind: Database
   role: database
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     vars:
       state: absent
 ```
@@ -103,7 +104,7 @@ role, rather than a playbook, with the `state` variable set to `absent`.
   kind: Database
   playbook: playbook.yml
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     role: teardown_database
 ```
 
@@ -116,7 +117,7 @@ This example will run the `/opt/ansible/roles/teardown_database` role when the C
   kind: Database
   playbook: playbook.yml
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     playbook: destroy.yml
 ```
 
@@ -129,7 +130,7 @@ This example will run the `/opt/ansible/destroy.yml` playbook when the Custom Re
   kind: Database
   playbook: playbook.yml
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     role: myNamespace.myCollection.myRole
 ```
 
@@ -150,7 +151,7 @@ interaction, with a different variable set.
   kind: Database
   playbook: playbook.yml
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     role: manage_credentials
     vars:
       state: revoked
@@ -165,7 +166,5 @@ causes the role to invalidate our credentials. For everything else in our applic
 automatic deletion of dependent resources will be sufficient, so we can exit successfully and
 let the operator remove our finalizer and allow the resource to be deleted.
 
-## Further reading
-• [Kubernetes finalizers](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers)
-
+[doc-crd-finalizers]:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers
 [ansible-watches]:/docs/building-operators/ansible/reference/watches/

--- a/website/content/en/docs/building-operators/ansible/reference/watches.md
+++ b/website/content/en/docs/building-operators/ansible/reference/watches.md
@@ -121,7 +121,7 @@ Some features can be overridden per resource via an annotation on that CR. The o
   watchDependentResources: False
   snakeCaseParameters: False
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     vars:
       state: absent
 ```
@@ -141,7 +141,7 @@ Some features can be overridden per resource via an annotation on that CR. The o
   manageStatus: False
   watchDependentResources: False
   finalizer:
-    name: finalizer.app.example.com
+    name: app.example.com/finalizer
     vars:
       state: absent
 

--- a/website/content/en/docs/building-operators/golang/advanced-topics.md
+++ b/website/content/en/docs/building-operators/golang/advanced-topics.md
@@ -135,7 +135,7 @@ import (
     "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const memcachedFinalizer = "finalizer.cache.example.com"
+const memcachedFinalizer = "cache.example.com/finalizer"
 
 func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
     reqLogger := r.log.WithValues("memcached", req.NamespacedName)


### PR DESCRIPTION
**Description of the change:** change all references to the old finalizer name format to the format suggested [upstream](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers).

**Motivation for the change:** This PR modifies the suggested format for finalizers from `<finalizer-name>.<qualified-group>` to `<qualified-group>/<finalizer-name>`, which is the recommended format in k8s docs. This change is not breaking because technically any name format is allowed

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
