### PR TITLE
[ansible]: mark variables from custom resources as unsafe

### DIFF
--- a/changelog/fragments/mark-variables-unsafe.yaml
+++ b/changelog/fragments/mark-variables-unsafe.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Mark the input variables from custom resources as unsafe by default in Ansible operators. 
+    kind: bugfix
+    breaking: false

--- a/internal/ansible/runner/runner.go
+++ b/internal/ansible/runner/runner.go
@@ -160,6 +160,7 @@ func New(watch watches.Watch, runnerArgs string) (Runner, error) {
 		ansibleVerbosity:    watch.AnsibleVerbosity,
 		ansibleArgs:         runnerArgs,
 		snakeCaseParameters: watch.SnakeCaseParameters,
+		markUnsafe:          watch.MarkUnsafe,
 	}, nil
 }
 
@@ -174,6 +175,7 @@ type runner struct {
 	maxRunnerArtifacts  int
 	ansibleVerbosity    int
 	snakeCaseParameters bool
+	markUnsafe          bool
 	ansibleArgs         string
 }
 
@@ -337,7 +339,13 @@ func (r *runner) makeParameters(u *unstructured.Unstructured) map[string]interfa
 		parameters = paramconv.MapToSnake(spec)
 	} else {
 		for k, v := range spec {
-			parameters[k] = markUnsafe(v)
+			parameters[k] = v
+		}
+	}
+
+	if r.markUnsafe {
+		for key, val := range parameters {
+			parameters[key] = markUnsafe(val)
 		}
 	}
 

--- a/internal/ansible/runner/runner_test.go
+++ b/internal/ansible/runner/runner_test.go
@@ -355,7 +355,9 @@ func TestMakeParameters(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		testRunner := runner{}
+		testRunner := runner{
+			markUnsafe: true,
+		}
 		parameters := testRunner.makeParameters(&tc.inputParams)
 
 		val, ok := parameters[inputSpec]

--- a/internal/ansible/watches/testdata/valid.yaml.tmpl
+++ b/internal/ansible/watches/testdata/valid.yaml.tmpl
@@ -6,6 +6,12 @@
   reconcilePeriod: 2s
 - version: v1alpha1
   group: app.example.com
+  kind: WithUnsafeMarked
+  playbook: {{ .ValidPlaybook }}
+  reconcilePeriod: 2s
+  markUnsafe: True
+- version: v1alpha1
+  group: app.example.com
   kind: Playbook
   playbook: {{ .ValidPlaybook }}
   finalizer:

--- a/internal/ansible/watches/watches.go
+++ b/internal/ansible/watches/watches.go
@@ -52,6 +52,7 @@ type Watch struct {
 	WatchDependentResources     bool                      `yaml:"watchDependentResources"`
 	WatchClusterScopedResources bool                      `yaml:"watchClusterScopedResources"`
 	SnakeCaseParameters         bool                      `yaml:"snakeCaseParameters"`
+	MarkUnsafe                  bool                      `yaml:"markUnsafe"`
 	Selector                    metav1.LabelSelector      `yaml:"selector"`
 
 	// Not configurable via watches.yaml
@@ -76,6 +77,7 @@ var (
 	watchDependentResourcesDefault     = true
 	watchClusterScopedResourcesDefault = false
 	snakeCaseParametersDefault         = true
+	markUnsafeDefault                  = false
 	selectorDefault                    = metav1.LabelSelector{}
 
 	// these are overridden by cmdline flags
@@ -127,6 +129,7 @@ type alias struct {
 	WatchDependentResources     *bool                     `yaml:"watchDependentResources,omitempty"`
 	WatchClusterScopedResources *bool                     `yaml:"watchClusterScopedResources,omitempty"`
 	SnakeCaseParameters         *bool                     `yaml:"snakeCaseParameters"`
+	MarkUnsafe                  *bool                     `yaml:"markUnsafe"`
 	Blacklist                   []schema.GroupVersionKind `yaml:"blacklist,omitempty"`
 	Finalizer                   *Finalizer                `yaml:"finalizer"`
 	Selector                    tempLabelSelector         `yaml:"selector"`
@@ -162,6 +165,10 @@ func (w *Watch) setValuesFromAlias(tmp alias) error {
 		tmp.SnakeCaseParameters = &snakeCaseParametersDefault
 	}
 
+	if tmp.MarkUnsafe == nil {
+		tmp.MarkUnsafe = &markUnsafeDefault
+	}
+
 	gvk := schema.GroupVersionKind{
 		Group:   tmp.Group,
 		Version: tmp.Version,
@@ -183,6 +190,7 @@ func (w *Watch) setValuesFromAlias(tmp alias) error {
 	w.ManageStatus = *tmp.ManageStatus
 	w.WatchDependentResources = *tmp.WatchDependentResources
 	w.SnakeCaseParameters = *tmp.SnakeCaseParameters
+	w.MarkUnsafe = *tmp.MarkUnsafe
 	w.WatchClusterScopedResources = *tmp.WatchClusterScopedResources
 	w.Finalizer = tmp.Finalizer
 	w.AnsibleVerbosity = getAnsibleVerbosity(gvk, ansibleVerbosityDefault)
@@ -316,6 +324,7 @@ func New(gvk schema.GroupVersionKind, role, playbook string, vars map[string]int
 		WatchDependentResources:     watchDependentResourcesDefault,
 		WatchClusterScopedResources: watchClusterScopedResourcesDefault,
 		SnakeCaseParameters:         snakeCaseParametersDefault,
+		MarkUnsafe:                  markUnsafeDefault,
 		Finalizer:                   finalizer,
 		AnsibleVerbosity:            ansibleVerbosityDefault,
 		Selector:                    selectorDefault,

--- a/internal/ansible/watches/watches_test.go
+++ b/internal/ansible/watches/watches_test.go
@@ -82,6 +82,9 @@ func TestNew(t *testing.T) {
 				t.Fatalf("Unexpected snakeCaseParameters %v expected %v", watch.SnakeCaseParameters,
 					snakeCaseParametersDefault)
 			}
+			if watch.MarkUnsafe != markUnsafeDefault {
+				t.Fatalf("Unexpected markUnsafe %v expected %v", watch.MarkUnsafe, markUnsafeDefault)
+			}
 			if watch.WatchClusterScopedResources != watchClusterScopedResourcesDefault {
 				t.Fatalf("Unexpected watchClusterScopedResources %v expected %v",
 					watch.WatchClusterScopedResources, watchClusterScopedResourcesDefault)
@@ -147,6 +150,18 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 			WatchDependentResources:     true,
 			WatchClusterScopedResources: false,
 			SnakeCaseParameters:         true,
+			MarkUnsafe:                  false,
+		},
+		Watch{
+			GroupVersionKind: schema.GroupVersionKind{
+				Version: "v1alpha1",
+				Group:   "app.example.com",
+				Kind:    "WithUnsafeMarked",
+			},
+			Playbook:        validTemplate.ValidPlaybook,
+			ManageStatus:    true,
+			ReconcilePeriod: twoSeconds,
+			MarkUnsafe:      true,
 		},
 		Watch{
 			GroupVersionKind: schema.GroupVersionKind{
@@ -535,6 +550,10 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 				if gotWatch.ReconcilePeriod != expectedWatch.ReconcilePeriod {
 					t.Fatalf("The GVK: %v unexpected reconcile period: %v expected reconcile period: %v", gvk,
 						gotWatch.ReconcilePeriod, expectedWatch.ReconcilePeriod)
+				}
+				if gotWatch.MarkUnsafe != expectedWatch.MarkUnsafe {
+					t.Fatalf("The GVK: %v unexpected mark unsafe: %v expected mark unsafe: %v", gvk,
+						gotWatch.MarkUnsafe, expectedWatch.MarkUnsafe)
 				}
 
 				for i, val := range expectedWatch.Blacklist {


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
User provided values from the custom resource are tagged
unsafe by default.

**Motivation for the change:**
Closes: #4169 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [X] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
