### PR TITLE
(manifests/v2) add support for webhooks by default and docs

### DIFF
--- a/changelog/fragments/bugfix-csv-webhooks.yaml
+++ b/changelog/fragments/bugfix-csv-webhooks.yaml
@@ -1,0 +1,32 @@
+entries:
+  - description: >
+      (manifests/v2) Added a `config/manifests` kustomize patch to remove the cert-manager
+      volume and volumeMount from manifests destined for `generate <bundle|packagemanifests>`
+    kind: bugfix
+    migration:
+      header: (manifests/v2) Add a kustomize patch to remove the cert-manager volume/volumeMount from your CSV
+      body: >
+        OLM does [not yet support cert-manager](https://olm.operatorframework.io/docs/advanced-tasks/adding-admission-and-conversion-webhooks/#certificate-authority-requirements),
+        so a JSON patch was added to remove this volume and mount such that
+        OLM can itself create and manage certs for your Operator.
+
+        In `config/manifests/kustomization.yaml`, add the following:
+
+        ```yaml
+        patchesJson6902:
+        - target:
+            group: apps
+            version: v1
+            kind: Deployment
+            name: controller-manager
+            namespace: system
+          patch: |-
+            # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
+            # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
+            - op: remove
+              path: /spec/template/spec/containers/1/volumeMounts/0
+            # Remove the "cert" volume, since OLM will create and mount a set of certs.
+            # Update the indices in this path if adding or removing volumes in the manager's Deployment.
+            - op: remove
+              path: /spec/template/spec/volumes/0
+        ```

--- a/hack/generate/samples/internal/go/v2/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/v2/memcached_with_webhooks.go
@@ -90,7 +90,8 @@ func (mh *MemcachedGoWithWebhooks) Run() {
 	pkg.CheckError("scaffolding webhook", err)
 
 	mh.implementingWebhooks()
-	mh.uncommentKustomizationFile()
+	mh.uncommentDefaultKustomization()
+	mh.uncommentManifestsKustomization()
 
 	log.Infof("creating the bundle")
 	err = mh.ctx.GenerateBundle()
@@ -106,35 +107,28 @@ func (mh *MemcachedGoWithWebhooks) Run() {
 	pkg.CheckError("cleaning up", os.RemoveAll(filepath.Join(mh.ctx.Dir, "bin")))
 }
 
-// uncommentKustomizationFile will uncomment the file kustomization.yaml
-func (mh *MemcachedGoWithWebhooks) uncommentKustomizationFile() {
-	log.Infof("uncomment kustomization.yaml to enable webhook and ca injection")
-	err := testutils.UncommentCode(
-		filepath.Join(mh.ctx.Dir, "config", "default", "kustomization.yaml"),
-		"#- ../webhook", "#")
+// uncommentDefaultKustomization will uncomment code in config/default/kustomization.yaml
+func (mh *MemcachedGoWithWebhooks) uncommentDefaultKustomization() {
+	var err error
+	kustomization := filepath.Join(mh.ctx.Dir, "config", "default", "kustomization.yaml")
+	log.Info("uncommenting config/default/kustomization.yaml to enable webhooks and ca injection")
+
+	err = testutils.UncommentCode(kustomization, "#- ../webhook", "#")
 	pkg.CheckError("uncomment webhook", err)
 
-	err = testutils.UncommentCode(
-		filepath.Join(mh.ctx.Dir, "config", "default", "kustomization.yaml"),
-		"#- ../certmanager", "#")
+	err = testutils.UncommentCode(kustomization, "#- ../certmanager", "#")
 	pkg.CheckError("uncomment certmanager", err)
 
-	err = testutils.UncommentCode(
-		filepath.Join(mh.ctx.Dir, "config", "default", "kustomization.yaml"),
-		"#- ../prometheus", "#")
+	err = testutils.UncommentCode(kustomization, "#- ../prometheus", "#")
 	pkg.CheckError("uncomment prometheus", err)
 
-	err = testutils.UncommentCode(
-		filepath.Join(mh.ctx.Dir, "config", "default", "kustomization.yaml"),
-		"#- manager_webhook_patch.yaml", "#")
+	err = testutils.UncommentCode(kustomization, "#- manager_webhook_patch.yaml", "#")
 	pkg.CheckError("uncomment manager_webhook_patch.yaml", err)
 
-	err = testutils.UncommentCode(
-		filepath.Join(mh.ctx.Dir, "config", "default", "kustomization.yaml"),
-		"#- webhookcainjection_patch.yaml", "#")
+	err = testutils.UncommentCode(kustomization, "#- webhookcainjection_patch.yaml", "#")
 	pkg.CheckError("uncomment webhookcainjection_patch.yaml", err)
 
-	err = testutils.UncommentCode(filepath.Join(mh.ctx.Dir, "config", "default", "kustomization.yaml"),
+	err = testutils.UncommentCode(kustomization,
 		`#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
 #  objref:
 #    kind: Certificate
@@ -162,6 +156,32 @@ func (mh *MemcachedGoWithWebhooks) uncommentKustomizationFile() {
 #    version: v1
 #    name: webhook-service`, "#")
 	pkg.CheckError("uncommented certificate CR", err)
+}
+
+// uncommentManifestsKustomization will uncomment code in config/manifests/kustomization.yaml
+func (mh *MemcachedGoWithWebhooks) uncommentManifestsKustomization() {
+	var err error
+	kustomization := filepath.Join(mh.ctx.Dir, "config", "manifests", "kustomization.yaml")
+	log.Info("uncommenting config/manifests/kustomization.yaml to enable webhooks in OLM")
+
+	err = testutils.UncommentCode(kustomization,
+		`#patchesJson6902:
+#- target:
+#    group: apps
+#    version: v1
+#    kind: Deployment
+#    name: controller-manager
+#    namespace: system
+#  patch: |-
+#    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
+#    # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
+#    - op: remove
+#      path: /spec/template/spec/containers/1/volumeMounts/0
+#    # Remove the "cert" volume, since OLM will create and mount a set of certs.
+#    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
+#    - op: remove
+#      path: /spec/template/spec/volumes/0`, "#")
+	pkg.CheckError("uncommented webhook volume removal patch", err)
 }
 
 // implementingWebhooks will customize the kind wekbhok file
@@ -327,7 +347,7 @@ const reconcileFragment = `// Fetch the Memcached instance
 			return ctrl.Result{}, err
 		}
 		// Ask to requeue after 1 minute in order to give enough time for the
-		// pods be created on the cluster side and the operand be able 
+		// pods be created on the cluster side and the operand be able
 		// to do the next update step accurately.
 		return ctrl.Result{RequeueAfter: time.Minute }, nil
 	}

--- a/internal/plugins/ansible/v1/init.go
+++ b/internal/plugins/ansible/v1/init.go
@@ -133,7 +133,7 @@ func (p *initSubcommand) Run(fs machinery.Filesystem) error {
 	}
 
 	// Run SDK phase 2 plugins.
-	if err := p.runPhase2(); err != nil {
+	if err := p.runPhase2(fs); err != nil {
 		return err
 	}
 
@@ -149,8 +149,8 @@ func (p *initSubcommand) Run(fs machinery.Filesystem) error {
 }
 
 // SDK phase 2 plugins.
-func (p *initSubcommand) runPhase2() error {
-	if err := manifestsv2.RunInit(p.config); err != nil {
+func (p *initSubcommand) runPhase2(fs machinery.Filesystem) error {
+	if err := manifestsv2.RunInit(p.config, fs); err != nil {
 		return err
 	}
 	if err := scorecardv2.RunInit(p.config); err != nil {

--- a/internal/plugins/golang/v2/init.go
+++ b/internal/plugins/golang/v2/init.go
@@ -47,7 +47,7 @@ func (p *initSubcommand) Run(fs machinery.Filesystem) error {
 	}
 
 	// Run SDK phase 2 plugins.
-	if err := p.runPhase2(); err != nil {
+	if err := p.runPhase2(fs); err != nil {
 		return err
 	}
 
@@ -55,11 +55,11 @@ func (p *initSubcommand) Run(fs machinery.Filesystem) error {
 }
 
 // SDK phase 2 plugins.
-func (p *initSubcommand) runPhase2() error {
+func (p *initSubcommand) runPhase2(fs machinery.Filesystem) error {
 	if err := envtest.RunInit(p.config); err != nil {
 		return err
 	}
-	if err := manifestsv2.RunInit(p.config); err != nil {
+	if err := manifestsv2.RunInit(p.config, fs); err != nil {
 		return err
 	}
 	if err := scorecardv2.RunInit(p.config); err != nil {

--- a/internal/plugins/golang/v3/init.go
+++ b/internal/plugins/golang/v3/init.go
@@ -46,7 +46,7 @@ func (p *initSubcommand) Run(fs machinery.Filesystem) error {
 	}
 
 	// Run SDK phase 2 plugins.
-	if err := p.runPhase2(); err != nil {
+	if err := p.runPhase2(fs); err != nil {
 		return err
 	}
 
@@ -54,8 +54,8 @@ func (p *initSubcommand) Run(fs machinery.Filesystem) error {
 }
 
 // SDK phase 2 plugins.
-func (p *initSubcommand) runPhase2() error {
-	if err := manifestsv2.RunInit(p.config); err != nil {
+func (p *initSubcommand) runPhase2(fs machinery.Filesystem) error {
+	if err := manifestsv2.RunInit(p.config, fs); err != nil {
 		return err
 	}
 	if err := scorecardv2.RunInit(p.config); err != nil {

--- a/internal/plugins/helm/v1/init.go
+++ b/internal/plugins/helm/v1/init.go
@@ -161,7 +161,7 @@ func (p *initSubcommand) Run(fs machinery.Filesystem) error {
 	}
 
 	// Run SDK phase 2 plugins.
-	if err := p.runPhase2(); err != nil {
+	if err := p.runPhase2(fs); err != nil {
 		return err
 	}
 
@@ -177,8 +177,8 @@ func (p *initSubcommand) Run(fs machinery.Filesystem) error {
 }
 
 // SDK phase 2 plugins.
-func (p *initSubcommand) runPhase2() error {
-	if err := manifestsv2.RunInit(p.config); err != nil {
+func (p *initSubcommand) runPhase2(fs machinery.Filesystem) error {
+	if err := manifestsv2.RunInit(p.config, fs); err != nil {
 		return err
 	}
 	if err := scorecardv2.RunInit(p.config); err != nil {

--- a/internal/plugins/manifests/v2/init.go
+++ b/internal/plugins/manifests/v2/init.go
@@ -1,0 +1,59 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+
+	"github.com/operator-framework/operator-sdk/internal/util/projutil"
+)
+
+// runInit runs the manifests SDK phase 2 plugin.
+func runInit(cfg config.Config, fs machinery.Filesystem) error {
+
+	if err := newInitScaffolder(cfg).scaffold(fs); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type initScaffolder struct {
+	config config.Config
+}
+
+func newInitScaffolder(config config.Config) *initScaffolder {
+	return &initScaffolder{
+		config: config,
+	}
+}
+
+func (s *initScaffolder) scaffold(fs machinery.Filesystem) error {
+
+	// Only Go operator types support webhooks right now.
+	operatorType := projutil.PluginKeyToOperatorType(s.config.GetPluginChain())
+
+	err := machinery.NewScaffold(fs, machinery.WithConfig(s.config)).Execute(
+		&Kustomization{SupportsWebhooks: operatorType == projutil.OperatorTypeGo},
+	)
+	if err != nil {
+		return fmt.Errorf("error scaffolding manifests: %v", err)
+	}
+
+	return nil
+}

--- a/internal/plugins/manifests/v2/kustomization.go
+++ b/internal/plugins/manifests/v2/kustomization.go
@@ -1,0 +1,76 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/model/file"
+)
+
+var _ file.Template = &Kustomization{}
+
+// Kustomization scaffolds a kustomization.yaml for the manifests overlay folder.
+type Kustomization struct {
+	file.TemplateMixin
+	file.ProjectNameMixin
+
+	SupportsWebhooks bool
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *Kustomization) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join(manifestsDir, "kustomization.yaml")
+	}
+
+	f.TemplateBody = kustomizationTemplate
+
+	if f.IfExistsAction == 0 && f.IfExistsAction != file.Skip {
+		f.IfExistsAction = file.Error
+	}
+
+	return nil
+}
+
+const kustomizationTemplate = `# These resources constitute the fully configured set of manifests
+# used to generate the 'manifests/' directory in a bundle.
+resources:
+- bases/{{ .ProjectName }}.clusterserviceversion.yaml
+- ../default
+- ../samples
+- ../scorecard
+{{ if .SupportsWebhooks }}
+# [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
+# Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
+# These patches remove the unnecessary "cert" volume and its manager container volumeMount.
+#patchesJson6902:
+#- target:
+#    group: apps
+#    version: v1
+#    kind: Deployment
+#    name: controller-manager
+#    namespace: system
+#  patch: |-
+#    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
+#    # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
+#    - op: remove
+#      path: /spec/template/spec/containers/1/volumeMounts/0
+#    # Remove the "cert" volume, since OLM will create and mount a set of certs.
+#    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
+#    - op: remove
+#      path: /spec/template/spec/volumes/0
+{{ end -}}
+`

--- a/internal/plugins/manifests/v2/plugin.go
+++ b/internal/plugins/manifests/v2/plugin.go
@@ -16,6 +16,7 @@ package v2
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
 	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
@@ -33,6 +34,8 @@ const (
 var (
 	pluginVersion   = plugin.Version{Number: 2}
 	pluginConfigKey = plugin.Key(pluginName, pluginVersion.String())
+
+	manifestsDir = filepath.Join("config", "manifests")
 )
 
 // Config configures this plugin, and is saved in the project config file.
@@ -45,9 +48,12 @@ func HasPluginConfig(cfg config.Config) bool {
 }
 
 // RunInit modifies the project scaffolded by kubebuilder's Init plugin.
-func RunInit(cfg config.Config) error {
-	// Only run these if project version is v3.
+func RunInit(cfg config.Config, fs machinery.Filesystem) error {
+	// These will only run if project version is v3.
 	if err := manifests.RunInit(cfg); err != nil {
+		return err
+	}
+	if err := runInit(cfg, fs); err != nil {
 		return err
 	}
 

--- a/testdata/ansible/memcached-operator/config/manifests/kustomization.yaml
+++ b/testdata/ansible/memcached-operator/config/manifests/kustomization.yaml
@@ -1,4 +1,7 @@
+# These resources constitute the fully configured set of manifests
+# used to generate the 'manifests/' directory in a bundle.
 resources:
+- bases/memcached-operator.clusterserviceversion.yaml
 - ../default
 - ../samples
 - ../scorecard

--- a/testdata/go/v2/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v2/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -137,16 +137,7 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 20Mi
-                volumeMounts:
-                - mountPath: /tmp/k8s-webhook-server/serving-certs
-                  name: cert
-                  readOnly: true
               terminationGracePeriodSeconds: 10
-              volumes:
-              - name: cert
-                secret:
-                  defaultMode: 420
-                  secretName: webhook-server-cert
       permissions:
       - rules:
         - apiGroups:

--- a/testdata/go/v2/memcached-operator/config/manifests/kustomization.yaml
+++ b/testdata/go/v2/memcached-operator/config/manifests/kustomization.yaml
@@ -1,4 +1,27 @@
+# These resources constitute the fully configured set of manifests
+# used to generate the 'manifests/' directory in a bundle.
 resources:
+- bases/memcached-operator.clusterserviceversion.yaml
 - ../default
 - ../samples
 - ../scorecard
+
+# [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
+# Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
+# These patches remove the unnecessary "cert" volume and its manager container volumeMount.
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: controller-manager
+    namespace: system
+  patch: |-
+    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
+    # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
+    - op: remove
+      path: /spec/template/spec/containers/1/volumeMounts/0
+    # Remove the "cert" volume, since OLM will create and mount a set of certs.
+    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
+    - op: remove
+      path: /spec/template/spec/volumes/0

--- a/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -153,19 +153,10 @@ spec:
                     memory: 20Mi
                 securityContext:
                   allowPrivilegeEscalation: false
-                volumeMounts:
-                - mountPath: /tmp/k8s-webhook-server/serving-certs
-                  name: cert
-                  readOnly: true
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: memcached-operator-controller-manager
               terminationGracePeriodSeconds: 10
-              volumes:
-              - name: cert
-                secret:
-                  defaultMode: 420
-                  secretName: webhook-server-cert
       permissions:
       - rules:
         - apiGroups:

--- a/testdata/go/v3/memcached-operator/config/manifests/kustomization.yaml
+++ b/testdata/go/v3/memcached-operator/config/manifests/kustomization.yaml
@@ -1,4 +1,27 @@
+# These resources constitute the fully configured set of manifests
+# used to generate the 'manifests/' directory in a bundle.
 resources:
+- bases/memcached-operator.clusterserviceversion.yaml
 - ../default
 - ../samples
 - ../scorecard
+
+# [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
+# Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
+# These patches remove the unnecessary "cert" volume and its manager container volumeMount.
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: controller-manager
+    namespace: system
+  patch: |-
+    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
+    # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
+    - op: remove
+      path: /spec/template/spec/containers/1/volumeMounts/0
+    # Remove the "cert" volume, since OLM will create and mount a set of certs.
+    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
+    - op: remove
+      path: /spec/template/spec/volumes/0

--- a/testdata/helm/memcached-operator/config/manifests/kustomization.yaml
+++ b/testdata/helm/memcached-operator/config/manifests/kustomization.yaml
@@ -1,4 +1,7 @@
+# These resources constitute the fully configured set of manifests
+# used to generate the 'manifests/' directory in a bundle.
 resources:
+- bases/memcached-operator.clusterserviceversion.yaml
 - ../default
 - ../samples
 - ../scorecard


### PR DESCRIPTION
**Description of the change:**
- internal/plugins/manifests/v2: initialize project with a `config/manifests/kustomization.yaml` that contains a patch to remove the [`cert` volume and mount](https://github.com/operator-framework/operator-sdk/blob/a07364f06aa14934ce52257f3af1aaf0da587401/testdata/go/v3/memcached-operator/config/default/manager_webhook_patch.yaml) from the default manager configuration.
- internal/cmd/operator-sdk/generate/kustomize: use the manifests/v2 kustomization.yaml for backwards-compatibility.

**Motivation for the change:** no kustomize helpers are created to enable webhooks by default. This is considered a bug since the CSV generator supports webhooks (see #4244).

Closes #4240 
Closes #4244
Closes #4439 

/kind bug

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
