### PR TITLE
Pin ansible galaxy installs

### DIFF
--- a/changelog/fragments/pin-ansible-galaxy-collections.yaml
+++ b/changelog/fragments/pin-ansible-galaxy-collections.yaml
@@ -1,0 +1,11 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For Ansible-based operators, collections as main dependencies for the operator installed with ansible-galaxy are
+      pinned to specific versions to prevent hard to track bugs.
+
+    kind: change
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
@@ -34,6 +34,7 @@ func (f *RequirementsYml) SetTemplateDefaults() error {
 const requirementsYmlTmpl = `---
 collections:
   - name: community.kubernetes
-    version: "<1.0.0"
+    version: "==1.1.1"
   - operator_sdk.util
+    version: "==0.1.0"
 `

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
@@ -34,7 +34,7 @@ func (f *RequirementsYml) SetTemplateDefaults() error {
 const requirementsYmlTmpl = `---
 collections:
   - name: community.kubernetes
-    version: "==1.1.1"
+    version: "1.1.1"
   - operator_sdk.util
-    version: "==0.1.0"
+    version: "0.1.0"
 `

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
@@ -34,7 +34,7 @@ func (f *RequirementsYml) SetTemplateDefaults() error {
 const requirementsYmlTmpl = `---
 collections:
   - name: community.kubernetes
-    version: "1.1.1"
+    version: "0.11.1"
   - operator_sdk.util
     version: "0.1.0"
 `

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
@@ -35,6 +35,6 @@ const requirementsYmlTmpl = `---
 collections:
   - name: community.kubernetes
     version: "0.11.1"
-  - operator_sdk.util
+  - name: operator_sdk.util
     version: "0.1.0"
 `

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
@@ -34,7 +34,7 @@ func (f *RequirementsYml) SetTemplateDefaults() error {
 const requirementsYmlTmpl = `---
 collections:
   - name: community.kubernetes
-    version: "0.11.1"
+    version: "1.1.1"
   - name: operator_sdk.util
     version: "0.1.0"
 `

--- a/testdata/ansible/memcached-operator/requirements.yml
+++ b/testdata/ansible/memcached-operator/requirements.yml
@@ -1,5 +1,6 @@
 ---
 collections:
   - name: community.kubernetes
-    version: "<1.0.0"
-  - operator_sdk.util
+    version: "1.1.1"
+  - name: operator_sdk.util
+    version: "0.1.0"


### PR DESCRIPTION
**Description of the change:**

This PR is part of #4237 to work towards a more user-friendly way of doing reproducible local builds

This PR pins versions of Ansible collections installed through ansible-galaxy

**Motivation for the change:**
Answers https://github.com/operator-framework/operator-sdk/issues/4237#issuecomment-770829132

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
