### PR TITLE
ansible/helm: add ssc to not allow root previleges

### DIFF
--- a/changelog/fragments/ansible-helm-ssc.yaml
+++ b/changelog/fragments/ansible-helm-ssc.yaml
@@ -1,0 +1,46 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      ansible/v1, helm/v1) Added `securityContext`'s to the manager's Deployment to disallow running as root user.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: (ansible/v1, helm/v1) Add `securityContext`'s to your manager's Deployment.
+      body: >
+        In `config/manager/manager.yaml`, add the following security contexts:
+        ```yaml
+        spec:
+          ...
+          template:
+            ...
+            spec:
+              securityContext:
+                runAsNonRoot: true
+              containers:
+              - name: manager
+                securityContext:
+                  allowPrivilegeEscalation: false
+        ```

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/config/manager/manager.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/config/manager/manager.go
@@ -69,6 +69,8 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      securityContext:
+        runAsNonRoot: true
       containers:
         - name: manager
           args:
@@ -78,6 +80,8 @@ spec:
             - name: ANSIBLE_GATHERING
               value: explicit
           image: {{ .Image }}
+          securityContext:
+            allowPrivilegeEscalation: false
           livenessProbe:
             httpGet:
               path: /healthz

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/config/manager/manager.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/config/manager/manager.go
@@ -69,12 +69,16 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      securityContext:
+        runAsNonRoot: true
       containers:
       - image: {{ .Image }}
         args:
         - "--enable-leader-election"
         - "--leader-election-id={{ .ProjectName }}"
         name: manager
+        securityContext:
+          allowPrivilegeEscalation: false
         livenessProbe:
           httpGet:
             path: /healthz

--- a/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -138,6 +138,10 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                 resources: {}
+                securityContext:
+                  allowPrivilegeEscalation: false
+              securityContext:
+                runAsNonRoot: true
               terminationGracePeriodSeconds: 10
       permissions:
       - rules:

--- a/testdata/ansible/memcached-operator/config/manager/manager.yaml
+++ b/testdata/ansible/memcached-operator/config/manager/manager.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      securityContext:
+        runAsNonRoot: true
       containers:
         - name: manager
           args:
@@ -31,6 +33,8 @@ spec:
             - name: ANSIBLE_GATHERING
               value: explicit
           image: controller:latest
+          securityContext:
+            allowPrivilegeEscalation: false
           livenessProbe:
             httpGet:
               path: /healthz

--- a/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -229,6 +229,10 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 60Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+              securityContext:
+                runAsNonRoot: true
               terminationGracePeriodSeconds: 10
       permissions:
       - rules:

--- a/testdata/helm/memcached-operator/config/manager/manager.yaml
+++ b/testdata/helm/memcached-operator/config/manager/manager.yaml
@@ -22,12 +22,16 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      securityContext:
+        runAsNonRoot: true
       containers:
       - image: controller:latest
         args:
         - "--enable-leader-election"
         - "--leader-election-id=memcached-operator"
         name: manager
+        securityContext:
+          allowPrivilegeEscalation: false
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Signed-off-by: Camila Macedo <cmacedo@redhat.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
- (ansible/v1)(helm/v1) Add SecurityContext to now allow root privileges and align project languages with Golang.


**Motivation for the change:**


- Reduce the complexities for we address https://github.com/kubernetes-sigs/kubebuilder/issues/2015
- Keep Ansible/Helm/Go aligned (Align Helm/Ansible plugins with the changes made for Golang ( go/v3 )) https://github.com/operator-framework/operator-sdk/issues/4542
- Closes: https://github.com/operator-framework/operator-sdk/issues/4656

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
