### PR TITLE
config3alphato3: convert config version 3-alpha to 3

### DIFF
--- a/changelog/fragments/confg-3-alpha-removed.yaml
+++ b/changelog/fragments/confg-3-alpha-removed.yaml
@@ -1,0 +1,33 @@
+entries:
+  - description: >
+      PROJECT config version 3-alpha has been upgraded to version 3
+    kind: change
+    breaking: true
+    migration:
+      header: PROJECT config version 3-alpha must be upgraded to 3
+      body: >
+        PROJECT config version 3-alpha has been stabilized as
+        [version 3](https://github.com/kubernetes-sigs/kubebuilder/blob/master/docs/book/src/migration/manually_migration_guide_v2_v3.md)
+        (the `version` key in your PROJECT file), and contains a set of config fields sufficient
+        to fully describe a project. While this change is not technically breaking
+        because the spec at that version was alpha, it was used by default in `operator-sdk` commands
+        so should be marked as breaking and have a convenient migration path.
+        The `alpha config-3alpha-to-3` command will convert most of your PROJECT file
+        from version 3-alpha to 3, and leave comments with directions where
+        automatic conversion is not possible:
+
+        ```console
+        $ cat PROJECT
+        version: 3-alpha
+        resources:
+        - crdVersion: v1
+        ...
+        $ operator-sdk alpha config-3alpha-to-3
+        Your PROJECT config file has been converted from version 3-alpha to 3. Please make sure all config data is correct.
+        $ cat PROJECT
+        version: "3"
+        resources:
+        - api:
+            crdVersion: v1
+        ...
+        ```

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/mod v0.3.0
 	golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e
 	gomodules.xyz/jsonpatch/v3 v3.0.1
 	helm.sh/helm/v3 v3.4.1

--- a/internal/cmd/operator-sdk/alpha/cmd.go
+++ b/internal/cmd/operator-sdk/alpha/cmd.go
@@ -1,0 +1,35 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alpha
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/operator-sdk/internal/cmd/operator-sdk/alpha/config3alphato3"
+)
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "alpha",
+		Short: "Commands in alpha stage",
+		Long:  "Commands in alpha stage. These APIs are not stable and may be removed at any time.",
+	}
+
+	cmd.AddCommand(
+		config3alphato3.NewCmd(),
+	)
+
+	return cmd
+}

--- a/internal/cmd/operator-sdk/alpha/config3alphato3/cmd.go
+++ b/internal/cmd/operator-sdk/alpha/config3alphato3/cmd.go
@@ -1,0 +1,82 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config3alphato3
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+)
+
+func NewCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "config-3alpha-to-3",
+		Short: "Convert your PROJECT config file from version 3-alpha to 3",
+		Long: `Your PROJECT file contains config data specified by some version.
+This version is not a kubernetes-style version. In general, alpha and beta config versions
+are unstable and support for them is dropped once a stable version is released.
+The 3-alpha version has recently become stable (3), and therefore is no longer
+supported by operator-sdk v1.5+. This command is intended to migrate 3-alpha PROJECT files
+to 3 with as few manual modifications required as possible.
+`,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			cfgBytes, err := ioutil.ReadFile("PROJECT")
+			if err != nil {
+				return fmt.Errorf("%v (config-3alpha-to-3 must be run from project root)", err)
+			}
+
+			if ver, err := getConfigVersion(cfgBytes); err == nil && ver != v3alpha {
+				fmt.Println("Your PROJECT config file is not convertible at version", ver)
+				return nil
+			}
+
+			b, err := convertConfig3AlphaTo3(cfgBytes)
+			if err != nil {
+				return err
+			}
+			if err := ioutil.WriteFile("PROJECT", b, 0666); err != nil {
+				return err
+			}
+
+			fmt.Println("Your PROJECT config file has been converted from version 3-alpha to 3. " +
+				"Please make sure all config data is correct.")
+
+			return nil
+		},
+	}
+}
+
+// RootPersistentPreRun prints a helpful message on any exit caused by kubebuilder's
+// config unmarshal step finding "3-alpha", since the CLI will not recognize this version.
+// Add this to the root command (`operator-sdk`).
+var RootPersistentPreRun = func(cmd *cobra.Command, args []string) {
+	if cfgBytes, err := ioutil.ReadFile("PROJECT"); err == nil {
+		if ver, err := getConfigVersion(cfgBytes); err == nil && ver == v3alpha {
+			log.Warn("Config version 3-alpha has been stabilized as 3, and 3-alpha is no longer supported. " +
+				"Run `operator-sdk alpha config-3alpha-to-3` to upgrade your PROJECT config file to version 3",
+			)
+		}
+	}
+}
+
+func getConfigVersion(b []byte) (string, error) {
+	var verObj struct {
+		Version string `json:"version"`
+	}
+	return verObj.Version, yaml.Unmarshal(b, &verObj)
+}

--- a/internal/cmd/operator-sdk/alpha/config3alphato3/convert_config_3-alpha_to_3.go
+++ b/internal/cmd/operator-sdk/alpha/config3alphato3/convert_config_3-alpha_to_3.go
@@ -1,0 +1,221 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config3alphato3
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"path"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"golang.org/x/mod/modfile"
+	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	v3alpha   = "3-alpha"
+	versionRe = regexp.MustCompile(`version:[ ]*(?:")?3-alpha(?:")?`)
+)
+
+// convertConfig3AlphaTo3 returns cfgBytes converted to 3 iff cfgBytes is version 3-alpha.
+func convertConfig3AlphaTo3(cfgBytes []byte) (_ []byte, err error) {
+	cfgObj := make(map[string]interface{}, 5)
+	if err := yaml.Unmarshal(cfgBytes, &cfgObj); err != nil {
+		return nil, err
+	}
+
+	if version, hasVersion := cfgObj["version"]; !hasVersion || version.(string) != v3alpha {
+		return cfgBytes, nil
+	}
+
+	cfgBytes = versionRe.ReplaceAll(cfgBytes, []byte(`version: "3"`))
+
+	var modulePath string
+	layout := cfgObj["layout"].(string)
+	isGo := strings.HasPrefix(layout, "go.kubebuilder.io/")
+	if isGo {
+		if modulePath, err = getModulePath(); err != nil {
+			return nil, err
+		}
+	}
+
+	multigroupObj, hasMultigroup := cfgObj["multigroup"]
+	isMultigroup := hasMultigroup && multigroupObj.(bool)
+
+	if obj, hasRes := cfgObj["resources"]; hasRes {
+		domain := cfgObj["domain"].(string)
+		resObjs := obj.([]interface{})
+		resources := make([]resource.Resource, len(resObjs))
+
+		for i, resObj := range resObjs {
+			resources[i].Domain = domain
+
+			res := resObj.(map[string]interface{})
+			if groupObj, ok := res["group"]; ok {
+				resources[i].Group = groupObj.(string)
+			}
+			if versionObj, ok := res["version"]; ok {
+				resources[i].Version = versionObj.(string)
+			}
+			if kindObj, ok := res["kind"]; ok {
+				resources[i].Kind = kindObj.(string)
+			}
+
+			if isGo {
+				// Only Go projects use "resources[*].path".
+				var apiPath string
+				if isMultigroup {
+					apiPath = path.Join("apis", resources[i].Group, resources[i].Version)
+				} else {
+					apiPath = path.Join("api", resources[i].Version)
+				}
+				resources[i].Path = path.Join(modulePath, apiPath)
+			}
+
+			// Only set "resources[i].api" if "crdVersion" is present. Otherwise there is
+			// likely no API defined by the project.
+			if crdVersionObj, ok := res["crdVersion"]; ok {
+				resources[i].API = &resource.API{
+					CRDVersion: crdVersionObj.(string),
+				}
+			} else if k8sDomain, found := coreGroups[resources[i].Group]; found {
+				// Core type case.
+				resources[i].Domain = k8sDomain
+				resources[i].Path = path.Join("k8s.io", "api", resources[i].Group, resources[i].Version)
+			}
+			// Only set "resources[i].webhooks" if "webhookVersion" is present. Otherwise there is
+			// likely no webhook defined by the project.
+			if whVersionObj, ok := res["webhookVersion"]; ok {
+				resources[i].Webhooks = &resource.Webhooks{
+					WebhookVersion: whVersionObj.(string),
+				}
+			}
+		}
+
+		out := bytes.Buffer{}
+		t := template.Must(template.New("").Parse(tmpl))
+		if err := t.Execute(&out, resources); err != nil {
+			return nil, err
+		}
+
+		// Scan for resources, then replace only reources to preserve comments/order of the rest of PROJECT.
+		scanner := bufio.NewScanner(bytes.NewBuffer(cfgBytes))
+		start, end := -1, len(cfgBytes)
+		for scanner.Scan() {
+			text := scanner.Text()
+			if strings.HasPrefix(text, "resources:") {
+				start = bytes.Index(cfgBytes, []byte("resources:"))
+				continue
+			}
+			if start != -1 && strings.Contains(text, ":") && !strings.HasPrefix(text, " ") {
+				key := strings.TrimRightFunc(text, func(c rune) bool {
+					return c != ':'
+				})
+				if _, hasKey := cfgObj[strings.TrimSuffix(key, ":")]; hasKey {
+					end = bytes.Index(cfgBytes, []byte(text))
+					break
+				}
+			}
+		}
+
+		if start == -1 {
+			return nil, errors.New("internal error: resources key not found in scanner")
+		}
+		cfgBytes = append(cfgBytes[:start], append(out.Bytes(), cfgBytes[end:]...)...)
+	}
+
+	return cfgBytes, nil
+}
+
+// Make this a var so it can be mocked in tests.
+var getModulePath = func() (string, error) {
+	b, err := ioutil.ReadFile("go.mod")
+	return modfile.ModulePath(b), err
+}
+
+// Comment-heavy "resources" template.
+const tmpl = `resources:
+{{- range $i, $res := . }}
+-{{- if $res.API }} api:
+    {{- if $res.API.CRDVersion }}
+    crdVersion: {{ $res.API.CRDVersion }}
+    {{- else }}
+    # TODO(user): Change this API's CRD version if not v1.
+    crdVersion: v1
+    {{- end }}
+    # TODO(user): Uncomment the below line if this resource's CRD is namespace scoped, else delete it.
+    # namespaced: true
+  {{- end }}
+  # TODO(user): Uncomment the below line if this resource implements a controller, else delete it.
+  # controller: true
+  {{- if $res.Domain }}
+  domain: {{ $res.Domain }}
+  {{- end }}
+  group: {{ $res.GVK.Group }}
+  kind: {{ $res.GVK.Kind }}
+  {{- if $res.Path }}
+  # TODO(user): Update the package path for your API if the below value is incorrect.
+  path: {{ $res.Path }}
+  {{- end }}
+  version: {{ $res.GVK.Version }}
+  {{- if $res.Webhooks }}
+  webhooks:
+    # TODO(user): Uncomment the below line if this resource's webhook implements a conversion webhook, else delete it.
+    # conversion: true
+    # TODO(user): Uncomment the below line if this resource's webhook implements a defaulting webhook, else delete it.
+    # defaulting: true
+    # TODO(user): Uncomment the below line if this resource's webhook implements a validating webhook, else delete it.
+    # validation: true
+    {{- if $res.Webhooks.WebhookVersion }}
+    webhookVersion: {{ $res.Webhooks.WebhookVersion }}
+    {{- else }}
+    # TODO(user): Change this API's webhook configuration version to the correct version if not v1.
+    webhookVersion: v1
+    {{- end }}
+  {{- end }}
+{{- end }}
+`
+
+// coreGroups maps a native k8s group to its domain. Several do not have a domain.
+var coreGroups = map[string]string{
+	"admission":             "k8s.io",
+	"admissionregistration": "k8s.io",
+	"apps":                  "",
+	"auditregistration":     "k8s.io",
+	"apiextensions":         "k8s.io",
+	"authentication":        "k8s.io",
+	"authorization":         "k8s.io",
+	"autoscaling":           "",
+	"batch":                 "",
+	"certificates":          "k8s.io",
+	"coordination":          "k8s.io",
+	"core":                  "",
+	"events":                "k8s.io",
+	"extensions":            "",
+	"imagepolicy":           "k8s.io",
+	"networking":            "k8s.io",
+	"node":                  "k8s.io",
+	"metrics":               "k8s.io",
+	"policy":                "",
+	"rbac.authorization":    "k8s.io",
+	"scheduling":            "k8s.io",
+	"setting":               "k8s.io",
+	"storage":               "k8s.io",
+}

--- a/internal/cmd/operator-sdk/alpha/config3alphato3/convert_config_3-alpha_to_3_test.go
+++ b/internal/cmd/operator-sdk/alpha/config3alphato3/convert_config_3-alpha_to_3_test.go
@@ -1,0 +1,172 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config3alphato3
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/format"
+)
+
+var _ = Describe("ConvertConfig3AlphaTo3", func() {
+	TruncatedDiff = false
+	// Mock go.mod reading to test "resources[*].path"
+	getModulePath = func() (string, error) {
+		return "github.com/example/memcached-operator", nil
+	}
+	DescribeTable("should return the expected config",
+		func(inputCfgStr, expectedCfgStr string) {
+			output, err := convertConfig3AlphaTo3([]byte(inputCfgStr))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(output)).To(MatchYAML(expectedCfgStr))
+		},
+		Entry("no resources", noResourcesConfig, noResourcesConfigExp),
+		Entry("basic", basicConfig, basicConfigExp),
+		Entry("complex", complexConfig, complexConfigExp),
+	)
+})
+
+const (
+	basicConfig = `domain: example.com
+layout: ansible.sdk.operatorframework.io/v1
+projectName: memcached-operator
+resources:
+- crdVersion: v1
+  group: cache
+  kind: Memcached
+  version: v1alpha1
+version: 3-alpha
+`
+	basicConfigExp = `domain: example.com
+layout: ansible.sdk.operatorframework.io/v1
+projectName: memcached-operator
+resources:
+- api:
+    crdVersion: v1
+    # TODO(user): Uncomment the below line if this resource's CRD is namespace scoped, else delete it.
+    # namespaced: true
+  # TODO(user): Uncomment the below line if this resource implements a controller, else delete it.
+  # controller: true
+  domain: example.com
+  group: cache
+  kind: Memcached
+  version: v1alpha1
+version: "3"
+`
+)
+
+const (
+	noResourcesConfig = `domain: example.com
+layout: ansible.sdk.operatorframework.io/v1
+projectName: memcached-operator
+version: 3-alpha
+`
+	noResourcesConfigExp = `domain: example.com
+layout: ansible.sdk.operatorframework.io/v1
+projectName: memcached-operator
+version: "3"
+`
+)
+
+const (
+	complexConfig = `domain: example.com
+layout: go.kubebuilder.io/v3
+projectName: memcached-operator
+resources:
+- crdVersion: v1
+  group: cache
+  kind: Memcached
+  version: v1alpha1
+  webhookVersion: v1
+- crdVersion: v1
+  group: cache
+  kind: MemcachedRS
+  version: v1alpha1
+- # This is a builtin type
+  group: apps
+  kind: Deployment
+  version: v1
+- # This is an internal type that looks like a core/v1.Pod
+  crdVersion: v1
+  group: core
+  kind: Pod
+  version: v1
+plugins:
+  manifests.sdk.operatorframework.io/v2: {}
+  scorecard.sdk.operatorframework.io/v2: {}
+version: 3-alpha
+`
+	complexConfigExp = `domain: example.com
+layout: go.kubebuilder.io/v3
+projectName: memcached-operator
+resources:
+- api:
+    crdVersion: v1
+    # TODO(user): Uncomment the below line if this resource's CRD is namespace scoped, else delete it.
+    # namespaced: true
+  # TODO(user): Uncomment the below line if this resource implements a controller, else delete it.
+  # controller: true
+  domain: example.com
+  group: cache
+  kind: Memcached
+  # TODO(user): Update the package path for your API if the below value is incorrect.
+  path: github.com/example/memcached-operator/api/v1alpha1
+  version: v1alpha1
+  webhooks:
+    # TODO(user): Uncomment the below line if this resource's webhook implements a conversion webhook, else delete it.
+    # conversion: true
+    # TODO(user): Uncomment the below line if this resource's webhook implements a defaulting webhook, else delete it.
+    # defaulting: true
+    # TODO(user): Uncomment the below line if this resource's webhook implements a validating webhook, else delete it.
+    # validation: true
+    webhookVersion: v1
+- api:
+    crdVersion: v1
+    # TODO(user): Uncomment the below line if this resource's CRD is namespace scoped, else delete it.
+    # namespaced: true
+  # TODO(user): Uncomment the below line if this resource implements a controller, else delete it.
+  # controller: true
+  domain: example.com
+  group: cache
+  kind: MemcachedRS
+  # TODO(user): Update the package path for your API if the below value is incorrect.
+  path: github.com/example/memcached-operator/api/v1alpha1
+  version: v1alpha1
+- # TODO(user): Uncomment the below line if this resource implements a controller, else delete it.
+  # controller: true
+  group: apps
+  kind: Deployment
+  # TODO(user): Update the package path for your API if the below value is incorrect.
+  path: k8s.io/api/apps/v1
+  version: v1
+- api:
+    crdVersion: v1
+    # TODO(user): Uncomment the below line if this resource's CRD is namespace scoped, else delete it.
+    # namespaced: true
+  # TODO(user): Uncomment the below line if this resource implements a controller, else delete it.
+  # controller: true
+  domain: example.com
+  group: core
+  kind: Pod
+  # TODO(user): Update the package path for your API if the below value is incorrect.
+  path: github.com/example/memcached-operator/api/v1
+  version: v1
+plugins:
+  manifests.sdk.operatorframework.io/v2: {}
+  scorecard.sdk.operatorframework.io/v2: {}
+version: "3"
+`
+)

--- a/internal/cmd/operator-sdk/alpha/config3alphato3/suite_test.go
+++ b/internal/cmd/operator-sdk/alpha/config3alphato3/suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config3alphato3
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestInternal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Internal Suite")
+}

--- a/internal/cmd/operator-sdk/cli/cli.go
+++ b/internal/cmd/operator-sdk/cli/cli.go
@@ -22,6 +22,8 @@ import (
 	cfgv2 "sigs.k8s.io/kubebuilder/v3/pkg/config/v2"
 	cfgv3 "sigs.k8s.io/kubebuilder/v3/pkg/config/v3"
 
+	"github.com/operator-framework/operator-sdk/internal/cmd/operator-sdk/alpha"
+	"github.com/operator-framework/operator-sdk/internal/cmd/operator-sdk/alpha/config3alphato3"
 	"github.com/operator-framework/operator-sdk/internal/cmd/operator-sdk/bundle"
 	"github.com/operator-framework/operator-sdk/internal/cmd/operator-sdk/cleanup"
 	"github.com/operator-framework/operator-sdk/internal/cmd/operator-sdk/completion"
@@ -38,6 +40,7 @@ import (
 )
 
 var commands = []*cobra.Command{
+	alpha.NewCmd(),
 	bundle.NewCmd(),
 	cleanup.NewCmd(),
 	completion.NewCmd(),
@@ -97,4 +100,6 @@ func rootPersistentPreRun(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.DebugLevel)
 		log.Debug("Debug logging is set")
 	}
+
+	config3alphato3.RootPersistentPreRun(cmd, args)
 }

--- a/website/content/en/docs/cli/operator-sdk.md
+++ b/website/content/en/docs/cli/operator-sdk.md
@@ -53,6 +53,7 @@ to obtain further info about available commands.
 
 ### SEE ALSO
 
+* [operator-sdk alpha](../operator-sdk_alpha)	 - Commands in alpha stage
 * [operator-sdk bundle](../operator-sdk_bundle)	 - Manage operator bundle metadata
 * [operator-sdk cleanup](../operator-sdk_cleanup)	 - Clean up an Operator deployed with the 'run' subcommand
 * [operator-sdk completion](../operator-sdk_completion)	 - Generators for shell completions

--- a/website/content/en/docs/cli/operator-sdk_alpha.md
+++ b/website/content/en/docs/cli/operator-sdk_alpha.md
@@ -1,0 +1,30 @@
+---
+title: "operator-sdk alpha"
+---
+## operator-sdk alpha
+
+Commands in alpha stage
+
+### Synopsis
+
+Commands in alpha stage. These APIs are not stable and may be removed at any time.
+
+### Options
+
+```
+  -h, --help   help for alpha
+```
+
+### Options inherited from parent commands
+
+```
+      --plugins strings          plugin keys of the plugin to initialize the project with
+      --project-version string   project version
+      --verbose                  Enable verbose logging
+```
+
+### SEE ALSO
+
+* [operator-sdk](../operator-sdk)	 - 
+* [operator-sdk alpha config-3alpha-to-3](../operator-sdk_alpha_config-3alpha-to-3)	 - Convert your PROJECT config file from version 3-alpha to 3
+

--- a/website/content/en/docs/cli/operator-sdk_alpha_config-3alpha-to-3.md
+++ b/website/content/en/docs/cli/operator-sdk_alpha_config-3alpha-to-3.md
@@ -1,0 +1,39 @@
+---
+title: "operator-sdk alpha config-3alpha-to-3"
+---
+## operator-sdk alpha config-3alpha-to-3
+
+Convert your PROJECT config file from version 3-alpha to 3
+
+### Synopsis
+
+Your PROJECT file contains config data specified by some version.
+This version is not a kubernetes-style version. In general, alpha and beta config versions
+are unstable and support for them is dropped once a stable version is released.
+The 3-alpha version has recently become stable (3), and therefore is no longer
+supported by operator-sdk v1.5+. This command is intended to migrate 3-alpha PROJECT files
+to 3 with as few manual modifications required as possible.
+
+
+```
+operator-sdk alpha config-3alpha-to-3 [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for config-3alpha-to-3
+```
+
+### Options inherited from parent commands
+
+```
+      --plugins strings          plugin keys of the plugin to initialize the project with
+      --project-version string   project version
+      --verbose                  Enable verbose logging
+```
+
+### SEE ALSO
+
+* [operator-sdk alpha](../operator-sdk_alpha)	 - Commands in alpha stage
+


### PR DESCRIPTION
**Description of the change:**
- internal/cmd/operator-sdk/alpha/config3alphato3: convert config version 3-alpha to 3, and exit after conversion
- internal/cmd/operator-sdk/cli: add PersistentPreRun to root cmd for helpful error message

**Motivation for the change:** Version 3-alpha has been removed after version 3 was released. While this change is not technically breaking because the spec at that version was alpha, it was used by default in `operator-sdk` commands so should be marked as breaking and have a convenient migration path. The `alpha config3alphato3` command will convert most of a PROJECT file from version 3-alpha to 3, and leave comments with directions where automatic conversion is not possible.

/kind feature

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>