### PR TITLE
Use controllerutil.ContainsFinalizer in delete example

### DIFF
--- a/website/content/en/docs/building-operators/golang/advanced-topics.md
+++ b/website/content/en/docs/building-operators/golang/advanced-topics.md
@@ -168,7 +168,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
     // indicated by the deletion timestamp being set.
     isMemcachedMarkedToBeDeleted := memcached.GetDeletionTimestamp() != nil
     if isMemcachedMarkedToBeDeleted {
-        if contains(memcached.GetFinalizers(), memcachedFinalizer) {
+        if controllerutil.ContainsFinalizer(memcached, memcachedFinalizer) {
             // Run finalization logic for memcachedFinalizer. If the
             // finalization logic fails, don't remove the finalizer so
             // that we can retry during the next reconciliation.
@@ -188,7 +188,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
     }
 
     // Add finalizer for this CR
-    if !contains(memcached.GetFinalizers(), memcachedFinalizer) {
+    if !controllerutil.ContainsFinalizer(memcached, memcachedFinalizer) {
         if err := r.addFinalizer(reqLogger, memcached); err != nil {
             return ctrl.Result{}, err
         }
@@ -219,15 +219,6 @@ func (r *MemcachedReconciler) addFinalizer(reqLogger logr.Logger, m *cachev1alph
         return err
     }
     return nil
-}
-
-func contains(list []string, s string) bool {
-    for _, v := range list {
-        if v == s {
-            return true
-        }
-    }
-    return false
 }
 ```
 


### PR DESCRIPTION
Replacing the custom `contains` implementation with
the version in controllerutil.

Signed-off-by: rearl <rearl@secureworks.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
