### PR TITLE
fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Operator SDK is under Apache 2.0 license. See the [LICENSE][license_file] file f
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime
 [license_file]:./LICENSE
 [of-home]: https://github.com/operator-framework
-[of-blog]: https://coreos.com/blog/introducing-operator-framework
+[of-blog]: https://www.openshift.com/blog/introducing-the-operator-framework
 [operator-link]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 [sdk-docs]: https://sdk.operatorframework.io
 [operator-framework-community]: https://github.com/operator-framework/community


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Fix link to "Introducing operator framework" blogpost in readme.

**Motivation for the change:**
Link does not work, it goes to openshift blog main page.

