### PR TITLE
tests: fix ansible-molecule tests, install deps in venv, pin versions

### DIFF
--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -5,27 +5,31 @@ source hack/lib/image_lib.sh
 
 set -eu
 
-header_text "Running tests to check ansible molecule"
+header_text "Running ansible molecule tests in a python3 virtual environment"
 
-ROOTDIR="$(pwd)"
+# Set up a python3.8 virtual environment.
+ENVDIR="$(mktemp -d)"
+trap_add "deactivate; rm -rf $ENVDIR" EXIT
+python3 -m venv "$ENVDIR"
+source "${ENVDIR}/bin/activate"
+
+# Install dependencies.
 TMPDIR="$(mktemp -d)"
-trap_add 'rm -rf $TMPDIR' EXIT
-export PATH=${HOME}/.local/bin:${PATH}
-pip3 install --user pyasn1==0.4.7 pyasn1-modules==0.2.6 idna==2.8 ipaddress==1.0.22
-pip3 install --user molecule==3.0.2
-pip3 install --user ansible-lint yamllint
-pip3 install --user docker==4.2.2 openshift jmespath
+trap_add "rm -rf $TMPDIR" EXIT
+pip3 install pyasn1==0.4.7 pyasn1-modules==0.2.6 idna==2.8 ipaddress==1.0.23
+pip3 install molecule==3.0.2
+pip3 install ansible-lint yamllint
+pip3 install docker==4.2.2 openshift==0.11.2 jmespath
 ansible-galaxy collection install 'community.kubernetes:<1.0.0'
 
 header_text "Copying molecule testdata scenarios"
+ROOTDIR="$(pwd)"
 cp -r $ROOTDIR/testdata/ansible/memcached-molecule-operator/ $TMPDIR/memcached-molecule-operator
 cp -r $ROOTDIR/testdata/ansible/advanced-molecule-operator/ $TMPDIR/advanced-molecule-operator
 
-pushd "$TMPDIR"
-popd
-cd $TMPDIR/memcached-molecule-operator
+pushd $TMPDIR/memcached-molecule-operator
 
-header_text "Running Kind test with memcached-molecule-operator/"
+header_text "Running Kind test with memcached-molecule-operator"
 make kustomize
 if [ -f ./bin/kustomize ] ; then
   KUSTOMIZE="$(realpath ./bin/kustomize)"
@@ -35,8 +39,8 @@ fi
 KUSTOMIZE_PATH=${KUSTOMIZE} TEST_OPERATOR_NAMESPACE=default molecule test -s kind
 
 
-header_text "Running Default test with advanced-molecule-operator/"
-cd $TMPDIR/advanced-molecule-operator
+header_text "Running Default test with advanced-molecule-operator"
+pushd $TMPDIR/advanced-molecule-operator
 
 make kustomize
 if [ -f ./bin/kustomize ] ; then

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -9,15 +9,15 @@ header_text "Running ansible molecule tests in a python3 virtual environment"
 
 # Set up a python3.8 virtual environment.
 ENVDIR="$(mktemp -d)"
-trap_add "deactivate; rm -rf $ENVDIR" EXIT
+trap_add "set +u; deactivate; set -u; rm -rf $ENVDIR" EXIT
 python3 -m venv "$ENVDIR"
-source "${ENVDIR}/bin/activate"
+set +u; source "${ENVDIR}/bin/activate"; set -u
 
 # Install dependencies.
 TMPDIR="$(mktemp -d)"
 trap_add "rm -rf $TMPDIR" EXIT
 pip3 install pyasn1==0.4.7 pyasn1-modules==0.2.6 idna==2.8 ipaddress==1.0.23
-pip3 install molecule==3.0.2
+pip3 install cryptography==3.3.2 molecule==3.0.2
 pip3 install ansible-lint yamllint
 pip3 install docker==4.2.2 openshift==0.11.2 jmespath
 ansible-galaxy collection install 'community.kubernetes:<1.0.0'


### PR DESCRIPTION
**Description of the change:**
- hack/tests/e2e-ansible-molecule.sh: run tests in venv, pin versions

**Motivation for the change:** ansible-molecule tests seem to be [broken](https://github.com/operator-framework/operator-sdk/runs/1983461382?check_suite_focus=true) (appears to be caused by version 12.0.0 of the `openshift` dependency, which was released a few hours ago). This PR changes ansible-molecule tests to run in a venv as to not pollute host environment, and pins the `openshift` dependency to the prior version.

/area testing

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
