### PR TITLE
release: push scorecard-test-kuttl images on `scorecard-kuttl/v*` tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,22 +15,25 @@ jobs:
     name: check_docs_only
     runs-on: ubuntu-18.04
     outputs:
-      should_skip_tests: ${{ steps.check_docs_only.outputs.skip-tests }}
+      is_skip: ${{ steps.check_docs_only.outputs.skip-deploy }}
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - id: check_docs_only
+        # Since PR's are squashed prior to merging to the branch checked out (default branch),
+        # HEAD^ will resolve to the previous point in history.
         run: |
-          REPO_MASTER_REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip-tests::$(hack/ci/check-doc-only-update.sh $REPO_MASTER_REF)"
-
+          REF="HEAD^"
+          [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
+          echo "::set-output name=skip-deploy::$(hack/ci/check-doc-only-update.sh $REF)"
 
   # Job to test release steps. This will only create a release remotely if run on a tagged commit.
   goreleaser:
     name: goreleaser
     needs: check_docs_only
-    if: needs.check_docs_only.outputs.should_skip_tests != 'true'
+    # Run this job on a tag like 'vX.Y.Z' or on a branch or pull request with code changes.
+    if: startsWith(github.ref, 'refs/tags/v') || ( needs.check_docs_only.outputs.is_skip != 'true' && !startsWith(github.ref, 'refs/tags/') )
     runs-on: ubuntu-18.04
     environment: deploy
     steps:
@@ -63,7 +66,8 @@ jobs:
   images:
     name: images
     needs: check_docs_only
-    if: needs.check_docs_only.outputs.should_skip_tests != 'true'
+    # Run this job on a tag like 'vX.Y.Z' or on a branch or pull request with code changes.
+    if: startsWith(github.ref, 'refs/tags/v') || ( needs.check_docs_only.outputs.is_skip != 'true' && !startsWith(github.ref, 'refs/tags/') )
     runs-on: ubuntu-18.04
     environment: deploy
     strategy:
@@ -103,14 +107,15 @@ jobs:
         file: ./images/${{ matrix.id }}/Dockerfile
         context: .
         platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
-        push: ${{ (github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) )) }}
+        push: ${{ (github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/') || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) )) }}
         tags: ${{ steps.tags.outputs.tags }}
 
   # scorecard-test-kuttl image build job. Only pushes if a tag with prefix "scorecard-kuttl/v" is present.
   image-scorecard-test-kuttl:
     name: image-scorecard-test-kuttl
     needs: check_docs_only
-    if: needs.check_docs_only.outputs.should_skip_tests != 'true'
+    # Run this job on a tag like 'scorecard-kuttl/vX.Y.Z' or on a branch or pull request with code changes.
+    if: startsWith(github.ref, 'refs/tags/scorecard-kuttl/v') || ( needs.check_docs_only.outputs.is_skip != 'true' && !startsWith(github.ref, 'refs/tags/') )
     runs-on: ubuntu-18.04
     environment: deploy
     steps:
@@ -148,5 +153,5 @@ jobs:
         context: .
         # s390x is not supported by the scorecard-test-kuttl base image.
         platforms: linux/amd64,linux/arm64,linux/ppc64le
-        push: ${{ (github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/scorecard-kuttl/v') || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) )) }}
+        push: ${{ (github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/') || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) )) }}
         tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
     - '**'
     tags:
     - 'v*'
+    - 'scorecard-kuttl/v*'
   pull_request:
     branches: [ master ]
 
@@ -51,14 +52,14 @@ jobs:
 
     - name: release
       run: |
-        if [[ $GITHUB_REF != refs/tags/* ]]; then
+        if [[ $GITHUB_REF != refs/tags/v* ]]; then
           export DRY_RUN=1
         fi
         make release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Job matrix for image builds.
+  # Job matrix for image builds. Only pushes if a tag with prefix "v" is present.
   images:
     name: images
     needs: check_docs_only
@@ -67,7 +68,7 @@ jobs:
     environment: deploy
     strategy:
       matrix:
-        id: ["operator-sdk", "ansible-operator", "helm-operator", "scorecard-test", "scorecard-test-kuttl"]
+        id: ["operator-sdk", "ansible-operator", "helm-operator", "scorecard-test"]
     steps:
 
     - name: set up qemu
@@ -84,35 +85,68 @@ jobs:
         password: ${{ secrets.QUAY_PASSWORD }}
         registry: quay.io
 
-    - name: create tags
-      id: tags
-      run: |
-        IMG=quay.io/${{ github.repository_owner }}/${{ matrix.id }}
-        if [[ $GITHUB_REF == refs/tags/* ]]; then
-          TAG=${GITHUB_REF#refs/tags/}
-          MAJOR_MINOR=${TAG%.*}
-          echo ::set-output name=tags::${IMG}:${TAG},${IMG}:${MAJOR_MINOR}
-
-        elif [[ $GITHUB_REF == refs/heads/* ]]; then
-          TAG=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-          echo ::set-output name=tags::${IMG}:${TAG}
-
-        elif [[ $GITHUB_REF == refs/pull/* ]]; then
-          TAG=pr-${{ github.event.number }}
-          echo ::set-output name=tags::${IMG}:${TAG}
-        fi
-
+    # Check out repo before tag step for script.
     - name: checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
+    - name: create tags
+      id: tags
+      run: |
+        IMG=quay.io/${{ github.repository_owner }}/${{ matrix.id }}
+        echo ::set-output name=tags::$(.github/workflows/get_image_tags.sh "$IMG" "v")
 
     - name: build and push
       uses: docker/build-push-action@v2
       with:
         file: ./images/${{ matrix.id }}/Dockerfile
         context: .
+        platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+        push: ${{ (github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) )) }}
+        tags: ${{ steps.tags.outputs.tags }}
+
+  # scorecard-test-kuttl image build job. Only pushes if a tag with prefix "scorecard-kuttl/v" is present.
+  image-scorecard-test-kuttl:
+    name: image-scorecard-test-kuttl
+    needs: check_docs_only
+    if: needs.check_docs_only.outputs.should_skip_tests != 'true'
+    runs-on: ubuntu-18.04
+    environment: deploy
+    steps:
+
+    - name: set up qemu
+      uses: docker/setup-qemu-action@v1
+
+    - name: set up buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: quay.io login
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+        registry: quay.io
+
+    # Check out repo before tag step for script.
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: create tags
+      id: tags
+      run: |
+        IMG=quay.io/${{ github.repository_owner }}/scorecard-test-kuttl
+        echo ::set-output name=tags::$(.github/workflows/get_image_tags.sh "$IMG" "scorecard-kuttl/v")
+
+    - name: build and push
+      uses: docker/build-push-action@v2
+      with:
+        file: ./images/scorecard-test-kuttl/Dockerfile
+        context: .
         # s390x is not supported by the scorecard-test-kuttl base image.
-        platforms: linux/amd64,linux/arm64,linux/ppc64le${{ matrix.id != 'scorecard-test-kuttl' && ',linux/s390x' || '' }}
-        push: ${{ (github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/') || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) )) }}
+        platforms: linux/amd64,linux/arm64,linux/ppc64le
+        push: ${{ (github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/scorecard-kuttl/v') || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) )) }}
         tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/get_image_tags.sh
+++ b/.github/workflows/get_image_tags.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+IMG="$1"
+TAG_PREFIX="$2"
+
+: ${IMG:?"\$1 must be set to an image tag"}
+: ${TAG_PREFIX:?"\$2 must be set to some tag prefix to pass to refs/tags/{prefix}*"}
+: ${GITHUB_REF:?"GITHUB_REF must be set to a git 'refs/' path in the environment (typically set by the Actions runner)"}
+
+if [[ $GITHUB_REF == refs/tags/${TAG_PREFIX}* ]]; then
+  # Release tags.
+  TAG="${GITHUB_REF#refs/tags/${TAG_PREFIX}}"
+  # Prepend "v" if removed by the above variable operation, since $TAG should always be semver.
+  [[ $TAG == v* ]] || TAG="v${TAG}"
+  MAJOR_MINOR="${TAG%.*}"
+  echo "${IMG}:${TAG},${IMG}:${MAJOR_MINOR}"
+
+elif [[ $GITHUB_REF == refs/tags/* ]]; then
+  # Any other tag, which will not be pushed.
+  TAG="$(echo "${GITHUB_REF#refs/tags/}" | sed -r 's|/+|-|g')-local"
+  echo "${IMG}:${TAG}"
+
+elif [[ $GITHUB_REF == refs/heads/* ]]; then
+  # Branch build.
+  TAG="$(echo "${GITHUB_REF#refs/heads/}" | sed -r 's|/+|-|g')"
+  echo "${IMG}:${TAG}"
+
+elif [[ $GITHUB_REF == refs/pull/* ]]; then
+  # PR build.
+  TAG="pr-$(echo "${GITHUB_REF}" | sed -E 's|refs/pull/([^/]+)/?.*|\1|')"
+  echo "${IMG}:${TAG}"
+fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,9 +13,12 @@ jobs:
         with:
           fetch-depth: 0
       - id: check_docs_only
+        # Since PR's are squashed prior to merging to the branch checked out (default branch),
+        # HEAD^ will resolve to the previous point in history.
         run: |
-          REPO_MASTER_REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip-tests::$(hack/ci/check-doc-only-update.sh $REPO_MASTER_REF)"
+          REF="HEAD^"
+          [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
+          echo "::set-output name=skip-deploy::$(hack/ci/check-doc-only-update.sh $REF)"
 
   integration:
     name: integration

--- a/.github/workflows/test-ansible.yml
+++ b/.github/workflows/test-ansible.yml
@@ -13,9 +13,12 @@ jobs:
         with:
           fetch-depth: 0
       - id: check_docs_only
+        # Since PR's are squashed prior to merging to the branch checked out (default branch),
+        # HEAD^ will resolve to the previous point in history.
         run: |
-          REPO_MASTER_REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip-tests::$(hack/ci/check-doc-only-update.sh $REPO_MASTER_REF)"
+          REF="HEAD^"
+          [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
+          echo "::set-output name=skip-deploy::$(hack/ci/check-doc-only-update.sh $REF)"
 
   e2e:
     name: e2e

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -13,9 +13,12 @@ jobs:
         with:
           fetch-depth: 0
       - id: check_docs_only
+        # Since PR's are squashed prior to merging to the branch checked out (default branch),
+        # HEAD^ will resolve to the previous point in history.
         run: |
-          REPO_MASTER_REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip-tests::$(hack/ci/check-doc-only-update.sh $REPO_MASTER_REF)"
+          REF="HEAD^"
+          [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
+          echo "::set-output name=skip-deploy::$(hack/ci/check-doc-only-update.sh $REF)"
 
   e2e:
     name: e2e

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -13,9 +13,12 @@ jobs:
         with:
           fetch-depth: 0
       - id: check_docs_only
+        # Since PR's are squashed prior to merging to the branch checked out (default branch),
+        # HEAD^ will resolve to the previous point in history.
         run: |
-          REPO_MASTER_REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip-tests::$(hack/ci/check-doc-only-update.sh $REPO_MASTER_REF)"
+          REF="HEAD^"
+          [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
+          echo "::set-output name=skip-deploy::$(hack/ci/check-doc-only-update.sh $REF)"
 
   e2e:
     name: e2e

--- a/.github/workflows/test-sanity.yml
+++ b/.github/workflows/test-sanity.yml
@@ -13,9 +13,12 @@ jobs:
       with:
         fetch-depth: 0
     - id: check_docs_only
+      # Since PR's are squashed prior to merging to the branch checked out (default branch),
+      # HEAD^ will resolve to the previous point in history.
       run: |
-        REPO_MASTER_REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-        echo "::set-output name=skip-tests::$(hack/ci/check-doc-only-update.sh $REPO_MASTER_REF)"
+        REF="HEAD^"
+        [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
+        echo "::set-output name=skip-deploy::$(hack/ci/check-doc-only-update.sh $REF)"
 
   sanity:
     name: sanity

--- a/images/scorecard-test-kuttl/main.go
+++ b/images/scorecard-test-kuttl/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	jsonOutput, err := json.MarshalIndent(s, "", "    ")
 	if err != nil {
-		printErrorStatus(fmt.Errorf("could not marshal scoreard output %v", err))
+		printErrorStatus(fmt.Errorf("could not marshal scorecard output %v", err))
 		return
 	}
 	fmt.Println(string(jsonOutput))

--- a/release/Makefile
+++ b/release/Makefile
@@ -7,7 +7,8 @@ SHELL = /bin/bash
 # Dry run flags.
 ifneq ($(DRY_RUN),)
 SNAPSHOT_FLAGS = --snapshot --skip-publish --skip-sign --rm-dist
-$(shell touch changelog/generated/$(GIT_VERSION).md)
+CHANGELOG = changelog/generated/tmp.md
+$(shell touch $(CHANGELOG))
 endif
 
 # Ensure that this Makefile is run from the project root (always contains the 'cmd/' directory).
@@ -18,14 +19,15 @@ endif
 ##@ Release
 
 .PHONY: release
+CHANGELOG ?= changelog/generated/$(GIT_VERSION).md
 release: ## Publish an operator-sdk release, with option for a dry run with DRY_RUN.
 ifeq (,$(GIT_VERSION))
 	$(error "GIT_VERSION must be set to a git tag")
 endif
 	$(SCRIPTS_DIR)/fetch goreleaser 0.147.2
-	GORELEASER_CURRENT_TAG=$(GIT_VERSION) $(TOOLS_DIR)/goreleaser $(SNAPSHOT_FLAGS) --release-notes=changelog/generated/$(GIT_VERSION).md --parallelism 5
+	GORELEASER_CURRENT_TAG=$(GIT_VERSION) $(TOOLS_DIR)/goreleaser $(SNAPSHOT_FLAGS) --release-notes=$(CHANGELOG) --parallelism 5
 ifneq ($(DRY_RUN),)
-	rm changelog/generated/$(GIT_VERSION).md
+	rm $(CHANGELOG)
 endif
 
 ##@ Pre-Release

--- a/release/Makefile
+++ b/release/Makefile
@@ -49,7 +49,7 @@ changelog: check_release_version ## Generate the changelog.
 	rm -f ./changelog/fragments/!(00-template.yaml)
 
 .PHONY: tag
-VERSION_REGEXP := ^v[0-9]+\.[0-9]+\.[0-9]+(\-(alpha|beta|rc)\.[0-9]+)?$
+VERSION_REGEXP := ^(scorecard-kuttl/)?v[0-9]+\.[0-9]+\.[0-9]+(\-(alpha|beta|rc)\.[0-9]+)?$
 tag: ## Create a release tag.
 ifeq (,$(RELEASE_VERSION))
 	$(error "RELEASE_VERSION must be set to tag HEAD")

--- a/website/content/en/docs/contribution-guidelines/releasing.md
+++ b/website/content/en/docs/contribution-guidelines/releasing.md
@@ -7,6 +7,13 @@ weight: 30
 These steps describe how to conduct a release of the operator-sdk repo using example versions.
 Replace these versions with the current and new version you are releasing, respectively.
 
+Table of contents:
+
+- [Major and minor releases](#major-and-minor-releases)
+- [Patch releases](#patch-releases)
+- [`scorecard-test-kuttl` image releases](#scorecard-test-kuttl-image-releases)
+- [Release tips](#helpful-tips-and-information)
+
 ## Prerequisites
 
 - [`git`](https://git-scm.com/downloads)
@@ -54,15 +61,16 @@ correctly prior to the release commit.
 Create a new branch to push the release commit:
 
 ```sh
+export RELEASE_VERSION=v1.3.0
 git checkout master
 git pull
-git checkout -b release-v1.3.0
+git checkout -b release-$RELEASE_VERSION
 ```
 
 Run the pre-release `make` target:
 
 ```sh
-make prerelease RELEASE_VERSION=v1.3.0
+make prerelease
 ```
 
 The following changes should be present:
@@ -76,8 +84,8 @@ Commit these changes and push:
 
 ```sh
 git add --all
-git commit -m "Release v1.3.0"
-git push -u origin release-v1.3.0
+git commit -m "Release $RELEASE_VERSION"
+git push -u origin release-$RELEASE_VERSION
 ```
 
 ### 2. Create and merge a new PR
@@ -92,8 +100,8 @@ Unlock the branch by changing the number of required approving reviewers in the 
 ### 4. Create and push a release tag
 
 ```sh
-make tag RELEASE_VERSION=v1.3.0
-git push upstream v1.3.0
+make tag
+git push upstream refs/tags/$RELEASE_VERSION
 ```
 
 ### 5. Fast-forward the `latest` and release branches
@@ -103,7 +111,7 @@ Run the following commands to do so:
 
 ```sh
 git checkout latest
-git reset --hard tags/v1.3.0
+git reset --hard tags/$RELEASE_VERSION
 git push -f upstream latest
 ```
 
@@ -111,7 +119,7 @@ Similarly, to update the release branch, run:
 
 ```sh
 git checkout v1.3.x
-git reset --hard tags/v1.3.0
+git reset --hard tags/$RELEASE_VERSION
 git push -f upstream v1.3.x
 ```
 
@@ -145,15 +153,16 @@ Create a new branch from the release branch, which should already exist for the 
 to push the release commit to:
 
 ```sh
+export RELEASE_VERSION=v1.3.1
 git checkout v1.3.x
 git pull
-git checkout -b release-v1.3.1
+git checkout -b release-$RELEASE_VERSION
 ```
 
 Run the pre-release `make` target:
 
 ```sh
-make prerelease RELEASE_VERSION=v1.3.1
+make prerelease
 ```
 
 The following changes should be present:
@@ -165,8 +174,8 @@ Commit these changes and push:
 
 ```sh
 git add --all
-git commit -m "Release v1.3.1"
-git push -u origin release-v1.3.1
+git commit -m "Release $RELEASE_VERSION"
+git push -u origin release-$RELEASE_VERSION
 ```
 
 ### 2. Create and merge a new PR
@@ -181,8 +190,8 @@ Unlock the branch by changing the number of required approving reviewers in the 
 ### 4. Create and push a release tag
 
 ```sh
-make tag RELEASE_VERSION=v1.3.1
-git push upstream v1.3.1
+make tag
+git push upstream refs/tags/$RELEASE_VERSION
 ```
 
 ### 5. Fast-forward the `latest` branch
@@ -192,7 +201,7 @@ Run the following commands to do so:
 
 ```sh
 git checkout latest
-git reset --hard tags/v1.3.1
+git reset --hard tags/$RELEASE_VERSION
 git push -f upstream latest
 ```
 
@@ -208,7 +217,28 @@ In case there are non-transient errors while building the release job, you must:
 2. Fix what broke in the release branch.
 3. Re-run the release with an incremented minor version to avoid Go module errors (ex. if v1.3.1 broke, then re-run the release as v1.3.2). Patch versions are cheap so this is not a big deal.
 
-## Further reading
+## `scorecard-test-kuttl` image releases
+
+The `quay.io/operator-framework/scorecard-test-kuttl` image is released separately from other images because it
+contains the [`kudobuilder/kuttl`](https://hub.docker.com/r/kudobuilder/kuttl/tags) image, which is subject to breaking changes.
+
+Release tags of this image are of the form: `scorecard-kuttl/vX.Y.Z`, where `X.Y.Z` is _not_ the current operator-sdk version.
+For the latest version, query the [operator-sdk repo tags](https://github.com/operator-framework/operator-sdk/tags) for `scorecard-kuttl/v`.
+
+The only step required is to create and push a tag.
+This example uses version `v2.0.0`, the first independent release version of this image:
+
+```sh
+export RELEASE_VERSION=scorecard-kuttl/v2.0.0
+make tag
+git push upstream refs/tags/$RELEASE_VERSION
+```
+
+The [`deploy/image-scorecard-test-kuttl`](https://github.com/operator-framework/operator-sdk/actions/workflows/deploy.yml)
+Action workflow will build and push this image.
+
+
+## Helpful tips and information
 
 ### Binaries and signatures
 


### PR DESCRIPTION
**Description of the change:**
- .github/workflows: release scorecard-test-kuttl images on `scorecard-kuttl/v*` tags, and only run image deploy jobs for code changes and appropriate tag patterns

**Motivation for the change:** breaking changes to kuttl happen, and the accepted solution is to version the scorecard-test-kuttl version independently, starting at v2.0.0 (see #4557 for details). Releases will be tagged with `scorecard-kuttl/vX.Y.Z`. operator-sdk releases will still have tags like `vA.B.C`, but will not cause scorecard-test-kuttl images to be published.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
