### PR TITLE
(ansible/v1) run `create api` plugin only after `init` plugin finishes execution

### DIFF
--- a/internal/plugins/ansible/v1/scaffolds/init.go
+++ b/internal/plugins/ansible/v1/scaffolds/init.go
@@ -50,15 +50,13 @@ var ansibleOperatorVersion = version.ImageVersion
 var _ cmdutil.Scaffolder = &initScaffolder{}
 
 type initScaffolder struct {
-	config        config.Config
-	apiScaffolder cmdutil.Scaffolder
+	config config.Config
 }
 
 // NewInitScaffolder returns a new Scaffolder for project initialization operations
-func NewInitScaffolder(config config.Config, apiScaffolder cmdutil.Scaffolder) cmdutil.Scaffolder {
+func NewInitScaffolder(config config.Config) cmdutil.Scaffolder {
 	return &initScaffolder{
-		config:        config,
-		apiScaffolder: apiScaffolder,
+		config: config,
 	}
 }
 
@@ -70,13 +68,7 @@ func (s *initScaffolder) newUniverse() *model.Universe {
 
 // Scaffold implements Scaffolder
 func (s *initScaffolder) Scaffold() error {
-	if err := s.scaffold(); err != nil {
-		return err
-	}
-	if s.apiScaffolder != nil {
-		return s.apiScaffolder.Scaffold()
-	}
-	return nil
+	return s.scaffold()
 }
 
 func (s *initScaffolder) scaffold() error {


### PR DESCRIPTION
**Description of the change:**
- internal/plugins/ansible/v1: refactor to run createAPISubcommand after initSubcommand finishes execution

**Motivation for the change:** This PR refactors `init --plugins=ansible` with GVK flags to run the `create api` plugin only after the `init` plugin completes, much like running `operator-sdk init && operator-sdk create api`.

Follows up on #4584

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
