### PR TITLE
docs/upgrade-sdk-version/v1.3.0.md: correct link to migration guide

### DIFF
--- a/website/content/en/docs/upgrading-sdk-version/v1.3.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.3.0.md
@@ -21,7 +21,9 @@ _See [#4282](https://github.com/operator-framework/operator-sdk/pull/4282) for m
 
 ## Upgrade your Go project from "go.kubebuilder.io/v2" to "go.kubebuilder.io/v3"
 
-The newly released go/v3 plugin has many new features and (breaking) changes incompatible with projects created by go/v2. You are not required to upgrade and your go/v2 project will continue to work with new operator-sdk versions. If you wish to upgrade, check out the upstream [migration guide](https://master.book.kubebuilder.io/migration/plugin/plugins.html).
+The newly released go/v3 plugin has many new features and (breaking) changes incompatible with projects created by go/v2.
+You are not required to upgrade and your go/v2 project will continue to work with new operator-sdk versions.
+If you wish to upgrade, check out the upstream [migration guide](https://master.book.kubebuilder.io/migration/v2vsv3.html).
 
 Additionally, if using project version "3-alpha", you must update your `plugins` config field:
 


### PR DESCRIPTION
**Description of the change:**
- docs/upgrade-sdk-version/v1.3.0.md: correct link to migration guide

**Motivation for the change:** broken link. Note that this may have to be updated again once book-v3 is realeased. For now this fixes the link check.

/kind documentation

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
