### PR TITLE
fix swapped liveness/readiness http paths. (#4541)

### DIFF
--- a/changelog/fragments/swap-readiness-liveness-paths-4541.yaml
+++ b/changelog/fragments/swap-readiness-liveness-paths-4541.yaml
@@ -1,0 +1,26 @@
+# issue #4541
+entries:
+  - description: >
+      For Ansible/Helm-based operators, fix swapped readinessProbe/livenessProbe in manager
+    kind: "bugfix"
+    breaking: false
+    migration:
+      header: For Ansible/Helm-based operators, swap the paths of the probes in config/manager/manager.yaml.
+      body: >
+        The liveness and readiness probe endpoints were incorrectly named, although this mismatch will not affect their behavior.
+        To fix, swap the `readinessProbe` and `livenessProbe` HTTP paths in `config/manager/manager.yaml`:
+
+        ```
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 6789
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 6789
+            initialDelaySeconds: 5
+            periodSeconds: 10
+        ```

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/config/manager/manager.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/config/manager/manager.go
@@ -80,13 +80,13 @@ spec:
           image: {{ .Image }}
           livenessProbe:
             httpGet:
-              path: /readyz
+              path: /healthz
               port: 6789
             initialDelaySeconds: 15
             periodSeconds: 20
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: 6789
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/config/manager/manager.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/config/manager/manager.go
@@ -77,13 +77,13 @@ spec:
         name: manager
         livenessProbe:
           httpGet:
-            path: /readyz
+            path: /healthz
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10

--- a/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -126,14 +126,14 @@ spec:
                 image: quay.io/example/memcached-operator:v0.0.1
                 livenessProbe:
                   httpGet:
-                    path: /readyz
+                    path: /healthz
                     port: 6789
                   initialDelaySeconds: 15
                   periodSeconds: 20
                 name: manager
                 readinessProbe:
                   httpGet:
-                    path: /healthz
+                    path: /readyz
                     port: 6789
                   initialDelaySeconds: 5
                   periodSeconds: 10

--- a/testdata/ansible/memcached-operator/config/manager/manager.yaml
+++ b/testdata/ansible/memcached-operator/config/manager/manager.yaml
@@ -33,13 +33,13 @@ spec:
           image: controller:latest
           livenessProbe:
             httpGet:
-              path: /readyz
+              path: /healthz
               port: 6789
             initialDelaySeconds: 15
             periodSeconds: 20
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: 6789
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -211,14 +211,14 @@ spec:
                 image: quay.io/example/memcached-operator:v0.0.1
                 livenessProbe:
                   httpGet:
-                    path: /readyz
+                    path: /healthz
                     port: 8081
                   initialDelaySeconds: 15
                   periodSeconds: 20
                 name: manager
                 readinessProbe:
                   httpGet:
-                    path: /healthz
+                    path: /readyz
                     port: 8081
                   initialDelaySeconds: 5
                   periodSeconds: 10

--- a/testdata/helm/memcached-operator/config/manager/manager.yaml
+++ b/testdata/helm/memcached-operator/config/manager/manager.yaml
@@ -30,13 +30,13 @@ spec:
         name: manager
         livenessProbe:
           httpGet:
-            path: /readyz
+            path: /healthz
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10


### PR DESCRIPTION
* created changelog fragment
* fixed scaffold template for the manager resource (ansible/helm)
* fixed testdata (ansible/helm)

Signed-off-by: Florin Hillebrand <flozzone@gmail.com>

**Description of the change:**

Fix wrong HTTP paths of the livenessProbe and readinessProbe in the scaffold templates and testdata.

**Motivation for the change:**

livenessProbe and readinessProbe were swapped in templates but are correctly documented in upgrade guide.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [X] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
