### PR TITLE
[v1.3.x] images/ansible-operator/Dockerfile: pin cryptography python package

### DIFF
--- a/images/ansible-operator/Dockerfile
+++ b/images/ansible-operator/Dockerfile
@@ -17,6 +17,7 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
   && yum -y update \
   && yum install -y libffi-devel openssl-devel python36-devel gcc python3-pip python3-setuptools \
   && pip3 install --no-cache-dir \
+    cryptography==3.3.1 \
     ansible-runner==1.3.4 \
     ansible-runner-http==1.0.0 \
     ipaddress==1.0.23 \


### PR DESCRIPTION
**Description of the change:**
- images/ansible-operator/Dockerfile: pin cryptography python package t…o version that does not require the rust compiler to set up

**Motivation for the change:** ansible-operator image build is broken:

```console
$ git checkout v1.3.x
$ make image/ansible-operator
...
Collecting cryptography (from ansible==2.9.15)
  Downloading https://files.pythonhosted.org/packages/27/5a/007acee0243186123a55423d49cbb5c15cb02d76dd1b6a27659a894b13a2/cryptography-3.4.4.tar.gz (545kB)
    Complete output from command python setup.py egg_info:
    
	...
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-7t2f19qr/cryptography/setup.py", line 14, in <module>
        from setuptools_rust import RustExtension
    ModuleNotFoundError: No module named 'setuptools_rust'
```

Users won't see a chance here because v1.3.1 was built with cryptography v3.3.1, which this PR pins to.

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
