### PR TITLE
ci: fix docs only check patterns and workflow output names

### DIFF
--- a/.github/workflows/check-docs-only.sh
+++ b/.github/workflows/check-docs-only.sh
@@ -9,18 +9,15 @@ set -e
 declare -a DOC_PATTERNS
 DOC_PATTERNS=(
   "(\.md)"
-  "(\.go.tmpl)"
   "(\.MD)"
   "(\.png)"
   "(\.pdf)"
   "(netlify\.toml)"
-  "^(doc/)"
-  "^(website/)"
-  "^(changelog/)"
-  "^(OWNERS)"
-  "^(MAINTAINERS)"
-  "^(SECURITY)"
-  "^(LICENSE)"
+  "(website/)"
+  "(changelog/)"
+  "(OWNERS)"
+  "(OWNERS_ALIASES)"
+  "(LICENSE)"
 )
 
 if ! git diff --name-only $1 | grep -qvE "$(IFS="|"; echo "${DOC_PATTERNS[*]}")"; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
     name: check_docs_only
     runs-on: ubuntu-18.04
     outputs:
-      is_skip: ${{ steps.check_docs_only.outputs.skip-deploy }}
+      skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -26,14 +26,14 @@ jobs:
         run: |
           REF="HEAD^"
           [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip-deploy::$(hack/ci/check-doc-only-update.sh $REF)"
+          echo "::set-output name=skip::$(.github/workflows/check-docs-only.sh $REF)"
 
   # Job to test release steps. This will only create a release remotely if run on a tagged commit.
   goreleaser:
     name: goreleaser
     needs: check_docs_only
     # Run this job on a tag like 'vX.Y.Z' or on a branch or pull request with code changes.
-    if: startsWith(github.ref, 'refs/tags/v') || ( needs.check_docs_only.outputs.is_skip != 'true' && !startsWith(github.ref, 'refs/tags/') )
+    if: startsWith(github.ref, 'refs/tags/v') || ( needs.check_docs_only.outputs.skip != 'true' && !startsWith(github.ref, 'refs/tags/') )
     runs-on: ubuntu-18.04
     environment: deploy
     steps:
@@ -67,7 +67,7 @@ jobs:
     name: images
     needs: check_docs_only
     # Run this job on a tag like 'vX.Y.Z' or on a branch or pull request with code changes.
-    if: startsWith(github.ref, 'refs/tags/v') || ( needs.check_docs_only.outputs.is_skip != 'true' && !startsWith(github.ref, 'refs/tags/') )
+    if: startsWith(github.ref, 'refs/tags/v') || ( needs.check_docs_only.outputs.skip != 'true' && !startsWith(github.ref, 'refs/tags/') )
     runs-on: ubuntu-18.04
     environment: deploy
     strategy:
@@ -115,7 +115,7 @@ jobs:
     name: image-scorecard-test-kuttl
     needs: check_docs_only
     # Run this job on a tag like 'scorecard-kuttl/vX.Y.Z' or on a branch or pull request with code changes.
-    if: startsWith(github.ref, 'refs/tags/scorecard-kuttl/v') || ( needs.check_docs_only.outputs.is_skip != 'true' && !startsWith(github.ref, 'refs/tags/') )
+    if: startsWith(github.ref, 'refs/tags/scorecard-kuttl/v') || ( needs.check_docs_only.outputs.skip != 'true' && !startsWith(github.ref, 'refs/tags/') )
     runs-on: ubuntu-18.04
     environment: deploy
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,7 +7,7 @@ jobs:
     name: check_docs_only
     runs-on: ubuntu-18.04
     outputs:
-      should_skip_tests: ${{ steps.check_docs_only.outputs.skip-tests }}
+      skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -18,13 +18,13 @@ jobs:
         run: |
           REF="HEAD^"
           [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip-deploy::$(hack/ci/check-doc-only-update.sh $REF)"
+          echo "::set-output name=skip::$(.github/workflows/check-docs-only.sh $REF)"
 
   integration:
     name: integration
     runs-on: ubuntu-18.04
     needs: check_docs_only
-    if: needs.check_docs_only.outputs.should_skip_tests != 'true'
+    if: needs.check_docs_only.outputs.skip != 'true'
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/test-ansible.yml
+++ b/.github/workflows/test-ansible.yml
@@ -7,7 +7,7 @@ jobs:
     name: check_docs_only
     runs-on: ubuntu-18.04
     outputs:
-      should_skip_tests: ${{ steps.check_docs_only.outputs.skip-tests }}
+      skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -18,13 +18,13 @@ jobs:
         run: |
           REF="HEAD^"
           [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip-deploy::$(hack/ci/check-doc-only-update.sh $REF)"
+          echo "::set-output name=skip::$(.github/workflows/check-docs-only.sh $REF)"
 
   e2e:
     name: e2e
     runs-on: ubuntu-18.04
     needs: check_docs_only
-    if: needs.check_docs_only.outputs.should_skip_tests != 'true'
+    if: needs.check_docs_only.outputs.skip != 'true'
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -39,7 +39,7 @@ jobs:
     name: e2e-molecule
     runs-on: ubuntu-18.04
     needs: check_docs_only
-    if: needs.check_docs_only.outputs.should_skip_tests != 'true'
+    if: needs.check_docs_only.outputs.skip != 'true'
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -7,7 +7,7 @@ jobs:
     name: check_docs_only
     runs-on: ubuntu-18.04
     outputs:
-      should_skip_tests: ${{ steps.check_docs_only.outputs.skip-tests }}
+      skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -18,13 +18,13 @@ jobs:
         run: |
           REF="HEAD^"
           [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip-deploy::$(hack/ci/check-doc-only-update.sh $REF)"
+          echo "::set-output name=skip::$(.github/workflows/check-docs-only.sh $REF)"
 
   e2e:
     name: e2e
     runs-on: ubuntu-18.04
     needs: check_docs_only
-    if: needs.check_docs_only.outputs.should_skip_tests != 'true'
+    if: needs.check_docs_only.outputs.skip != 'true'
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -39,7 +39,7 @@ jobs:
     name: unit
     runs-on: ubuntu-18.04
     needs: check_docs_only
-    if: needs.check_docs_only.outputs.should_skip_tests != 'true'
+    if: needs.check_docs_only.outputs.skip != 'true'
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -7,7 +7,7 @@ jobs:
     name: check_docs_only
     runs-on: ubuntu-18.04
     outputs:
-      should_skip_tests: ${{ steps.check_docs_only.outputs.skip-tests }}
+      skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -18,13 +18,13 @@ jobs:
         run: |
           REF="HEAD^"
           [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip-deploy::$(hack/ci/check-doc-only-update.sh $REF)"
+          echo "::set-output name=skip::$(.github/workflows/check-docs-only.sh $REF)"
 
   e2e:
     name: e2e
     runs-on: ubuntu-18.04
     needs: check_docs_only
-    if: needs.check_docs_only.outputs.should_skip_tests != 'true'
+    if: needs.check_docs_only.outputs.skip != 'true'
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/test-sanity.yml
+++ b/.github/workflows/test-sanity.yml
@@ -7,7 +7,7 @@ jobs:
     name: check_docs_only
     runs-on: ubuntu-18.04
     outputs:
-      should_skip_tests: ${{ steps.check_docs_only.outputs.skip-tests }}
+      skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -18,13 +18,13 @@ jobs:
       run: |
         REF="HEAD^"
         [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-        echo "::set-output name=skip-deploy::$(hack/ci/check-doc-only-update.sh $REF)"
+        echo "::set-output name=skip::$(.github/workflows/check-docs-only.sh $REF)"
 
   sanity:
     name: sanity
     runs-on: ubuntu-18.04
     needs: check_docs_only
-    if: needs.check_docs_only.outputs.should_skip_tests != 'true'
+    if: needs.check_docs_only.outputs.skip != 'true'
     steps:
     - uses: actions/setup-go@v2
       with:


### PR DESCRIPTION
**Description of the change:**
- .github/workflows: move docs only check script here, make all calls reference the same outputs

**Motivation for the change:** patterns were incorrect, output name in workflows was incorrect

/kind bug

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
