### PR TITLE
Improve/Upgrade the migration guide to address the need of the users to move from pre-1.0.0 to latest

### DIFF
--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -27,7 +27,7 @@ Projects are now scaffold using:
 
 - [kustomize][kustomize] to manage Kubernetes resources needed to deploy your operator
 - A `Makefile` with helpful targets to build, test, deploy and tailor things based on your project needs
-- Helpers and options to work with webhooks. For further information see [What is webhook?][webhook-doc]
+- Helpers and options to work with webhooks. For further information see [What is a Webhook?][webhook-doc]
 - Updated metrics configuration using [kube-auth-proxy][kube-auth-proxy], a `--metrics-addr` flag, and [kustomize][kustomize]-based deployment of a Kubernetes `Service` and prometheus operator `ServiceMonitor`
 - Scaffolded tests that use the [`envtest`][envtest] test framework
 - A preliminary support for plugins. For more info see the [extensible CLI and scaffolding plugins design document][plugins-phase1-design-doc] 

--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -1,14 +1,13 @@
 ---
-link: Migrating pre-v1.0.0 Projects
-linkTitle: Migrating pre-v1.0.0 Projects
+link: Migrating Projects from pre-v1.0.0 to the latest release
+linkTitle: Migrating from pre-v1.0.0 to latest
 weight: 200
-description: Instructions for migrating a Go-based project built prior to v1.0.0 to use the new Kubebuilder-style layout.
+description: Instructions for migrating a Go-based project built prior to v1.0.0 (0.19.x+) to use the Kubebuilder-style layout which is the default layout adopted by SDK since the `1.0.0` release.
 ---
 
 ## Overview
 
-The motivations for the new layout are related to bringing more flexibility to users and
-part of the process to [integrate Kubebuilder and Operator SDK][integration-doc].
+The motivations for the new layout are related to bringing more flexibility to users and part of the process to [integrate Kubebuilder and Operator SDK][integration-doc]. For further information check [What are the the differences between Kubebuilder and Operator-SDK?][what-are-the-the-differences-between-kubebuilder-and-operator-sdk]. 
 
 ### What was changed
 
@@ -28,9 +27,23 @@ Projects are now scaffold using:
 
 - [kustomize][kustomize] to manage Kubernetes resources needed to deploy your operator
 - A `Makefile` with helpful targets for build, test, and deployment, and to give you flexibility to tailor things to your project's needs
-- Helpers and options to work with webhooks
+- Helpers and options to work with webhooks. For further information see [What is webhook?][webhook-doc]
 - Updated metrics configuration using [kube-auth-proxy][kube-auth-proxy], a `--metrics-addr` flag, and [kustomize][kustomize]-based deployment of a Kubernetes `Service` and prometheus operator `ServiceMonitor`
 - Scaffolded tests that use the [`envtest`][envtest] test framework
+- A preliminary support for plugins. For more info see the [Extensible CLI and Scaffolding Plugins][plugins-phase1-design-doc] 
+- A PROJECT file which stores more information about what resources are in use, to better enable plugins to make useful decisions when scaffolding`
+- Liveness and Readiness probes using [`healthz.Ping`][healthz-ping].
+- A new option to create the projects using ComponentConfig. For more info see its [enhancement proposal][enhancement proposal] and the [Component config tutorial][component-config-tutorial]
+- [controller-tools][controller-tools] `v0.4.1` and [controller-runtime][controller-runtime] `v0.7.0`
+- Go version `1.15` (previously it was `1.13).
+
+Generated files with the default API versions:
+
+- `apiextensions/v1` for generated CRDs (`apiextensions/v1beta1` was deprecated in Kubernetes `1.16`)
+- `admissionregistration.k8s.io/v1` for webhooks (`admissionregistration.k8s.io/v1beta1` was deprecated in Kubernetes `1.16`)
+- `cert-manager.io/v1` for the certificate manager when webhooks are used (`cert-manager.io/v1alpha2` was deprecated in `Cert-Manager 0.14`. More info: [CertManager v1.0 docs][cert-manager-docs])
+
+**NOTE** You are still able to use the deprecated APIs which is only needed if you want your operator to support Kubernetes `1.15` and earlier.
 
 ## Migration Steps
 
@@ -38,8 +51,9 @@ The most straightforward migration path is to:
 1. Create a new project from scratch to let `operator-sdk` scaffold the new project.
 2. Copy your existing code and configuration into the new project structure.
 
-**Note:** It is recommended that you have your project upgraded to the latest SDK release version before following the
-steps of this guide to migrate to new layout.
+**Note:** It is recommend that you have your project upgraded to the latest SDK release version (0.19.x+) before following the steps of this guide to migrate to new layout. 
+
+Please, ensure that you have checked [Can I customize the projects generated with SDK tool?][faq-custom] in the [FAQ][faq] before continuing.
 
 ### Create a new project
 
@@ -75,7 +89,7 @@ For further information see the [Single Group to Multi-Group][multigroup-kubebui
 
 ## Migrate APIs and Controllers
 
-Now that we have our new project initialized, we need to re-create each of our APIs.
+Now we have our new project initialized, we need to re-create each of our APIs.
 Using our API example from earlier (`cache.example.com`), we'll use `cache` for the
 `--group`, `v1alpha1` for the `--version` and `Memcached` for `--kind` flag.
 
@@ -90,6 +104,14 @@ operator-sdk create api \
     --controller
 ```
 
+### How to keep `apiextensions.k8s.io/v1beta1` for CRDs?
+
+From now on, the CRDs that will be created by controller-gen will be using the Kubernetes API version `apiextensions.k8s.io/v1`  by default, instead of `apiextensions.k8s.io/v1beta1`. 
+
+The `apiextensions.k8s.io/v1beta1` was deprecated in Kubernetes `1.16` and will be removed in Kubernetes `1.22`.
+
+So, if you would like to keep using the previous version use the flag `--crd-version=v1beta1` in the above command which is only needed if you want your operator to support Kubernetes `1.15` and earlier.
+
 ### API's
 
 Now let’s copy the API definition from `pkg/apis/<group>/<version>/<kind>_types.go` to `api/<version>/<kind>_types.go`. For our example, it is only required to copy the code from the `Spec` and `Status` fields.
@@ -99,7 +121,7 @@ This file is quite similar to the old one. Once you copy over your API definitio
 - The `+k8s:deepcopy-gen:interfaces=...` marker was replaced with `+kubebuilder:object:root=true`.
 - If you are not using [openapi-gen][openapi-gen] to generate OpenAPI Go code, then `// +k8s:openapi-gen=true` and other related openapi markers can be removed.
 
-**NOTE** The `operator-sdk generate openapi` command was deprecated in `0.13.0` and was removed from `0.17` SDK release version. So far, it is recommended to use [openapi-gen][openapi-gen] directly for OpenAPI code generation.
+**NOTE:** The `operator-sdk generate openapi` command was deprecated in `0.13.0` and was removed from `0.17` SDK release version. So far, it is recommended to use [openapi-gen][openapi-gen] directly for OpenAPI code generation.
 
 Our Memcached API types will look like:
 
@@ -127,6 +149,46 @@ type Memcached struct {...}
 // MemcachedList contains a list of Memcached
 type MemcachedList struct {...}
 ```
+
+## Webhooks
+
+From the SDK version `1.0.0`, webhooks are supported by the CLI. If you don't have any webhooks, you can skip this section. However, if have been use it via customizations done in your project then, you should use the tool to re-scaffold the webhooks. 
+
+A webhook can only be scaffold for a pre-existent API in your project. Then, for each case you will run the command `operator-sdk create webhook` informing the `--group`, `--kind` and `version` of the API which should be used. 
+
+The valid types are: `defaulting`, `validation` and `conversion`. Use the same type used before to do this scaffold. To create defaulting and validating webhooks :
+
+```sh
+operator-sdk create webhook \
+    --group=cache \
+    --version=<version> \
+    --kind=<Kind> \
+    --defaulting \
+    --programmatic-validation
+```
+
+And then, to create conversion webhook use:
+
+```sh
+operator-sdk create webhook \
+    --group=cache \
+    --version=<version> \
+    --kind=<Kind> \
+    --conversion 
+```
+
+After generate the webhook you will need to 
+copy the webhook definition and content from your old project to the new one. You will find the file in `api/v1/<kind>_webhook.go`. 
+
+### How to keep using `apiextensions.k8s.io/v1beta1` for Webhooks?
+
+From now on, the Webhooks that will be created by SDK using by default the Kubernetes API version `admissionregistration.k8s.io/v1` instead of `admissionregistration.k8s.io/v1beta1` and the `cert-manager.io/v1` instead of `cert-manager.io/v1alpha2`. 
+    
+Note that `apiextensions/v1beta1` and `admissionregistration.k8s.io/v1beta1` were deprecated in Kubernetes `1.16` and will be removed  in Kubernetes `1.22`. If you use `apiextensions/v1` and `admissionregistration.k8s.io/v1` then you need to use `cert-manager.io/v1` which will be the API adopted per SDK CLI by default in this case.  
+
+**NOTE** If you are using the API `cert-manager.io/v1alpha2` is not compatible with the latest Kubernetes API versions. (`cert-manager.io/v1alpha2` was deprecated in `Cert-Manager 0.14`. More info: [CertManager v1.0 docs][cert-manager-docs])
+
+So, if you would like to keep using the previous version use the flag `--webhook-version=v1beta1` in the above command which is only needed if you want your operator to support Kubernetes `1.15` and earlier.
 
 ### Controllers
 
@@ -166,6 +228,8 @@ By default, new projects are cluster-scoped (i.e. they have cluster-scoped permi
 
 See the complete migrated `memcached_controller.go` code [here][memcached_controller].
 
+**Note:** The version of [controller-runtime][controller-runtime] used in the projects scaffold via SDK was `0.19.x+` was `v0.6.0`. Then, check [sigs.k8s.io/controller-runtime release docs from 0.7.0+ version][controller-runtime] for breaking changes.
+
 ## Migrate `main.go`
 
 By checking our new `main.go` we will find that:
@@ -196,11 +260,12 @@ In order to use the previous one ensure that you have the [operator-lib][operato
 func main() {
 ...
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:             scheme,
-		MetricsBindAddress: metricsAddr,
-		Port:               9443,
-		LeaderElection:     enableLeaderElection,
-		LeaderElectionID:   "f1c5ece8.example.com",
+		Scheme:                 scheme,
+		MetricsBindAddress:     metricsAddr,
+		Port:                   9443,
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "86f835c3.example.com",
 	})
 ...
 }
@@ -322,9 +387,10 @@ make manifests
 make docker-build IMG=<some-registry>/<project-name>:<tag>
 ```
 
+
 ## Verify the migration
 
-The project can now be built, and the operator can be deployed on-cluster. For further steps regarding the deployment of the operator, creation of custom resources, and cleaning up of resources, see the [quickstart guide][quickstart].
+The project can now be built, and the operator can be deployed on-cluster. You can use the command `make deploy IMG=<some-registry>/<project-name>:<tag>`. For further steps regarding the deployment of the operator, creation of custom resources, and cleaning up of resources, see the [quickstart guide][quickstart].
 
 Note that, you also can troubleshooting by checking the container logs.
 E.g `kubectl logs deployment.apps/memcached-operator-controller-manager -n memcached-operator-system -c manager`  
@@ -333,7 +399,7 @@ E.g `kubectl logs deployment.apps/memcached-operator-controller-manager -n memca
 [integration-doc]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/integrating-kubebuilder-and-osdk.md
 [quickstart]: /docs/building-operators/golang/quickstart/
 [metrics]: https://book.kubebuilder.io/reference/metrics.html?highlight=metr#metrics
-[memcached_controller]: https://github.com/operator-framework/operator-sdk/blob/v1.2.0/testdata/go/memcached-operator/controllers/memcached_controller.go
+[memcached_controller]: https://github.com/operator-framework/operator-sdk/tree/master/testdata/go/v3/memcached-operator
 [rbac_markers]: https://book.kubebuilder.io/reference/markers/rbac.html
 [kube-auth-proxy]: https://github.com/brancz/kube-rbac-proxy
 [markers]: https://book.kubebuilder.io/reference/markers.html?highlight=markers#marker-syntax
@@ -353,3 +419,14 @@ E.g `kubectl logs deployment.apps/memcached-operator-controller-manager -n memca
 [envtest]: https://godoc.org/sigs.k8s.io/controller-runtime/pkg/envtest
 [gomega]: https://onsi.github.io/gomega/
 [multigroup-kubebuilder-doc]: https://book.kubebuilder.io/migration/multi-group.html
+[what-are-the-the-differences-between-kubebuilder-and-operator-sdk]: /docs/faqs/#what-are-the-the-differences-between-kubebuilder-and-operator-sdk
+[controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime/releases
+[cert-manager-docs]: https://cert-manager.io/docs/installation/upgrading/
+[faq-custom]: /docs/faqs/#can-i-customize-the-projects-generated-with-sdk-tool
+[faq]: /docs/faqs/
+[webhook-doc]: https://book.kubebuilder.io/reference/webhook-overview.html
+[healthz-ping]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/healthz#CheckHandler
+[controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime/releases
+[controller-tools]: https://github.com/kubernetes-sigs/controller-tools/releases
+[component-config-tutorial]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/docs/book/src/component-config-tutorial/tutorial.md
+[plugins-phase1-design-doc]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/extensible-cli-and-scaffolding-plugins-phase-1.md

--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -2,12 +2,12 @@
 link: Migrating Projects from pre-v1.0.0 to the latest release
 linkTitle: Migrating from pre-v1.0.0 to latest
 weight: 200
-description: Instructions for migrating a Go-based project built prior to v1.0.0 (0.19.x+) to use the Kubebuilder-style layout which is the default layout adopted by SDK since the `1.0.0` release.
+description: Instructions for migrating a Go-based project built prior to `v1.0.0` (`0.19.x+`) to use the Kubebuilder-style layout which is the default layout adopted by SDK since the `1.0.0` release.
 ---
 
 ## Overview
 
-The motivations for the new layout are related to bringing more flexibility to users and part of the process to [integrate Kubebuilder and Operator SDK][integration-doc]. For further information check [What are the the differences between Kubebuilder and Operator-SDK?][what-are-the-the-differences-between-kubebuilder-and-operator-sdk]. 
+The motivation for the new layout was to [integrate Kubebuilder and Operator SDK][integration-doc] based projects. This enables Kubebuilder based projects to use the features provided by Operator SDK. For further information behind this motivation, check [What are the the differences between Kubebuilder and Operator-SDK?][what-are-the-the-differences-between-kubebuilder-and-operator-sdk]. 
 
 ### What was changed
 
@@ -26,15 +26,14 @@ The motivations for the new layout are related to bringing more flexibility to u
 Projects are now scaffold using:
 
 - [kustomize][kustomize] to manage Kubernetes resources needed to deploy your operator
-- A `Makefile` with helpful targets for build, test, and deployment, and to give you flexibility to tailor things to your project's needs
+- A `Makefile` with helpful targets to build, test, deploy and tailor things to your project's needs
 - Helpers and options to work with webhooks. For further information see [What is webhook?][webhook-doc]
 - Updated metrics configuration using [kube-auth-proxy][kube-auth-proxy], a `--metrics-addr` flag, and [kustomize][kustomize]-based deployment of a Kubernetes `Service` and prometheus operator `ServiceMonitor`
 - Scaffolded tests that use the [`envtest`][envtest] test framework
 - A preliminary support for plugins. For more info see the [Extensible CLI and Scaffolding Plugins][plugins-phase1-design-doc] 
-- A PROJECT file which stores more information about what resources are in use, to better enable plugins to make useful decisions when scaffolding`
+- A PROJECT file which stores more information about the resources in use, to better enable plugins to make useful decisions while scaffolding
 - Liveness and Readiness probes using [`healthz.Ping`][healthz-ping].
 - A new option to create the projects using ComponentConfig. For more info see its [enhancement proposal][enhancement proposal] and the [Component config tutorial][component-config-tutorial]
-- [controller-tools][controller-tools] `v0.4.1` and [controller-runtime][controller-runtime] `v0.7.0`
 - Go version `1.15` (previously it was `1.13).
 
 Generated files with the default API versions:
@@ -43,7 +42,7 @@ Generated files with the default API versions:
 - `admissionregistration.k8s.io/v1` for webhooks (`admissionregistration.k8s.io/v1beta1` was deprecated in Kubernetes `1.16`)
 - `cert-manager.io/v1` for the certificate manager when webhooks are used (`cert-manager.io/v1alpha2` was deprecated in `Cert-Manager 0.14`. More info: [CertManager v1.0 docs][cert-manager-docs])
 
-**NOTE** You are still able to use the deprecated APIs which is only needed if you want your operator to support Kubernetes `1.15` and earlier.
+**NOTE** You can still use the deprecated APIs which are only needed to support Kubernetes `1.15` and earlier.
 
 ## Migration Steps
 
@@ -51,7 +50,7 @@ The most straightforward migration path is to:
 1. Create a new project from scratch to let `operator-sdk` scaffold the new project.
 2. Copy your existing code and configuration into the new project structure.
 
-**Note:** It is recommend that you have your project upgraded to the latest SDK release version (0.19.x+) before following the steps of this guide to migrate to new layout. 
+**Note:** It is recommended that you have your project upgraded to the latest SDK release version (0.19.x+) before following the steps of this guide to migrate to new layout. 
 
 Please, ensure that you have checked [Can I customize the projects generated with SDK tool?][faq-custom] in the [FAQ][faq] before continuing.
 
@@ -110,7 +109,7 @@ From now on, the CRDs that will be created by controller-gen will be using the K
 
 The `apiextensions.k8s.io/v1beta1` was deprecated in Kubernetes `1.16` and will be removed in Kubernetes `1.22`.
 
-So, if you would like to keep using the previous version use the flag `--crd-version=v1beta1` in the above command which is only needed if you want your operator to support Kubernetes `1.15` and earlier.
+If you would like to keep using the previous version, use the flag `--crd-version=v1beta1` in the above command. This is only needed if you want your operator to support Kubernetes `1.15` and earlier.
 
 ### API's
 
@@ -121,7 +120,7 @@ This file is quite similar to the old one. Once you copy over your API definitio
 - The `+k8s:deepcopy-gen:interfaces=...` marker was replaced with `+kubebuilder:object:root=true`.
 - If you are not using [openapi-gen][openapi-gen] to generate OpenAPI Go code, then `// +k8s:openapi-gen=true` and other related openapi markers can be removed.
 
-**NOTE:** The `operator-sdk generate openapi` command was deprecated in `0.13.0` and was removed from `0.17` SDK release version. So far, it is recommended to use [openapi-gen][openapi-gen] directly for OpenAPI code generation.
+**NOTE:** The `operator-sdk generate openapi` command was deprecated in `0.13.0` and was removed in `0.17` SDK release. Hence, it is recommended to use [openapi-gen][openapi-gen] directly for OpenAPI code generation.
 
 Our Memcached API types will look like:
 
@@ -152,11 +151,11 @@ type MemcachedList struct {...}
 
 ## Webhooks
 
-From the SDK version `1.0.0`, webhooks are supported by the CLI. If you don't have any webhooks, you can skip this section. However, if have been use it via customizations done in your project then, you should use the tool to re-scaffold the webhooks. 
+SDK version `1.0.0` and later has support for webhooks by the CLI. If your project doesn't require any webhooks, you can skip this section. However, if have been using it via customizations in your project, you should use the tool to re-scaffold the webhooks.  
 
-A webhook can only be scaffold for a pre-existent API in your project. Then, for each case you will run the command `operator-sdk create webhook` informing the `--group`, `--kind` and `version` of the API which should be used. 
+A webhook can only be scaffolded for a pre-existent API in your project. Then, for each case you will run the command `operator-sdk create webhook` providing the `--group`, `--kind` and `version` of the API based on the flags that need to be used.
 
-The valid types are: `defaulting`, `validation` and `conversion`. Use the same type used before to do this scaffold. To create defaulting and validating webhooks :
+The valid flags for its types are: `--defaulting`, `--programmatic-validation` and `--conversion`. Use the same type that was used for scaffolding. To create `defaulting` and `validating` webhook:
 
 ```sh
 operator-sdk create webhook \
@@ -167,7 +166,7 @@ operator-sdk create webhook \
     --programmatic-validation
 ```
 
-And then, to create conversion webhook use:
+To create `conversion` webhook:
 
 ```sh
 operator-sdk create webhook \
@@ -177,18 +176,17 @@ operator-sdk create webhook \
     --conversion 
 ```
 
-After generate the webhook you will need to 
-copy the webhook definition and content from your old project to the new one. You will find the file in `api/v1/<kind>_webhook.go`. 
+After the webhook is generated, you will need to copy the webhook definition and content from your old project to the new one. You can find the respective file in `api/v1/<kind>_webhook.go`.
 
 ### How to keep using `apiextensions.k8s.io/v1beta1` for Webhooks?
 
-From now on, the Webhooks that will be created by SDK using by default the Kubernetes API version `admissionregistration.k8s.io/v1` instead of `admissionregistration.k8s.io/v1beta1` and the `cert-manager.io/v1` instead of `cert-manager.io/v1alpha2`. 
+Hereafter, the webhooks that are created by SDK will use Kubernetes API version `admissionregistration.k8s.io/v1` by default instead of `admissionregistration.k8s.io/v1beta1` and `cert-manager.io/v1` instead of `cert-manager.io/v1alpha2`. 
     
-Note that `apiextensions/v1beta1` and `admissionregistration.k8s.io/v1beta1` were deprecated in Kubernetes `1.16` and will be removed  in Kubernetes `1.22`. If you use `apiextensions/v1` and `admissionregistration.k8s.io/v1` then you need to use `cert-manager.io/v1` which will be the API adopted per SDK CLI by default in this case.  
+Note that `apiextensions/v1beta1` and `admissionregistration.k8s.io/v1beta1` were deprecated in Kubernetes `1.16` and will be removed in Kubernetes `1.22`. If you use `apiextensions/v1` and `admissionregistration.k8s.io/v1`, then you need to use `cert-manager.io/v1` which will be the default API adopted by the SDK CLI.
 
-**NOTE** If you are using the API `cert-manager.io/v1alpha2` is not compatible with the latest Kubernetes API versions. (`cert-manager.io/v1alpha2` was deprecated in `Cert-Manager 0.14`. More info: [CertManager v1.0 docs][cert-manager-docs])
+**NOTE** If you are using the API `cert-manager.io/v1alpha2`, it is not compatible with the latest Kubernetes API version. (`cert-manager.io/v1alpha2` was deprecated in `Cert-Manager 0.14`. More info: [CertManager v1.0 docs][cert-manager-docs])
 
-So, if you would like to keep using the previous version use the flag `--webhook-version=v1beta1` in the above command which is only needed if you want your operator to support Kubernetes `1.15` and earlier.
+If you would like to use the previous version, use the flag `--webhook-version=v1beta1` in the above command which is only required if you want your operator to support Kubernetes `1.15` and earlier.
 
 ### Controllers
 
@@ -228,7 +226,7 @@ By default, new projects are cluster-scoped (i.e. they have cluster-scoped permi
 
 See the complete migrated `memcached_controller.go` code [here][memcached_controller].
 
-**Note:** The version of [controller-runtime][controller-runtime] used in the projects scaffold via SDK was `0.19.x+` was `v0.6.0`. Then, check [sigs.k8s.io/controller-runtime release docs from 0.7.0+ version][controller-runtime] for breaking changes.
+**Note:** The version of [controller-runtime][controller-runtime] used in the projects scaffolded by SDK `0.19.x+` was `v0.6.0`. Please check [sigs.k8s.io/controller-runtime release docs from 0.7.0+ version][controller-runtime] for breaking changes.
 
 ## Migrate `main.go`
 
@@ -390,9 +388,9 @@ make docker-build IMG=<some-registry>/<project-name>:<tag>
 
 ## Verify the migration
 
-The project can now be built, and the operator can be deployed on-cluster. You can use the command `make deploy IMG=<some-registry>/<project-name>:<tag>`. For further steps regarding the deployment of the operator, creation of custom resources, and cleaning up of resources, see the [quickstart guide][quickstart].
+The project can now be built, and the operator can be deployed on cluster. You can use the command `make deploy IMG=<some-registry>/<project-name>:<tag>`. For further steps regarding the deployment of the operator, creation of custom resources, and cleaning up of resources, see the [quickstart guide][quickstart].
 
-Note that, you also can troubleshooting by checking the container logs.
+Note that, you can also troubleshoot by checking the container logs.
 E.g `kubectl logs deployment.apps/memcached-operator-controller-manager -n memcached-operator-system -c manager`  
 
 [quickstart-legacy]: https://v0-19-x.sdk.operatorframework.io/docs/golang/legacy/quickstart/
@@ -427,6 +425,5 @@ E.g `kubectl logs deployment.apps/memcached-operator-controller-manager -n memca
 [webhook-doc]: https://book.kubebuilder.io/reference/webhook-overview.html
 [healthz-ping]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/healthz#CheckHandler
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime/releases
-[controller-tools]: https://github.com/kubernetes-sigs/controller-tools/releases
 [component-config-tutorial]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/docs/book/src/component-config-tutorial/tutorial.md
 [plugins-phase1-design-doc]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/extensible-cli-and-scaffolding-plugins-phase-1.md

--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -7,7 +7,7 @@ description: Instructions for migrating a Go-based project built prior to `v1.0.
 
 ## Overview
 
-The motivation for the new layout was to [integrate Kubebuilder and Operator SDK][integration-doc] based projects. This enables Kubebuilder based projects to use the features provided by Operator SDK. For further information behind this motivation, check [What are the the differences between Kubebuilder and Operator-SDK?][what-are-the-the-differences-between-kubebuilder-and-operator-sdk]. 
+The motivation for the new layout is to [integrate Kubebuilder and Operator SDK][integration-doc] based projects. This enables Kubebuilder based projects to use the features provided by Operator SDK. For further information behind this motivation, check [the differences between Kubebuilder and Operator-SDK][what-are-the-the-differences-between-kubebuilder-and-operator-sdk]. 
 
 ### What was changed
 
@@ -26,14 +26,14 @@ The motivation for the new layout was to [integrate Kubebuilder and Operator SDK
 Projects are now scaffold using:
 
 - [kustomize][kustomize] to manage Kubernetes resources needed to deploy your operator
-- A `Makefile` with helpful targets to build, test, deploy and tailor things to your project's needs
+- A `Makefile` with helpful targets to build, test, deploy and tailor things based on your project needs
 - Helpers and options to work with webhooks. For further information see [What is webhook?][webhook-doc]
 - Updated metrics configuration using [kube-auth-proxy][kube-auth-proxy], a `--metrics-addr` flag, and [kustomize][kustomize]-based deployment of a Kubernetes `Service` and prometheus operator `ServiceMonitor`
 - Scaffolded tests that use the [`envtest`][envtest] test framework
-- A preliminary support for plugins. For more info see the [Extensible CLI and Scaffolding Plugins][plugins-phase1-design-doc] 
-- A PROJECT file which stores more information about the resources in use, to better enable plugins to make useful decisions while scaffolding
+- A preliminary support for plugins. For more info see the [extensible CLI and scaffolding plugins design document][plugins-phase1-design-doc] 
+- A PROJECT file which stores more information about the resources in use, to enable plugins make useful decisions while scaffolding
 - Liveness and Readiness probes using [`healthz.Ping`][healthz-ping].
-- A new option to create the projects using ComponentConfig. For more info see its [enhancement proposal][enhancement proposal] and the [Component config tutorial][component-config-tutorial]
+- A new option to create projects using ComponentConfig. For more info, see [enhancement proposal][enhancement proposal] and the [Component config tutorial][component-config-tutorial]
 - Go version `1.15` (previously it was `1.13).
 
 Generated files with the default API versions:
@@ -50,9 +50,9 @@ The most straightforward migration path is to:
 1. Create a new project from scratch to let `operator-sdk` scaffold the new project.
 2. Copy your existing code and configuration into the new project structure.
 
-**Note:** It is recommended that you have your project upgraded to the latest SDK release version (0.19.x+) before following the steps of this guide to migrate to new layout. 
+**Note:** It is recommended that you have your project upgraded to the latest SDK release version (0.19.x+) before following the steps in this guide to migrate to new layout. 
 
-Please, ensure that you have checked [Can I customize the projects generated with SDK tool?][faq-custom] in the [FAQ][faq] before continuing.
+Please ensure that you have read [Can I customize the projects generated with SDK tool?][faq-custom] in the [FAQ][faq] before continuing further.
 
 ### Create a new project
 
@@ -88,7 +88,7 @@ For further information see the [Single Group to Multi-Group][multigroup-kubebui
 
 ## Migrate APIs and Controllers
 
-Now we have our new project initialized, we need to re-create each of our APIs.
+Now that we have our new project initialized, we need to re-create each of our APIs.
 Using our API example from earlier (`cache.example.com`), we'll use `cache` for the
 `--group`, `v1alpha1` for the `--version` and `Memcached` for `--kind` flag.
 
@@ -105,7 +105,7 @@ operator-sdk create api \
 
 ### How to keep `apiextensions.k8s.io/v1beta1` for CRDs?
 
-From now on, the CRDs that will be created by controller-gen will be using the Kubernetes API version `apiextensions.k8s.io/v1`  by default, instead of `apiextensions.k8s.io/v1beta1`. 
+From now on, the CRDs that will be created by controller-gen will be using Kubernetes API version `apiextensions.k8s.io/v1` by default, instead of `apiextensions.k8s.io/v1beta1`. 
 
 The `apiextensions.k8s.io/v1beta1` was deprecated in Kubernetes `1.16` and will be removed in Kubernetes `1.22`.
 
@@ -184,7 +184,7 @@ Hereafter, the webhooks that are created by SDK will use Kubernetes API version 
     
 Note that `apiextensions/v1beta1` and `admissionregistration.k8s.io/v1beta1` were deprecated in Kubernetes `1.16` and will be removed in Kubernetes `1.22`. If you use `apiextensions/v1` and `admissionregistration.k8s.io/v1`, then you need to use `cert-manager.io/v1` which will be the default API adopted by the SDK CLI.
 
-**NOTE** If you are using the API `cert-manager.io/v1alpha2`, it is not compatible with the latest Kubernetes API version. (`cert-manager.io/v1alpha2` was deprecated in `Cert-Manager 0.14`. More info: [CertManager v1.0 docs][cert-manager-docs])
+**NOTE** If you are using the API `cert-manager.io/v1alpha2`, it is not compatible with the latest Kubernetes API version. (`cert-manager.io/v1alpha2` was deprecated in `Cert-Manager 0.14`. For more info, refer to [CertManager v1.0 docs][cert-manager-docs])
 
 If you would like to use the previous version, use the flag `--webhook-version=v1beta1` in the above command which is only required if you want your operator to support Kubernetes `1.15` and earlier.
 
@@ -388,7 +388,13 @@ make docker-build IMG=<some-registry>/<project-name>:<tag>
 
 ## Verify the migration
 
-The project can now be built, and the operator can be deployed on cluster. You can use the command `make deploy IMG=<some-registry>/<project-name>:<tag>`. For further steps regarding the deployment of the operator, creation of custom resources, and cleaning up of resources, see the [quickstart guide][quickstart].
+The project can now be built, and the operator can be deployed on cluster by running the command: 
+
+```sh
+make deploy IMG=<some-registry>/<project-name>:<tag>
+```
+
+For further steps regarding the deployment of the operator, creation of custom resources, and cleaning up of resources, see the [quickstart guide][quickstart].
 
 Note that, you can also troubleshoot by checking the container logs.
 E.g `kubectl logs deployment.apps/memcached-operator-controller-manager -n memcached-operator-system -c manager`  

--- a/website/content/en/docs/faqs/_index.md
+++ b/website/content/en/docs/faqs/_index.md
@@ -20,6 +20,12 @@ For further context about the relationship between Kubebuilder and Operator SDK,
 
 Please see the upstream [Controller Runtime FAQ][cr-faq] first for any questions related to runtime mechanics or controller-runtime APIs.
 
+## Can I customize the projects generated with SDK tool?
+
+After using the CLI to create your project, you are free to customise how you see fit. Bear in mind, that it is not recommended to deviate from the proposed layout unless you know what you are doing.
+
+For example, you should refrain from moving the scaffolded files, doing so will make it difficult in upgrading your project in the future. You may also lose the ability to use some of the CLI features and helpers. For further information on the project layout, see the doc [What's in a basic project?][basic-project-doc]
+
 ## How can I have separate logic for Create, Update, and Delete events? When reconciling an object can I access its previous state?
 
 You should not have separate logic. Instead design your reconciler to be idempotent. See the [controller-runtime FAQ][controller-runtime_faq] for more details.
@@ -135,3 +141,4 @@ Now run `make manifests` to update your `role.yaml`.
 [rbac-markers]: https://book.kubebuilder.io/reference/markers/rbac.html
 [rbac]:https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 [scorecard-doc]: https://sdk.operatorframework.io/docs/advanced-topics/scorecard/
+[basic-project-doc]: https://book.kubebuilder.io/cronjob-tutorial/basic-project.html

--- a/website/content/en/docs/faqs/_index.md
+++ b/website/content/en/docs/faqs/_index.md
@@ -22,7 +22,7 @@ Please see the upstream [Controller Runtime FAQ][cr-faq] first for any questions
 
 ## Can I customize the projects generated with SDK tool?
 
-After using the CLI to create your project, you are free to customise how you see fit. Bear in mind, that it is not recommended to deviate from the proposed layout unless you know what you are doing.
+After using the CLI to create your project, you are free to customize based on how you see fit. Please note that it is not recommended to deviate from the proposed layout unless you know what you are doing.
 
 For example, you should refrain from moving the scaffolded files, doing so will make it difficult to upgrade your project in the future. You may also lose the ability to use some of the CLI features and helpers. For further information on the project layout, see the doc [What's in a basic project?][basic-project-doc]
 

--- a/website/content/en/docs/faqs/_index.md
+++ b/website/content/en/docs/faqs/_index.md
@@ -24,7 +24,7 @@ Please see the upstream [Controller Runtime FAQ][cr-faq] first for any questions
 
 After using the CLI to create your project, you are free to customise how you see fit. Bear in mind, that it is not recommended to deviate from the proposed layout unless you know what you are doing.
 
-For example, you should refrain from moving the scaffolded files, doing so will make it difficult in upgrading your project in the future. You may also lose the ability to use some of the CLI features and helpers. For further information on the project layout, see the doc [What's in a basic project?][basic-project-doc]
+For example, you should refrain from moving the scaffolded files, doing so will make it difficult to upgrade your project in the future. You may also lose the ability to use some of the CLI features and helpers. For further information on the project layout, see the doc [What's in a basic project?][basic-project-doc]
 
 ## How can I have separate logic for Create, Update, and Delete events? When reconciling an object can I access its previous state?
 


### PR DESCRIPTION
**Description of the change:**

Improve/Upgrade the migration guide to address the need of the users to move from pre-1.0.0 to latest

**Motivation for the change:**

- Closes: https://github.com/operator-framework/operator-sdk/issues/4392

Preview: https://deploy-preview-4536--operator-sdk.netlify.app/docs/building-operators/golang/migration/