### PR TITLE
docs: Remove mercurial from current install guide.

### DIFF
--- a/website/content/en/docs/building-operators/golang/installation.md
+++ b/website/content/en/docs/building-operators/golang/installation.md
@@ -12,7 +12,6 @@ Follow the steps in the [installation guide][install-guide] to learn how to inst
 
 - [git][git_tool]
 - [go][go_tool] version v1.13+.
-- [mercurial][mercurial_tool] version 3.9+
 - [docker][docker_tool] version 17.03+.
 - [kubectl][kubectl_tool] version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster (v1.16.0+ if using `apiextensions.k8s.io/v1` CRDs).
@@ -22,5 +21,4 @@ Follow the steps in the [installation guide][install-guide] to learn how to inst
 [git_tool]:https://git-scm.com/downloads
 [go_tool]:https://golang.org/dl/
 [docker_tool]:https://docs.docker.com/install/
-[mercurial_tool]:https://www.mercurial-scm.org/downloads
 [kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/

--- a/website/content/en/docs/installation/_index.md
+++ b/website/content/en/docs/installation/_index.md
@@ -88,7 +88,6 @@ chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/l
 #### Prerequisites
 
 - [git][git_tool]
-- [bazaar][bazaar_tool] version 2.7.0+
 - [go][go_tool] version v1.15+.
 
 ```sh
@@ -103,5 +102,4 @@ versions 1.15+ which is `"https://proxy.golang.org|direct"`.
 
 [homebrew_tool]:https://brew.sh/
 [git_tool]:https://git-scm.com/downloads
-[bazaar_tool]:http://wiki.bazaar.canonical.com/Download
 [go_tool]:https://golang.org/dl/

--- a/website/content/en/docs/installation/_index.md
+++ b/website/content/en/docs/installation/_index.md
@@ -88,7 +88,6 @@ chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/l
 #### Prerequisites
 
 - [git][git_tool]
-- [mercurial][mercurial_tool] version 3.9+
 - [bazaar][bazaar_tool] version 2.7.0+
 - [go][go_tool] version v1.15+.
 
@@ -104,6 +103,5 @@ versions 1.15+ which is `"https://proxy.golang.org|direct"`.
 
 [homebrew_tool]:https://brew.sh/
 [git_tool]:https://git-scm.com/downloads
-[mercurial_tool]:https://www.mercurial-scm.org/downloads
 [bazaar_tool]:http://wiki.bazaar.canonical.com/Download
 [go_tool]:https://golang.org/dl/


### PR DESCRIPTION
Signed-off-by: jesus m. rodriguez <jesusr@redhat.com>

**Description of the change:**
Remove `mercurial` from the prerequisites list for current docs.

**Motivation for the change:**
Fixes #4559 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [X] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
