### PR TITLE
Makefile: `test-docs` target tests docs only

### DIFF
--- a/.github/workflows/test-sanity.yml
+++ b/.github/workflows/test-sanity.yml
@@ -3,9 +3,25 @@ on:
   pull_request: {}
 
 jobs:
+  check_docs_only:
+    name: check_docs_only
+    runs-on: ubuntu-18.04
+    outputs:
+      should_skip_tests: ${{ steps.check_docs_only.outputs.skip-tests }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - id: check_docs_only
+      run: |
+        REPO_MASTER_REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
+        echo "::set-output name=skip-tests::$(hack/ci/check-doc-only-update.sh $REPO_MASTER_REF)"
+
   sanity:
     name: sanity
     runs-on: ubuntu-18.04
+    needs: check_docs_only
+    if: needs.check_docs_only.outputs.should_skip_tests != 'true'
     steps:
     - uses: actions/setup-go@v2
       with:
@@ -17,15 +33,15 @@ jobs:
     - run: sudo rm -rf /usr/local/bin/kustomize
     - run: make test-sanity
 
-  links:
-    name: doc links
+  docs:
+    name: docs
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
         submodules: recursive
-    - run: make test-links
+    - run: make test-docs
     - uses: gaurav-nelson/github-action-markdown-link-check@1.0.2
       with:
         max-depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,9 +72,9 @@ jobs:
         - make test-sanity
 
     # Run website checks
-    - name: doc links
+    - name: docs
       script:
-        - make test-links
+        - make test-docs
 
     ## Operator test stage jobs ##
 

--- a/Makefile
+++ b/Makefile
@@ -114,20 +114,20 @@ tag: ## Tag a release commit. See 'make -f release/Makefile help' for more infor
 test-all: test-static test-e2e ## Run all tests
 
 .PHONY: test-static
-test-static: test-sanity test-unit test-links ## Run all non-cluster-based tests
+test-static: test-sanity test-unit test-docs ## Run all non-cluster-based tests
 
 .PHONY: test-sanity
 test-sanity: generate fix ## Test repo formatting, linting, etc.
 	git diff --exit-code # fast-fail if generate or fix produced changes
 	./hack/check-license.sh
 	./hack/check-error-log-msg-format.sh
-	go run ./release/changelog/gen-changelog.go -validate-only
 	go vet ./...
 	$(SCRIPTS_DIR)/fetch golangci-lint 1.31.0 && $(TOOLS_DIR)/golangci-lint run
 	git diff --exit-code # diff again to ensure other checks don't change repo
 
-.PHONY: test-links
-test-links: ## Test doc links
+.PHONY: test-docs
+test-docs: ## Test doc links
+	go run ./release/changelog/gen-changelog.go -validate-only
 	git submodule update --init --recursive website/
 	./hack/check-links.sh
 

--- a/website/content/en/docs/contribution-guidelines/documentation.md
+++ b/website/content/en/docs/contribution-guidelines/documentation.md
@@ -34,9 +34,9 @@ hugo server
 Any changes will be included in real time.
 
 
-## Check Links
+## Check Docs
 
-`make test-links` will use containers to build html and check the links.
+`make test-docs` will validate changelog fragments, build doc HTML in a container, and check its links.
 Please consider running this locally before creating a PR to save CI resources.
 
 


### PR DESCRIPTION
**Description of the change:**
- Makefile: rename test-links to test-docs, move changelog validator here
- *: update docs/tests with test-docs target

**Motivation for the change:** docs-only PR's always run code-checking tests in the sanity action, which are not required and use action minutes unnecessarily.

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
