### PR TITLE
Upgrade kuttl testing image to 0.9.0 version

### DIFF
--- a/images/scorecard-test-kuttl/Dockerfile
+++ b/images/scorecard-test-kuttl/Dockerfile
@@ -17,7 +17,8 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/scorecard-test-kuttl
 
 # Final image.
-FROM kudobuilder/kuttl:v0.8.0
+#FROM kudobuilder/kuttl@sha256:924a709a1d2c6bede8815415ea5d5be640b506ec5aeaddc68acb443ae8ee7926
+FROM kudobuilder/kuttl:v0.9.0
 
 ENV HOME=/opt/scorecard-test-kuttl \
     USER_NAME=scorecard-test-kuttl \


### PR DESCRIPTION
**Description of the change:**
Upgrade kuttl to version [0.9.0](https://github.com/kudobuilder/kuttl/releases/tag/v0.9.0) 

**Motivation for the change:**
New version contains the [capability](https://github.com/kudobuilder/kuttl/pull/272) to run assertion based on commands/scripts, that enable more complete testing of the objects being managed
