### PR TITLE
allow we see the alpha option output the bundle validation in another format

### DIFF
--- a/internal/cmd/operator-sdk/bundle/validate/validate.go
+++ b/internal/cmd/operator-sdk/bundle/validate/validate.go
@@ -80,12 +80,8 @@ func (c *bundleValidateCmd) addToFlagSet(fs *pflag.FlagSet) {
 		"List all optional validators available. When set, no validators will be run")
 
 	fs.StringVarP(&c.outputFormat, "output", "o", internal.Text,
-		"Result format for results. One of: [text, json-alpha1]")
-	// It is hidden because it is an alpha option
-	// The idea is the next versions of Operator Registry will return a List of errors
-	if err := fs.MarkHidden("output"); err != nil {
-		panic(err)
-	}
+		"Result format for results. One of: [text, json-alpha1]. Note: output format types containing "+
+			"\"alphaX\" are subject to change and not covered by guarantees of stable APIs.")
 }
 
 func (c bundleValidateCmd) run(logger *log.Entry, bundleRaw string) (res *internal.Result, err error) {

--- a/website/content/en/docs/cli/operator-sdk_bundle_validate.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle_validate.md
@@ -71,6 +71,7 @@ To validate a bundle with a superset of requirements for operatorhub.io specific
   -h, --help                     help for validate
   -b, --image-builder string     Tool to pull and unpack bundle images. Only used when validating a bundle image. One of: [docker, podman, none] (default "docker")
       --list-optional            List all optional validators available. When set, no validators will be run
+  -o, --output string            Result format for results. One of: [text, json-alpha1]. Note: output format types containing "alphaX" are subject to change and not covered by guarantees of stable APIs. (default "text")
       --select-optional string   Label selector to select optional validators to run. Run this command with '--list-optional' to list available optional validators
 ```
 


### PR DESCRIPTION
closes: https://github.com/operator-framework/operator-sdk/issues/4562