### PR TITLE
`generate kustomize manifests`: skip parsing definitions on a non-existent API root dir

### DIFF
--- a/changelog/fragments/bugfix-nonexistent-apis-dir-generate-bundle.yaml
+++ b/changelog/fragments/bugfix-nonexistent-apis-dir-generate-bundle.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Skip CSV definitions parsing in `generate kustomize manifests` if the APIs dir does not exist,
+      as projects may use only required APIs.
+    kind: bugfix

--- a/internal/generate/clusterserviceversion/bases/definitions/definitions.go
+++ b/internal/generate/clusterserviceversion/bases/definitions/definitions.go
@@ -41,6 +41,12 @@ type descriptionValues struct {
 // to populate csv spec fields. Go code with relevant markers and information is expected to be
 // in a package under apisRootDir and match a GVK in keys.
 func ApplyDefinitionsForKeysGo(csv *v1alpha1.ClusterServiceVersion, apisRootDir string, gvks []schema.GroupVersionKind) error {
+	// Skip definitions parsing if dir doesn't exist, otherwise g.contextForRoots() will error.
+	if _, err := os.Stat(apisRootDir); err != nil && errors.Is(err, os.ErrNotExist) {
+		log.Warnf("Skipping definitions parsing: APIs root dir %q does not exist", apisRootDir)
+		return nil
+	}
+
 	wd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -86,7 +92,7 @@ func ApplyDefinitionsForKeysGo(csv *v1alpha1.ClusterServiceVersion, apisRootDir 
 
 	// Leftover GVKs are ignored because their types can't be found.
 	for _, gvk := range gvkSet {
-		log.Warnf("Skipping CSV annotation parsing for API %s: type not found", gvk)
+		log.Warnf("Skipping definitions parsing for API %s: Go type not found", gvk)
 	}
 
 	// Update csv with all values parsed.

--- a/internal/generate/clusterserviceversion/bases/definitions/definitions_test.go
+++ b/internal/generate/clusterserviceversion/bases/definitions/definitions_test.go
@@ -241,13 +241,31 @@ func TestApplyDefinitionsForKeysGo(t *testing.T) {
 			},
 		},
 		{
-			description: "Return error for non-existent package dir",
+			description: "Return the CSV unchanged for non-existent APIs dir",
 			apisDir:     filepath.Join("pkg", "notexist"),
-			csv:         &v1alpha1.ClusterServiceVersion{},
-			gvks: []schema.GroupVersionKind{
-				{Group: "cache.example.com", Version: "v1alpha2", Kind: "Dummy"},
+			csv: &v1alpha1.ClusterServiceVersion{
+				Spec: v1alpha1.ClusterServiceVersionSpec{
+					CustomResourceDefinitions: v1alpha1.CustomResourceDefinitions{
+						Owned: []v1alpha1.CRDDescription{
+							{
+								Name: "nokinds.cache.example.com", Version: "v1alpha2", Kind: "NoKind",
+								DisplayName: "NoKind App",
+								Description: "NoKind is the Schema for the other nokind API",
+							},
+						},
+					},
+				},
 			},
-			wantErr: true,
+			expectedCRDs: v1alpha1.CustomResourceDefinitions{
+				Owned: []v1alpha1.CRDDescription{
+					{
+						Name: "nokinds.cache.example.com", Version: "v1alpha2", Kind: "NoKind",
+						DisplayName: "NoKind App",
+						Description: "NoKind is the Schema for the other nokind API",
+					},
+				},
+			},
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
**Description of the change:**
- internal/generate/clusterserviceversion/bases/definitions: skip on a non-existent API root dir

**Motivation for the change:** bugfix

/kind bug

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
