### PR TITLE
ci: add ansible-operator-base image and manual build workflow

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -1,0 +1,53 @@
+name: deploy-manual
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: ansible-operator-base image tag, ex. "v1.2.3-10-g6e1b47e6ca7c507b8ecf197a8edcd412dd64d85d"
+        required: false
+
+jobs:
+  # Build the ansible-operator-base image.
+  ansible-operator-base:
+    runs-on: ubuntu-18.04
+    environment: deploy
+    steps:
+
+    - name: set up qemu
+      uses: docker/setup-qemu-action@v1
+
+    - name: set up buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: quay.io login
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+        registry: quay.io
+
+    - name: create tag
+      id: tag
+      run: |
+        set -e
+        IMG=quay.io/operator-framework/ansible-operator-base
+        TAG="${{ github.event.inputs.tag }}"
+        if [[ "$TAG" == "" ]]; then
+          TAG=$(git describe --tags --always --dirty --long --abbrev=100)
+        fi
+        echo ::set-output name=tag::${IMG}:${TAG}
+
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: build and push
+      uses: docker/build-push-action@v2
+      with:
+        file: ./images/ansible-operator/base.Dockerfile
+        context: ./images/ansible-operator
+        platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+        push: true
+        tags: ${{ steps.tag.outputs.tag }}

--- a/images/ansible-operator/Dockerfile
+++ b/images/ansible-operator/Dockerfile
@@ -17,6 +17,8 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/ansible-operator
 
 # Final image.
+# TODO(estroz): replace ubi image in FROM with the following base image once a build has occurred:
+# FROM quay.io/operator-framework/ansible-operator-base:<tag>-<commit-ish>
 FROM registry.access.redhat.com/ubi8/ubi:8.3-227
 ARG TARGETARCH
 

--- a/images/ansible-operator/base.Dockerfile
+++ b/images/ansible-operator/base.Dockerfile
@@ -48,3 +48,5 @@ RUN curl -L -o /tini https://github.com/krallin/tini/releases/download/${TINI_VE
 
 WORKDIR ${HOME}
 USER ${USER_UID}
+
+ENTRYPOINT ["/tini", "--"]

--- a/images/ansible-operator/base.Dockerfile
+++ b/images/ansible-operator/base.Dockerfile
@@ -1,0 +1,50 @@
+# This Dockerfile defines the base image for the ansible-operator image.
+# It is built with dependencies that take a while to download, thus speeding
+# up ansible deploy jobs.
+
+FROM registry.access.redhat.com/ubi8/ubi:8.3-227
+ARG TARGETARCH
+
+RUN mkdir -p /etc/ansible \
+  && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
+  && echo '\n\
+[defaults]\n\
+roles_path = /opt/ansible/roles\n\
+library = /usr/share/ansible/openshift\n'\
+> /etc/ansible/ansible.cfg
+
+ENV HOME=/opt/ansible \
+    USER_NAME=ansible \
+    USER_UID=1001
+
+# Install python dependencies
+# Ensure fresh metadata rather than cached metadata in the base by running
+# yum clean all && rm -rf /var/yum/cache/* first
+RUN yum clean all && rm -rf /var/cache/yum/* \
+  && yum -y update \
+  && yum install -y libffi-devel openssl-devel python38-devel gcc python38-pip python38-setuptools \
+  && pip3 install --no-cache-dir \
+    cryptography==3.3.2 \
+    ansible-runner==1.3.4 \
+    ansible-runner-http==1.0.0 \
+    ipaddress==1.0.23 \
+    kubernetes==10.1.0 \
+    openshift==0.10.3 \
+    ansible==2.9.15 \
+    jmespath==0.10.0 \
+  && yum remove -y gcc libffi-devel openssl-devel python38-devel \
+  && yum clean all \
+  && rm -rf /var/cache/yum
+
+# Ensure directory permissions are properly set
+RUN echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd \
+  && mkdir -p ${HOME}/.ansible/tmp \
+  && chown -R ${USER_UID}:0 ${HOME} \
+  && chmod -R ug+rwx ${HOME}
+
+ENV TINI_VERSION=v0.19.0
+RUN curl -L -o /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} \
+  && chmod +x /tini && /tini --version
+
+WORKDIR ${HOME}
+USER ${USER_UID}


### PR DESCRIPTION
**Description of the change:**
- images/ansible-operator/base.Dockerfile: Dockerfile for the ansible-operator-base image
- .github/workflows/deploy-manual.yml: start workflows manually, namely the ansible-operator-base image deployment job

**Motivation for the change:** the ansible-operator image takes awhile to build, so it would be nice to build a base image containing the long-running dependency installation steps every so often, ex. when dependencies are updated.

/area dependency

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
