### PR TITLE
doc: align ansible/helm migration guides with go

### DIFF
--- a/website/content/en/docs/building-operators/ansible/migration.md
+++ b/website/content/en/docs/building-operators/ansible/migration.md
@@ -1,14 +1,15 @@
 ---
-link: Migrating pre-v1.0.0 Projects
-linkTitle: Migrating pre-v1.0.0 Projects
-weight: 6
-description: Instructions for migrating a Ansible-based project built prior to v1.0.0 to use the new Kubebuilder-style layout.
+link: Migrating Projects from pre-v1.0.0 to the latest release
+linkTitle: Migrating from pre-v1.0.0 to latest
+weight: 200
+description: Instructions for migrating an Ansible-based operator built prior to `v1.0.0` to use a Kubebuilder-style.
 ---
 
 ## Overview
 
-The motivations for the new layout are related to bringing more flexibility to users and
-part of the process to [Integrating Kubebuilder and Operator SDK][integration-doc].
+The v1.0 release improves upon prior `operator-sdk` releases with a new project structure and CLI, each of which enhances project extensibility and customizability. These design changes are influenced by [`kubebuilder`](https://book.kubebuilder.io/).
+
+**Note:** It is recommended that you have your project upgraded to the latest SDK release version (0.19.x+) before following the steps in this guide to migrate to the new layout. However, the steps might work from previous versions as well. In this case, if you find an issue which is not covered here then check the previous [Migration Guides][migration-doc] which might help out.
 
 ### What was changed
 
@@ -28,10 +29,17 @@ Scaffolded projects now use:
 - [kustomize][kustomize] to manage Kubernetes resources needed to deploy your operator
 - A `Makefile` with helpful targets for build, test, and deployment, and to give you flexibility to tailor things to your project's needs
 - Updated metrics configuration using [kube-auth-proxy][kube-auth-proxy], a `--metrics-addr` flag, and [kustomize][kustomize]-based deployment of a Kubernetes `Service` and prometheus operator `ServiceMonitor`
+- Preliminary support for CLI plugins. For more info see the [plugins design document][plugins-phase1-design-doc]
+- A `PROJECT` configuration file to store information about GVKs, plugins, and help the CLI make decisions.
+
+Generated files with the default API versions:
+
+- `apiextensions/v1` for generated CRDs (`apiextensions/v1beta1` was deprecated in Kubernetes `1.16` and will be removed in `1.22`)
+- `admissionregistration.k8s.io/v1` for webhooks (`admissionregistration.k8s.io/v1beta1` was deprecated in Kubernetes `1.16` and will be removed in `1.22` )
 
 ## How to migrate
 
-The easy migration path is to a project from the scratch and let the tool scaffold the new layout. Then, add your customizations and implementations. See below for an example.
+The easy migration path is to initialize a new project, re-recreate APIs, then copy pre-v1.0.0 configuration files into the new project.
 
 ### Creating a new project
 
@@ -239,3 +247,4 @@ E.g `$ kubectl logs deployment.apps/memcached-operator-controller-manager -n mem
 [marker]: https://book.kubebuilder.io/reference/markers.html?highlight=markers#marker-syntax
 [molecule]: https://molecule.readthedocs.io/en/latest/#
 [testing-guide]: /docs/building-operators/ansible/testing-guide
+[migration-doc]: /docs/upgrading-sdk-version/

--- a/website/content/en/docs/building-operators/ansible/testing-guide.md
+++ b/website/content/en/docs/building-operators/ansible/testing-guide.md
@@ -7,7 +7,7 @@ weight: 4
 ## Getting started
 
 ### Requirements
-To begin, you sould have:
+To begin, you should have:
 
 - The latest version of the [operator-sdk](https://github.com/operator-framework/operator-sdk) installed.
 - Docker installed and running

--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -7,7 +7,10 @@ description: Instructions for migrating a Go-based project built prior to `v1.0.
 
 ## Overview
 
-The motivation for the new layout is to [integrate Kubebuilder and Operator SDK][integration-doc] based projects. This enables Kubebuilder based projects to use the features provided by Operator SDK. For further information behind this motivation, check [the differences between Kubebuilder and Operator-SDK][what-are-the-the-differences-between-kubebuilder-and-operator-sdk].
+
+The v1.0 release improves upon prior `operator-sdk` releases with a new project structure and CLI, each of which enhances project extensibility and customizability. These design changes are influenced by [`kubebuilder`](https://book.kubebuilder.io/).
+
+**Note:** It is recommended that you have your project upgraded to the latest SDK release version (0.19.x+) before following the steps in this guide to migrate to the new layout. However, the steps might work from previous versions as well. In this case, if you find an issue which is not covered here then check the previous [Migration Guides][migration-doc] which might help out.
 
 ### What was changed
 
@@ -23,34 +26,25 @@ The motivation for the new layout is to [integrate Kubebuilder and Operator SDK]
 
 ### What is new
 
-Projects are now scaffold using:
+Scaffolded projects now use:
 
 - [kustomize][kustomize] to manage Kubernetes resources needed to deploy your operator
 - A `Makefile` with helpful targets to build, test, deploy and tailor things based on your project needs
 - Helpers and options to work with webhooks. For further information see [What is a Webhook?][webhook-doc]
 - Updated metrics configuration using [kube-auth-proxy][kube-auth-proxy], a `--metrics-addr` flag, and [kustomize][kustomize]-based deployment of a Kubernetes `Service` and prometheus operator `ServiceMonitor`
 - Scaffolded tests that use the [`envtest`][envtest] test framework
-- A preliminary support for plugins. For more info see the [extensible CLI and scaffolding plugins design document][plugins-phase1-design-doc]
-- A PROJECT file which stores more information about the resources in use, to enable plugins make useful decisions while scaffolding
-- Liveness and Readiness probes using [`healthz.Ping`][healthz-ping].
+- Preliminary support for CLI plugins. For more info see the [plugins design document][plugins-phase1-design-doc]
+- A `PROJECT` configuration file to store information about GVKs, plugins, and help the CLI make decisions.
 - A new option to create projects using ComponentConfig. For more info, see [enhancement proposal][enhancement proposal] and the [Component config tutorial][component-config-tutorial]
 - Go version `1.15` (previously it was `1.13`).
 
 Generated files with the default API versions:
 
-- `apiextensions/v1` for generated CRDs (`apiextensions/v1beta1` was deprecated in Kubernetes `1.16`)
-- `admissionregistration.k8s.io/v1` for webhooks (`admissionregistration.k8s.io/v1beta1` was deprecated in Kubernetes `1.16`)
+- `apiextensions/v1` for generated CRDs (`apiextensions/v1beta1` was deprecated in Kubernetes `1.16` and will be removed in `1.22`)
+- `admissionregistration.k8s.io/v1` for webhooks (`admissionregistration.k8s.io/v1beta1` was deprecated in Kubernetes `1.16` and will be removed in `1.22` )
 - `cert-manager.io/v1` for the certificate manager when webhooks are used (`cert-manager.io/v1alpha2` was deprecated in `Cert-Manager 0.14`. More info: [CertManager v1.0 docs][cert-manager-docs])
 
 **NOTE** You can still use the deprecated APIs which are only needed to support Kubernetes `1.15` and earlier.
-
-## Migration Steps
-
-The most straightforward migration path is to:
-1. Create a new project from scratch to let `operator-sdk` scaffold the new project.
-2. Copy your existing code and configuration into the new project structure.
-
-**Note:** It is recommended that you have your project upgraded to the latest SDK release version (0.19.x+) before following the steps in this guide to migrate to new layout.
 
 Please ensure that you have read [Can I customize the projects generated with SDK tool?][faq-custom] in the [FAQ][faq] before continuing further.
 
@@ -442,3 +436,4 @@ E.g `kubectl logs deployment.apps/memcached-operator-controller-manager -n memca
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime/releases
 [component-config-tutorial]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/docs/book/src/component-config-tutorial/tutorial.md
 [plugins-phase1-design-doc]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/extensible-cli-and-scaffolding-plugins-phase-1.md
+[migration-doc]: /docs/upgrading-sdk-version/

--- a/website/content/en/docs/building-operators/helm/migration.md
+++ b/website/content/en/docs/building-operators/helm/migration.md
@@ -1,14 +1,15 @@
 ---
-link: Migrating pre-v1.0.0 Projects
-linkTitle: Migrating pre-v1.0.0 Projects
-weight: 300
-description: Instructions for migrating a Helm-based project built prior to v1.0.0 to use the new Kubebuilder-style layout.
+link: Migrating Projects from pre-v1.0.0 to the latest release
+linkTitle: Migrating from pre-v1.0.0 to latest
+weight: 200
+description: Instructions for migrating an Helm-based operator built prior to `v1.0.0` to use a Kubebuilder-style.
 ---
 
 ## Overview
 
-The motivations for the new layout are related to bringing more flexibility to users and
-part of the process to [Integrating Kubebuilder and Operator SDK][integration-doc].
+The v1.0 release improves upon prior `operator-sdk` releases with a new project structure and CLI, each of which enhances project extensibility and customizability. These design changes are influenced by [`kubebuilder`](https://book.kubebuilder.io/).
+
+**Note:** It is recommended that you have your project upgraded to the latest SDK release version (0.19.x+) before following the steps in this guide to migrate to the new layout. However, the steps might work from previous versions as well. In this case, if you find an issue which is not covered here then check the previous [Migration Guides][migration-doc] which might help out.
 
 ### What was changed
 
@@ -22,16 +23,22 @@ part of the process to [Integrating Kubebuilder and Operator SDK][integration-do
 
 ### What is new
 
-Projects are now scaffold using:
+Scaffolded projects now use:
 
 - [kustomize][kustomize] to manage Kubernetes resources needed to deploy your operator
 - A `Makefile` with helpful targets for build, test, and deployment, and to give you flexibility to tailor things to your project's needs
 - Updated metrics configuration using [kube-auth-proxy][kube-auth-proxy], a `--metrics-addr` flag, and [kustomize][kustomize]-based deployment of a Kubernetes `Service` and prometheus operator `ServiceMonitor`
+- Preliminary support for CLI plugins. For more info see the [plugins design document][plugins-phase1-design-doc]
+- A `PROJECT` configuration file to store information about GVKs, plugins, and help the CLI make decisions.
+
+Generated files with the default API versions:
+
+- `apiextensions/v1` for generated CRDs (`apiextensions/v1beta1` was deprecated in Kubernetes `1.16` and will be removed in `1.22`)
+- `admissionregistration.k8s.io/v1` for webhooks (`admissionregistration.k8s.io/v1beta1` was deprecated in Kubernetes `1.16` and will be removed in `1.22` )
 
 ## How to migrate
 
-The easy migration path is to create a new project from the scratch and let the tool scaffold the files properly and then,
-just replace with your customizations and implementations. Following an example.
+The easy migration path is to initialize a new project, re-recreate APIs, then copy pre-v1.0.0 configuration files into the new project.
 
 ### Creating a new project
 
@@ -151,3 +158,4 @@ Finally, follow the steps in the ["run the Operator"][run-the-operator] section 
 [kube-auth-proxy]: https://github.com/brancz/kube-rbac-proxy
 [metrics]: https://book.kubebuilder.io/reference/metrics.html?highlight=metr#metrics
 [marker]: https://book.kubebuilder.io/reference/markers.html?highlight=markers#marker-syntax
+[migration-doc]: /docs/upgrading-sdk-version/


### PR DESCRIPTION
**Description of the change:**
Align/Fix the Helm/Asible migration guides 

**Motivation for the change:**

Follow up of #4392 and https://github.com/operator-framework/operator-sdk/pull/4536


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
