### PR TITLE
deps: bump kubebuilder to dd3942c

### DIFF
--- a/changelog/fragments/kubebuilder-dd3942c.yaml
+++ b/changelog/fragments/kubebuilder-dd3942c.yaml
@@ -1,0 +1,86 @@
+entries:
+  - description: >
+      (go/v3) Pin controller-runtime to v0.7.2
+    kind: change
+    migration:
+      header: (go/v3) Upgrade controller-runtime to v0.7.2
+      body: >
+        In your go.mod file, upgrade `sigs.k8s.io/controller-runtime` to v0.7.2.
+  - description: >
+      (go/v3) Create and bind to a non-default service account ([kubebuilder#2070](https://github.com/kubernetes-sigs/kubebuilder/pull/2070))
+    kind: addition
+    migration:
+      header: (go/v3) Add a `system:controller-manager` ServiceAccount to your project.
+      body: >
+        A non-default ServiceAccount `controller-manager` is scaffolded on `operator-sdk init`,
+        to improve security for operators installed in shared namespaces. To add this ServiceAccount
+        to your project, do the following:
+
+        ```sh
+        # Create the ServiceAccount.
+        cat <<EOF > config/rbac/service_account.yaml
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: controller-manager
+          namespace: system
+        EOF
+
+        # Add it to the list of RBAC resources.
+        echo "- service_account.yaml" >> config/rbac/kustomization.yaml
+
+        # Update all RoleBinding and ClusterRoleBinding subjects that reference the operator's ServiceAccount.
+        find config/rbac -name *_binding.yaml -exec sed -i -E 's/  name: default/  name: controller-manager/g' {} \;
+
+        # Add the ServiceAccount name to the manager Deployment's spec.template.spec.serviceAccountName.
+        sed -i -E 's/([ ]+)(terminationGracePeriodSeconds:)/\1serviceAccountName: controller-manager\n\1\2/g' config/manager/manager.yaml
+        ```
+
+        The changes should look like:
+
+        ```diff
+        # config/manager/manager.yaml
+                   requests:
+                     cpu: 100m
+                     memory: 20Mi
+        +      serviceAccountName: controller-manager
+               terminationGracePeriodSeconds: 10
+
+        # config/rbac/auth_proxy_role_binding.yaml
+           name: proxy-role
+         subjects:
+         - kind: ServiceAccount
+        -  name: default
+        +  name: controller-manager
+           namespace: system
+
+        # config/rbac/kustomization.yaml
+         resources:
+        +- service_account.yaml
+         - role.yaml
+         - role_binding.yaml
+         - leader_election_role.yaml
+
+        # config/rbac/leader_election_role_binding.yaml
+           name: leader-election-role
+         subjects:
+         - kind: ServiceAccount
+        -  name: default
+        +  name: controller-manager
+           namespace: system
+
+        # config/rbac/role_binding.yaml
+           name: manager-role
+         subjects:
+         - kind: ServiceAccount
+        -  name: default
+        +  name: controller-manager
+           namespace: system
+
+        # config/rbac/service_account.yaml
+        +apiVersion: v1
+        +kind: ServiceAccount
+        +metadata:
+        +  name: controller-manager
+        +  namespace: system
+        ```

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 	github.com/kr/text v0.1.0
 	github.com/markbates/inflect v1.0.4
-	github.com/onsi/ginkgo v1.14.1
-	github.com/onsi/gomega v1.10.2
+	github.com/onsi/ginkgo v1.15.0
+	github.com/onsi/gomega v1.10.5
 	github.com/operator-framework/api v0.5.3
 	github.com/operator-framework/operator-lib v0.4.0
 	github.com/operator-framework/operator-registry v1.15.3
@@ -22,7 +22,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.6.1
-	golang.org/x/tools v0.0.0-20201014231627-1610a49f37af
+	golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e
 	gomodules.xyz/jsonpatch/v3 v3.0.1
 	helm.sh/helm/v3 v3.4.1
 	k8s.io/api v0.20.2
@@ -34,7 +34,7 @@ require (
 	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/controller-runtime v0.8.2
 	sigs.k8s.io/controller-tools v0.5.0
-	sigs.k8s.io/kubebuilder/v3 v3.0.0-alpha.0.0.20210211121616-05abe25e7215
+	sigs.k8s.io/kubebuilder/v3 v3.0.0-alpha.0.0.20210309225704-dd3942c97cf5
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -723,6 +723,8 @@ github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.1 h1:jMU0WaQrP0a/YAEq8eJmJKjBoMs+pClEr1vDMlM/Do4=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.15.0 h1:1V1NfVQR87RtWAgp1lv9JZJ5Jap+XFGKPi00andXGi4=
+github.com/onsi/ginkgo v1.15.0/go.mod h1:hF8qUzuuC8DJGygJH3726JnCZX4MYbRB8yFfISqnKUg=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -733,6 +735,8 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2 h1:aY/nuoWlKJud2J6U0E3NWsjlg+0GtwXxgEqthRdzlcs=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/onsi/gomega v1.10.5 h1:7n6FEkpFmfCoo2t+YYqXH0evK+a9ICQz0xcAy9dYcaQ=
+github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -1085,10 +1089,11 @@ golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
-golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb h1:eBmm0M9fYhWpKZLjQUUKka/LtIxf46G4fxeEz5KJr9U=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1104,8 +1109,8 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
-golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1167,6 +1172,8 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210112080510-489259a85091 h1:DMyOG0U+gKfu8JZzg2UQe9MeaC1X+xQWlAKcRnjxjCw=
+golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -1224,12 +1231,11 @@ golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
-golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20201014231627-1610a49f37af h1:VIUWFyOgzG3c0t9KYop5Ybp4m56LupfOnFYX7Ipnz+I=
-golang.org/x/tools v0.0.0-20201014231627-1610a49f37af/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e h1:4nW4NLDYnU28ojHaHO8OVxFHk/aQ33U01a9cjED+pzE=
+golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1481,8 +1487,8 @@ sigs.k8s.io/controller-tools v0.4.1 h1:VkuV0MxlRPmRu5iTgBZU4UxUX2LiR99n3sdQGRxZF
 sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/controller-tools v0.5.0 h1:3u2RCwOlp0cjCALAigpOcbAf50pE+kHSdueUosrC/AE=
 sigs.k8s.io/controller-tools v0.5.0/go.mod h1:JTsstrMpxs+9BUj6eGuAaEb6SDSPTeVtUyp0jmnAM/I=
-sigs.k8s.io/kubebuilder/v3 v3.0.0-alpha.0.0.20210211121616-05abe25e7215 h1:pwEHSu3/ODNEr33DNrKt2DovGV84LhRBLt4QyrT6FJA=
-sigs.k8s.io/kubebuilder/v3 v3.0.0-alpha.0.0.20210211121616-05abe25e7215/go.mod h1:b1WkCy5t/3VSRBCffSfPV1WbH+f45ls69d4ic37sW6w=
+sigs.k8s.io/kubebuilder/v3 v3.0.0-alpha.0.0.20210309225704-dd3942c97cf5 h1:tPK6p11aAjyXe79qsgJF2fvRnzEaYIYuzosFkK9OXDY=
+sigs.k8s.io/kubebuilder/v3 v3.0.0-alpha.0.0.20210309225704-dd3942c97cf5/go.mod h1:O+YpPPkBBBQ+H7b2W1SqL8ygxDHFrVanJICzV8ToZtE=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/internal/plugins/ansible/v1/api.go
+++ b/internal/plugins/ansible/v1/api.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
+	pluginutil "sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang"
 
 	"github.com/operator-framework/operator-sdk/internal/kubebuilder/cmdutil"
@@ -167,8 +168,8 @@ func (p *createAPIPSubcommand) Validate() error {
 		return errors.New("multiple groups are not allowed by default, to enable multi-group set 'multigroup: true' in your PROJECT file")
 	}
 
-	// Check CRDVersion against all other CRDVersions in p.config for compatibility.
-	if !p.config.IsCRDVersionCompatible(p.resource.API.CRDVersion) {
+	// Selected CRD version must match existing CRD versions.
+	if pluginutil.HasDifferentCRDVersion(p.config, p.resource.API.CRDVersion) {
 		return fmt.Errorf("only one CRD version can be used for all resources, cannot add %q", p.resource.API.CRDVersion)
 	}
 

--- a/internal/plugins/helm/v1/api.go
+++ b/internal/plugins/helm/v1/api.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
+	pluginutil "sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 
 	"github.com/operator-framework/operator-sdk/internal/kubebuilder/cmdutil"
 	"github.com/operator-framework/operator-sdk/internal/plugins/helm/v1/chartutil"
@@ -196,8 +197,8 @@ func (p *createAPISubcommand) Validate() (err error) {
 		return errors.New("multiple groups are not allowed by default, to enable multi-group set 'multigroup: true' in your PROJECT file")
 	}
 
-	// Check CRDVersion against all other CRDVersions in p.config for compatibility.
-	if !p.config.IsCRDVersionCompatible(p.resource.API.CRDVersion) {
+	// Selected CRD version must match existing CRD versions.
+	if pluginutil.HasDifferentCRDVersion(p.config, p.resource.API.CRDVersion) {
 		return fmt.Errorf("only one CRD version can be used for all resources, cannot add %q", p.resource.API.CRDVersion)
 	}
 

--- a/test/e2e/go/cluster_test.go
+++ b/test/e2e/go/cluster_test.go
@@ -119,18 +119,17 @@ var _ = Describe("operator-sdk", func() {
 			}, time.Minute, time.Second).Should(Succeed())
 
 			By("granting permissions to access the metrics and read the token")
-			_, err = tc.Kubectl.Command(
-				"create",
-				"clusterrolebinding", metricsClusterRoleBindingName,
+			_, err = tc.Kubectl.Command("create", "clusterrolebinding", metricsClusterRoleBindingName,
 				fmt.Sprintf("--clusterrole=%s-metrics-reader", tc.ProjectName),
-				fmt.Sprintf("--serviceaccount=%s:default", tc.Kubectl.Namespace))
+				fmt.Sprintf("--serviceaccount=%s:%s", tc.Kubectl.Namespace, tc.Kubectl.ServiceAccount))
 			Expect(err).NotTo(HaveOccurred())
 
-			By("reading the token")
-			b64Token, err := tc.Kubectl.Get(
-				true,
-				"secrets",
-				"-o=jsonpath={.items[0].data.token}")
+			By("reading the metrics token")
+			// Filter token query by service account in case more than one exists in a namespace.
+			query := fmt.Sprintf(`{.items[?(@.metadata.annotations.kubernetes\.io/service-account\.name=="%s")].data.token}`,
+				tc.Kubectl.ServiceAccount,
+			)
+			b64Token, err := tc.Kubectl.Get(true, "secrets", "-o=jsonpath="+query)
 			Expect(err).NotTo(HaveOccurred())
 			token, err := base64.StdEncoding.DecodeString(strings.TrimSpace(b64Token))
 			Expect(err).NotTo(HaveOccurred())
@@ -141,7 +140,8 @@ var _ = Describe("operator-sdk", func() {
 			// it should not make any difference and work locally successfully when the flag is removed
 			// the test will fail and the curl pod is not found when the flag is not used
 			cmdOpts := []string{
-				"run", "--generator=run-pod/v1", "curl", "--image=curlimages/curl:7.68.0", "--restart=OnFailure", "--",
+				"run", "--generator=run-pod/v1", "curl", "--image=curlimages/curl:7.68.0", "--restart=OnFailure",
+				"--serviceaccount", tc.Kubectl.ServiceAccount, "--",
 				"curl", "-v", "-k", "-H", fmt.Sprintf(`Authorization: Bearer %s`, token),
 				fmt.Sprintf("https://%s-controller-manager-metrics-service.%s.svc:8443/metrics", tc.ProjectName, tc.Kubectl.Namespace),
 			}

--- a/test/e2e/go/suite_test.go
+++ b/test/e2e/go/suite_test.go
@@ -53,6 +53,7 @@ var _ = BeforeSuite(func() {
 	tc.Resources = "memcacheds"
 	tc.ProjectName = "memcached-operator"
 	tc.Kubectl.Namespace = fmt.Sprintf("%s-system", tc.ProjectName)
+	tc.Kubectl.ServiceAccount = fmt.Sprintf("%s-controller-manager", tc.ProjectName)
 
 	By("copying sample to a temporary e2e directory")
 	Expect(exec.Command("cp", "-r", "../../../testdata/go/v3/memcached-operator", tc.Dir).Run()).To(Succeed())

--- a/testdata/go/v2/memcached-operator/go.mod
+++ b/testdata/go/v2/memcached-operator/go.mod
@@ -4,6 +4,8 @@ go 1.13
 
 require (
 	github.com/go-logr/logr v0.1.0
+	github.com/onsi/ginkgo v1.12.1
+	github.com/onsi/gomega v1.10.1
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6

--- a/testdata/go/v3/memcached-operator/Makefile
+++ b/testdata/go/v3/memcached-operator/Makefile
@@ -75,7 +75,7 @@ vet: ## Run go vet against code.
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: manifests generate fmt vet ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.0/hack/setup-envtest.sh
+	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
 
 ##@ Build

--- a/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator-controller-manager_v1_serviceaccount.yaml
+++ b/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator-controller-manager_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: memcached-operator-controller-manager

--- a/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -94,7 +94,7 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: default
+        serviceAccountName: memcached-operator-controller-manager
       deployments:
       - name: memcached-operator-controller-manager
         spec:
@@ -159,6 +159,7 @@ spec:
                   readOnly: true
               securityContext:
                 runAsNonRoot: true
+              serviceAccountName: memcached-operator-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:
               - name: cert
@@ -188,7 +189,7 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: default
+        serviceAccountName: memcached-operator-controller-manager
     strategy: deployment
   installModes:
   - supported: false

--- a/testdata/go/v3/memcached-operator/config/manager/manager.yaml
+++ b/testdata/go/v3/memcached-operator/config/manager/manager.yaml
@@ -52,4 +52,5 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/testdata/go/v3/memcached-operator/config/rbac/auth_proxy_role_binding.yaml
+++ b/testdata/go/v3/memcached-operator/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/testdata/go/v3/memcached-operator/config/rbac/kustomization.yaml
+++ b/testdata/go/v3/memcached-operator/config/rbac/kustomization.yaml
@@ -1,4 +1,10 @@
 resources:
+# All RBAC will be applied under this service account in
+# the deployment namespace. You may comment out this resource
+# if your manager will use a service account that exists at
+# runtime. Be sure to update RoleBinding and ClusterRoleBinding
+# subjects if changing service account names.
+- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/testdata/go/v3/memcached-operator/config/rbac/leader_election_role_binding.yaml
+++ b/testdata/go/v3/memcached-operator/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/testdata/go/v3/memcached-operator/config/rbac/role_binding.yaml
+++ b/testdata/go/v3/memcached-operator/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/testdata/go/v3/memcached-operator/config/rbac/service_account.yaml
+++ b/testdata/go/v3/memcached-operator/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: system

--- a/testdata/go/v3/memcached-operator/controllers/memcached_controller.go
+++ b/testdata/go/v3/memcached-operator/controllers/memcached_controller.go
@@ -56,7 +56,7 @@ type MemcachedReconciler struct {
 // the user.
 //
 // For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.0/pkg/reconcile
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.2/pkg/reconcile
 func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("memcached", req.NamespacedName)
 

--- a/testdata/go/v3/memcached-operator/go.mod
+++ b/testdata/go/v3/memcached-operator/go.mod
@@ -4,8 +4,10 @@ go 1.15
 
 require (
 	github.com/go-logr/logr v0.3.0
+	github.com/onsi/ginkgo v1.14.1
+	github.com/onsi/gomega v1.10.2
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2
-	sigs.k8s.io/controller-runtime v0.7.0
+	sigs.k8s.io/controller-runtime v0.7.2
 )

--- a/testdata/go/v3/memcached-operator/go.sum
+++ b/testdata/go/v3/memcached-operator/go.sum
@@ -629,8 +629,8 @@ k8s.io/utils v0.0.0-20200912215256-4140de9c8800 h1:9ZNvfPvVIEsp/T1ez4GQuzCcCTEQW
 k8s.io/utils v0.0.0-20200912215256-4140de9c8800/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9/go.mod h1:dzAXnQbTRyDlZPJX2SUPEqvnB+j7AJjtlox7PEwigU0=
-sigs.k8s.io/controller-runtime v0.7.0 h1:bU20IBBEPccWz5+zXpLnpVsgBYxqclaHu1pVDl/gEt8=
-sigs.k8s.io/controller-runtime v0.7.0/go.mod h1:pJ3YBrJiAqMAZKi6UVGuE98ZrroV1p+pIhoHsMm9wdU=
+sigs.k8s.io/controller-runtime v0.7.2 h1:gD2JZp0bBLLuvSRYVNvox+bRCz1UUUxKDjPUCb56Ukk=
+sigs.k8s.io/controller-runtime v0.7.2/go.mod h1:pJ3YBrJiAqMAZKi6UVGuE98ZrroV1p+pIhoHsMm9wdU=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1 h1:YXTMot5Qz/X1iBRJhAt+vI+HVttY0WkSqqhKxQ0xVbA=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/website/content/en/docs/advanced-topics/scorecard/custom-tests.md
+++ b/website/content/en/docs/advanced-topics/scorecard/custom-tests.md
@@ -256,17 +256,19 @@ pods created by scorecard.
 
 Scorecard does not deploy service accounts, RBAC resources, or
 namespaces for your test but instead considers these resources
-to be outside its scope.  You can however implement whatever
-service accounts your tests require and then specify
-that service account from the command line using the service-account flag:
+to be outside its scope. You can however specify whichever service account
+your tests require, like `config/rbac/service_account.yaml` in
+Go operator projects, and then specify that service account
+from the command line:
+
 ```console
-$ operator-sdk scorecard <bundle_dir_or_image> --service-account=mycustomsa
+$ operator-sdk scorecard <bundle_dir_or_image> --service-account=my-project-controller-manager
 ```
 
-Also, you can set up a non-default namespace that your tests
-will be executed within using the following namespace flag:
+Also, you can specify a non-default namespace that scorecard will run in:
+
 ```console
-$ operator-sdk scorecard <bundle_dir_or_image> --namespace=mycustomns
+$ operator-sdk scorecard <bundle_dir_or_image> --namespace=my-project-system
 ```
 
 If you do not specify either of these flags, the default namespace
@@ -275,12 +277,12 @@ and service account will be used by the scorecard to run test pods.
 ### Returning Multiple Test Results
 
 Some custom tests might require or be better implemented to return
-more than a single test result.  For this case, scorecard's output
+more than a single test result. For this case, scorecard's output
 API allows [multiple test results][testresults] to be defined for a single test.
 
 ### Accessing the Kube API
 
-Within your custom tests you might require connecting to the Kube API.  
+Within your custom tests you might require connecting to the Kube API.
 In golang, you could use the [client-go][client_go] API for example to
 check Kube resources within your tests, or even create custom resources. Your
 custom test image is being executed within a Pod, so you can use an in-cluster

--- a/website/content/en/docs/advanced-topics/scorecard/kuttl-tests.md
+++ b/website/content/en/docs/advanced-topics/scorecard/kuttl-tests.md
@@ -64,7 +64,7 @@ end user along with any other test results.
 With the above kuttl test configuration, you can execute that
 kuttl test using scorecard as follows:
 ```bash
-operator-sdk scorecard <bundle_dir_or_image> --selector=suite=kuttlsuite 
+operator-sdk scorecard <bundle_dir_or_image> --selector=suite=kuttlsuite
 ```
 
 ## Defining kuttl Specific Configuration Options
@@ -92,7 +92,7 @@ use cases.  See [kuttl configuration][kuttl_configuration] for more details on k
 
 ### kuttl Tests Explained
 
-The kuttl test tool looks for tests to execute within the bundle 
+The kuttl test tool looks for tests to execute within the bundle
 following a naming convention as follows:
 ```
         └── kuttl
@@ -124,21 +124,22 @@ kuttl tests are named and executed.
 
 ### kuttl Test Privileges
 
-The kuttl tests a user might write can vary widely in functionality 
-and in particular require special Kubernetes RBAC priviledges outside 
-of what your default service account might have.  It is therefore very likely
-you will be required to run scorecard with a custom service account
-that holds the required RBAC permissions.
-
+The kuttl tests a user might write can vary widely in functionality
+and in particular require special Kubernetes RBAC privileges outside
+of what the default service account for a namespace might have.
+It is therefore very likely you will be required to run scorecard
+in a custom service account that holds the required RBAC permissions,
+like `config/rbac/service_account.yaml` in Go operator projects.
 You can specify a custom service account in scorecard as follows:
-```
-operator-sdk scorecard <bundle_dir_or_image> --service-account=mycustomsa
+
+```console
+$ operator-sdk scorecard <bundle_dir_or_image> --service-account=my-project-controller-manager
 ```
 
-Also, you can set up a non-default namespace that your tests
-will be executed within using the following namespace flag:
-```
-operator-sdk scorecard <bundle_dir_or_image> --namespace=mycustomns
+Also, you can specify a non-default namespace that scorecard will run in:
+
+```console
+$ operator-sdk scorecard <bundle_dir_or_image> --namespace=my-project-system
 ```
 
 If you do not specify either of these flags, the default namespace
@@ -146,7 +147,7 @@ and service account will be used by the scorecard to run test pods.
 
 It is worth noting that scorecard-test-kuttl specifies a namespace
 to the kubectl-kuttl command which causes kuttl to not create a
-namespace for each test.  This might impact your kuttl tests in 
+namespace for each test.  This might impact your kuttl tests in
 that you might need to perform resource cleanup in your tests
 instead of depending upon namespace deletion to perform that cleanup.
 

--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -228,6 +228,15 @@ See the complete migrated `memcached_controller.go` code [here][memcached_contro
 
 **Note:** The version of [controller-runtime][controller-runtime] used in the projects scaffolded by SDK `0.19.x+` was `v0.6.0`. Please check [sigs.k8s.io/controller-runtime release docs from 0.7.0+ version][controller-runtime] for breaking changes.
 
+##### Updating your ServiceAccount in Go operator projects
+
+New Go projects come with a ServiceAccount `controller-manager` in `config/rbac/service_account.yaml`.
+Your project's RoleBinding and ClusterRoleBinding subjects, and Deployment's `spec.template.spec.serviceAccountName`
+that reference a ServiceAccount already refer to this new name. When you run `make deploy`,
+your project's name will be prepended to `controller-manager`, making it unique within a namespace,
+much like your old `deploy/service_account.yaml`. If you wish to use the old ServiceAccount,
+make sure to update all RBAC bindings and your manager Deployment.
+
 ## Migrate `main.go`
 
 By checking our new `main.go` we will find that:


### PR DESCRIPTION
**Description of the change:**
- deps: bump kubebuilder to https://github.com/kubernetes-sigs/kubebuilder/commit/dd3942c97cf5ade5e686a4531712297a9deb1cc9, update where necessary
- docs/: document service account featrue

**Motivation for the change:** recent changes in kubebuilder

Closes #4468 

/area dependency

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
