### PR TITLE
website/content: update non-existent coreos.com blogpost link to openshift.com

### DIFF
--- a/website/content/en/_index.html
+++ b/website/content/en/_index.html
@@ -23,5 +23,5 @@ This project is a component of the [Operator
 Framework](https://github.com/operator-framework), an open source toolkit to
 manage Kubernetes native applications, called Operators, in an effective,
 automated, and scalable way. Read more in the [introduction blog
-post](https://coreos.com/blog/introducing-operator-framework).
+post](https://www.openshift.com/blog/introducing-the-operator-framework.
 {{< /blocks/lead >}}

--- a/website/content/en/docs/overview/_index.md
+++ b/website/content/en/docs/overview/_index.md
@@ -147,7 +147,7 @@ Operator SDK is under Apache 2.0 license. See the [LICENSE][license_file] file f
 [helm-guide]:/docs/building-operators/helm/quickstart/
 [install_guide]: /docs/installation/
 [license_file]:https://github.com/operator-framework/operator-sdk/blob/master/LICENSE
-[of-blog]: https://coreos.com/blog/introducing-operator-framework
+[of-blog]:https://www.openshift.com/blog/introducing-the-operator-framework
 [of-home]: https://github.com/operator-framework
 [operator_link]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 [proposals_docs]: https://github.com/operator-framework/operator-sdk/tree/master/proposals


### PR DESCRIPTION
**Description of the change:**
- website/content: update coreos.com blogpost link to openshift.com

**Motivation for the change:** old coreos.com link no longer exists

/kind documentation


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
