### PR TITLE
Rename golang occurrences to go

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -30,7 +30,7 @@ Thanks for contributing!
 
 ### Code style
 
-The coding style suggested by the Golang community is used in operator-sdk. See the [style doc][golang-style-doc] for details.
+The coding style suggested by the Go community is used in operator-sdk. See the [style doc][golang-style-doc] for details.
 
 Please follow this style to make operator-sdk easy to review, maintain and develop.
 

--- a/internal/plugins/ansible/v1/api.go
+++ b/internal/plugins/ansible/v1/api.go
@@ -191,7 +191,7 @@ func newResource(cfg config.Config, opts createOptions) *resource.Resource {
 
 	r := opts.NewResource(cfg)
 	r.Domain = cfg.GetDomain()
-	// Remove the path since this is not a Golang project.
+	// Remove the path since this is not a Go project.
 	r.Path = ""
 	return &r
 }

--- a/internal/plugins/helm/v1/chartutil/chart.go
+++ b/internal/plugins/helm/v1/chartutil/chart.go
@@ -205,7 +205,7 @@ func (opts CreateOptions) NewResource(cfg config.Config) *resource.Resource {
 
 	r := ro.NewResource(cfg)
 	r.Domain = cfg.GetDomain()
-	// remove the path since is not a Golang project
+	// remove the path since is not a Go project
 	r.Path = ""
 	return &r
 }

--- a/website/content/en/docs/building-operators/ansible/development-tips.md
+++ b/website/content/en/docs/building-operators/ansible/development-tips.md
@@ -186,7 +186,7 @@ This is the list of CR annotations which will modify the behavior of the operato
 - `ansible.operator-sdk/reconcile-period`: Specifies the maximum time before a
   reconciliation is triggered. Note that at scale, this can reduce
   performance, see [watches][watches] reference for more information. This value
-  is parsed using the standard Golang package [time][time_pkg]. Specifically
+  is parsed using the standard Go package [time][time_pkg]. Specifically
   [ParseDuration][time_parse_duration] is used which will apply the default
   suffix of `s` giving the value in seconds.
 

--- a/website/content/en/docs/building-operators/golang/_index.md
+++ b/website/content/en/docs/building-operators/golang/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Golang
+title: Go
 weight: 2
-description: Guide to building a Golang Based Operator using Operator SDK
+description: Guide to building a Go-based Operator using Operator SDK
 ---

--- a/website/content/en/docs/building-operators/golang/references/_index.md
+++ b/website/content/en/docs/building-operators/golang/references/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Golang Based Operator Reference
+title: Go-based Operator Reference
 linkTitle: Reference
 weight: 100
 ---

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -1,5 +1,5 @@
 ---
-title: Golang Operator Tutorial
+title: Go Operator Tutorial
 linkTitle: Tutorial
 weight: 30
 description: An in-depth walkthough of building and running a Go-based operator.

--- a/website/content/en/docs/overview/_index.md
+++ b/website/content/en/docs/overview/_index.md
@@ -22,7 +22,7 @@ The Operator SDK is a framework that uses the [controller-runtime][controller_ru
 
 The SDK provides workflows to develop operators in Go, Ansible, or Helm.
 
-The following workflow is for a new [Golang operator][golang-guide]:
+The following workflow is for a new [Go operator][golang-guide]:
 
   1. Create a new operator project using the SDK Command Line Interface(CLI)
   2. Define new resource APIs by adding Custom Resource Definitions(CRD)

--- a/website/content/en/docs/upgrading-sdk-version/v1.2.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.2.0.md
@@ -3,19 +3,19 @@ title: v1.2.0
 weight: 998998000
 ---
 
-## (Golang based operators) Update Makefile's bundle target
+## (Go-based operators) Update Makefile's bundle target
 
 In the `Makefile` file, replace `bundle: manifests` with `bundle: manifests kustomize` to call the kustomize target when the `bundle` target is used.
 
 _See [#4090](https://github.com/operator-framework/operator-sdk/pull/4090) for more details._
 
-## (Golang based operators)  Upgrade sigs.k8s.io/controller-runtime version to v0.6.3
+## (Go-based operators)  Upgrade sigs.k8s.io/controller-runtime version to v0.6.3
 
 In the `go.mod` file replace `sigs.k8s.io/controller-runtime v0.6.2` with `sigs.k8s.io/controller-runtime v0.6.3` and then run `go mod tidy`.
 
 _See [#4062](https://github.com/operator-framework/operator-sdk/pull/4062) for more details._
 
-## (Golang based operators with multigroup support) Fix `CRDDirectoryPath` in `controllers/<group>/suite_test.go`
+## (Go-based operators with multigroup support) Fix `CRDDirectoryPath` in `controllers/<group>/suite_test.go`
 
 If your project is multi-group, then replace `CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},` with `CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},` in `suite_test.go` files found in `controllers/<group>/` directories. Otherwise, the tests will fail since this EnvTest will not be looking for the CRD's in the correct location. For more info, see [kubebuilder#1665](https://github.com/kubernetes-sigs/kubebuilder/issues/1665).
 


### PR DESCRIPTION
**Description of the change:**
This PR renames most of the `Golang` occurrences to `Go`. The only exception are the proposals, which, are historical archives, so,  I believe that there's no need for a change.

**Motivation for the change:**
The main motivation is to keep consistency with the naming across the project. Some sections mention Go and others  Golang. Also, [according](https://tip.golang.org/doc/faq#go_or_golang) to the official website, `Go` is the proper name to use.

**Checklist**

- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
