### PR TITLE
fix(Helm.controller.watch): Process watch for List kind

### DIFF
--- a/changelog/fragments/helm-handle-list-kind.yaml
+++ b/changelog/fragments/helm-handle-list-kind.yaml
@@ -1,0 +1,11 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For Helm-based operators, fixes handling of `kind: List` whereby the 
+      operator fails when trying to set watch on the object. The fix now sets
+      the watch on the objects of the list instead. 
+
+    kind: "bugfix"
+
+    breaking: false


### PR DESCRIPTION
**Description of the change:**

The Kubernetes `kind: List` is not actually a resource and therefore cannot have a watch set on it. This PR iterates on the `List` items instead and sets the watch on those Kubernetes kinds. 

**Motivation for the change:**

Helm operator controller errors out when a Helm chart has a `kind: List` declared.

Closes #4636 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
