### PR TITLE
cleanup command has additional flags to handle deletion of CRDs

### DIFF
--- a/changelog/fragments/optional-flags-cleanup.yaml
+++ b/changelog/fragments/optional-flags-cleanup.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Added new optional flags `--delete-all`, `--delete-crds` and `--delete-operator-groups` to the cleanup command
+    kind: "addition"
+    breaking: false

--- a/internal/cmd/operator-sdk/cleanup/cmd.go
+++ b/internal/cmd/operator-sdk/cleanup/cmd.go
@@ -17,7 +17,7 @@ package cleanup
 import (
 	"context"
 	"errors"
-	"fmt"
+	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -44,7 +44,8 @@ func NewCmd() *cobra.Command {
 			u.Logf = log.Infof
 
 			if err := u.Validate(); err != nil {
-				return fmt.Errorf("invalid command options: %v", err)
+				log.Errorf("Invalid command options: %v", err)
+				os.Exit(1)
 			}
 
 			ctx, cancel := context.WithTimeout(cmd.Context(), timeout)

--- a/internal/cmd/operator-sdk/cleanup/cmd.go
+++ b/internal/cmd/operator-sdk/cleanup/cmd.go
@@ -28,6 +28,7 @@ import (
 func NewCmd() *cobra.Command {
 	var timeout time.Duration
 	cfg := &operator.Configuration{}
+	u := operator.NewUninstall(cfg)
 	cmd := &cobra.Command{
 		Use:   "cleanup <operatorPackageName>",
 		Short: "Clean up an Operator deployed with the 'run' subcommand",
@@ -37,9 +38,7 @@ func NewCmd() *cobra.Command {
 			return cfg.Load()
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			u := operator.NewUninstall(cfg)
 			u.Package = args[0]
-			u.DeleteAll = true
 			u.DeleteOperatorGroupNames = []string{operator.SDKOperatorGroupName}
 			u.Logf = log.Infof
 
@@ -59,7 +58,9 @@ func NewCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().DurationVar(&timeout, "timeout", 2*time.Minute, "Time to wait for the command to complete before failing")
+	cmd.Flags().SortFlags = false
 	cfg.BindFlags(cmd.PersistentFlags())
+	u.BindFlags(cmd.Flags())
 
 	return cmd
 }

--- a/internal/cmd/operator-sdk/cleanup/cmd.go
+++ b/internal/cmd/operator-sdk/cleanup/cmd.go
@@ -17,7 +17,6 @@ package cleanup
 import (
 	"context"
 	"errors"
-	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -42,11 +41,6 @@ func NewCmd() *cobra.Command {
 			u.Package = args[0]
 			u.DeleteOperatorGroupNames = []string{operator.SDKOperatorGroupName}
 			u.Logf = log.Infof
-
-			if err := u.Validate(); err != nil {
-				log.Errorf("Invalid command options: %v", err)
-				os.Exit(1)
-			}
 
 			ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
 			defer cancel()

--- a/internal/cmd/operator-sdk/cleanup/cmd.go
+++ b/internal/cmd/operator-sdk/cleanup/cmd.go
@@ -17,6 +17,7 @@ package cleanup
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -42,6 +43,10 @@ func NewCmd() *cobra.Command {
 			u.DeleteOperatorGroupNames = []string{operator.SDKOperatorGroupName}
 			u.Logf = log.Infof
 
+			if err := u.Validate(); err != nil {
+				return fmt.Errorf("invalid command options: %v", err)
+			}
+
 			ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
 			defer cancel()
 
@@ -58,7 +63,6 @@ func NewCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().DurationVar(&timeout, "timeout", 2*time.Minute, "Time to wait for the command to complete before failing")
-	cmd.Flags().SortFlags = false
 	cfg.BindFlags(cmd.PersistentFlags())
 	u.BindFlags(cmd.Flags())
 

--- a/internal/olm/operator/uninstall.go
+++ b/internal/olm/operator/uninstall.go
@@ -16,7 +16,6 @@ package operator
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -57,18 +56,9 @@ func NewUninstall(cfg *Configuration) *Uninstall {
 }
 
 func (u *Uninstall) BindFlags(fs *pflag.FlagSet) {
-	fs.BoolVar(&u.DeleteCRDs, "delete-crds", true, "If set to false, owned CRDs and CRs will not be deleted")
+	fs.BoolVar(&u.DeleteCRDs, "delete-crds", false, "If set to true, owned CRDs and CRs will be deleted")
 	fs.BoolVar(&u.DeleteAll, "delete-all", true, "If set to true, all other delete options will be enabled")
-	fs.BoolVar(&u.DeleteOperatorGroups, "delete-operator-groups", true, "If set to false, operator groups will not be deleted")
-}
-
-func (u *Uninstall) Validate() error {
-	if u.DeleteAll {
-		if !u.DeleteCRDs || !u.DeleteOperatorGroups {
-			return errors.New("if --delete-all flag is enabled, any other delete flag cannot be set to false")
-		}
-	}
-	return nil
+	fs.BoolVar(&u.DeleteOperatorGroups, "delete-operator-groups", false, "If set to true, operator groups will be deleted")
 }
 
 type ErrPackageNotFound struct {

--- a/website/content/en/docs/cli/operator-sdk_cleanup.md
+++ b/website/content/en/docs/cli/operator-sdk_cleanup.md
@@ -16,10 +16,12 @@ operator-sdk cleanup <operatorPackageName> [flags]
 ### Options
 
 ```
-  -h, --help                help for cleanup
+      --timeout duration    Time to wait for the command to complete before failing (default 2m0s)
+      --delete-crds         If set to false, owned CRDs and CRs will not be deleted (default true)
+      --delete-all          If set to true, it will enable all the delete flags (default true)
       --kubeconfig string   Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string    If present, namespace scope for this CLI request
-      --timeout duration    Time to wait for the command to complete before failing (default 2m0s)
+  -h, --help                help for cleanup
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/cli/operator-sdk_cleanup.md
+++ b/website/content/en/docs/cli/operator-sdk_cleanup.md
@@ -17,8 +17,8 @@ operator-sdk cleanup <operatorPackageName> [flags]
 
 ```
       --delete-all               If set to true, all other delete options will be enabled (default true)
-      --delete-crds              If set to false, owned CRDs and CRs will not be deleted (default true)
-      --delete-operator-groups   If set to false, operator groups will not be deleted (default true)
+      --delete-crds              If set to true, owned CRDs and CRs will be deleted
+      --delete-operator-groups   If set to true, operator groups will be deleted
   -h, --help                     help for cleanup
       --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string         If present, namespace scope for this CLI request

--- a/website/content/en/docs/cli/operator-sdk_cleanup.md
+++ b/website/content/en/docs/cli/operator-sdk_cleanup.md
@@ -16,7 +16,7 @@ operator-sdk cleanup <operatorPackageName> [flags]
 ### Options
 
 ```
-      --delete-all               If set to true, it will enable all the delete flags (default true)
+      --delete-all               If set to true, all other delete options will be enabled (default true)
       --delete-crds              If set to false, owned CRDs and CRs will not be deleted (default true)
       --delete-operator-groups   If set to false, operator groups will not be deleted (default true)
   -h, --help                     help for cleanup

--- a/website/content/en/docs/cli/operator-sdk_cleanup.md
+++ b/website/content/en/docs/cli/operator-sdk_cleanup.md
@@ -16,12 +16,13 @@ operator-sdk cleanup <operatorPackageName> [flags]
 ### Options
 
 ```
-      --timeout duration    Time to wait for the command to complete before failing (default 2m0s)
-      --delete-crds         If set to false, owned CRDs and CRs will not be deleted (default true)
-      --delete-all          If set to true, it will enable all the delete flags (default true)
-      --kubeconfig string   Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string    If present, namespace scope for this CLI request
-  -h, --help                help for cleanup
+      --delete-all               If set to true, it will enable all the delete flags (default true)
+      --delete-crds              If set to false, owned CRDs and CRs will not be deleted (default true)
+      --delete-operator-groups   If set to false, operator groups will not be deleted (default true)
+  -h, --help                     help for cleanup
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, namespace scope for this CLI request
+      --timeout duration         Time to wait for the command to complete before failing (default 2m0s)
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/olm-integration/testing-deployment.md
+++ b/website/content/en/docs/olm-integration/testing-deployment.md
@@ -123,7 +123,7 @@ Let's look at the anatomy of the `run bundle-upgrade` configuration model:
 `run packagemanifests`.
 
 ```
-operator-sdk cleanup <operatorPackageName> [--delete-all=] [--delete-crds=] [--kubeconfig=] [--namespace=] [--timeout=]
+operator-sdk cleanup <operatorPackageName> [--delete-all=] [--delete-crds=] [--delete-operator-groups=] [--kubeconfig=] [--namespace=] [--timeout=]
 ```
 
 Let's look at the configuration shared between `run bundle`, `run
@@ -147,6 +147,8 @@ Let's look at the anatomy of the `cleanup` configuration model:
 - **delete-crds**: a boolean indicating to delete all owned CRDs and CRs. This is an optional field
   which will default to true if not provided. If set to false, owned CRDs and CRs
   will stay intact.
+- **delete-operator-groups**: a boolean indicating to delete all operator groups. This is an optional field
+  which will default to true if not provided. If set to false, operator groups will not be deleted.
 
 ### Caveats
 

--- a/website/content/en/docs/olm-integration/testing-deployment.md
+++ b/website/content/en/docs/olm-integration/testing-deployment.md
@@ -141,14 +141,13 @@ Let's look at the anatomy of the `cleanup` configuration model:
 
 - **operatorPackageName**: the Operator's package name which you want to remove
   from the cluster, e.g. memcached-operator. This is a required parameter.
-- **delete-all**: a boolean indicating to enable all the delete flags that are present. This is an optional field
-  which will default to true if not provided. If set to false, it will enable
-  specific delete flags.
+- **delete-all**: a boolean indicating to enable all the delete flags that are present. This is an optional
+  field which will default to true if not provided. If set to true, it will enable all the delete flags to be true. If set to false, it will enable specific delete flags.
 - **delete-crds**: a boolean indicating to delete all owned CRDs and CRs. This is an optional field
-  which will default to true if not provided. If set to false, owned CRDs and CRs
-  will stay intact.
+  which will default to false if not provided. If set to true, owned CRDs and CRs
+  will be deleted.
 - **delete-operator-groups**: a boolean indicating to delete all operator groups. This is an optional field
-  which will default to true if not provided. If set to false, operator groups will not be deleted.
+  which will default to false if not provided. If set to true, operator groups will be deleted.
 
 ### Caveats
 

--- a/website/content/en/docs/olm-integration/testing-deployment.md
+++ b/website/content/en/docs/olm-integration/testing-deployment.md
@@ -123,7 +123,7 @@ Let's look at the anatomy of the `run bundle-upgrade` configuration model:
 `run packagemanifests`.
 
 ```
-operator-sdk cleanup <operatorPackageName> [--kubeconfig=] [--namespace=] [--timeout=]
+operator-sdk cleanup <operatorPackageName> [--delete-all=] [--delete-crds=] [--kubeconfig=] [--namespace=] [--timeout=]
 ```
 
 Let's look at the configuration shared between `run bundle`, `run
@@ -141,6 +141,12 @@ Let's look at the anatomy of the `cleanup` configuration model:
 
 - **operatorPackageName**: the Operator's package name which you want to remove
   from the cluster, e.g. memcached-operator. This is a required parameter.
+- **delete-all**: a boolean indicating to enable all the delete flags that are present. This is an optional field
+  which will default to true if not provided. If set to false, it will enable
+  specific delete flags.
+- **delete-crds**: a boolean indicating to delete all owned CRDs and CRs. This is an optional field
+  which will default to true if not provided. If set to false, owned CRDs and CRs
+  will stay intact.
 
 ### Caveats
 


### PR DESCRIPTION
**Description of the change:**
operator-sdk cleanup command has optional additional flags (`--delete-all` and `--delete-crds`) to handle deletion of CRDs. 

To preserve the current behavior, both these flags will be set to true by default. 
If a user intends to not cleanup CRDs, then the user will have to set the flags as below:
`operator-sdk cleanup <operatorPackageName> --delete-all=false --delete-crds=false` to prevent deletion of CRDs

**Motivation for the change:**
The existing operator-sdk cleanup command currently deletes the CRDs and all other resources owned by the operator, without an option to disable this behavior. Ideally, the cleanup command should have certain flags that prevent deletion of CRDs, for feature parity with the kubectl operator plugin and also so that eventually SDK can opt-in and use OLM's operand cleanup feature.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Signed-off-by: rashmigottipati <chowdary.grashmi@gmail.com>
