### PR TITLE
samples(go/v3): add watch verb to RBAC marker

### DIFF
--- a/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
@@ -274,7 +274,7 @@ func GenerateMemcachedGoWithWebhooksSample(samplesPath string) {
 
 const rbacFragment = `
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;`
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch`
 
 const reconcileFragment = `// Fetch the Memcached instance
 	memcached := &cachev1alpha1.Memcached{}

--- a/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -81,6 +81,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - authentication.k8s.io
           resources:

--- a/testdata/go/v3/memcached-operator/config/rbac/role.yaml
+++ b/testdata/go/v3/memcached-operator/config/rbac/role.yaml
@@ -51,3 +51,4 @@ rules:
   verbs:
   - get
   - list
+  - watch

--- a/testdata/go/v3/memcached-operator/controllers/memcached_controller.go
+++ b/testdata/go/v3/memcached-operator/controllers/memcached_controller.go
@@ -45,7 +45,7 @@ type MemcachedReconciler struct {
 //+kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=update
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
**Description of the change:**
- hack/generate/samples/internal/go/v3/memcached_with_webhooks.go: add `watch` verb to RBAC marker

**Motivation for the change:** see https://github.com/operator-framework/operator-sdk/issues/4059#issuecomment-712858011

Closes #4433 


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
