### PR TITLE
fix ansible custom controller image name

### DIFF
--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
@@ -67,6 +67,7 @@ func (f *Makefile) SetTemplateDefaults() error {
 const makefileTemplate = `
 # Image URL to use all building/pushing image targets
 IMG ?= {{ .Image }}
+IMG_NAME ?= $(${IMG} $(subst :, ,$1))
 
 all: docker-build
 
@@ -84,7 +85,7 @@ uninstall: kustomize
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: kustomize
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image ${IMG_NAME}=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 # Undeploy controller in the configured Kubernetes cluster in ~/.kube/config

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
@@ -67,7 +67,7 @@ func (f *Makefile) SetTemplateDefaults() error {
 const makefileTemplate = `
 # Image URL to use all building/pushing image targets
 IMG ?= {{ .Image }}
-IMG_NAME ?= $(${IMG} $(subst :, ,$1))
+IMG_NAME = $(shell echo $(IMG) | cut -d : -f 1)
 
 all: docker-build
 


### PR DESCRIPTION
**Description of the change:**
If controller image name is not '**controller**', 
then run `make deploy IMG='custom_controller_image_name:newtag' `,
will can't generate right image name/newName in config/manager/kustomization.yaml.
And the eployment.apps/redis-operator-controller-manager unchanged, the update of the new version of the controller is ignored.

**Motivation for the change:**
Split IMG string, get custom controller image name.

**Checklist**
None