### PR TITLE
docs/building-operators/golang: fix context.Context usage, imports, general formatting

### DIFF
--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -182,7 +182,8 @@ func main() {
     	log.Error(err, "")
     	os.Exit(1)
 	}
-..
+...
+}
 ```
 
 In order to use the previous one ensure that you have the [operator-lib][operator-lib] as a dependency of your project.
@@ -202,6 +203,7 @@ func main() {
 		LeaderElectionID:   "f1c5ece8.example.com",
 	})
 ...
+}
 ```
 
 - Ensure that you copy all customizations made in `cmd/manager/main.go` to `main.go`. You’ll also need to ensure that all needed schemes have been registered, if you have been using third-party API's (i.e Route Api from OpenShift).
@@ -244,7 +246,7 @@ If not, you can install Prometheus via [kube-prometheus](https://github.com/core
 kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.33/bundle.yaml
 ```
 - Now uncomment the line `- ../prometheus` in the `config/default/kustomization.yaml` file. It creates the `ServiceMonitor` resource which enables exporting the metrics:
-```sh
+```yaml
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 - ../prometheus
 ```
@@ -280,7 +282,7 @@ func (r *MemcachedReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 In this way, the following metric with the resource info will be exported:
 
-```shell             
+```
 resource_created_at_seconds{"name", "namespace", "group", "version", "kind"}
 ```
 
@@ -294,7 +296,7 @@ The Dockerfile image also changes and now it is a `multi-stage`, `distroless` an
 
  See that, you might need to port some customizations made in your old Dockerfile as well. Also, if you wish to still using the previous UBI image replace:
 
-```sh
+```docker
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
@@ -302,7 +304,7 @@ FROM gcr.io/distroless/static:nonroot
 
 With:
 
-```sh
+```docker
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ```
 

--- a/website/content/en/docs/building-operators/golang/references/client.md
+++ b/website/content/en/docs/building-operators/golang/references/client.md
@@ -6,7 +6,7 @@ weight: 10
 
 ## Overview
 
-The [`controller-runtime`][repo-controller-runtime] library provides various abstractions to watch and reconcile resources in a Kubernetes cluster via CRUD (Create, Update, Delete, as well as Get and List in this case) operations. Operators use at least one controller to perform a coherent set of tasks within a cluster, usually through a combination of CRUD operations. The Operator SDK uses controller-runtime's [Client][doc-client-client] interface, which provides the interface for these operations.
+The [`controller-runtime`][repo-controller-runtime] library provides various abstractions to watch and reconcile resources in a Kubernetes cluster via CRUD (Create, Update, Delete, as well as Get and List in this case) operations. Operators use at least one controller to perform a coherent set of tasks within a cluster, usually through a combination of CRUD operations. The Operator SDK uses controller-runtime's [Client][doc-client] interface, which provides the interface for these operations.
 
 controller-runtime defines several interfaces used for cluster interaction:
 - `client.Client`: implementers perform CRUD operations on a Kubernetes cluster.
@@ -15,26 +15,35 @@ controller-runtime defines several interfaces used for cluster interaction:
 
 Clients are the focus of this document. A separate document will discuss Managers.
 
+**Note:** this document uses parts of the sample [`memcached-operator`][memcached-testdata] for example code.
+Import paths may be different for brevity.
+
 ## Client Usage
 
 ### Default Client
 
 The SDK relies on a `manager.Manager` to create a `client.Client` interface that performs Create, Update, Delete, Get, and List operations within a `reconcile.Reconciler`'s Reconcile function. The SDK will generate code to create a Manager, which holds a Cache and a Client to be used in CRUD operations and communicate with the API server. By default a Controller's Reconciler will be populated with the Manager's Client which is a [split-client][doc-split-client].
 
-`controllers/<kind>_controller.go`:
-```Go
-import ctrl "sigs.k8s.io/controller-runtime"
+The following code, found in `controllers/memcached_controller.go`, demonstrates how the Manager's client is passed to a reconciler.
 
-func (r *KindReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&cachev1alpha1.Kind{}).
+```Go
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	cachev1alpha1 "github.com/example/memcached-operator/api/v1alpha1"
+)
+
+func (r *MemcachedReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr). // mgr's Client is passed to r.
+		For(&cachev1alpha1.Memcached{}).
 		Owns(&appsv1.Deployment{}).
 		Complete(r)
 }
 
-type KindReconciler struct {
-    // Populated above from a manager.Manager.
-    client.Client
+type MemcachedReconciler struct {
+    client.Client // Populated above from a manager.Manager.
+
     Log    logr.Logger
     Scheme *runtime.Scheme
 }
@@ -63,7 +72,9 @@ type Options struct {
     Mapper meta.RESTMapper
 }
 ```
+
 Example:
+
 ```Go
 import (
     "sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -85,8 +96,8 @@ Creating a new Client is not usually necessary nor advised, as the default Clien
 A Reconciler implements the [`reconcile.Reconciler`][doc-reconcile-reconciler] interface, which exposes the Reconcile method. Reconcilers are added to a corresponding Controller for a Kind; Reconcile is called in response to cluster or external Events, with a `reconcile.Request` object argument, to read and write cluster state by the Controller, and returns a `ctrl.Result`. SDK Reconcilers have access to a Client in order to make Kubernetes API calls.
 
 ```Go
-// KindReconciler reconciles a Kind object
-type KindReconciler struct {
+// MemcachedReconciler reconciles a Memcached object
+type MemcachedReconciler struct {
     // client, initialized using mgr.Client() above, is a split client
     // that reads objects from the cache and writes to the apiserver
     client.Client
@@ -106,34 +117,37 @@ type KindReconciler struct {
 // The Controller will requeue the Request to be processed again if an error
 // is non-nil or Result.Requeue is true, otherwise upon completion it will
 // remove the work from the queue.
-func (r *KindReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Result, error)
+func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error)
 ```
 
-Reconcile is where Controller business logic lives, i.e. where Client API calls are made via `KindReconciler.client`. A `client.Client` implementer performs the following operations:
+Reconcile is where Controller business logic lives, i.e. where Client API calls are made via `MemcachedReconciler.client`. A `client.Client` implementer performs the following operations:
 
 #### Get
 
 ```Go
 // Get retrieves an API object for a given object key from the Kubernetes cluster
 // and stores it in obj.
-func (c Client) Get(ctx context.Context, key ObjectKey, obj runtime.Object) error
+func (c Client) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error
 ```
-**Note**: An `ObjectKey` is simply a `client` package alias for [`types.NamespacedName`][doc-types-nsname].
+
+**Note**: A `client.ObjectKey` is simply an alias for [`types.NamespacedName`][doc-types-nsname].
 
 Example:
+
 ```Go
 import (
     "context"
-    "github.com/example-org/app-operator/pkg/apis/cache/v1alpha1"
+
     ctrl "sigs.k8s.io/controller-runtime"
+
+    cachev1alpha1 "github.com/example/memcached-operator/api/v1alpha1"
 )
 
-func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
     ...
 
-    app := &v1alpha1.App{}
-    ctx := context.TODO()
-    err := r.Get(ctx, request.NamespacedName, app)
+    memcached := &cachev1alpha1.Memcached{}
+    err := r.Get(ctx, request.NamespacedName, memcached)
 
     ...
 }
@@ -144,7 +158,7 @@ func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Resul
 ```Go
 // List retrieves a list of objects for a given namespace and list options
 // and stores the list in obj.
-func (c Client) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error
+func (c Client) List(ctx context.Context, list client.Object, opts ...client.ListOption) error
 ```
 
 A `client.ListOption` is an interface that sets [`client.ListOptions`][list-options] fields. A `client.ListOption` is created by using one of the provided implementations: [`MatchingLabels`][matching-labels], [`MatchingFields`][matching-fields], [`InNamespace`][in-namespace].
@@ -155,23 +169,23 @@ Example:
 import (
     "context"
     "fmt"
+
     "k8s.io/api/core/v1"
-    "sigs.k8s.io/controller-runtime/pkg/client"
     ctrl "sigs.k8s.io/controller-runtime"
+    "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
     ...
 
-    // Return all pods in the request namespace with a label of `app=<name>`
+    // Return all pods in the request namespace with a label of `instance=<name>`
     // and phase `Running`.
     podList := &v1.PodList{}
     opts := []client.ListOption{
         client.InNamespace(request.NamespacedName.Namespace),
-        client.MatchingLabels{"app": request.NamespacedName.Name},
+        client.MatchingLabels{"instance": request.NamespacedName.Name},
         client.MatchingFields{"status.phase": "Running"},
     }
-    ctx := context.TODO()
     err := r.List(ctx, podList, opts...)
 
     ...
@@ -188,7 +202,7 @@ func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Resul
 ```Go
 // Create saves the object obj in the Kubernetes cluster.
 // Returns an error
-func (c Client) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error
+func (c Client) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error
 ```
 
 A `client.CreateOption` is an interface that sets [`client.CreateOptions`][create-options] fields. A `client.CreateOption` is created by using one of the provided implementations: [`DryRunAll`][dry-run-all], [`ForceOwnership`][force-ownership]. Generally these options are not needed.
@@ -198,18 +212,18 @@ Example:
 ```Go
 import (
     "context"
+
     "k8s.io/api/apps/v1"
     ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
     ...
 
-    app := &v1.Deployment{ // Any cluster object you want to create.
+    dep := &v1.Deployment{ // Any cluster object you want to create.
         ...
     }
-    ctx := context.TODO()
-    err := r.Create(ctx, app)
+    err := r.Create(ctx, dep)
 
     ...
 }
@@ -224,7 +238,7 @@ func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Resul
 // struct pointer so that obj can be updated with the content returned
 // by the API server. Update does *not* update the resource's status
 // subresource
-func (c Client) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error
+func (c Client) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error
 ```
 
 A `client.UpdateOption` is an interface that sets [`client.UpdateOptions`][update-options] fields. A `client.UpdateOption` is created by using one of the provided implementations: [`DryRunAll`][dry-run-all], [`ForceOwnership`][force-ownership]. Generally these options are not needed.
@@ -234,19 +248,19 @@ Example:
 ```Go
 import (
     "context"
+
     "k8s.io/api/apps/v1"
     ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
     ...
 
     dep := &v1.Deployment{}
-    err := r.Get(context.TODO(), request.NamespacedName, dep)
+    err := r.Get(ctx, request.NamespacedName, dep)
 
     ...
 
-    ctx := context.TODO()
     dep.Spec.Selector.MatchLabels["is_running"] = "true"
     err := r.Update(ctx, dep)
 
@@ -261,7 +275,7 @@ func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Resul
 ```Go
 // Patch patches the given obj in the Kubernetes cluster. obj must be a
 // struct pointer so that obj can be updated with the content returned by the Server.
-func (c Client) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.UpdateOption) error
+func (c Client) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.UpdateOption) error
 ```
 
 A `client.PatchOption` is an interface that sets [`client.PatchOptions`][patch-options] fields. A `client.PatchOption` is created by using one of the provided implementations: [`DryRunAll`][dry-run-all], [`ForceOwnership`][force-ownership]. Generally these options are not needed.
@@ -271,20 +285,20 @@ Example:
 ```Go
 import (
     "context"
+
     "k8s.io/api/apps/v1"
-    "sigs.k8s.io/controller-runtime/pkg/client"
     ctrl "sigs.k8s.io/controller-runtime"
+    "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
     ...
 
     dep := &v1.Deployment{}
-    err := r.Get(context.TODO(), request.NamespacedName, dep)
+    err := r.Get(ctx, request.NamespacedName, dep)
 
     ...
 
-    ctx := context.TODO()
     // A merge patch will preserve other fields modified at runtime.
     patch := client.MergeFrom(dep.DeepCopy())
     dep.Spec.Selector.MatchLabels["is_running"] = "true"
@@ -316,14 +330,15 @@ Example:
 ```Go
 import (
     "context"
-    cachev1alpha1 "github.com/example/memcached-operator/pkg/apis/cache/v1alpha1"
+
     ctrl "sigs.k8s.io/controller-runtime"
+
+    cachev1alpha1 "github.com/example/memcached-operator/api/v1alpha1"
 )
 
-func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
     ...
 
-    ctx := context.TODO()
     mem := &cachev1alpha1.Memcached{}
     err := r.Get(ctx, request.NamespacedName, mem)
 
@@ -350,7 +365,7 @@ func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Resul
 
 ```Go
 // Delete deletes the given obj from Kubernetes cluster.
-func (c Client) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error
+func (c Client) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error
 ```
 
 A `client.DeleteOption` is an interface that sets [`client.DeleteOptions`][delete-opts] fields. A `client.DeleteOption` is created by using one of the provided implementations: [`GracePeriodSeconds`][grace-period-seconds], [`Preconditions`][preconditions], [`PropagationPolicy`][propagation-policy].
@@ -360,20 +375,20 @@ Example:
 ```Go
 import (
     "context"
+
     "k8s.io/api/core/v1"
-    "sigs.k8s.io/controller-runtime/pkg/client"
     ctrl "sigs.k8s.io/controller-runtime"
+    "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
     ...
 
     pod := &v1.Pod{}
-    err := r.Get(context.TODO(), request.NamespacedName, pod)
+    err := r.Get(ctx, request.NamespacedName, pod)
 
     ...
 
-    ctx := context.TODO()
     if pod.Status.Phase == v1.PodUnknown {
         // Delete the pod after 5 seconds.
         err := r.Delete(ctx, pod, client.GracePeriodSeconds(5))
@@ -393,7 +408,7 @@ func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Resul
 
 ```Go
 // DeleteAllOf deletes all objects of the given type matching the given options.
-func (c Client) DeleteAllOf(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error
+func (c Client) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error
 ```
 
 A `client.DeleteAllOfOption` is an interface that sets [`client.DeleteAllOfOptions`][deleteallof-opts] fields. A `client.DeleteAllOfOption` wraps a [`client.ListOption`](#list) and [`client.DeleteOption`](#delete).
@@ -404,24 +419,24 @@ Example:
 import (
     "context"
     "fmt"
+
     "k8s.io/api/core/v1"
-    "sigs.k8s.io/controller-runtime/pkg/client"
     ctrl "sigs.k8s.io/controller-runtime"
+    "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
     ...
 
-    // Delete all pods in the request namespace with a label of `app=<name>`
+    // Delete all pods in the request namespace with a label of `instance=<name>`
     // and phase `Failed`.
     pod := &v1.Pod{}
     opts := []client.DeleteAllOfOption{
         client.InNamespace(request.NamespacedName.Namespace),
-        client.MatchingLabels{"app", request.NamespacedName.Name},
+        client.MatchingLabels{"instance", request.NamespacedName.Name},
         client.MatchingFields{"status.phase": "Failed"},
         client.GracePeriodSeconds(5),
     }
-    ctx := context.TODO()
     err := r.DeleteAllOf(ctx, pod, opts...)
 
     ...
@@ -437,8 +452,6 @@ import (
     "context"
     "reflect"
 
-    appv1alpha1 "github.com/example-org/app-operator/api/v1alpha1"
-
     appsv1 "k8s.io/api/apps/v1"
     corev1 "k8s.io/api/core/v1"
     "k8s.io/apimachinery/pkg/api/errors"
@@ -446,22 +459,24 @@ import (
     "k8s.io/apimachinery/pkg/labels"
     "k8s.io/apimachinery/pkg/runtime"
     "k8s.io/apimachinery/pkg/types"
+    ctrl "sigs.k8s.io/controller-runtime"
     "sigs.k8s.io/controller-runtime/pkg/client"
     "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-    ctrl "sigs.k8s.io/controller-runtime"
+
+    cachev1alpha1 "github.com/example/memcached-operator/api/v1alpha1"
 )
 
-type AppReconciler struct {
+type MemcachedReconciler struct {
     client.Client
     Log    logr.Logger
     Scheme *runtime.Scheme
 }
 
-func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 
-    // Fetch the App instance.
-    app := &appv1alpha1.App{}
-    err := r.Get(context.TODO(), request.NamespacedName, app)
+    // Fetch the Memcached instance.
+    memcached := &cachev1alpha1.Memcached{}
+    err := r.Get(ctx, request.NamespacedName, memcached)
     if err != nil {
         if errors.IsNotFound(err) {
             return ctrl.Result{}, nil
@@ -471,12 +486,12 @@ func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Resul
 
     // Check if the deployment already exists, if not create a new deployment.
     found := &appsv1.Deployment{}
-    err = r.Get(context.TODO(), types.NamespacedName{Name: app.Name, Namespace: app.Namespace}, found)
+    err = r.Get(ctx, types.NamespacedName{Name: memcached.Name, Namespace: memcached.Namespace}, found)
     if err != nil {
          if errors.IsNotFound(err) {
             // Define and create a new deployment.
-            dep := r.deploymentForApp(app)
-            if err = r.Create(context.TODO(), dep); err != nil {
+            dep := r.deploymentForMemcached(memcached)
+            if err = r.Create(ctx, dep); err != nil {
                 return ctrl.Result{}, err
             }
             return ctrl.Result{Requeue: true}, nil
@@ -486,31 +501,31 @@ func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Resul
     }
 
     // Ensure the deployment size is the same as the spec.
-    size := app.Spec.Size
+    size := memcached.Spec.Size
     if *found.Spec.Replicas != size {
         found.Spec.Replicas = &size
-        if err = r.Update(context.TODO(), found); err != nil {
+        if err = r.Update(ctx, found); err != nil {
             return ctrl.Result{}, err
         }
         return ctrl.Result{Requeue: true}, nil
     }
 
-    // Update the App status with the pod names.
-    // List the pods for this app's deployment.
+    // Update the Memcached status with the pod names.
+    // List the pods for this CR's deployment.
     podList := &corev1.PodList{}
     listOpts := []client.ListOption{
-        client.InNamespace(app.Namespace),
-        client.MatchingLabels(labelsForApp(app.Name)),
+        client.InNamespace(memcached.Namespace),
+        client.MatchingLabels(labelsForApp(memcached.Name)),
     }
-    if err = r.List(context.TODO(), podList, listOpts...); err != nil {
+    if err = r.List(ctx, podList, listOpts...); err != nil {
         return ctrl.Result{}, err
     }
 
     // Update status.Nodes if needed.
     podNames := getPodNames(podList.Items)
-    if !reflect.DeepEqual(podNames, app.Status.Nodes) {
-        app.Status.Nodes = podNames
-        if err := r.Status().Update(context.TODO(), app); err != nil {
+    if !reflect.DeepEqual(podNames, memcached.Status.Nodes) {
+        memcached.Status.Nodes = podNames
+        if err := r.Status().Update(ctx, memcached); err != nil {
             return ctrl.Result{}, err
         }
     }
@@ -518,8 +533,8 @@ func (r *AppReconciler) Reconcile(context.Context, req ctrl.Request) (ctrl.Resul
     return ctrl.Request{}, nil
 }
 
-// deploymentForApp returns a app Deployment object.
-func (r *KindReconciler) deploymentForApp(m *appv1alpha1.App) *appsv1.Deployment {
+// deploymentForMemcached returns a Deployment object for data from m.
+func (r *MemcachedReconciler) deploymentForMemcached(m *cachev1alpha1.Memcached) *appsv1.Deployment {
     lbls := labelsForApp(m.Name)
     replicas := m.Spec.Size
 
@@ -539,12 +554,12 @@ func (r *KindReconciler) deploymentForApp(m *appv1alpha1.App) *appsv1.Deployment
                 },
                 Spec: corev1.PodSpec{
                     Containers: []corev1.Container{{
-                        Image:   "app:alpine",
-                        Name:    "app",
-                        Command: []string{"app", "-a=64", "-b"},
+                        Image:   "memcached:alpine",
+                        Name:    "memcached",
+                        Command: []string{"memcached", "-a=64", "-b"},
                         Ports: []corev1.ContainerPort{{
                             ContainerPort: 10000,
-                            Name:          "app",
+                            Name:          "memcached",
                         }},
                     }},
                 },
@@ -552,21 +567,22 @@ func (r *KindReconciler) deploymentForApp(m *appv1alpha1.App) *appsv1.Deployment
         },
     }
 
-    // Set App instance as the owner and controller.
+    // Set Memcached instance as the owner and controller.memcac
     // NOTE: calling SetControllerReference, and setting owner references in
     // general, is important as it allows deleted objects to be garbage collected.
     controllerutil.SetControllerReference(m, dep, r.scheme)
     return dep
 }
 
-// labelsForApp creates a simple set of labels for App.
+// labelsForApp creates a simple set of labels for Memcached.
 func labelsForApp(name string) map[string]string {
-    return map[string]string{"app_name": "app", "app_cr": name}
+    return map[string]string{"cr_name": name}
 }
 ```
 
+[memcached-testdata]:https://github.com/operator-framework/operator-sdk/tree/master/testdata/go/v3/memcached-operator
 [repo-controller-runtime]:https://github.com/kubernetes-sigs/controller-runtime
-[doc-client-client]:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/client#Client
+[doc-client]:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/client#Client
 [doc-split-client]:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/client#DelegatingClient
 [doc-client-constr]:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/client#New
 [code-scheme-default]:https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/client.go#L51

--- a/website/content/en/docs/building-operators/golang/references/event-filtering.md
+++ b/website/content/en/docs/building-operators/golang/references/event-filtering.md
@@ -66,7 +66,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	cachev1alpha1 "github.com/example/app-operator/apis/cache/v1alpha1"
+	cachev1alpha1 "github.com/example/app-operator/api/v1alpha1"
 )
 
 ...

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -79,7 +79,7 @@ This will scaffold the Memcached resource API at `api/v1alpha1/memcached_types.g
 
 For an in-depth explanation of Kubernetes APIs and the group-version-kind model, check out these [kubebuilder docs][kb-doc-gkvs].
 
-In general, it's recommended to have one controller responsible for manage each API created for the project to 
+In general, it's recommended to have one controller responsible for manage each API created for the project to
 properly follow the design goals set by [controller-runtime][controller-runtime].
 
 ### Define the API
@@ -433,7 +433,7 @@ Next, try adding the following to your project:
 1. Validating and mutating [admission webhooks][create_a_webhook].
 2. Operator packaging and distribution with [OLM][olm-integration].
 
-Also see the [advanced topics][advanced_topics] doc for more use cases and under the hood details. 
+Also see the [advanced topics][advanced_topics] doc for more use cases and under the hood details.
 
 [legacy-quickstart-doc]:https://v0-19-x.sdk.operatorframework.io/docs/golang/legacy/quickstart/
 [migration-guide]:/docs/building-operators/golang/migration


### PR DESCRIPTION
**Description of the change:**
- docs/building-operators/golang: fix `context.Context` usage, imports, and general formatting

**Motivation for the change:** docs weren't using the correct `context.Context` value (see #4474), imports weren't formatted correctly, and different GVKs were used which is confusing.

/kind documentation

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
