### PR TITLE
ansible/helm : align flags and deprecate the old ones

### DIFF
--- a/changelog/fragments/ansible-helm-flags.yaml
+++ b/changelog/fragments/ansible-helm-flags.yaml
@@ -1,0 +1,109 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      (ansible/v1, helm/v1) The flags `--enable-leader-election` and `--metrics-addr` were deprecated in favor of `--leader-elect` and `--metrics-bind-address`, respectively, to follow upstream conventions.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "deprecation"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: (helm/v1) Replace deprecated leader election and metrics address flags
+      body: >
+        Replace deprecated flags `--enable-leader-election` and `--metrics-addr` with `--leader-elect` and `--metrics-bind-address`, respectively.
+  - description: >
+      (helm/v1) Explicitly set `--health-probe-bind-address` in the manager's auth proxy patch.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: (helm/v1) Explicitly set `--health-probe-bind-address` in the manager's auth proxy patch.
+      body: >
+        Add the arg `--health-probe-bind-address=:8081` to the `config/default/manager_auth_proxy_patch.yaml`:
+        ```yaml
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
+        ```
+  - description: >
+      (ansible/v1) Explicitly set `--health-probe-bind-address` in the manager's auth proxy patch.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: (ansible/v1) Explicitly set `--health-probe-bind-address` in the manager's auth proxy patch.
+      body: >
+        Add the arg `--health-probe-bind-address=:8081` to the `config/default/manager_auth_proxy_patch.yaml`:
+        ```yaml
+        - "--health-probe-bind-address=:6789"
+        - "--metrics-bind-address=127.0.0.1:6789"
+        - "--leader-elect"
+        ```
+
+
+
+
+
+

--- a/hack/generate/samples/internal/ansible/advanced_molecule.go
+++ b/hack/generate/samples/internal/ansible/advanced_molecule.go
@@ -178,7 +178,7 @@ func (ma *AdvancedMolecule) updateConfig() {
         - "--ansible-args='--vault-password-file /opt/ansible/pwd.yml'"`
 	err = kbtestutils.InsertCode(
 		filepath.Join(ma.ctx.Dir, "config", "default", "manager_auth_proxy_patch.yaml"),
-		"- \"--enable-leader-election\"",
+		"- \"--leader-elect\"",
 		managerAuthArgs)
 	pkg.CheckError("adding vaulting args to the proxy auth", err)
 

--- a/internal/ansible/flags/flag.go
+++ b/internal/ansible/flags/flag.go
@@ -26,12 +26,12 @@ type Flags struct {
 	ReconcilePeriod         time.Duration
 	WatchesFile             string
 	InjectOwnerRef          bool
-	EnableLeaderElection    bool
+	LeaderElection          bool
 	MaxConcurrentReconciles int
 	AnsibleVerbosity        int
 	AnsibleRolesPath        string
 	AnsibleCollectionsPath  string
-	MetricsAddress          string
+	MetricsBindAddress      string
 	ProbeAddr               string
 	LeaderElectionID        string
 	LeaderElectionNamespace string
@@ -79,8 +79,15 @@ func (f *Flags) AddTo(flagSet *pflag.FlagSet) {
 		"",
 		"Path to installed Ansible Collections. If set, collections should be located in {{value}}/ansible_collections/. If unset, collections are assumed to be in ~/.ansible/collections or /usr/share/ansible/collections.",
 	)
-	flagSet.StringVar(&f.MetricsAddress,
+	// todo:remove it for 2.0.0
+	flagSet.StringVar(&f.MetricsBindAddress,
 		"metrics-addr",
+		":8080",
+		"The address the metric endpoint binds to",
+	)
+	_ = flagSet.MarkDeprecated("metrics-addr", "use --metrics-bind-address instead")
+	flagSet.StringVar(&f.MetricsBindAddress,
+		"metrics-bind-address",
 		":8080",
 		"The address the metric endpoint binds to",
 	)
@@ -92,8 +99,16 @@ func (f *Flags) AddTo(flagSet *pflag.FlagSet) {
 		":6789",
 		"The address the probe endpoint binds to.",
 	)
-	flagSet.BoolVar(&f.EnableLeaderElection,
+	// todo:remove it for 2.0.0
+	flagSet.BoolVar(&f.LeaderElection,
 		"enable-leader-election",
+		false,
+		"Enable leader election for controller manager. Enabling this will"+
+			" ensure there is only one active controller manager.",
+	)
+	_ = flagSet.MarkDeprecated("enable-leader-election", "use --leader-elect instead")
+	flagSet.BoolVar(&f.LeaderElection,
+		"leader-elect",
 		false,
 		"Enable leader election for controller manager. Enabling this will"+
 			" ensure there is only one active controller manager.",

--- a/internal/cmd/ansible-operator/run/cmd.go
+++ b/internal/cmd/ansible-operator/run/cmd.go
@@ -15,6 +15,7 @@
 package run
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -99,12 +100,23 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 		}
 	}
 
+	//todo: remove the following checks for 2.0.0 they are required just because of the flags deprecation
+	if cmd.Flags().Changed("leader-elect") && cmd.Flags().Changed("enable-leader-election") {
+		log.Error(errors.New("only one of --leader-elect and --enable-leader-election may be set"), "invalid flags usage")
+		os.Exit(1)
+	}
+
+	if cmd.Flags().Changed("metrics-addr") && cmd.Flags().Changed("metrics-bind-address") {
+		log.Error(errors.New("only one of --metrics-addr and --metrics-bind-address may be set"), "invalid flags usage")
+		os.Exit(1)
+	}
+
 	// Set default manager options
 	// TODO: probably should expose the host & port as an environment variables
 	options := manager.Options{
-		MetricsBindAddress:         f.MetricsAddress,
+		MetricsBindAddress:         f.MetricsBindAddress,
 		HealthProbeBindAddress:     f.ProbeAddr,
-		LeaderElection:             f.EnableLeaderElection,
+		LeaderElection:             f.LeaderElection,
 		LeaderElectionID:           f.LeaderElectionID,
 		LeaderElectionResourceLock: resourcelock.ConfigMapsResourceLock,
 		LeaderElectionNamespace:    f.LeaderElectionNamespace,

--- a/internal/helm/flags/flag.go
+++ b/internal/helm/flags/flag.go
@@ -25,8 +25,8 @@ import (
 type Flags struct {
 	ReconcilePeriod         time.Duration
 	WatchesFile             string
-	MetricsAddress          string
-	EnableLeaderElection    bool
+	MetricsBindAddress      string
+	LeaderElection          bool
 	LeaderElectionID        string
 	LeaderElectionNamespace string
 	MaxConcurrentReconciles int
@@ -45,20 +45,39 @@ func (f *Flags) AddTo(flagSet *pflag.FlagSet) {
 		"./watches.yaml",
 		"Path to the watches file to use",
 	)
-	flagSet.StringVar(&f.MetricsAddress,
+	// todo:remove it for 2.0.0
+	flagSet.StringVar(&f.MetricsBindAddress,
 		"metrics-addr",
 		":8080",
 		"The address the metric endpoint binds to",
 	)
+	_ = flagSet.MarkDeprecated("metrics-addr", "use --metrics-bind-address instead")
+	flagSet.StringVar(&f.MetricsBindAddress,
+		"metrics-bind-address",
+		":8080",
+		"The address the metric endpoint binds to",
+	)
+	// todo: for Go/Helm the port used is: 8081
+	// update it to keep the project aligned to the other
+	// types for 2.0
 	flagSet.StringVar(&f.ProbeAddr,
 		"health-probe-bind-address",
 		":8081",
 		"The address the probe endpoint binds to.",
 	)
-	flagSet.BoolVar(&f.EnableLeaderElection,
+	// todo:remove it for 2.0.0
+	flagSet.BoolVar(&f.LeaderElection,
 		"enable-leader-election",
 		false,
-		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.",
+		"Enable leader election for controller manager. Enabling this will"+
+			" ensure there is only one active controller manager.",
+	)
+	_ = flagSet.MarkDeprecated("enable-leader-election", "use --leader-elect instead.")
+	flagSet.BoolVar(&f.LeaderElection,
+		"leader-elect",
+		false,
+		"Enable leader election for controller manager. Enabling this will"+
+			" ensure there is only one active controller manager.",
 	)
 	flagSet.StringVar(&f.LeaderElectionID,
 		"leader-election-id",
@@ -68,7 +87,9 @@ func (f *Flags) AddTo(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&f.LeaderElectionNamespace,
 		"leader-election-namespace",
 		"",
-		"Namespace in which to create the leader election configmap for holding the leader lock (required if running locally with leader election enabled).",
+		"Namespace in which to create the leader election configmap for"+
+			" holding the leader lock (required if running locally with leader"+
+			" election enabled).",
 	)
 	flagSet.IntVar(&f.MaxConcurrentReconciles,
 		"max-concurrent-reconciles",

--- a/internal/plugins/ansible/v1/scaffolds/init.go
+++ b/internal/plugins/ansible/v1/scaffolds/init.go
@@ -100,11 +100,11 @@ func (s *initScaffolder) Scaffold() error {
 		&prometheus.Kustomization{},
 		&prometheus.ServiceMonitor{},
 
-		&manager.Manager{Image: imageName},
+		&manager.Config{Image: imageName},
 		&manager.Kustomization{},
 
-		&kdefault.Kustomize{},
-		&kdefault.AuthProxyPatch{},
+		&kdefault.Kustomization{},
+		&kdefault.ManagerAuthProxyPatch{},
 
 		&roles.Placeholder{},
 		&playbooks.Placeholder{},

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -23,16 +23,16 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/file"
 )
 
-var _ file.Template = &Kustomize{}
+var _ file.Template = &Kustomization{}
 
-// Kustomize scaffolds the Kustomization file for the default overlay
-type Kustomize struct {
+// Kustomization scaffolds a file that defines the kustomization scheme for the default overlay folder
+type Kustomization struct {
 	file.TemplateMixin
 	file.ProjectNameMixin
 }
 
-// SetTemplateDefaults implements input.Template
-func (f *Kustomize) SetTemplateDefaults() error {
+// SetTemplateDefaults implements file.Template
+func (f *Kustomization) SetTemplateDefaults() error {
 	if f.Path == "" {
 		f.Path = filepath.Join("config", "default", "kustomization.yaml")
 	}
@@ -66,8 +66,8 @@ bases:
 #- ../prometheus
 
 patchesStrategicMerge:
-  # Protect the /metrics endpoint by putting it behind auth.
-  # If you want your controller-manager to expose the /metrics
-  # endpoint w/o any authn/z, please comment the following line.
+# Protect the /metrics endpoint by putting it behind auth.
+# If you want your controller-manager to expose the /metrics
+# endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 `

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
@@ -23,17 +23,16 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/file"
 )
 
-var _ file.Template = &AuthProxyPatch{}
+var _ file.Template = &ManagerAuthProxyPatch{}
 
-// AuthProxyPatch scaffolds the patch file for enabling
-// prometheus metrics for manager Pod.
-type AuthProxyPatch struct {
+// ManagerAuthProxyPatch scaffolds a file that defines the patch that enables prometheus metrics for the manager
+type ManagerAuthProxyPatch struct {
 	file.TemplateMixin
 	file.ProjectNameMixin
 }
 
-// SetTemplateDefaults implements input.Template
-func (f *AuthProxyPatch) SetTemplateDefaults() error {
+// SetTemplateDefaults implements file.Template
+func (f *ManagerAuthProxyPatch) SetTemplateDefaults() error {
 	if f.Path == "" {
 		f.Path = filepath.Join("config", "default", "manager_auth_proxy_patch.yaml")
 	}
@@ -68,7 +67,8 @@ spec:
           name: https
       - name: manager
         args:
-        - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"
+        - "--health-probe-bind-address=:6789"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
         - "--leader-election-id={{ .ProjectName }}"
 `

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/config/manager/config.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/config/manager/config.go
@@ -23,10 +23,10 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/file"
 )
 
-var _ file.Template = &Manager{}
+var _ file.Template = &Config{}
 
-// Manager scaffolds yaml config for the manager.
-type Manager struct {
+// Config scaffolds a file that defines the namespace and the manager deployment
+type Config struct {
 	file.TemplateMixin
 	file.ProjectNameMixin
 
@@ -34,18 +34,18 @@ type Manager struct {
 	Image string
 }
 
-// SetTemplateDefaults implements input.Template
-func (f *Manager) SetTemplateDefaults() error {
+// SetTemplateDefaults implements file.Template
+func (f *Config) SetTemplateDefaults() error {
 	if f.Path == "" {
 		f.Path = filepath.Join("config", "manager", "manager.yaml")
 	}
 
-	f.TemplateBody = managerTemplate
+	f.TemplateBody = configTemplate
 
 	return nil
 }
 
-const managerTemplate = `apiVersion: v1
+const configTemplate = `apiVersion: v1
 kind: Namespace
 metadata:
   labels:
@@ -72,32 +72,28 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
-      - image: {{ .Image }}
-        args:
-        - "--enable-leader-election"
-        - "--leader-election-id={{ .ProjectName }}"
-        name: manager
-        securityContext:
-          allowPrivilegeEscalation: false
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          limits:
-            cpu: 100m
-            memory: 90Mi
-          requests:
-            cpu: 100m
-            memory: 60Mi
+        - name: manager
+          args:
+            - "--leader-elect"
+            - "--leader-election-id={{ .ProjectName }}"
+          env:
+            - name: ANSIBLE_GATHERING
+              value: explicit
+          image: {{ .Image }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 6789
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 6789
+            initialDelaySeconds: 5
+            periodSeconds: 10
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
 `

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/config/manager/kustomization.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/config/manager/kustomization.go
@@ -24,12 +24,12 @@ import (
 
 var _ file.Template = &Kustomization{}
 
-// Kustomization scaffolds the Kustomization file in manager folder.
+// Kustomization scaffolds a file that defines the kustomization scheme for the manager folder
 type Kustomization struct {
 	file.TemplateMixin
 }
 
-// SetTemplateDefaults implements input.Template
+// SetTemplateDefaults implements file.Template
 func (f *Kustomization) SetTemplateDefaults() error {
 	if f.Path == "" {
 		f.Path = filepath.Join("config", "manager", "kustomization.yaml")

--- a/internal/plugins/helm/v1/scaffolds/init.go
+++ b/internal/plugins/helm/v1/scaffolds/init.go
@@ -98,10 +98,10 @@ func (s *initScaffolder) Scaffold() error {
 		&rbac.ManagerRoleBinding{},
 		&rbac.ServiceAccount{},
 		&manager.Kustomization{},
-		&manager.Manager{Image: imageName},
+		&manager.Config{Image: imageName},
 		&prometheus.Kustomization{},
 		&prometheus.ServiceMonitor{},
-		&kdefault.AuthProxyPatch{},
+		&kdefault.ManagerAuthProxyPatch{},
 		&kdefault.Kustomization{},
 	)
 }

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -31,7 +31,7 @@ type Kustomization struct {
 	file.ProjectNameMixin
 }
 
-// SetTemplateDefaults implements input.Template
+// SetTemplateDefaults implements file.Template
 func (f *Kustomization) SetTemplateDefaults() error {
 	if f.Path == "" {
 		f.Path = filepath.Join("config", "default", "kustomization.yaml")
@@ -66,8 +66,8 @@ bases:
 #- ../prometheus
 
 patchesStrategicMerge:
-  # Protect the /metrics endpoint by putting it behind auth.
-  # If you want your controller-manager to expose the /metrics
-  # endpoint w/o any authn/z, please comment the following line.
+# Protect the /metrics endpoint by putting it behind auth.
+# If you want your controller-manager to expose the /metrics
+# endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 `

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
@@ -23,17 +23,16 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/file"
 )
 
-var _ file.Template = &AuthProxyPatch{}
+var _ file.Template = &ManagerAuthProxyPatch{}
 
-// AuthProxyPatch scaffolds the patch file for enabling
-// prometheus metrics for manager Pod.
-type AuthProxyPatch struct {
+// ManagerAuthProxyPatch scaffolds a file that defines the patch that enables prometheus metrics for the manager
+type ManagerAuthProxyPatch struct {
 	file.TemplateMixin
 	file.ProjectNameMixin
 }
 
-// SetTemplateDefaults implements input.Template
-func (f *AuthProxyPatch) SetTemplateDefaults() error {
+// SetTemplateDefaults implements file.Template
+func (f *ManagerAuthProxyPatch) SetTemplateDefaults() error {
 	if f.Path == "" {
 		f.Path = filepath.Join("config", "default", "manager_auth_proxy_patch.yaml")
 	}
@@ -68,7 +67,8 @@ spec:
           name: https
       - name: manager
         args:
-        - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
         - "--leader-election-id={{ .ProjectName }}"
 `

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/config/manager/kustomization.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/config/manager/kustomization.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,12 +24,12 @@ import (
 
 var _ file.Template = &Kustomization{}
 
-// Kustomization scaffolds the Kustomization file in manager folder.
+// Kustomization scaffolds a file that defines the kustomization scheme for the manager folder
 type Kustomization struct {
 	file.TemplateMixin
 }
 
-// SetTemplateDefaults implements input.Template
+// SetTemplateDefaults implements file.Template
 func (f *Kustomization) SetTemplateDefaults() error {
 	if f.Path == "" {
 		f.Path = filepath.Join("config", "manager", "kustomization.yaml")

--- a/test/e2e/ansible/suite_test.go
+++ b/test/e2e/ansible/suite_test.go
@@ -63,7 +63,7 @@ var _ = BeforeSuite(func() {
 
 	By("enabling debug logging in the manager")
 	err = testutils.ReplaceInFile(filepath.Join(tc.Dir, "config", "default", "manager_auth_proxy_patch.yaml"),
-		"- \"--enable-leader-election\"", "- \"--enable-leader-election\"\n        - \"--zap-log-level=2\"")
+		"- \"--leader-elect\"", "- \"--zap-log-level=2\"\n        - \"--leader-elect\"")
 	Expect(err).NotTo(HaveOccurred())
 
 	By("fetching the current-context")

--- a/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -117,8 +117,9 @@ spec:
                   name: https
                 resources: {}
               - args:
-                - --metrics-addr=127.0.0.1:8080
-                - --enable-leader-election
+                - --health-probe-bind-address=:6789
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
                 - --leader-election-id=memcached-operator
                 env:
                 - name: ANSIBLE_GATHERING

--- a/testdata/ansible/memcached-operator/config/default/kustomization.yaml
+++ b/testdata/ansible/memcached-operator/config/default/kustomization.yaml
@@ -20,7 +20,7 @@ bases:
 - ../prometheus
 
 patchesStrategicMerge:
-  # Protect the /metrics endpoint by putting it behind auth.
-  # If you want your controller-manager to expose the /metrics
-  # endpoint w/o any authn/z, please comment the following line.
+# Protect the /metrics endpoint by putting it behind auth.
+# If you want your controller-manager to expose the /metrics
+# endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml

--- a/testdata/ansible/memcached-operator/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/ansible/memcached-operator/config/default/manager_auth_proxy_patch.yaml
@@ -21,6 +21,7 @@ spec:
           name: https
       - name: manager
         args:
-        - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"
+        - "--health-probe-bind-address=:6789"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
         - "--leader-election-id=memcached-operator"

--- a/testdata/ansible/memcached-operator/config/manager/manager.yaml
+++ b/testdata/ansible/memcached-operator/config/manager/manager.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: manager
           args:
-            - "--enable-leader-election"
+            - "--leader-elect"
             - "--leader-election-id=memcached-operator"
           env:
             - name: ANSIBLE_GATHERING

--- a/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -205,8 +205,9 @@ spec:
                   name: https
                 resources: {}
               - args:
-                - --metrics-addr=127.0.0.1:8080
-                - --enable-leader-election
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
                 - --leader-election-id=memcached-operator
                 image: quay.io/example/memcached-operator:v0.0.1
                 livenessProbe:

--- a/testdata/helm/memcached-operator/config/default/kustomization.yaml
+++ b/testdata/helm/memcached-operator/config/default/kustomization.yaml
@@ -20,7 +20,7 @@ bases:
 - ../prometheus
 
 patchesStrategicMerge:
-  # Protect the /metrics endpoint by putting it behind auth.
-  # If you want your controller-manager to expose the /metrics
-  # endpoint w/o any authn/z, please comment the following line.
+# Protect the /metrics endpoint by putting it behind auth.
+# If you want your controller-manager to expose the /metrics
+# endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml

--- a/testdata/helm/memcached-operator/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/helm/memcached-operator/config/default/manager_auth_proxy_patch.yaml
@@ -21,6 +21,7 @@ spec:
           name: https
       - name: manager
         args:
-        - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
         - "--leader-election-id=memcached-operator"

--- a/testdata/helm/memcached-operator/config/manager/manager.yaml
+++ b/testdata/helm/memcached-operator/config/manager/manager.yaml
@@ -27,8 +27,8 @@ spec:
       containers:
       - image: controller:latest
         args:
-        - "--enable-leader-election"
-        - "--leader-election-id=memcached-operator"
+          - "--leader-elect"
+          - "--leader-election-id=memcached-operator"
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/website/content/en/docs/building-operators/ansible/migration.md
+++ b/website/content/en/docs/building-operators/ansible/migration.md
@@ -28,7 +28,7 @@ Scaffolded projects now use:
 
 - [kustomize][kustomize] to manage Kubernetes resources needed to deploy your operator
 - A `Makefile` with helpful targets for build, test, and deployment, and to give you flexibility to tailor things to your project's needs
-- Updated metrics configuration using [kube-auth-proxy][kube-auth-proxy], a `--metrics-addr` flag, and [kustomize][kustomize]-based deployment of a Kubernetes `Service` and prometheus operator `ServiceMonitor`
+- Updated metrics configuration using [kube-auth-proxy][kube-auth-proxy], a `--metrics-bind-address` flag, and [kustomize][kustomize]-based deployment of a Kubernetes `Service` and prometheus operator `ServiceMonitor`
 - Preliminary support for CLI plugins. For more info see the [plugins design document][plugins-phase1-design-doc]
 - A `PROJECT` configuration file to store information about GVKs, plugins, and help the CLI make decisions.
 
@@ -237,7 +237,7 @@ Note that the following environment variables are no longer used.
 If you are using metrics and would like to keep them exported you will need to configure
 it in the `config/default/kustomization.yaml`. Please see the [metrics][metrics] doc to know how you can perform this setup.
 
-The default port used by the metric endpoint binds to was changed from `:8383` to `:8080`. To continue using port `8383`, specify `--metrics-addr=:8383` when you start the operator.
+The default port used by the metric endpoint binds to was changed from `:8383` to `:8080`. To continue using port `8383`, specify `--metrics-bind-address=:8383` when you start the operator.
 
 ## Checking the changes
 

--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -253,7 +253,7 @@ func main() {
 
 In order to use the previous one ensure that you have the [operator-lib][operator-lib] as a dependency of your project.
 
-- The default port used by the metric endpoint binds to `:8080` from the previous `:8383`. To continue using port `8383`, specify `--metrics-addr=:8383` when you start the operator.
+- The default port used by the metric endpoint binds to `:8080` from the previous `:8383`. To continue using port `8383`, specify `--metrics-bind-address=:8383` when you start the operator.
 
 - `OPERATOR_NAME` and `POD_NAME` environment variables are no longer used. `OPERATOR_NAME` was used to define the name for a leader election config map. Operator authors should use the `LeaderElectionID` attribute from the [Manager Options][ctrl-options] which is hardcoded in `main.go`:
 

--- a/website/content/en/docs/building-operators/golang/operator-scope.md
+++ b/website/content/en/docs/building-operators/golang/operator-scope.md
@@ -200,7 +200,7 @@ spec:
   - command:
     - /manager
     args:
-    - --enable-leader-election
+    - --leader-elect
     image: controller:latest
     name: manager
     resources:

--- a/website/content/en/docs/building-operators/golang/references/logging.md
+++ b/website/content/en/docs/building-operators/golang/references/logging.md
@@ -175,8 +175,8 @@ spec:
           name: https
       - name: manager
         args:
-        - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"
         - "--zap-encoder=console"
         - "--zap-log-level=debug"
 ```

--- a/website/content/en/docs/building-operators/helm/migration.md
+++ b/website/content/en/docs/building-operators/helm/migration.md
@@ -27,7 +27,7 @@ Scaffolded projects now use:
 
 - [kustomize][kustomize] to manage Kubernetes resources needed to deploy your operator
 - A `Makefile` with helpful targets for build, test, and deployment, and to give you flexibility to tailor things to your project's needs
-- Updated metrics configuration using [kube-auth-proxy][kube-auth-proxy], a `--metrics-addr` flag, and [kustomize][kustomize]-based deployment of a Kubernetes `Service` and prometheus operator `ServiceMonitor`
+- Updated metrics configuration using [kube-auth-proxy][kube-auth-proxy], a `--metrics-bind-address` flag, and [kustomize][kustomize]-based deployment of a Kubernetes `Service` and prometheus operator `ServiceMonitor`
 - Preliminary support for CLI plugins. For more info see the [plugins design document][plugins-phase1-design-doc]
 - A `PROJECT` configuration file to store information about GVKs, plugins, and help the CLI make decisions.
 
@@ -154,7 +154,7 @@ Note that the following environment variables are no longer used.
 If you are using metrics and would like to keep them exported you will need to configure
 it in the `config/default/kustomization.yaml`. Please see the [metrics][metrics] doc to know how you can perform this setup.
 
-The default port used by the metric endpoint binds to was changed from `:8383` to `:8080`. To continue using port `8383`, specify `--metrics-addr=:8383` when you start the operator.
+The default port used by the metric endpoint binds to was changed from `:8383` to `:8080`. To continue using port `8383`, specify `--metrics-bind-address=:8383` when you start the operator.
 
 ## Checking the changes
 

--- a/website/content/en/docs/upgrading-sdk-version/v1.0.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.0.0.md
@@ -245,7 +245,7 @@ _See [#3525](https://github.com/operator-framework/operator-sdk/pull/3525) for m
 
 ### Default Ansible and Helm operator metrics port has changed
 
-To continue using port 8383, specify `--metrics-addr=:8383` when you start the operator.
+To continue using port 8383, specify `--metrics-bind-address=:8383` when you start the operator.
 
 _See [#3489](https://github.com/operator-framework/operator-sdk/pull/3489) and [#3440](https://github.com/operator-framework/operator-sdk/pull/3440) for more details._
 


### PR DESCRIPTION
**Description of the change:**
- Deprecated the flags which were removed in the Golang project in order to keep it better aligned with K8S
- Add the new flags
- Ensure that that metrics port is passed to the proxy. 

**Motivation for the change:**

- Reduce the complexities for we address https://github.com/kubernetes-sigs/kubebuilder/issues/2015
- Fix docs that were not updated.
- Keep Ansible/Helm/Go aligned (Align Helm/Ansible plugins with the changes made for Golang ( go/v3 ))
- Closes: Ansible/Helm providing the same flags as Go #4627

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
