### PR TITLE
docs: fix incorrect file path

### DIFF
--- a/website/content/en/docs/building-operators/golang/advanced-topics.md
+++ b/website/content/en/docs/building-operators/golang/advanced-topics.md
@@ -126,9 +126,10 @@ deleted until you remove the finalizer (ie, after your cleanup logic has success
 
 **Example:**
 
-The following is a snippet from the controller file under `pkg/controller/memcached/memcached_controller.go`
+The following is a snippet from a theoretical controller file `controllers/memcached_controller.go`
+that implements a finalizer handler:
 
-```Go
+```go
 import (
     ...
     "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"


### PR DESCRIPTION
**Description of the change:**
- docs/building-operators/golang/advanced-topics.md: fix file path reference

**Motivation for the change:** old file path

/kind documentation

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
