### PR TITLE
docs: remove redundancy in Go migration, discuss service account in scope doc

### DIFF
--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -228,7 +228,7 @@ See the complete migrated `memcached_controller.go` code [here][memcached_contro
 
 **Note:** The version of [controller-runtime][controller-runtime] used in the projects scaffolded by SDK `0.19.x+` was `v0.6.0`. Please check [sigs.k8s.io/controller-runtime release docs from 0.7.0+ version][controller-runtime] for breaking changes.
 
-##### Updating your ServiceAccount in Go operator projects
+##### Updating your ServiceAccount
 
 New Go projects come with a ServiceAccount `controller-manager` in `config/rbac/service_account.yaml`.
 Your project's RoleBinding and ClusterRoleBinding subjects, and Deployment's `spec.template.spec.serviceAccountName`


### PR DESCRIPTION
**Description of the change:**
- docs/building-operators/golang: remove redundant info in migration guide, discuss service account in scope guide

**Motivation for the change:** non-default service account support was added in #4626. This PR adds follow-up docs and corrects docs added in that PR

/kind documentation

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
