### PR TITLE
docs/installation: use version in download URL

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -41,6 +41,7 @@ endif
 .PHONY: prerelease
 prerelease: check_release_version changelog ## Create release commit changes to commit.
 	./website/scripts/update_branch_mappings.sh $(RELEASE_VERSION)
+	./website/scripts/update_download_url.sh $(RELEASE_VERSION)
 
 .PHONY: changelog
 changelog: check_release_version ## Generate the changelog.

--- a/website/content/en/docs/installation/_index.md
+++ b/website/content/en/docs/installation/_index.md
@@ -36,7 +36,7 @@ export OS=$(uname | awk '{print tolower($0)}')
 Download the binary for your platform:
 
 ```sh
-export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/latest/download
+export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/v1.5.0
 curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
 ```
 

--- a/website/scripts/update_download_url.sh
+++ b/website/scripts/update_download_url.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# This script updates the operator-sdk download link with the current release version.
+# This change should be committed in the prerelease commit.
+
+set -e
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DOC_PATH="${DIR}/../content/en/docs/installation/_index.md"
+
+VERSION="${1?"A Version is required"}"
+
+TARGET="export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/"
+
+sed -i -E 's@('"${TARGET}"').+@\1'"${VERSION}"'@g' "$DOC_PATH"
+
+# Ensure the file was updated.
+if ! grep -q "${TARGET}${VERSION}" "$DOC_PATH"; then
+  echo "$0 failed to update ${DOC_PATH}"
+  exit 1
+fi


### PR DESCRIPTION
**Description of the change:**
- docs/installation: use version in download URL
- release/Makefile,website/scripts: include script to update download URL as a part of prerelease steps

**Motivation for the change:** following up on #4661, which addresses a broken download link for operator-sdk, I discovered that it would actually make more sense to pin the download link to a particular operator-sdk version so that older docs do not point to newer operator-sdk binaries.

This reverts part of #4034.

Closes #4661 

/kind documentation

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
