### PR TITLE
(helm/v1) run `create api` plugin only after `init` plugin finishes execution

### DIFF
--- a/changelog/fragments/bugfix-4575.yaml
+++ b/changelog/fragments/bugfix-4575.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Fixed samples kustomization.yaml generation on `operator-sdk init --plugins=helm --helm-chart=<chart>`,
+      caused by out-of-order operations in plugin code.
+    kind: bugfix

--- a/hack/generate/samples/internal/helm/memcached.go
+++ b/hack/generate/samples/internal/helm/memcached.go
@@ -65,21 +65,16 @@ func (mh *MemcachedHelm) Run() {
 	// role and cause sanity testing to fail.
 	os.Setenv("KUBECONFIG", "broken_so_we_generate_static_default_rules")
 
-	log.Infof("creating the project")
+	helmChartPath := "../../../hack/generate/samples/internal/helm/testdata/memcached-0.0.1.tgz"
+	log.Infof("creating the project using the helm chart in: (%v)", helmChartPath)
 	err := mh.ctx.Init(
 		"--plugins", "helm",
-		"--domain", mh.ctx.Domain)
-	pkg.CheckError("creating the project", err)
-
-	helmChartPath := "../../../hack/generate/samples/internal/helm/testdata/memcached-0.0.1.tgz"
-	log.Infof("using the helm chart in: (%v)", helmChartPath)
-
-	err = mh.ctx.CreateAPI(
+		"--domain", mh.ctx.Domain,
 		"--group", mh.ctx.Group,
 		"--version", mh.ctx.Version,
 		"--kind", mh.ctx.Kind,
 		"--helm-chart", helmChartPath)
-	pkg.CheckError("scaffolding apis", err)
+	pkg.CheckError("creating the project", err)
 
 	log.Infof("customizing the sample")
 	err = testutils.ReplaceInFile(

--- a/internal/plugins/helm/v1/api.go
+++ b/internal/plugins/helm/v1/api.go
@@ -17,7 +17,6 @@ package v1
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -37,7 +36,7 @@ type createAPISubcommand struct {
 	config        config.Config
 	createOptions chartutil.CreateOptions
 
-	resource resource.Resource
+	resource *resource.Resource
 	chrt     *chart.Chart
 }
 
@@ -159,7 +158,7 @@ func (p *createAPISubcommand) runPhase2() error {
 }
 
 // Validate perform the required validations for this plugin
-func (p *createAPISubcommand) Validate() error {
+func (p *createAPISubcommand) Validate() (err error) {
 	if len(strings.TrimSpace(p.createOptions.Chart)) == 0 {
 		if len(strings.TrimSpace(p.createOptions.Repo)) != 0 {
 			return fmt.Errorf("value of --%s can only be used with --%s", helmChartRepoFlag, helmChartFlag)
@@ -181,11 +180,7 @@ func (p *createAPISubcommand) Validate() error {
 	}
 
 	// Create and validate the resource and chart from CreateOptions.
-	projectDir, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	p.resource, p.chrt, err = chartutil.CreateChart(p.config, projectDir, p.createOptions)
+	p.resource, p.chrt, err = chartutil.CreateChart(p.config, p.createOptions)
 	if err != nil {
 		return err
 	}

--- a/internal/plugins/helm/v1/api.go
+++ b/internal/plugins/helm/v1/api.go
@@ -135,6 +135,9 @@ func (p *createAPISubcommand) Run() error {
 
 // SDK phase 2 plugins.
 func (p *createAPISubcommand) runPhase2() error {
+	if p.resource == nil {
+		return errors.New("resource must not be nil")
+	}
 	// Initially the helm/v1 plugin was written to not create a "plugins" config entry
 	// for any phase 2 plugin because they did not have their own keys. Now there are phase 2
 	// plugin keys, so those plugins should be run if keys exist. Otherwise, enact old behavior.

--- a/internal/plugins/helm/v1/chartutil/chart_test.go
+++ b/internal/plugins/helm/v1/chartutil/chart_test.go
@@ -24,7 +24,8 @@ import (
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/repo/repotest"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang"
+	cfgv3 "sigs.k8s.io/kubebuilder/v3/pkg/config/v3"
+	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
 
 	"github.com/operator-framework/operator-sdk/internal/plugins/helm/v1/chartutil"
 )
@@ -202,20 +203,18 @@ type createChartTestCase struct {
 	helmChartVersion string
 	helmChartRepo    string
 
-	expectResource     *golang.Options
+	expectResource     resource.Resource
 	expectChartName    string
 	expectChartVersion string
 	expectErr          bool
 }
 
-func mustNewResource(group, version, kind string) *golang.Options {
-	r := &golang.Options{
-		Namespaced: true,
-		Group:      group,
-		Version:    version,
-		Kind:       kind,
-	}
-	return r
+func mustNewResource(group, version, kind string) resource.Resource {
+	opts := chartutil.CreateOptions{}
+	opts.GVK.Group = group
+	opts.GVK.Version = version
+	opts.GVK.Kind = kind
+	return opts.NewResource(cfgv3.New())
 }
 
 func runTestCase(t *testing.T, testDir string, tc createChartTestCase) {
@@ -242,7 +241,7 @@ func runTestCase(t *testing.T, testDir string, tc createChartTestCase) {
 		Version: tc.helmChartVersion,
 		Repo:    tc.helmChartRepo,
 	}
-	resource, chrt, err := chartutil.CreateChart(outputDir, opts)
+	resource, chrt, err := chartutil.CreateChart(cfgv3.New(), outputDir, opts)
 	if tc.expectErr {
 		assert.Error(t, err)
 		return

--- a/internal/plugins/helm/v1/chartutil/chart_test.go
+++ b/internal/plugins/helm/v1/chartutil/chart_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/repo/repotest"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	cfgv3 "sigs.k8s.io/kubebuilder/v3/pkg/config/v3"
@@ -203,13 +202,13 @@ type createChartTestCase struct {
 	helmChartVersion string
 	helmChartRepo    string
 
-	expectResource     resource.Resource
+	expectResource     *resource.Resource
 	expectChartName    string
 	expectChartVersion string
 	expectErr          bool
 }
 
-func mustNewResource(group, version, kind string) resource.Resource {
+func mustNewResource(group, version, kind string) *resource.Resource {
 	opts := chartutil.CreateOptions{}
 	opts.GVK.Group = group
 	opts.GVK.Version = version
@@ -218,10 +217,6 @@ func mustNewResource(group, version, kind string) resource.Resource {
 }
 
 func runTestCase(t *testing.T, testDir string, tc createChartTestCase) {
-	outputDir := filepath.Join(testDir, "output")
-	assert.NoError(t, os.Mkdir(outputDir, 0755))
-	defer os.RemoveAll(outputDir)
-
 	os.Setenv("XDG_CONFIG_HOME", filepath.Join(testDir, ".config"))
 	os.Setenv("XDG_CACHE_HOME", filepath.Join(testDir, ".cache"))
 	os.Setenv("HELM_REPOSITORY_CONFIG", filepath.Join(testDir, "repositories.yaml"))
@@ -241,7 +236,7 @@ func runTestCase(t *testing.T, testDir string, tc createChartTestCase) {
 		Version: tc.helmChartVersion,
 		Repo:    tc.helmChartRepo,
 	}
-	resource, chrt, err := chartutil.CreateChart(cfgv3.New(), outputDir, opts)
+	resource, chrt, err := chartutil.CreateChart(cfgv3.New(), opts)
 	if tc.expectErr {
 		assert.Error(t, err)
 		return
@@ -253,11 +248,4 @@ func runTestCase(t *testing.T, testDir string, tc createChartTestCase) {
 	assert.Equal(t, tc.expectResource, resource)
 	assert.Equal(t, tc.expectChartName, chrt.Name())
 	assert.Equal(t, tc.expectChartVersion, chrt.Metadata.Version)
-
-	loadedChart, err := loader.Load(filepath.Join(outputDir, chartutil.HelmChartsDir, chrt.Name()))
-	if err != nil {
-		t.Fatalf("Could not load chart from expected location: %s", err)
-	}
-
-	assert.Equal(t, loadedChart, chrt)
 }

--- a/internal/plugins/helm/v1/scaffolds/api.go
+++ b/internal/plugins/helm/v1/scaffolds/api.go
@@ -18,6 +18,7 @@ limitations under the License.
 package scaffolds
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -69,6 +70,10 @@ func (s *apiScaffolder) newUniverse(r *resource.Resource) *model.Universe {
 }
 
 func (s *apiScaffolder) scaffold() error {
+	if s.resource == nil {
+		return errors.New("resource must not be nil")
+	}
+
 	if err := s.config.UpdateResource(*s.resource); err != nil {
 		return err
 	}

--- a/internal/plugins/helm/v1/scaffolds/init.go
+++ b/internal/plugins/helm/v1/scaffolds/init.go
@@ -47,15 +47,13 @@ var helmOperatorVersion = version.ImageVersion
 var _ cmdutil.Scaffolder = &initScaffolder{}
 
 type initScaffolder struct {
-	config        config.Config
-	apiScaffolder cmdutil.Scaffolder
+	config config.Config
 }
 
 // NewInitScaffolder returns a new Scaffolder for project initialization operations
-func NewInitScaffolder(config config.Config, apiScaffolder cmdutil.Scaffolder) cmdutil.Scaffolder {
+func NewInitScaffolder(config config.Config) cmdutil.Scaffolder {
 	return &initScaffolder{
-		config:        config,
-		apiScaffolder: apiScaffolder,
+		config: config,
 	}
 }
 
@@ -67,13 +65,7 @@ func (s *initScaffolder) newUniverse() *model.Universe {
 
 // Scaffold implements Scaffolder
 func (s *initScaffolder) Scaffold() error {
-	if err := s.scaffold(); err != nil {
-		return err
-	}
-	if s.apiScaffolder != nil {
-		return s.apiScaffolder.Scaffold()
-	}
-	return nil
+	return s.scaffold()
 }
 
 func (s *initScaffolder) scaffold() error {


### PR DESCRIPTION
**Description of the change:**
- internal/plugins/helm/v1/chartutil: have CreateChart() return a resource.Resource instead of golang.Options
- internal/plugins/helm/v1: refactor to run createAPISubcommand after initSubcommand finishes execution

**Motivation for the change:**
This PR fixes samples kustomization.yaml generation when running `operator-sdk init --plugins=helm --helm-chart=<chart>`, an error caused by out-of-order operations in plugin code.

Closes #4575 

/kind bug

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
