### PR TITLE
docs: fix wrong paths in 1.4.2 upgrade guide. (#4541)

### DIFF
--- a/website/content/en/docs/upgrading-sdk-version/v1.4.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.4.0.md
@@ -30,7 +30,7 @@ _See [#4412](https://github.com/operator-framework/operator-sdk/pull/4407) for m
 ## For Helm-based operators, add Liveness and Readiness probe
 
 New projects built with the tool will have the probes configured by default. The endpoints `/healthz` and `/readyz` are available now in the image based provided.
-You can update your pre-existing project to use them. For that update the Dockerfile to use the latest release base image, then add the following to the `manager` container in `config/default/manager/manager.yaml`:
+You can update your pre-existing project to use them. For that update the Dockerfile to use the latest release base image, then add the following to the `manager` container in `config/manager/manager.yaml`:
 ```yaml
   livenessProbe:
     httpGet:
@@ -51,7 +51,7 @@ _See [#4326](https://github.com/operator-framework/operator-sdk/pull/4326) for m
 ## For Ansible-based operators, add Liveness and Readiness probe
 
 New projects built with the tool will have the probes configured by default. The endpoints `/healthz` and `/readyz` are available now in the image based provided.
-You can update your pre-existing project to use them. For that update the Dockerfile to use the latest release base image, then add the following to the `manager` container in `config/default/manager/manager.yaml`:
+You can update your pre-existing project to use them. For that update the Dockerfile to use the latest release base image, then add the following to the `manager` container in `config/manager/manager.yaml`:
 ```yaml
   livenessProbe:
     httpGet:


### PR DESCRIPTION
Signed-off-by: Florin Hillebrand <flozzone@gmail.com>


**Description of the change:**

Fix the paths to the manager resource file in the docs upgrade docs for version 1.4.2.

**Motivation for the change:**

Paths to the resource file were wrong.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [X] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
