### PR TITLE
images/ansible-operator/Dockerfile: use ansible-operator-base image

### DIFF
--- a/images/ansible-operator/Dockerfile
+++ b/images/ansible-operator/Dockerfile
@@ -17,45 +17,17 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/ansible-operator
 
 # Final image.
-# TODO(estroz): replace ubi image in FROM with the following base image once a build has occurred:
-# FROM quay.io/operator-framework/ansible-operator-base:<tag>-<commit-ish>
-FROM registry.access.redhat.com/ubi8/ubi:8.3-227
-ARG TARGETARCH
-
-RUN mkdir -p /etc/ansible \
-  && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
-  && echo '[defaults]' > /etc/ansible/ansible.cfg \
-  && echo 'roles_path = /opt/ansible/roles' >> /etc/ansible/ansible.cfg \
-  && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg
+FROM quay.io/operator-framework/ansible-operator-base:v1.4.0-45-g65af4898a1cbeb032954979c68bba0d422454b6d
 
 ENV HOME=/opt/ansible \
     USER_NAME=ansible \
     USER_UID=1001
-
-# Install python dependencies after freshening metadata.
-RUN dnf clean all && rm -rf /var/cache/dnf/* \
-  && dnf update -y \
-  && dnf install -y libffi-devel openssl-devel python38-devel gcc python38-pip python38-setuptools \
-  && pip3 install --no-cache-dir \
-    cryptography==3.3.2 \
-    ansible-runner==1.3.4 \
-    ansible-runner-http==1.0.0 \
-    ipaddress==1.0.23 \
-    kubernetes==10.1.0 \
-    openshift==0.10.3 \
-    ansible==2.9.15 \
-    jmespath==0.10.0 \
-  && dnf remove -y gcc libffi-devel openssl-devel python38-devel \
-  && dnf clean all && rm -rf /var/cache/dnf/*
 
 # Ensure directory permissions are properly set
 RUN echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd \
   && mkdir -p ${HOME}/.ansible/tmp \
   && chown -R ${USER_UID}:0 ${HOME} \
   && chmod -R ug+rwx ${HOME}
-
-RUN curl -L -o /tini https://github.com/krallin/tini/releases/latest/download/tini-${TARGETARCH} \
-  && chmod +x /tini
 
 WORKDIR ${HOME}
 USER ${USER_UID}


### PR DESCRIPTION
**Description of the change:**
- images/ansible-operator/Dockerfile: use ansible-operator-base image as ansible-operator final base image @[v1.4.0-45-g65af4898a1cbeb032954979c68bba0d422454b6d](https://github.com/operator-framework/operator-sdk/runs/2034778959).

**Motivation for the change:** newly built ansible-operator-base image.

Follows up on #4555

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
