### PR TITLE
Fix kube rbac proxy

### DIFF
--- a/changelog/fragments/kube-rbac-proxy.yaml
+++ b/changelog/fragments/kube-rbac-proxy.yaml
@@ -2,7 +2,7 @@
 # release notes and/or the migration guide
 entries:
   - description: >
-      For Ansible/Helm based-operators, upgrade the `kube-rbac-proxy` image version from `0.5.0` to `0.8.0` to address security concerns. More info [#kubernetes-sigs/kubebuilder#1955](https://github.com/kubernetes-sigs/kubebuilder/pull/1955).
+      (ansible/v1, helm/v1) Upgraded the `gcr.io/kubebuilder/kube-rbac-proxy` image version from `0.5.0` to `0.8.0` to support rootless run mode.
     kind: "bugfix"
     breaking: false
     header: (ansible/v1, helm/v1) Upgrade the `gcr.io/kubebuilder/kube-rbac-proxy` image version from `0.5.0` to `0.8.0`

--- a/changelog/fragments/kube-rbac-proxy.yaml
+++ b/changelog/fragments/kube-rbac-proxy.yaml
@@ -1,0 +1,10 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For Ansible/Helm based-operators, upgrade the `kube-rbac-proxy` image version from `0.5.0` to `0.8.0` to address security concerns. More info [#kubernetes-sigs/kubebuilder#1955](https://github.com/kubernetes-sigs/kubebuilder/pull/1955).
+    kind: "bugfix"
+    breaking: false
+    header: For Ansible/Helm based-operators, upgrade the `kube-rbac-proxy` from `0.5.0` to `0.8.0` to solve security concerns
+    body: >
+      In the `config/default/manager_auth_proxy_patch.yaml` file, replace `gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0` with `gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0`.

--- a/changelog/fragments/kube-rbac-proxy.yaml
+++ b/changelog/fragments/kube-rbac-proxy.yaml
@@ -5,7 +5,7 @@ entries:
       For Ansible/Helm based-operators, upgrade the `kube-rbac-proxy` image version from `0.5.0` to `0.8.0` to address security concerns. More info [#kubernetes-sigs/kubebuilder#1955](https://github.com/kubernetes-sigs/kubebuilder/pull/1955).
     kind: "bugfix"
     breaking: false
-    header: For Ansible/Helm based-operators, upgrade the `kube-rbac-proxy` from `0.5.0` to `0.8.0` to solve security concerns
+    header: (ansible/v1, helm/v1) Upgrade the `gcr.io/kubebuilder/kube-rbac-proxy` image version from `0.5.0` to `0.8.0`
     body: >
       The 0.8.0 version of kube-rbac-proxy supports rootless run mode.
       To take advantage of this and other features, replace `gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0`

--- a/changelog/fragments/kube-rbac-proxy.yaml
+++ b/changelog/fragments/kube-rbac-proxy.yaml
@@ -7,4 +7,6 @@ entries:
     breaking: false
     header: For Ansible/Helm based-operators, upgrade the `kube-rbac-proxy` from `0.5.0` to `0.8.0` to solve security concerns
     body: >
-      In the `config/default/manager_auth_proxy_patch.yaml` file, replace `gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0` with `gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0`.
+      The 0.8.0 version of kube-rbac-proxy supports rootless run mode.
+      To take advantage of this and other features, replace `gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0`
+      with `gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0` in your `config/default/manager_auth_proxy_patch.yaml` file.

--- a/internal/generate/testdata/clusterserviceversions/output/memcached-operator.clusterserviceversion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/output/memcached-operator.clusterserviceversion.yaml
@@ -81,7 +81,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/internal/generate/testdata/clusterserviceversions/output/with-ui-metadata.clusterserviceversion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/output/with-ui-metadata.clusterserviceversion.yaml
@@ -125,7 +125,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/internal/generate/testdata/go/static/basic.operator.yaml
+++ b/internal/generate/testdata/go/static/basic.operator.yaml
@@ -266,7 +266,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/config/kdefault/auth_proxy_patch.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/config/kdefault/auth_proxy_patch.go
@@ -57,7 +57,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/config/kdefault/auth_proxy_patch.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/config/kdefault/auth_proxy_patch.go
@@ -57,7 +57,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -110,7 +110,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/testdata/ansible/memcached-operator/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/ansible/memcached-operator/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -198,7 +198,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/testdata/helm/memcached-operator/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/helm/memcached-operator/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/website/content/en/docs/building-operators/golang/references/logging.md
+++ b/website/content/en/docs/building-operators/golang/references/logging.md
@@ -164,7 +164,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/website/content/en/docs/building-operators/golang/references/logging.md
+++ b/website/content/en/docs/building-operators/golang/references/logging.md
@@ -164,7 +164,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION

**Description of the change:**

-   For Ansible/Helm based-operators, upgrade the `kube-rbac-proxy` image version from `0.5.0` to `0.8.0` to address security concerns. More info [#kubernetes-sigs/kubebuilder#1955](https://github.com/kubernetes-sigs/kubebuilder/pull/1955).


**Motivation for the change:**

- Closes: #3925

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
