### PR TITLE
enable 'alpha config-gen' command

### DIFF
--- a/changelog/fragments/alpha-config-gen.yaml
+++ b/changelog/fragments/alpha-config-gen.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      Added [`alpha config-gen`](https://github.com/kubernetes-sigs/kubebuilder/tree/master/pkg/cli/alpha/config-gen),
+      a kustomize plugin to specialize configuration for kubebuilder-style projects. This feature is *alpha*
+      and subject to breaking changes.
+    kind: addition

--- a/internal/cmd/operator-sdk/cli/cli.go
+++ b/internal/cmd/operator-sdk/cli/cli.go
@@ -92,24 +92,6 @@ func GetPluginsCLIAndRoot() (*cli.CLI, *cobra.Command) {
 	}
 	root.PersistentPreRun = rootPersistentPreRun
 
-	// Hide `alpha config-gen` subcommand
-	// TODO: stop hiding `alpha config-gen` subcommand when it is more mature
-	var alpha *cobra.Command
-	for _, subcmd := range root.Commands() {
-		if subcmd.Name() == "alpha" {
-			alpha = subcmd
-			break
-		}
-	}
-	if alpha != nil {
-		for _, subcmd := range alpha.Commands() {
-			if subcmd.Name() == "config-gen" {
-				subcmd.Hidden = true
-				break
-			}
-		}
-	}
-
 	return c, root
 }
 

--- a/website/content/en/docs/cli/operator-sdk_alpha.md
+++ b/website/content/en/docs/cli/operator-sdk_alpha.md
@@ -30,4 +30,5 @@ Alpha subcommands are for unstable features.
 
 * [operator-sdk](../operator-sdk)	 - 
 * [operator-sdk alpha config-3alpha-to-3](../operator-sdk_alpha_config-3alpha-to-3)	 - Convert your PROJECT config file from version 3-alpha to 3
+* [operator-sdk alpha config-gen](../operator-sdk_alpha_config-gen)	 - Generate configuration for controller-runtime based projects
 

--- a/website/content/en/docs/cli/operator-sdk_alpha_config-gen.md
+++ b/website/content/en/docs/cli/operator-sdk_alpha_config-gen.md
@@ -1,0 +1,192 @@
+---
+title: "operator-sdk alpha config-gen"
+---
+## operator-sdk alpha config-gen
+
+Generate configuration for controller-runtime based projects
+
+### Synopsis
+
+config-gen programatically generates configuration for a controller-runtime based
+project using the project source code (golang) and a KubebuilderConfigGen resource file.
+
+This is an alternative to expressing configuration as a static set of kustomize patches
+in the "config" directory.
+
+config-gen may be used as a standalone command run against a file, as a kustomize
+transformer plugin, or as a configuration function (e.g. kpt).
+
+config-gen uses the controller-tools generators to generate CRDs from the go source
+and then generates additional resources such as the namespace, controller-manager,
+webhooks, etc.
+
+Following is an example KubebuilderConfigGen resource used by config-gen:
+
+  # kubebuilderconfiggen.yaml
+  # this resource describes how to generate configuration for a controller-runtime
+  # based project
+  apiVersion: kubebuilder.sigs.k8s.io/v1alpha1
+  kind: KubebuilderConfigGen
+  metadata:
+    name: my-project-name
+  spec:
+    controllerManager:
+      image: my-org-name/my-project-name:v0.1.0
+
+If this file was at the project source root, config-gen could be used to emit
+configuration using:
+
+  kubebuilder alpha config-gen ./kubebuilderconfiggen.yaml
+
+The KubebuilderConfigGen resource has the following fields:
+
+  apiVersion: kubebuilder.sigs.k8s.io/v1alpha1
+  kind: KubebuilderConfigGen
+
+  metadata:
+    # name of the project.  used in various resource names.
+    # required
+    name: project-name
+
+    # namespace for the project
+    # optional -- defaults to "${metadata.name}-system"
+    namespace: project-namespace
+
+  spec:
+    # configure how CRDs are generated
+    crds:
+      # path to go module source directory provided to controller-gen libraries
+      # optional -- defaults to '.'
+      sourceDirectory: ./relative/path
+
+    # configure how the controller-manager is generated
+    controllerManager:
+      # image to run
+      image: my-org/my-project:v0.1.0
+
+      # if set, use component config for the controller-manager
+      # optional
+      componentConfig:
+        # use component config
+        enable: true
+
+        # path to component config to put into a ConfigMap
+        configFilepath: ./path/to/componentconfig.yaml
+
+      # configure how metrics are exposed
+      metrics:
+        # disable the auth proxy required for scraping metrics
+        # disable: false
+
+        # generate prometheus ServiceMonitor resource
+        enableServiceMonitor: true
+
+    # configure how webhooks are generated
+    # optional -- defaults to not generating webhook configuration
+    webhooks:
+      # enable will cause webhook config to be generated
+      enable: true
+
+      # configures crds which use conversion webhooks
+      enableConversion:
+        # key is the name of the CRD
+        "bars.example.my.domain": true
+
+      # configures where to get the certificate used for webhooks
+      # discriminated union
+      certificateSource:
+        # type of certificate source
+        # one of ["certManager", "dev", "manual"] -- defaults to "manual"
+        # certManager: certmanager is used to manage certificates -- requires CertManager to be installed
+        # dev: certificate is generated and wired into resources
+        # manual: no certificate is generated or wired into resources
+        type: "dev"
+
+        # options for a dev certificate -- requires "dev" as the type
+        devCertificate:
+          duration: 1h
+
+```
+operator-sdk alpha config-gen PROJECT_FILE [RESOURCE_PATCHES...] [flags]
+```
+
+### Examples
+
+```
+#
+# As command
+#
+# create the kubebuilderconfiggen.yaml at project root
+cat > kubebuilderconfiggen.yaml <<EOF
+apiVersion: kubebuilder.sigs.k8s.io/v1alpha1
+  kind: KubebuilderConfigGen
+  metadata:
+    name: project
+  spec:
+    controllerManager
+      image: org/project:v0.1.0
+EOF
+
+# run the config generator
+kubebuilder alpha config-gen kubebuilderconfiggen.yaml
+
+# run the config generator and apply
+kubebuilder alpha config-gen kubebuilderconfiggen.yaml | kubectl apply -f -
+
+# generate configuration from a file with patches
+kubebuilder alpha config-gen kubebuilderconfiggen.yaml patch1.yaml patch2.yaml
+
+#
+# As Kustomize plugin
+# this allows using config-gen with kustomize features such as patches, commonLabels,
+# commonAnnotations, resources, configMapGenerator and other transformer plugins.
+#
+
+# install the latest kustomize
+GO111MODULE=on go get sigs.k8s.io/kustomize/kustomize/v4
+
+# install the command as a kustomize plugin
+kubebuilder alpha config-gen install-as-plugin
+
+# create the kustomization.yaml containing the KubebuilderConfigGen resource
+cat > kustomization.yaml <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+transformers:
+- |-
+  apiVersion: kubebuilder.sigs.k8s.io
+  kind: KubebuilderConfigGen
+  metadata:
+    name: my-project
+  spec:
+    controllerManager:
+      image: my-org/my-project:v0.1.0
+EOF
+
+# generate configuration from kustomize > v4.0.0
+kustomize build --enable-alpha-plugins .
+
+# generate configuration from kustomize <= v4.0.0
+kustomize build --enable_alpha_plugins .
+```
+
+### Options
+
+```
+  -h, --help    help for config-gen
+      --stack   print the stack trace on failure
+```
+
+### Options inherited from parent commands
+
+```
+      --plugins strings          plugin keys of the plugin to initialize the project with
+      --project-version string   project version
+      --verbose                  Enable verbose logging
+```
+
+### SEE ALSO
+
+* [operator-sdk alpha](../operator-sdk_alpha)	 - Alpha-stage subcommands
+* [operator-sdk alpha config-gen install-as-plugin](../operator-sdk_alpha_config-gen_install-as-plugin)	 - Install config-gen as a kustomize plugin
+

--- a/website/content/en/docs/cli/operator-sdk_alpha_config-gen_install-as-plugin.md
+++ b/website/content/en/docs/cli/operator-sdk_alpha_config-gen_install-as-plugin.md
@@ -1,0 +1,43 @@
+---
+title: "operator-sdk alpha config-gen install-as-plugin"
+---
+## operator-sdk alpha config-gen install-as-plugin
+
+Install config-gen as a kustomize plugin
+
+### Synopsis
+
+Write a script to kustomize/plugin/kubebuilder.sigs.k8s.io/v1alpha1/kubebuilderconfiggen/KubebuilderConfigGen for kustomize to locate as a plugin.
+This path will be written to $XDG_CONFIG_HOME if set, otherwise $HOME.
+
+
+```
+operator-sdk alpha config-gen install-as-plugin [flags]
+```
+
+### Examples
+
+```
+
+kubebuilder alpha config-gen install-as-plugin
+
+```
+
+### Options
+
+```
+  -h, --help   help for install-as-plugin
+```
+
+### Options inherited from parent commands
+
+```
+      --plugins strings          plugin keys of the plugin to initialize the project with
+      --project-version string   project version
+      --verbose                  Enable verbose logging
+```
+
+### SEE ALSO
+
+* [operator-sdk alpha config-gen](../operator-sdk_alpha_config-gen)	 - Generate configuration for controller-runtime based projects
+


### PR DESCRIPTION
**Description of the change:**
- internal/cmd/operator-sdk/cli: un-hide `alpha config-gen`

**Motivation for the change:** users should be able to use and give feedback on alpha commands. See https://github.com/operator-framework/operator-sdk/pull/4667#discussion_r595122390 for discussion.

/kind feature

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
