### PR TITLE
Fix typo in the event filtering docs

### DIFF
--- a/website/content/en/docs/building-operators/golang/references/event-filtering.md
+++ b/website/content/en/docs/building-operators/golang/references/event-filtering.md
@@ -34,14 +34,8 @@ All event types contain Kubernetes [metadata][doc_object_metadata] about the obj
 
 ```Go
 type UpdateEvent struct {
-  // MetaOld is the ObjectMeta of the Kubernetes Type that was updated (before the update).
-  MetaOld v1.Object
-
   // ObjectOld is the object from the event.
   ObjectOld runtime.Object
-
-  // MetaNew is the ObjectMeta of the Kubernetes Type that was updated (after the update).
-  MetaNew v1.Object
 
   // ObjectNew is the object from the event.
   ObjectNew runtime.Object
@@ -75,7 +69,7 @@ func ignoreDeletionPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			// Ignore updates to CR status in which case metadata.Generation does not change
-			return e.MetaOld.GetGeneration() != e.MetaNew.GetGeneration()
+			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			// Evaluates to false if the object has been confirmed deleted.


### PR DESCRIPTION
**Description of the change:**

The documentation for the event filtering was using `MetaOld` and `MetaNew`
for filtering update events. In the latest version of the event package
this should be `ObjectOld` and `ObjectNew`.

Ref: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/event#UpdateEvent

**Motivation for the change:**

Fix the documentation.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
