### PR TITLE
docs: document k8s version compatibility and platform support

### DIFF
--- a/website/content/en/docs/building-operators/ansible/installation.md
+++ b/website/content/en/docs/building-operators/ansible/installation.md
@@ -9,16 +9,22 @@ weight: 1
 Follow the steps in the [installation guide][install-guide] to learn how to install the `operator-sdk` CLI tool.
 
 ## Additional Prerequisites
+
+- [docker][docker_tool] version 17.03+.
 - [python][python] version 3.8.6+
 - [ansible][ansible] version v2.9.0+
 - [ansible-runner][ansible-runner] version v1.1.0+
 - [ansible-runner-http][ansible-runner-http-plugin] version v1.0.0+
 - [openshift][openshift-module] version v0.11.2+
+- [kubectl][kubectl_tool] and access to a Kubernetes cluster of a [compatible version][k8s-version-compat].
 
 
+[docker_tool]:https://docs.docker.com/install/
 [install-guide]:/docs/installation/
 [python]:https://www.python.org/downloads/
 [ansible]:https://docs.ansible.com/ansible/latest/index.html
 [ansible-runner]:https://ansible-runner.readthedocs.io/en/latest/install.html
 [ansible-runner-http-plugin]:https://github.com/ansible/ansible-runner-http
 [openshift-module]:https://pypi.org/project/openshift/
+[kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
+[k8s-version-compat]:/docs/overview#kubernetes-version-compatibility

--- a/website/content/en/docs/building-operators/golang/installation.md
+++ b/website/content/en/docs/building-operators/golang/installation.md
@@ -13,8 +13,7 @@ Follow the steps in the [installation guide][install-guide] to learn how to inst
 - [git][git_tool]
 - [go][go_tool] version 1.15
 - [docker][docker_tool] version 17.03+.
-- [kubectl][kubectl_tool] version v1.11.3+.
-- Access to a Kubernetes v1.11.3+ cluster (v1.16.0+ if using `apiextensions.k8s.io/v1` CRDs).
+- [kubectl][kubectl_tool] and access to a Kubernetes cluster of a [compatible version][k8s-version-compat].
 
 
 [install-guide]:/docs/installation/
@@ -22,3 +21,4 @@ Follow the steps in the [installation guide][install-guide] to learn how to inst
 [go_tool]:https://golang.org/dl/
 [docker_tool]:https://docs.docker.com/install/
 [kubectl_tool]:https://kubernetes.io/docs/tasks/tools/install-kubectl/
+[k8s-version-compat]:/docs/overview#kubernetes-version-compatibility

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -11,7 +11,6 @@ please [migrate][migration-guide], or consult the [legacy docs][legacy-quickstar
 ## Prerequisites
 
 - Go through the [installation guide][install-guide].
-- Access to a Kubernetes v1.11.3+ cluster (v1.16.0+ if using `apiextensions.k8s.io/v1` CRDs).
 - User authorized with `cluster-admin` permissions.
 
 ## Overview

--- a/website/content/en/docs/building-operators/helm/installation.md
+++ b/website/content/en/docs/building-operators/helm/installation.md
@@ -11,8 +11,7 @@ Follow the steps in the [installation guide][install-guide] to learn how to inst
 ### Additional Prerequisites
 
 - [docker][docker_tool] version 17.03+.
-- [kubectl][kubectl_tool] version v1.11.3+.
-- Access to a Kubernetes v1.11.3+ cluster (v1.16.0+ if using `apiextensions.k8s.io/v1` CRDs).
+- [kubectl][kubectl_tool] and access to a Kubernetes cluster of a [compatible version][k8s-version-compat].
 
 
 [install-guide]:/docs/installation/

--- a/website/content/en/docs/contribution-guidelines/testing.md
+++ b/website/content/en/docs/contribution-guidelines/testing.md
@@ -34,7 +34,7 @@ make test-all
 
 ## Local Test Environment
 
-If running tests locally, access to a Kubernetes cluster of server version v1.11.3 or higher is required.
+If running tests locally, access to a Kubernetes cluster of a [compatible version][k8s-version-compat] is required.
 These tests require `KUBECONFIG` be set or kubeconfig file be present in a default location like `$HOME/.kube/config`.
 
 You will also need to set up an `envtest` environment for cluster tests. Follow [this doc][envtest-setup]
@@ -54,3 +54,4 @@ All the tests are run through the [`Makefile`][makefile]. Run `make help` for a 
 [kind]: https://kind.sigs.k8s.io/
 [envtest-setup]: /docs/building-operators/golang/references/envtest-setup
 [makefile]: https://github.com/operator-framework/operator-sdk/blob/master/Makefile
+[k8s-version-compat]:/docs/overview#kubernetes-version-compatibility

--- a/website/content/en/docs/overview/_index.md
+++ b/website/content/en/docs/overview/_index.md
@@ -56,6 +56,60 @@ Note that each operator type has a different set of capabilities. When choosing 
 
 Find more details about the various levels and the feature requirements for them in the [capability level documentation][capability_levels].
 
+## Kubernetes version compatibility
+
+Each `operator-sdk` release is tested with a specific version of Kubernetes. This version matches
+that of [kubernetes/kubernetes][k-k] or [client-go][client-go] that `operator-sdk` depends on directly,
+or that generated Operator projects depend on.
+
+In general, client-go's [compatibility matrix][client-go-compat] will determine whether
+a particular Kubernetes version is compatible with a particular `operator-sdk` version
+or generated Operator project. The following tables contains the canonical way per
+binary or project type to look up a Y-axis version to plug into the compatibility matrix.
+
+By binary:
+
+| Binary                  | Lookup strategy               |
+|-------------------------|-------------------------------|
+| `operator-sdk`          | `$ operator-sdk version`      |
+| `ansible-operator`      | `$ ansible-operator version`  |
+| `helm-operator`         | `$ helm-operator version`     |
+
+By project type (replace `${IMAGE_VERSION}` with base image version in your project `Dockerfile`):
+
+| Project type   | Lookup strategy                           |
+|----------------|-------------------------------------------|
+| Go             | controller-runtime version (see `go.mod`) |
+| Ansible        | `$ docker run --entrypoint ansible-operator quay.io/operator-framework/ansible-operator:${IMAGE_VERSION} version` |
+| Helm           | `$ docker run --entrypoint helm-operator quay.io/operator-framework/helm-operator:${IMAGE_VERSION} version` |
+
+
+[k-k]:https://github.com/kubernetes/kubernetes
+[client-go]:https://github.com/kubernetes/client-go
+[client-go-compat]:https://github.com/kubernetes/client-go#compatibility-matrix
+
+## Platform support
+
+Official build architectures for binaries:
+
+| Binary                    | `linux/amd64` | `linux/arm64` |`linux/ppc64le` | `linux/s390x` | `darwin/amd64` | `darwin/arm64` |
+|---------------------------|---------------|---------------|----------------|---------------|----------------|----------------|
+| `operator-sdk`            | ✓             | ✓             | ✓              | ✓             | ✓              | -              |
+| `ansible-operator`        | ✓             | ✓             | ✓              | ✓             | ✓              | -              |
+| `helm-operator`           | ✓             | ✓             | ✓              | ✓             | ✓              | -              |
+
+Official build architectures for images:
+
+| Binary                    | `linux/amd64` | `linux/arm64` |`linux/ppc64le` | `linux/s390x` |
+|---------------------------|---------------|---------------|----------------|---------------|
+| `operator-sdk`            | ✓             | ✓             | ✓              | ✓             |
+| `ansible-operator`        | ✓             | ✓             | ✓              | ✓             |
+| `helm-operator`           | ✓             | ✓             | ✓              | ✓             |
+| `scorecard-test`          | ✓             | ✓             | ✓              | ✓             |
+| `scorecard-test-kuttl`    | ✓             | ✓             | ✓              | -             |
+
+Official support for any Windows architecture is not on the roadmap at this time.
+
 ## Samples
 
 To explore any operator samples built using the operator-sdk, see the samples in [operator-sdk/testdata/][testdata_samples].


### PR DESCRIPTION
**Description of the change:**
- docs/overview/_index.md: document k8s version compatibility and platform support
- docs/building-operators: update all cluster version references

**Motivation for the change:** k8s versions required are not actually correct. This PR adds instructions to correctly deduce whether a project/binary is compatible with a particular k8s version.

Closes #4385 

/kind documentation

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
