### PR TITLE
.github/workflows: use 'github.repository_owner' in image tags

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -36,7 +36,7 @@ jobs:
       id: tag
       run: |
         set -e
-        IMG=quay.io/operator-framework/ansible-operator-base
+        IMG=quay.io/${{ github.repository_owner }}/ansible-operator-base
         TAG="${{ github.event.inputs.tag }}"
         if [[ "$TAG" == "" ]]; then
           TAG=$(git describe --tags --always --dirty --long --abbrev=100)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,7 @@ jobs:
     - name: create tags
       id: tags
       run: |
-        IMG=quay.io/operator-framework/${{ matrix.id }}
+        IMG=quay.io/${{ github.repository_owner }}/${{ matrix.id }}
         if [[ $GITHUB_REF == refs/tags/* ]]; then
           TAG=${GITHUB_REF#refs/tags/}
           MAJOR_MINOR=${TAG%.*}


### PR DESCRIPTION
**Description of the change:**
- .github/workflows: use 'github.repository_owner' context in image tags for easier testing in fork repos

**Motivation for the change:** easier testing in forks

/area testing

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
