### PR TITLE
deps: bump kubebuilder to 646f742

### DIFF
--- a/changelog/fragments/kubebuilder-646f742.yaml
+++ b/changelog/fragments/kubebuilder-646f742.yaml
@@ -1,0 +1,32 @@
+entries:
+  - description: >
+      (go/v2, go/v3, ansible/v1, helm/v1) Fixed the Prometheus `ServiceMonitor` metrics endpoint,
+      which was not configured to be scraped correctly.
+    kind: bugfix
+    migration:
+      header: (go/v2, go/v3, ansible/v1, helm/v1) Add scheme, token, and TLS config to the Prometheus `ServiceMonitor` metrics endpoint.
+      body: >
+        The `/metrics` endpoint, while specifying the `https` port on the manager Pod, was not actually configured
+        to serve over https because no tlsConfig was set. Since kube-rbac-proxy secures this endpoint as a
+        manager sidecar, using the service account token mounted into the Pod by default corrects this problem.
+
+        The changes should look like:
+
+        ```diff
+        # config/prometheus/monitor.yaml
+
+        spec:
+           endpoints:
+             - path: /metrics
+               port: https
+        +      scheme: https
+        +      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+        +      tlsConfig:
+        +        insecureSkipVerify: true
+           selector:
+             matchLabels:
+               control-plane: controller-manager
+        ```
+
+        **Note:** if you have removed kube-rbac-proxy from your project, make sure to secure the `/metrics`
+        endpoint using a proper [TLS configuration](https://prometheus.io/docs/guides/tls-encryption/).

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/controller-runtime v0.8.2
 	sigs.k8s.io/controller-tools v0.5.0
-	sigs.k8s.io/kubebuilder/v3 v3.0.0-alpha.0.0.20210316110635-104672d382aa
+	sigs.k8s.io/kubebuilder/v3 v3.0.0-alpha.0.0.20210318180717-646f742d9407
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1555,8 +1555,8 @@ sigs.k8s.io/controller-tools v0.4.1 h1:VkuV0MxlRPmRu5iTgBZU4UxUX2LiR99n3sdQGRxZF
 sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/controller-tools v0.5.0 h1:3u2RCwOlp0cjCALAigpOcbAf50pE+kHSdueUosrC/AE=
 sigs.k8s.io/controller-tools v0.5.0/go.mod h1:JTsstrMpxs+9BUj6eGuAaEb6SDSPTeVtUyp0jmnAM/I=
-sigs.k8s.io/kubebuilder/v3 v3.0.0-alpha.0.0.20210316110635-104672d382aa h1:gCcgLy5G7RMRYmRQUsG440sl9t2g6ffuJeeXPHYOarM=
-sigs.k8s.io/kubebuilder/v3 v3.0.0-alpha.0.0.20210316110635-104672d382aa/go.mod h1:eVtLdWzmvL1ixDYLlVrvQe8wjpikJVoSOg5PghTk2Lw=
+sigs.k8s.io/kubebuilder/v3 v3.0.0-alpha.0.0.20210318180717-646f742d9407 h1:t0QuAKNpt3NEcQFoKtAjGlcvOYWA7OY34ozN81xrKlY=
+sigs.k8s.io/kubebuilder/v3 v3.0.0-alpha.0.0.20210318180717-646f742d9407/go.mod h1:eVtLdWzmvL1ixDYLlVrvQe8wjpikJVoSOg5PghTk2Lw=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/kustomize/kyaml v0.10.10 h1:caAxDDkaXZp+0kDsZVik4leFJV8LCy09PdVqpaoNeF4=

--- a/internal/cmd/operator-sdk/generate/kustomize/manifests.go
+++ b/internal/cmd/operator-sdk/generate/kustomize/manifests.go
@@ -196,7 +196,7 @@ func (c manifestsCmd) run(cfg config.Config) error {
 	}
 	base := bases.ClusterServiceVersion{
 		OperatorName: c.packageName,
-		OperatorType: projutil.PluginKeyToOperatorType(cfg.GetLayout()),
+		OperatorType: projutil.PluginKeyToOperatorType(cfg.GetPluginChain()),
 		APIsDir:      c.apisDir,
 		Interactive:  requiresInteraction(basePath, c.interactiveLevel),
 		GVKs:         gvks,

--- a/internal/plugins/ansible/v1/init.go
+++ b/internal/plugins/ansible/v1/init.go
@@ -99,7 +99,7 @@ func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {
 }
 
 func (p *initSubcommand) InjectConfig(c config.Config) {
-	_ = c.SetLayout(pluginKey)
+	_ = c.SetPluginChain([]string{pluginKey})
 	p.config = c
 	p.apiSubc.config = p.config
 }

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/config/prometheus/monitor.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/config/prometheus/monitor.go
@@ -53,6 +53,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/internal/plugins/helm/v1/init.go
+++ b/internal/plugins/helm/v1/init.go
@@ -127,7 +127,7 @@ func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {
 // InjectConfig will inject the PROJECT file/config in the plugin
 func (p *initSubcommand) InjectConfig(c config.Config) {
 	// v3 project configs get a 'layout' value.
-	_ = c.SetLayout(pluginKey)
+	_ = c.SetPluginChain([]string{pluginKey})
 	p.config = c
 	p.apiSubc.config = p.config
 }

--- a/internal/plugins/helm/v1/scaffolds/internal/templates/config/prometheus/monitor.go
+++ b/internal/plugins/helm/v1/scaffolds/internal/templates/config/prometheus/monitor.go
@@ -53,6 +53,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/internal/plugins/manifests/init.go
+++ b/internal/plugins/manifests/init.go
@@ -48,9 +48,9 @@ func RunInit(cfg config.Config) error {
 
 // initUpdateMakefile updates a vanilla kubebuilder Makefile with operator-sdk recipes.
 func initUpdateMakefile(cfg config.Config, filePath string) error {
-	operatorType := projutil.PluginKeyToOperatorType(cfg.GetLayout())
+	operatorType := projutil.PluginKeyToOperatorType(cfg.GetPluginChain())
 	if operatorType == projutil.OperatorTypeUnknown {
-		return fmt.Errorf("unsupported plugin key %q", cfg.GetLayout())
+		return fmt.Errorf("unsupported plugin key %q", cfg.GetPluginChain())
 	}
 
 	makefileBytes, err := ioutil.ReadFile(filePath)

--- a/internal/testutils/olm.go
+++ b/internal/testutils/olm.go
@@ -79,14 +79,17 @@ func (tc TestContext) AddPackagemanifestsTarget() error {
 	}
 
 	// Unmarshal the file content
-	if err := c.Unmarshal(b); err != nil {
+	if err := c.UnmarshalYAML(b); err != nil {
 		return err
 	}
 
 	// add the manifests target when is a Go project.
 	replaceTarget := ""
-	if strings.HasPrefix(c.GetLayout(), "go") {
-		replaceTarget = "manifests"
+	for _, pluginKey := range c.GetPluginChain() {
+		if strings.HasPrefix(pluginKey, "go") {
+			replaceTarget = "manifests"
+			break
+		}
 	}
 	makefilePackagemanifestsFragment = fmt.Sprintf(makefilePackagemanifestsFragment, replaceTarget)
 

--- a/testdata/ansible/memcached-operator/PROJECT
+++ b/testdata/ansible/memcached-operator/PROJECT
@@ -1,5 +1,6 @@
 domain: example.com
-layout: ansible.sdk.operatorframework.io/v1
+layout:
+- ansible.sdk.operatorframework.io/v1
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}

--- a/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -6,8 +6,12 @@ metadata:
   name: memcached-operator-controller-manager-metrics-monitor
 spec:
   endpoints:
-  - path: /metrics
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
     port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/testdata/ansible/memcached-operator/config/prometheus/monitor.yaml
+++ b/testdata/ansible/memcached-operator/config/prometheus/monitor.yaml
@@ -11,6 +11,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/testdata/go/v2/memcached-operator/PROJECT
+++ b/testdata/go/v2/memcached-operator/PROJECT
@@ -1,5 +1,6 @@
 domain: example.com
-layout: go.kubebuilder.io/v2
+layout:
+- go.kubebuilder.io/v2
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}

--- a/testdata/go/v2/memcached-operator/bundle/manifests/memcached-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/testdata/go/v2/memcached-operator/bundle/manifests/memcached-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -6,8 +6,12 @@ metadata:
   name: memcached-operator-controller-manager-metrics-monitor
 spec:
   endpoints:
-  - path: /metrics
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
     port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/testdata/go/v2/memcached-operator/config/prometheus/monitor.yaml
+++ b/testdata/go/v2/memcached-operator/config/prometheus/monitor.yaml
@@ -11,6 +11,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/testdata/go/v3/memcached-operator/PROJECT
+++ b/testdata/go/v3/memcached-operator/PROJECT
@@ -1,5 +1,6 @@
 domain: example.com
-layout: go.kubebuilder.io/v3
+layout:
+- go.kubebuilder.io/v3
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}

--- a/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -6,8 +6,12 @@ metadata:
   name: memcached-operator-controller-manager-metrics-monitor
 spec:
   endpoints:
-  - path: /metrics
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
     port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/testdata/go/v3/memcached-operator/config/prometheus/monitor.yaml
+++ b/testdata/go/v3/memcached-operator/config/prometheus/monitor.yaml
@@ -11,6 +11,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/testdata/helm/memcached-operator/PROJECT
+++ b/testdata/helm/memcached-operator/PROJECT
@@ -1,5 +1,6 @@
 domain: example.com
-layout: helm.sdk.operatorframework.io/v1
+layout:
+- helm.sdk.operatorframework.io/v1
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}

--- a/testdata/helm/memcached-operator/bundle/manifests/memcached-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/testdata/helm/memcached-operator/bundle/manifests/memcached-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -6,8 +6,12 @@ metadata:
   name: memcached-operator-controller-manager-metrics-monitor
 spec:
   endpoints:
-  - path: /metrics
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
     port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/testdata/helm/memcached-operator/config/prometheus/monitor.yaml
+++ b/testdata/helm/memcached-operator/config/prometheus/monitor.yaml
@@ -11,6 +11,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager


### PR DESCRIPTION
**Description of the change:** bump kubebuilder to https://github.com/kubernetes-sigs/kubebuilder/commit/646f742d9407f253aff90b7f6930a0aea94cffeb, and make plugin API changes.

**Motivation for the change:** dep bump, and has a change needed by #4670.

/area dependency

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
