### PR TITLE
Make getInstalledCSV testable

### DIFF
--- a/internal/olm/operator/registry/configmap.go
+++ b/internal/olm/operator/registry/configmap.go
@@ -65,9 +65,9 @@ func (c ConfigMapCatalogCreator) registryUp(ctx context.Context, cs *v1alpha1.Ca
 	rr := configmap.RegistryResources{
 		Pkg:     c.Package,
 		Bundles: c.Bundles,
-	}
-	if rr.Client, err = olmclient.NewClientForConfig(c.cfg.RESTConfig); err != nil {
-		return err
+		Client: &olmclient.Client{
+			KubeClient: c.cfg.Client,
+		},
 	}
 
 	if exists, err := rr.IsRegistryExist(ctx, c.cfg.Namespace); err != nil {

--- a/internal/olm/operator/registry/operator_installer.go
+++ b/internal/olm/operator/registry/operator_installer.go
@@ -291,10 +291,7 @@ func (o OperatorInstaller) createSubscription(ctx context.Context, csName string
 }
 
 func (o OperatorInstaller) getInstalledCSV(ctx context.Context) (*v1alpha1.ClusterServiceVersion, error) {
-	c, err := olmclient.NewClientForConfig(o.cfg.RESTConfig)
-	if err != nil {
-		return nil, err
-	}
+	c := olmclient.Client{KubeClient: o.cfg.Client}
 
 	// BUG(estroz): if namespace is not contained in targetNamespaces,
 	// DoCSVWait will fail because the CSV is not deployed in namespace.
@@ -303,13 +300,13 @@ func (o OperatorInstaller) getInstalledCSV(ctx context.Context) (*v1alpha1.Clust
 		Namespace: o.cfg.Namespace,
 	}
 	log.Infof("Waiting for ClusterServiceVersion %q to reach 'Succeeded' phase", nn)
-	if err = c.DoCSVWait(ctx, nn); err != nil {
+	if err := c.DoCSVWait(ctx, nn); err != nil {
 		return nil, fmt.Errorf("error waiting for CSV to install: %w", err)
 	}
 
 	// TODO: check status of all resources in the desired bundle/package.
 	csv := &v1alpha1.ClusterServiceVersion{}
-	if err = o.cfg.Client.Get(ctx, nn, csv); err != nil {
+	if err := o.cfg.Client.Get(ctx, nn, csv); err != nil {
 		return nil, fmt.Errorf("error getting installed CSV: %w", err)
 	}
 	return csv, nil


### PR DESCRIPTION
**Description of the change:**
Updated `getInstalledCSV` to accept an `Option` type to allow passing in an OLM client.

**Motivation for the change:**
`getInstalledCSV` was not testable because there was no way to fake out the OLM client which was created directly in the code. Running unit tests locally without a running cluster would cause the test to fail. Because of this there were no unit tests for it.

Fixes #4173

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Signed-off-by: jesus m. rodriguez <jmrodri@gmail.com>