### PR TITLE
actions/deploy: check if docs-only before running

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,26 @@ on:
     branches: [ master ]
 
 jobs:
+  check_docs_only:
+    name: check_docs_only
+    runs-on: ubuntu-18.04
+    outputs:
+      should_skip_tests: ${{ steps.check_docs_only.outputs.skip-tests }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - id: check_docs_only
+        run: |
+          REPO_MASTER_REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
+          echo "::set-output name=skip-tests::$(hack/ci/check-doc-only-update.sh $REPO_MASTER_REF)"
+
+
   # Job to test release steps. This will only create a release remotely if run on a tagged commit.
   goreleaser:
     name: goreleaser
+    needs: check_docs_only
+    if: needs.check_docs_only.outputs.should_skip_tests != 'true'
     runs-on: ubuntu-18.04
     environment: deploy
     steps:
@@ -44,6 +61,8 @@ jobs:
   # Job matrix for image builds.
   images:
     name: images
+    needs: check_docs_only
+    if: needs.check_docs_only.outputs.should_skip_tests != 'true'
     runs-on: ubuntu-18.04
     environment: deploy
     strategy:


### PR DESCRIPTION
**Description of the change:**
- .github/workflows/deploy.yml: check if docs-only before running

**Motivation for the change:** image builds do not need to run on docs-only PRs

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
