### PR TITLE
ansible output should log with GVK info, namespace as the CR name

### DIFF
--- a/internal/ansible/controller/reconcile.go
+++ b/internal/ansible/controller/reconcile.go
@@ -284,6 +284,7 @@ func printEventStats(statusEvent eventapi.StatusJobEvent, u *unstructured.Unstru
 }
 
 func (r *AnsibleOperatorReconciler) printAnsibleResult(result runner.RunResult, u *unstructured.Unstructured) {
+
 	if r.AnsibleDebugLogs {
 		if res, err := result.Stdout(); err == nil && len(res) > 0 {
 			str := "\n--------------------------- Ansible Debug Result -----------------------------\n"

--- a/internal/ansible/controller/reconcile.go
+++ b/internal/ansible/controller/reconcile.go
@@ -275,23 +275,16 @@ func (r *AnsibleOperatorReconciler) Reconcile(ctx context.Context, request recon
 
 func printEventStats(statusEvent eventapi.StatusJobEvent, u *unstructured.Unstructured) {
 	if len(statusEvent.StdOut) > 0 {
-		str := "\n--------------------------- Ansible Task Status Event StdOut  -----------------\n"
-		str += fmt.Sprintf("\n----- %70s -----\n", fmt.Sprintf("%s %s/%s", u.GroupVersionKind(), u.GetName(), u.GetNamespace()))
-		str += fmt.Sprintf("\n%s\n", statusEvent.StdOut)
-		str += "\n-------------------------------------------------------------------------------\n"
-		fmt.Println(str)
+		str := fmt.Sprintf("Ansible Task Status Event StdOut (%s, %s/%s)", u.GroupVersionKind(), u.GetName(), u.GetNamespace())
+		fmt.Printf("\n----- %70s -----\n\n%s\n\n----------\n", str, statusEvent.StdOut)
 	}
 }
 
 func (r *AnsibleOperatorReconciler) printAnsibleResult(result runner.RunResult, u *unstructured.Unstructured) {
-
 	if r.AnsibleDebugLogs {
 		if res, err := result.Stdout(); err == nil && len(res) > 0 {
-			str := "\n--------------------------- Ansible Debug Result -----------------------------\n"
-			str += fmt.Sprintf("\n----- %70s -----\n", fmt.Sprintf("%s %s/%s", u.GroupVersionKind(), u.GetName(), u.GetNamespace()))
-			str += fmt.Sprintf("\n%s\n", res)
-			str += "\n-------------------------------------------------------------------------------\n"
-			fmt.Println(str)
+			str := fmt.Sprintf("Ansible Debug Result (%s, %s/%s)", u.GroupVersionKind(), u.GetName(), u.GetNamespace())
+			fmt.Printf("\n----- %70s -----\n\n%s\n\n----------\n", str, res)
 		}
 	}
 }

--- a/internal/ansible/controller/reconcile.go
+++ b/internal/ansible/controller/reconcile.go
@@ -178,12 +178,12 @@ func (r *AnsibleOperatorReconciler) Reconcile(ctx context.Context, request recon
 			// convert to StatusJobEvent; would love a better way to do this
 			data, err := json.Marshal(event)
 			if err != nil {
-				printEventStats(statusEvent, request, u.GroupVersionKind().String())
+				printEventStats(statusEvent, u)
 				return reconcile.Result{}, err
 			}
 			err = json.Unmarshal(data, &statusEvent)
 			if err != nil {
-				printEventStats(statusEvent, request, u.GroupVersionKind().String())
+				printEventStats(statusEvent, u)
 				return reconcile.Result{}, err
 			}
 		}
@@ -210,10 +210,10 @@ func (r *AnsibleOperatorReconciler) Reconcile(ctx context.Context, request recon
 	}
 
 	// To print the stats of the task
-	printEventStats(statusEvent, request, u.GroupVersionKind().String())
+	printEventStats(statusEvent, u)
 
 	// To print the full ansible result
-	r.printAnsibleResult(result, request, u.GroupVersionKind().String())
+	r.printAnsibleResult(result, u)
 
 	if statusEvent.Event == "" {
 		eventErr := errors.New("did not receive playbook_on_stats event")
@@ -273,22 +273,24 @@ func (r *AnsibleOperatorReconciler) Reconcile(ctx context.Context, request recon
 	return reconcileResult, nil
 }
 
-func printEventStats(statusEvent eventapi.StatusJobEvent, request reconcile.Request, gvkStr string) {
+func printEventStats(statusEvent eventapi.StatusJobEvent, u *unstructured.Unstructured) {
 	if len(statusEvent.StdOut) > 0 {
-		fmt.Printf("\n--------------------------- Ansible Task Status Event StdOut  -----------------\n")
-		fmt.Printf("-----%68v -----\n", gvkStr+" "+request.Namespace+" "+request.Name)
-		fmt.Println(statusEvent.StdOut)
-		fmt.Printf("\n-------------------------------------------------------------------------------\n")
+		str := "\n--------------------------- Ansible Task Status Event StdOut  -----------------\n"
+		str += fmt.Sprintf("\n----- %70s -----\n", fmt.Sprintf("Ansible Task Status Event StdOut (%s, %s/%s)", u.GroupVersionKind(), u.GetName(), u.GetNamespace()))
+		str += fmt.Sprintf("\n%s\n", statusEvent.StdOut)
+		str += "\n-------------------------------------------------------------------------------\n"
+		fmt.Println(str)
 	}
 }
 
-func (r *AnsibleOperatorReconciler) printAnsibleResult(result runner.RunResult, request reconcile.Request, gvkStr string) {
+func (r *AnsibleOperatorReconciler) printAnsibleResult(result runner.RunResult, u *unstructured.Unstructured) {
 	if r.AnsibleDebugLogs {
 		if res, err := result.Stdout(); err == nil && len(res) > 0 {
-			fmt.Printf("\n--------------------------- Ansible Debug Result -----------------------------\n")
-			fmt.Printf("-----%68v -----\n", gvkStr+" "+request.Namespace+" "+request.Name)
-			fmt.Println(res)
-			fmt.Printf("\n-------------------------------------------------------------------------------\n")
+			str := "\n--------------------------- Ansible Debug Result -----------------------------\n"
+			str += fmt.Sprintf("\n----- %70s -----\n", fmt.Sprintf("Ansible Task Status Event StdOut (%s, %s/%s)", u.GroupVersionKind(), u.GetName(), u.GetNamespace()))
+			str += fmt.Sprintf("\n%s\n", res)
+			str += "\n-------------------------------------------------------------------------------\n"
+			fmt.Println(str)
 		}
 	}
 }

--- a/internal/ansible/controller/reconcile.go
+++ b/internal/ansible/controller/reconcile.go
@@ -276,7 +276,7 @@ func (r *AnsibleOperatorReconciler) Reconcile(ctx context.Context, request recon
 func printEventStats(statusEvent eventapi.StatusJobEvent, u *unstructured.Unstructured) {
 	if len(statusEvent.StdOut) > 0 {
 		str := "\n--------------------------- Ansible Task Status Event StdOut  -----------------\n"
-		str += fmt.Sprintf("\n----- %70s -----\n", fmt.Sprintf("Ansible Task Status Event StdOut (%s, %s/%s)", u.GroupVersionKind(), u.GetName(), u.GetNamespace()))
+		str += fmt.Sprintf("\n----- %70s -----\n", fmt.Sprintf("%s %s/%s", u.GroupVersionKind(), u.GetName(), u.GetNamespace()))
 		str += fmt.Sprintf("\n%s\n", statusEvent.StdOut)
 		str += "\n-------------------------------------------------------------------------------\n"
 		fmt.Println(str)
@@ -287,7 +287,7 @@ func (r *AnsibleOperatorReconciler) printAnsibleResult(result runner.RunResult, 
 	if r.AnsibleDebugLogs {
 		if res, err := result.Stdout(); err == nil && len(res) > 0 {
 			str := "\n--------------------------- Ansible Debug Result -----------------------------\n"
-			str += fmt.Sprintf("\n----- %70s -----\n", fmt.Sprintf("Ansible Task Status Event StdOut (%s, %s/%s)", u.GroupVersionKind(), u.GetName(), u.GetNamespace()))
+			str += fmt.Sprintf("\n----- %70s -----\n", fmt.Sprintf("%s %s/%s", u.GroupVersionKind(), u.GetName(), u.GetNamespace()))
 			str += fmt.Sprintf("\n%s\n", res)
 			str += "\n-------------------------------------------------------------------------------\n"
 			fmt.Println(str)

--- a/internal/ansible/controller/reconcile.go
+++ b/internal/ansible/controller/reconcile.go
@@ -172,7 +172,7 @@ func (r *AnsibleOperatorReconciler) Reconcile(ctx context.Context, request recon
 	failureMessages := eventapi.FailureMessages{}
 	for event := range result.Events() {
 		for _, eHandler := range r.EventHandlers {
-			go eHandler.Handle(ident, u, event, request)
+			go eHandler.Handle(ident, u, event)
 		}
 		if event.Event == eventapi.EventPlaybookOnStats {
 			// convert to StatusJobEvent; would love a better way to do this

--- a/internal/ansible/events/log_events.go
+++ b/internal/ansible/events/log_events.go
@@ -45,8 +45,8 @@ type EventHandler interface {
 }
 
 type loggingEventHandler struct {
-	LogLevel  LogLevel
-	mutexLock sync.Mutex
+	LogLevel LogLevel
+	mutex    sync.Mutex
 }
 
 func (l loggingEventHandler) Handle(ident string, u *unstructured.Unstructured, e eventapi.JobEvent) {

--- a/internal/ansible/events/log_events.go
+++ b/internal/ansible/events/log_events.go
@@ -123,5 +123,6 @@ func (l loggingEventHandler) logAnsibleStdOut(e eventapi.JobEvent) {
 func NewLoggingEventHandler(l LogLevel) EventHandler {
 	return loggingEventHandler{
 		LogLevel: l,
+		mux:      &sync.Mutex{},
 	}
 }

--- a/internal/ansible/events/log_events.go
+++ b/internal/ansible/events/log_events.go
@@ -46,7 +46,7 @@ type EventHandler interface {
 
 type loggingEventHandler struct {
 	LogLevel LogLevel
-	mux      sync.Mutex
+	mux      *sync.Mutex
 }
 
 func (l loggingEventHandler) Handle(ident string, u *unstructured.Unstructured, e eventapi.JobEvent) {

--- a/internal/ansible/events/log_events.go
+++ b/internal/ansible/events/log_events.go
@@ -91,16 +91,20 @@ func (l loggingEventHandler) Handle(ident string, u *unstructured.Unstructured, 
 			if taskPath, ok := e.EventData["task_path"]; ok {
 				errKVs = append(errKVs, "EventData.FailedTaskPath", taskPath)
 			}
+			mutexLock.Lock()
 			logger.Error(errors.New("[playbook task failed]"), "", errKVs...)
-			l.logAnsibleStdOut(e, request, u.GroupVersionKind().String())
+			l.logAnsibleStdOut(e)
+			mutexLock.Unlock()
 			return
 		}
 	}
 
 	// log everything else for the 'Everything' LogLevel
 	if l.LogLevel == Everything {
+		mutexLock.Lock()
 		logger.Info("", "EventData", e.EventData)
-		l.logAnsibleStdOut(e, request, u.GroupVersionKind().String())
+		l.logAnsibleStdOut(e, request)
+		mutexLock.Unlock()
 	}
 }
 

--- a/internal/ansible/events/log_events.go
+++ b/internal/ansible/events/log_events.go
@@ -50,7 +50,7 @@ type loggingEventHandler struct {
 	mutexLock sync.Mutex
 }
 
-func (l loggingEventHandler) Handle(ident string, u *unstructured.Unstructured, e eventapi.JobEvent, request reconcile.Request) {
+func (l loggingEventHandler) Handle(ident string, u *unstructured.Unstructured, e eventapi.JobEvent) {
 	if l.LogLevel == Nothing {
 		return
 	}
@@ -103,7 +103,7 @@ func (l loggingEventHandler) Handle(ident string, u *unstructured.Unstructured, 
 	if l.LogLevel == Everything {
 		mutexLock.Lock()
 		logger.Info("", "EventData", e.EventData)
-		l.logAnsibleStdOut(e, request)
+		l.logAnsibleStdOut(e)
 		mutexLock.Unlock()
 	}
 }

--- a/internal/ansible/events/log_events.go
+++ b/internal/ansible/events/log_events.go
@@ -72,14 +72,14 @@ func (l loggingEventHandler) Handle(ident string, u *unstructured.Unstructured, 
 		if e.Event == eventapi.EventPlaybookOnTaskStart && !setFactAction && !debugAction {
 			mutexLock.Lock()
 			logger.Info("[playbook task]", "EventData.Name", e.EventData["name"])
-			l.logAnsibleStdOut(e, request, u.GroupVersionKind().String())
+			l.logAnsibleStdOut(e)
 			mutexLock.Unlock()
 			return
 		}
 		if e.Event == eventapi.EventRunnerOnOk && debugAction {
 			mutexLock.Lock()
 			logger.Info("[playbook debug]", "EventData.TaskArgs", e.EventData["task_args"])
-			l.logAnsibleStdOut(e, request, u.GroupVersionKind().String())
+			l.logAnsibleStdOut(e)
 			mutexLock.Unlock()
 			return
 		}

--- a/internal/ansible/events/log_events.go
+++ b/internal/ansible/events/log_events.go
@@ -69,17 +69,17 @@ func (l loggingEventHandler) Handle(ident string, u *unstructured.Unstructured, 
 		debugAction := e.EventData["task_action"] == eventapi.TaskActionDebug
 
 		if e.Event == eventapi.EventPlaybookOnTaskStart && !setFactAction && !debugAction {
-			l.mutexLock.Lock()
+			l.mutex.Lock()
 			logger.Info("[playbook task]", "EventData.Name", e.EventData["name"])
 			l.logAnsibleStdOut(e)
-			l.mutexLock.Unlock()
+			l.mutex.Unlock()
 			return
 		}
 		if e.Event == eventapi.EventRunnerOnOk && debugAction {
-			l.mutexLock.Lock()
+			l.mutex.Lock()
 			logger.Info("[playbook debug]", "EventData.TaskArgs", e.EventData["task_args"])
 			l.logAnsibleStdOut(e)
-			l.mutexLock.Unlock()
+			l.mutex.Unlock()
 			return
 		}
 		if e.Event == eventapi.EventRunnerOnFailed {
@@ -90,20 +90,20 @@ func (l loggingEventHandler) Handle(ident string, u *unstructured.Unstructured, 
 			if taskPath, ok := e.EventData["task_path"]; ok {
 				errKVs = append(errKVs, "EventData.FailedTaskPath", taskPath)
 			}
-			l.mutexLock.Lock()
+			l.mutex.Lock()
 			logger.Error(errors.New("[playbook task failed]"), "", errKVs...)
 			l.logAnsibleStdOut(e)
-			l.mutexLock.Unlock()
+			l.mutex.Unlock()
 			return
 		}
 	}
 
 	// log everything else for the 'Everything' LogLevel
 	if l.LogLevel == Everything {
-		l.mutexLock.Lock()
+		l.mutex.Lock()
 		logger.Info("", "EventData", e.EventData)
 		l.logAnsibleStdOut(e)
-		l.mutexLock.Unlock()
+		l.mutex.Unlock()
 	}
 }
 


### PR DESCRIPTION
**Description of the change:**
Log GVK, namespace and CR name as part of the ansible output

**Motivation for the change:**
If our ansible operator allows multiple workers to run reconcile on multiple namespaces with different CR type, then the concurrency of multiple reconcile is very hard to know which CR that the output tie to, so we need to put more info in the output

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
