### PR TITLE
actions(deploy-manual): use commit as ansible-operator-base tag

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -3,8 +3,8 @@ name: deploy-manual
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: ansible-operator-base image tag, ex. "v1.2.3-10-g6e1b47e6ca7c507b8ecf197a8edcd412dd64d85d"
+      ansible_operator_base_tag:
+        description: ansible-operator-base image tag, ex. "6e1b47e6ca7c507b8ecf197a8edcd412dd64d85d"
         required: false
 
 jobs:
@@ -30,7 +30,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
     - name: create tag
       id: tag
@@ -39,7 +39,7 @@ jobs:
         IMG=quay.io/${{ github.repository_owner }}/ansible-operator-base
         TAG="${{ github.event.inputs.tag }}"
         if [[ "$TAG" == "" ]]; then
-          TAG=$(git describe --tags --always --dirty --long --abbrev=100)
+          TAG=$(git rev-parse HEAD)
         fi
         echo ::set-output name=tag::${IMG}:${TAG}
 


### PR DESCRIPTION
**Description of the change:**
- .github/workflows/deploy-manual.yml: specify ansible_operator_base_tag as input, use only HEAD commit hash as default tag

**Motivation for the change:** Now that the operator-sdk is a monorepo with multiple tags, ex. `scorecard-kuttl/vX.Y.Z`, ansible-operator-base tags containing git tag data don't make sense. Instead, a commit should be used.

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
