### PR TITLE
test/: refactor scorecard e2e test, clean up existing test poll funcs

### DIFF
--- a/test/common/scorecard.go
+++ b/test/common/scorecard.go
@@ -1,0 +1,95 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
+	"github.com/operator-framework/operator-sdk/internal/testutils"
+)
+
+// ScorecardSpec runs a set of scorecard tests common to all operator types.
+func ScorecardSpec(tc *testutils.TestContext, operatorType string) func() {
+	return func() {
+		var (
+			err         error
+			cmd         *exec.Cmd
+			outputBytes []byte
+			output      v1alpha3.TestList
+		)
+
+		It("should run a single scorecard test successfully", func() {
+			cmd = exec.Command(tc.BinaryName, "scorecard", "bundle",
+				"--selector", "suite=basic",
+				"--output", "json",
+				"--wait-time", "2m")
+			outputBytes, err = tc.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(json.Unmarshal(outputBytes, &output)).To(Succeed())
+
+			Expect(output.Items).To(HaveLen(1))
+			results := output.Items[0].Status.Results
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].Name).To(Equal("basic-check-spec"))
+			Expect(results[0].State).To(Equal(v1alpha3.PassState))
+		})
+
+		It("should run all enabled scorecard tests successfully", func() {
+			cmd = exec.Command(tc.BinaryName, "scorecard", "bundle",
+				"--output", "json",
+				"--wait-time", "4m")
+			outputBytes, err = tc.Run(cmd)
+			// Some tests are expected to fail, which results in scorecard exiting 1.
+			Expect(err).To(HaveOccurred())
+			Expect(json.Unmarshal(outputBytes, &output)).To(Succeed())
+
+			expected := map[string]v1alpha3.State{
+				// Basic suite.
+				"basic-check-spec": v1alpha3.PassState,
+				// OLM suite.
+				"olm-bundle-validation":    v1alpha3.PassState,
+				"olm-crds-have-validation": v1alpha3.FailState,
+				"olm-crds-have-resources":  v1alpha3.FailState,
+				"olm-spec-descriptors":     v1alpha3.FailState,
+				"olm-status-descriptors":   v1alpha3.FailState,
+			}
+			if strings.ToLower(operatorType) == "go" {
+				// Go projects have generated CRD validation.
+				expected["olm-crds-have-validation"] = v1alpha3.PassState
+				// The Go sample project tests a custom suite.
+				expected["customtest1"] = v1alpha3.PassState
+				expected["customtest2"] = v1alpha3.PassState
+			}
+
+			Expect(output.Items).To(HaveLen(len(expected)))
+			for i := 0; i < len(output.Items); i++ {
+				results := output.Items[i].Status.Results
+				Expect(results).To(HaveLen(1))
+				Expect(results[0].Name).NotTo(BeEmpty())
+				fmt.Fprintln(GinkgoWriter, "    - Name: ", results[0].Name)
+				fmt.Fprintln(GinkgoWriter, "      Expected: ", expected[results[0].Name])
+				fmt.Fprintln(GinkgoWriter, "      Output: ", results[0].State)
+				Expect(results[0].State).To(Equal(expected[results[0].Name]))
+			}
+		})
+	}
+}

--- a/test/e2e/ansible/cluster_test.go
+++ b/test/e2e/ansible/cluster_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Running ansible projects", func() {
 		It("should run correctly in a cluster", func() {
 			By("checking if the Operator project Pod is running")
 			verifyControllerUp := func() error {
-				By("getting the controller-manager pod name")
+				// Get the controller-manager pod name
 				podOutput, err := tc.Kubectl.Get(
 					true,
 					"pods", "-l", "control-plane=controller-manager",
@@ -79,8 +79,6 @@ var _ = Describe("Running ansible projects", func() {
 				if err != nil {
 					return fmt.Errorf("could not get pods: %v", err)
 				}
-
-				By("ensuring the created controller-manager Pod")
 				podNames := kbtestutils.GetNonEmptyLines(podOutput)
 				if len(podNames) != 1 {
 					return fmt.Errorf("expecting 1 pod, have %d", len(podNames))
@@ -90,12 +88,12 @@ var _ = Describe("Running ansible projects", func() {
 					return fmt.Errorf("expecting pod name %q to contain %q", controllerPodName, "controller-manager")
 				}
 
-				By("checking the controller-manager Pod is running")
+				// Ensure the controller-manager Pod is running.
 				status, err := tc.Kubectl.Get(
 					true,
 					"pods", controllerPodName, "-o", "jsonpath={.status.phase}")
 				if err != nil {
-					return fmt.Errorf("failed to get pod stauts for %q: %v", controllerPodName, err)
+					return fmt.Errorf("failed to get pod status for %q: %v", controllerPodName, err)
 				}
 				if status != "Running" {
 					return fmt.Errorf("controller pod in %s status", status)

--- a/test/e2e/ansible/scorecard_test.go
+++ b/test/e2e/ansible/scorecard_test.go
@@ -15,63 +15,9 @@
 package e2e_ansible_test
 
 import (
-	"encoding/json"
-	"fmt"
-	"os/exec"
-
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
+
+	"github.com/operator-framework/operator-sdk/test/common"
 )
 
-var _ = Describe("Testing Ansible Projects with Scorecard", func() {
-	Context("with operator-sdk", func() {
-		const (
-			OLMBundleValidationTest   = "olm-bundle-validation"
-			OLMCRDsHaveValidationTest = "olm-crds-have-validation"
-			OLMCRDsHaveResourcesTest  = "olm-crds-have-resources"
-			OLMSpecDescriptorsTest    = "olm-spec-descriptors"
-			OLMStatusDescriptorsTest  = "olm-status-descriptors"
-		)
-
-		It("should work successfully with scorecard", func() {
-			By("running basic scorecard tests")
-			var scorecardOutput v1alpha3.TestList
-			runScorecardCmd := exec.Command(tc.BinaryName, "scorecard", "bundle",
-				"--selector=suite=basic",
-				"--output=json",
-				"--wait-time=120s")
-			scorecardOutputBytes, err := tc.Run(runScorecardCmd)
-			Expect(err).NotTo(HaveOccurred())
-			err = json.Unmarshal(scorecardOutputBytes, &scorecardOutput)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(scorecardOutput.Items).To(HaveLen(1))
-			Expect(scorecardOutput.Items[0].Status.Results[0].State).To(Equal(v1alpha3.PassState))
-
-			By("running olm scorecard tests")
-			runOLMScorecardCmd := exec.Command(tc.BinaryName, "scorecard", "bundle",
-				"--selector=suite=olm",
-				"--output=json",
-				"--wait-time=120s")
-			scorecardOutputBytes, err = tc.Run(runOLMScorecardCmd)
-			Expect(err).To(HaveOccurred())
-			err = json.Unmarshal(scorecardOutputBytes, &scorecardOutput)
-			Expect(err).NotTo(HaveOccurred())
-
-			expected := make(map[string]v1alpha3.State)
-			expected[OLMBundleValidationTest] = v1alpha3.PassState
-			expected[OLMCRDsHaveResourcesTest] = v1alpha3.FailState
-			expected[OLMCRDsHaveValidationTest] = v1alpha3.FailState
-			expected[OLMSpecDescriptorsTest] = v1alpha3.FailState
-			expected[OLMStatusDescriptorsTest] = v1alpha3.FailState
-
-			Expect(len(scorecardOutput.Items)).To(Equal(len(expected)))
-			for a := 0; a < len(scorecardOutput.Items); a++ {
-				fmt.Println("    - Name: ", scorecardOutput.Items[a].Status.Results[0].Name)
-				fmt.Println("      Expected: ", expected[scorecardOutput.Items[a].Status.Results[0].Name])
-				fmt.Println("      Output: ", scorecardOutput.Items[a].Status.Results[0].State)
-				Expect(scorecardOutput.Items[a].Status.Results[0].State).To(Equal(expected[scorecardOutput.Items[a].Status.Results[0].Name]))
-			}
-		})
-	})
-})
+var _ = Describe("scorecard", common.ScorecardSpec(&tc, "ansible"))

--- a/test/e2e/ansible/suite_test.go
+++ b/test/e2e/ansible/suite_test.go
@@ -126,9 +126,8 @@ var _ = BeforeSuite(func() {
 		Expect(tc.LoadImageToKindClusterWithName("quay.io/operator-framework/scorecard-test:dev")).To(Succeed())
 	}
 
-	By("creating bundle image")
-	err = tc.GenerateBundle()
-	Expect(err).NotTo(HaveOccurred())
+	By("generating bundle")
+	Expect(tc.GenerateBundle()).To(Succeed())
 })
 
 // AfterSuite run after all the specs have run, regardless of whether any tests have failed to ensures that

--- a/test/e2e/go/cluster_test.go
+++ b/test/e2e/go/cluster_test.go
@@ -62,7 +62,7 @@ var _ = Describe("operator-sdk", func() {
 		It("should run correctly in a cluster", func() {
 			By("checking if the Operator project Pod is running")
 			verifyControllerUp := func() error {
-				By("getting the controller-manager pod name")
+				// Get the controller-manager pod name
 				podOutput, err := tc.Kubectl.Get(
 					true,
 					"pods", "-l", "control-plane=controller-manager",
@@ -71,8 +71,6 @@ var _ = Describe("operator-sdk", func() {
 				if err != nil {
 					return fmt.Errorf("could not get pods: %v", err)
 				}
-
-				By("ensuring the created controller-manager Pod")
 				podNames := kbtestutils.GetNonEmptyLines(podOutput)
 				if len(podNames) != 1 {
 					return fmt.Errorf("expecting 1 pod, have %d", len(podNames))
@@ -82,7 +80,7 @@ var _ = Describe("operator-sdk", func() {
 					return fmt.Errorf("expecting pod name %q to contain %q", controllerPodName, "controller-manager")
 				}
 
-				By("checking the controller-manager Pod is running")
+				// Ensure the controller-manager Pod is running.
 				status, err := tc.Kubectl.Get(
 					true,
 					"pods", controllerPodName, "-o", "jsonpath={.status.phase}")

--- a/test/e2e/go/scorecard_test.go
+++ b/test/e2e/go/scorecard_test.go
@@ -15,71 +15,9 @@
 package e2e_go_test
 
 import (
-	"encoding/json"
-	"os/exec"
-
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
-	"github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
+	"github.com/operator-framework/operator-sdk/test/common"
 )
 
-var _ = Describe("Testing Go Projects with Scorecard", func() {
-	Context("with operator-sdk", func() {
-		const (
-			OLMBundleValidationTest   = "olm-bundle-validation"
-			OLMCRDsHaveValidationTest = "olm-crds-have-validation"
-			OLMCRDsHaveResourcesTest  = "olm-crds-have-resources"
-			OLMSpecDescriptorsTest    = "olm-spec-descriptors"
-			OLMStatusDescriptorsTest  = "olm-status-descriptors"
-		)
-
-		It("should work successfully with scorecard", func() {
-			By("running basic scorecard tests")
-			var scorecardOutput v1alpha3.TestList
-			runScorecardCmd := exec.Command(tc.BinaryName, "scorecard", "bundle",
-				"--selector=suite=basic",
-				"--output=json",
-				"--wait-time=120s")
-			scorecardOutputBytes, err := tc.Run(runScorecardCmd)
-			Expect(err).NotTo(HaveOccurred())
-			err = json.Unmarshal(scorecardOutputBytes, &scorecardOutput)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(scorecardOutput.Items).To(HaveLen(1))
-			Expect(scorecardOutput.Items[0].Status.Results[0].State).To(Equal(v1alpha3.PassState))
-
-			By("running custom scorecard tests")
-			runScorecardCmd = exec.Command(tc.BinaryName, "scorecard", "bundle",
-				"--selector=suite=custom",
-				"--output=json",
-				"--wait-time=120s")
-			scorecardOutputBytes, err = tc.Run(runScorecardCmd)
-			Expect(err).NotTo(HaveOccurred())
-			err = json.Unmarshal(scorecardOutputBytes, &scorecardOutput)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(scorecardOutput.Items).To(HaveLen(2))
-
-			By("running olm scorecard tests")
-			runOLMScorecardCmd := exec.Command(tc.BinaryName, "scorecard", "bundle",
-				"--selector=suite=olm",
-				"--output=json",
-				"--wait-time=120s")
-			scorecardOutputBytes, err = tc.Run(runOLMScorecardCmd)
-			Expect(err).To(HaveOccurred())
-			err = json.Unmarshal(scorecardOutputBytes, &scorecardOutput)
-			Expect(err).NotTo(HaveOccurred())
-
-			resultTable := make(map[string]v1alpha3.State)
-			resultTable[OLMStatusDescriptorsTest] = v1alpha3.FailState
-			resultTable[OLMCRDsHaveResourcesTest] = v1alpha3.FailState
-			resultTable[OLMBundleValidationTest] = v1alpha3.PassState
-			resultTable[OLMSpecDescriptorsTest] = v1alpha3.FailState
-			resultTable[OLMCRDsHaveValidationTest] = v1alpha3.PassState
-
-			Expect(len(scorecardOutput.Items)).To(Equal(len(resultTable)))
-			for a := 0; a < len(scorecardOutput.Items); a++ {
-				Expect(scorecardOutput.Items[a].Status.Results[0].State).To(Equal(resultTable[scorecardOutput.Items[a].Status.Results[0].Name]))
-			}
-		})
-	})
-})
+var _ = Describe("scorecard", common.ScorecardSpec(&tc, "go"))

--- a/test/e2e/go/suite_test.go
+++ b/test/e2e/go/suite_test.go
@@ -83,9 +83,8 @@ var _ = BeforeSuite(func() {
 		Expect(tc.LoadImageToKindClusterWithName("quay.io/operator-framework/custom-scorecard-tests:dev")).To(Succeed())
 	}
 
-	By("creating bundle image")
-	err = tc.GenerateBundle()
-	Expect(err).NotTo(HaveOccurred())
+	By("generating bundle")
+	Expect(tc.GenerateBundle()).To(Succeed())
 
 	By("installing cert manager bundle")
 	Expect(tc.InstallCertManager(false)).To(Succeed())

--- a/test/e2e/helm/cluster_test.go
+++ b/test/e2e/helm/cluster_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Running Helm projects", func() {
 		It("should run correctly in a cluster", func() {
 			By("checking if the Operator project Pod is running")
 			verifyControllerUp := func() error {
-				By("getting the controller-manager pod name")
+				// Get the controller-manager pod name
 				podOutput, err := tc.Kubectl.Get(
 					true,
 					"pods", "-l", "control-plane=controller-manager",
@@ -73,8 +73,6 @@ var _ = Describe("Running Helm projects", func() {
 				if err != nil {
 					return fmt.Errorf("could not get pods: %v", err)
 				}
-
-				By("ensuring the created controller-manager Pod")
 				podNames := kbtestutils.GetNonEmptyLines(podOutput)
 				if len(podNames) != 1 {
 					return fmt.Errorf("expecting 1 pod, have %d", len(podNames))
@@ -84,12 +82,12 @@ var _ = Describe("Running Helm projects", func() {
 					return fmt.Errorf("expecting pod name %q to contain %q", controllerPodName, "controller-manager")
 				}
 
-				By("checking the controller-manager Pod is running")
+				// Ensure the controller-manager Pod is running.
 				status, err := tc.Kubectl.Get(
 					true,
 					"pods", controllerPodName, "-o", "jsonpath={.status.phase}")
 				if err != nil {
-					return fmt.Errorf("failed to get pod stauts for %q: %v", controllerPodName, err)
+					return fmt.Errorf("failed to get pod status for %q: %v", controllerPodName, err)
 				}
 				if status != "Running" {
 					return fmt.Errorf("controller pod in %s status", status)

--- a/test/e2e/helm/scorecard_test.go
+++ b/test/e2e/helm/scorecard_test.go
@@ -15,64 +15,9 @@
 package e2e_helm_test
 
 import (
-	"encoding/json"
-	"fmt"
-	"os/exec"
-
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
-	"github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
+	"github.com/operator-framework/operator-sdk/test/common"
 )
 
-var _ = Describe("Testing Helm Projects with Scorecard", func() {
-	Context("with operator-sdk", func() {
-		const (
-			OLMBundleValidationTest   = "olm-bundle-validation"
-			OLMCRDsHaveValidationTest = "olm-crds-have-validation"
-			OLMCRDsHaveResourcesTest  = "olm-crds-have-resources"
-			OLMSpecDescriptorsTest    = "olm-spec-descriptors"
-			OLMStatusDescriptorsTest  = "olm-status-descriptors"
-		)
-
-		It("should work successfully with scorecard", func() {
-			By("running basic scorecard tests")
-			var scorecardOutput v1alpha3.TestList
-			runScorecardCmd := exec.Command(tc.BinaryName, "scorecard", "bundle",
-				"--selector=suite=basic",
-				"--output=json",
-				"--wait-time=120s")
-			scorecardOutputBytes, err := tc.Run(runScorecardCmd)
-			Expect(err).NotTo(HaveOccurred())
-			err = json.Unmarshal(scorecardOutputBytes, &scorecardOutput)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(scorecardOutput.Items).To(HaveLen(1))
-			Expect(scorecardOutput.Items[0].Status.Results[0].State).To(Equal(v1alpha3.PassState))
-
-			By("running olm scorecard tests")
-			runOLMScorecardCmd := exec.Command(tc.BinaryName, "scorecard", "bundle",
-				"--selector=suite=olm",
-				"--output=json",
-				"--wait-time=120s")
-			scorecardOutputBytes, err = tc.Run(runOLMScorecardCmd)
-			Expect(err).To(HaveOccurred())
-			err = json.Unmarshal(scorecardOutputBytes, &scorecardOutput)
-			Expect(err).NotTo(HaveOccurred())
-
-			expected := make(map[string]v1alpha3.State)
-			expected[OLMBundleValidationTest] = v1alpha3.PassState
-			expected[OLMCRDsHaveResourcesTest] = v1alpha3.FailState
-			expected[OLMCRDsHaveValidationTest] = v1alpha3.FailState
-			expected[OLMSpecDescriptorsTest] = v1alpha3.FailState
-			expected[OLMStatusDescriptorsTest] = v1alpha3.FailState
-
-			Expect(len(scorecardOutput.Items)).To(Equal(len(expected)))
-			for a := 0; a < len(scorecardOutput.Items); a++ {
-				fmt.Println("    - Name: ", scorecardOutput.Items[a].Status.Results[0].Name)
-				fmt.Println("      Expected: ", expected[scorecardOutput.Items[a].Status.Results[0].Name])
-				fmt.Println("      Output: ", scorecardOutput.Items[a].Status.Results[0].State)
-				Expect(scorecardOutput.Items[a].Status.Results[0].State).To(Equal(expected[scorecardOutput.Items[a].Status.Results[0].Name]))
-			}
-		})
-	})
-})
+var _ = Describe("scorecard", common.ScorecardSpec(&tc, "helm"))

--- a/test/e2e/helm/suite_test.go
+++ b/test/e2e/helm/suite_test.go
@@ -87,9 +87,8 @@ var _ = BeforeSuite(func() {
 		Expect(tc.LoadImageToKindClusterWithName("quay.io/operator-framework/scorecard-test:dev")).To(Succeed())
 	}
 
-	By("creating bundle image")
-	err = tc.GenerateBundle()
-	Expect(err).NotTo(HaveOccurred())
+	By("generating bundle")
+	Expect(tc.GenerateBundle()).To(Succeed())
 })
 
 // AfterSuite run after all the specs have run, regardless of whether any tests have failed to ensures that


### PR DESCRIPTION
**Description of the change:**
- test/: refactor scorecard tests into a spec function in common, remove 'By()' calls in poll function

**Motivation for the change:** scorecard test code is repeated across all e2e test types. This PR refactors that code into a spec-running function.

/area testing

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
