### PR TITLE
docs/migration: add prereqs, align guides for all languages

### DIFF
--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -7,10 +7,9 @@ description: Instructions for migrating a Go-based project built prior to `v1.0.
 
 ## Overview
 
-
 The v1.0 release improves upon prior `operator-sdk` releases with a new project structure and CLI, each of which enhances project extensibility and customizability. These design changes are influenced by [`kubebuilder`](https://book.kubebuilder.io/).
 
-**Note:** It is recommended that you have your project upgraded to the latest SDK release version (0.19.x+) before following the steps in this guide to migrate to the new layout. However, the steps might work from previous versions as well. In this case, if you find an issue which is not covered here then check the previous [Migration Guides][migration-doc] which might help out.
+**Note:** It is recommended that you have your project upgraded to the latest SDK v1.y release version before following the steps in this guide to migrate to the new layout. However, the steps might work from previous versions as well. In this case, if you find an issue which is not covered here then check the previous [Migration Guides][migration-doc] which might help out.
 
 ### What was changed
 
@@ -44,7 +43,22 @@ Generated files with the default API versions:
 - `admissionregistration.k8s.io/v1` for webhooks (`admissionregistration.k8s.io/v1beta1` was deprecated in Kubernetes `1.16` and will be removed in `1.22` )
 - `cert-manager.io/v1` for the certificate manager when webhooks are used (`cert-manager.io/v1alpha2` was deprecated in `Cert-Manager 0.14`. More info: [CertManager v1.0 docs][cert-manager-docs])
 
-**NOTE** You can still use the deprecated APIs which are only needed to support Kubernetes `1.15` and earlier.
+**Note:** You can still use the deprecated APIs which are only needed to support Kubernetes `1.15` and earlier.
+
+## How to migrate
+
+The easy migration path is to initialize a new project, re-recreate APIs, then copy pre-v1.0.0 configuration files into the new project.
+
+### Prerequisites
+
+- Go through the [installation guide][install-guide].
+- User authorized with `cluster-admin` permissions.
+- An accessible image registry for various operator images (ex. [hub.docker.com](https://hub.docker.com/signup),
+[quay.io](https://quay.io/)) and be logged in in your command line environment.
+  - `example.com` is used as the registry Docker Hub namespace in these examples.
+  Replace it with another value if using a different registry or namespace.
+  - The registry/namespace must be public, or the cluster must be provisioned with an
+  [image pull secret][k8s-image-pull-sec] if the image namespace is private.
 
 ### Create a new project
 
@@ -69,16 +83,16 @@ cd memcached-operator
 operator-sdk init --domain example.com --repo github.com/example/memcached-operator
 ```
 
-**Note**: `operator-sdk` attempts to automatically discover the Go module path of your project by looking for a `go.mod` file, or if in `$GOPATH`, by using the directory path. Use the `--repo` flag to explicitly set the module path.
+**Note:**: `operator-sdk` attempts to automatically discover the Go module path of your project by looking for a `go.mod` file, or if in `$GOPATH`, by using the directory path. Use the `--repo` flag to explicitly set the module path.
 
-## Check if your project is multi-group
+### Check if your project is multi-group
 
 Before we start to create the APIs, check if your project has more than one group such as : `foo.example.com/v1` and `crew.example.com/v1`. If you intend to work with multiple groups in your project, then to change the project's layout to support multi-group, run the command `operator-sdk edit --multigroup=true`
 
 **Note:** In multi-group projects, APIs are defined in `apis/<group>/<version>` and controllers are defined in `controllers/<group>`.
 For further information see the [Single Group to Multi-Group][multigroup-kubebuilder-doc]
 
-## Migrate APIs and Controllers
+### Migrate APIs and Controllers
 
 Now that we have our new project initialized, we need to re-create each of our APIs.
 Using our API example from earlier (`cache.example.com`), we'll use `cache` for the
@@ -95,7 +109,7 @@ operator-sdk create api \
     --controller
 ```
 
-### How to keep `apiextensions.k8s.io/v1beta1` for CRDs?
+#### How to keep `apiextensions.k8s.io/v1beta1` for CRDs?
 
 From now on, the CRDs that will be created by controller-gen will be using Kubernetes API version `apiextensions.k8s.io/v1` by default, instead of `apiextensions.k8s.io/v1beta1`.
 
@@ -112,7 +126,7 @@ This file is quite similar to the old one. Once you copy over your API definitio
 - The `+k8s:deepcopy-gen:interfaces=...` marker was replaced with `+kubebuilder:object:root=true`.
 - If you are not using [openapi-gen][openapi-gen] to generate OpenAPI Go code, then `// +k8s:openapi-gen=true` and other related openapi markers can be removed.
 
-**NOTE:** The `operator-sdk generate openapi` command was deprecated in `0.13.0` and was removed in `0.17` SDK release. Hence, it is recommended to use [openapi-gen][openapi-gen] directly for OpenAPI code generation.
+**Note::** The `operator-sdk generate openapi` command was deprecated in `0.13.0` and was removed in `0.17` SDK release. Hence, it is recommended to use [openapi-gen][openapi-gen] directly for OpenAPI code generation.
 
 Our Memcached API types will look like:
 
@@ -141,7 +155,7 @@ type Memcached struct {...}
 type MemcachedList struct {...}
 ```
 
-## Webhooks
+### Webhooks
 
 SDK version `1.0.0` and later has support for webhooks by the CLI. If your project doesn't require any webhooks, you can skip this section. However, if have been using it via customizations in your project, you should use the tool to re-scaffold the webhooks.  
 
@@ -170,13 +184,13 @@ operator-sdk create webhook \
 
 After the webhook is generated, you will need to copy the webhook definition and content from your old project to the new one. You can find the respective file in `api/v1/<kind>_webhook.go`.
 
-### How to keep using `apiextensions.k8s.io/v1beta1` for Webhooks?
+#### How to keep using `apiextensions.k8s.io/v1beta1` for Webhooks?
 
 Hereafter, the webhooks that are created by SDK will use Kubernetes API version `admissionregistration.k8s.io/v1` by default instead of `admissionregistration.k8s.io/v1beta1` and `cert-manager.io/v1` instead of `cert-manager.io/v1alpha2`.
 
 Note that `apiextensions/v1beta1` and `admissionregistration.k8s.io/v1beta1` were deprecated in Kubernetes `1.16` and will be removed in Kubernetes `1.22`. If you use `apiextensions/v1` and `admissionregistration.k8s.io/v1`, then you need to use `cert-manager.io/v1` which will be the default API adopted by the SDK CLI.
 
-**NOTE** If you are using the API `cert-manager.io/v1alpha2`, it is not compatible with the latest Kubernetes API version. (`cert-manager.io/v1alpha2` was deprecated in `Cert-Manager 0.14`. For more info, refer to [CertManager v1.0 docs][cert-manager-docs])
+**Note:** If you are using the API `cert-manager.io/v1alpha2`, it is not compatible with the latest Kubernetes API version. (`cert-manager.io/v1alpha2` was deprecated in `Cert-Manager 0.14`. For more info, refer to [CertManager v1.0 docs][cert-manager-docs])
 
 If you would like to use the previous version, use the flag `--webhook-version=v1beta1` in the above command which is only required if you want your operator to support Kubernetes `1.15` and earlier.
 
@@ -185,7 +199,7 @@ If you would like to use the previous version, use the flag `--webhook-version=v
 Now let’s migrate the controller code from `pkg/controller/<kind>/<kind>_controller.go` to `controllers/<kind>_controller.go`. Following the steps:
 
 1. Copy over any struct fields from the existing project into the new `<Kind>Reconciler` struct.
-**Note** The `Reconciler` struct has been renamed from `Reconcile<Kind>` to `<Kind>Reconciler`. In our example, we would see `ReconcileMemcached` instead of `MemcachedReconciler`.
+**Note:** The `Reconciler` struct has been renamed from `Reconcile<Kind>` to `<Kind>Reconciler`. In our example, we would see `ReconcileMemcached` instead of `MemcachedReconciler`.
 2. Replace the `// your logic here` in the new layout with your reconcile logic.
 3. Copy the code under `func add(mgr manager.Manager, r reconcile.Reconciler)` to `func SetupWithManager`:
 ```go
@@ -199,7 +213,7 @@ func (r *MemcachedReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 In our example, the `Watch` implemented for the Deployment will be replaced with `Owns(&appsv1.Deployment{})`. Setting up controller `Watches` is simplified in more recent versions of controller-runtime, which has controller [Builder][builder] helpers to handle more of the details.
 
-### Set the RBAC permissions
+#### Set RBAC permissions
 
 The RBAC permissions are now configured via [RBAC markers][rbac_markers], which are used to generate and update the manifest files present in `config/rbac/`. These markers can be found (and should be defined) on the `Reconcile()` method of each controller.
 
@@ -229,7 +243,7 @@ your project's name will be prepended to `controller-manager`, making it unique 
 much like your old `deploy/service_account.yaml`. If you wish to use the old ServiceAccount,
 make sure to update all RBAC bindings and your manager Deployment.
 
-## Migrate `main.go`
+### Migrate `main.go`
 
 By checking our new `main.go` we will find that:
 
@@ -272,7 +286,7 @@ func main() {
 
 - Ensure that you copy all customizations made in `cmd/manager/main.go` to `main.go`. You’ll also need to ensure that all needed schemes have been registered, if you have been using third-party API's (i.e Route Api from OpenShift).
 
-## Migrate your tests
+### Migrate your tests
 
 For the new layout, you will see that `controllers/suite_test.go` is created when a controller is scaffolded by the tool. This file contains boilerplate for executing integration tests using [envtest][envtest] with [ginkgo](https://onsi.github.io/ginkgo/) and [gomega][gomega].
 
@@ -282,23 +296,23 @@ The Operator SDK project recommends controller-runtime's [envtest][envtest] beca
 
 To learn more about how you can test your controllers, see the documentation about [writing controller tests][writing-controller-tests].
 
-## Migrate your Custom Resources
+### Migrate your Custom Resources
 
 Custom resource samples are stored in `./config/samples` in the new project structure. Copy the examples from your existing project into this directory. In existing projects, CR files have the format `./deploy/crds/<group>.<domain>_<version>_<kind>_cr.yaml`.
 
 In our example, we'll copy the specs from `deploy/crds/cache.example.com_v1alpha1_memcached_cr.yaml`
 to `config/samples/cache_v1alpha1_memcached.yaml`
 
-## Configure your Operator
+### Configure your Operator
 
 In case your project has customizations in the `deploy/operator.yaml` then, it needs to be port to
 `config/manager/manager.yaml`. Note that, `OPERATOR_NAME` and `POD_NAME` env vars are no longer used. For further information came back to the section [Migrate `main.go` ][migration-guide-main-section].
 
-## Export Metrics
+### Export Metrics
 
 If you are using metrics and would like to keep them exported, see that the `func addMetrics()` is no longer generated in the `main.go` and it is now configurable via [kustomize][kustomize]. Following the steps.
 
-### Configure Prometheus metrics
+#### Configure Prometheus metrics
 
 - Ensure that you have Prometheus installed in the cluster:
 To check if you have the required API resource to create the `ServiceMonitor` run:
@@ -315,7 +329,7 @@ kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/re
 - ../prometheus
 ```
 
-### Use Handler from `operator-lib`
+#### Use Handler from `operator-lib`
 
 By using the [InstrumentedEnqueueRequestForObject](https://pkg.go.dev/github.com/operator-framework/operator-lib@v0.1.0/handler?tab=doc#InstrumentedEnqueueRequestForObject) you will able to export metrics from your Custom Resources.  In our example, it would like:  
 
@@ -342,7 +356,7 @@ func (r *MemcachedReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 ```
 
-**Note** Ensure that you have the [operator-lib][operator-lib] added to your `go.mod`.
+**Note:** Ensure that you have the [operator-lib][operator-lib] added to your `go.mod`.
 
 In this way, the following metric with the resource info will be exported:
 
@@ -354,11 +368,11 @@ resource_created_at_seconds{"name", "namespace", "group", "version", "kind"}
 
 For more info see the [metrics][metrics].
 
-## Operator image
+### Operator image
 
 The Dockerfile image also changes and now it is a `multi-stage`, `distroless` and still been `rootless`, however, users can change it to work as however they want.
 
- See that, you might need to port some customizations made in your old Dockerfile as well. Also, if you wish to still using the previous UBI image replace:
+See that, you might need to port some customizations made in your old Dockerfile as well. Also, if you wish to still using the previous UBI image replace:
 
 ```docker
 # Use distroless as minimal base image to package the manager binary
@@ -372,37 +386,38 @@ With:
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ```
 
-## Generate Manifests and Build the operator
+### Generate Manifests and Build the operator
 
 Note that:
 
 - `operator-sdk generate crds` is replaced with `make manifests`, which generates CRDs and RBAC rules.
-- `operator-sdk build` is replaced with `make docker-build IMG=<some-registry>/<project-name>:tag`.
+- `operator-sdk build` is replaced with `make docker-build IMG=<some-registry>/<project-name>:<tag>`.
 
 In this way, run:
 
 ```sh
-make manifests
-make docker-build IMG=<some-registry>/<project-name>:<tag>
+make manifests docker-build docker-push IMG=example.com/memcached-operator:v0.0.1
 ```
 
 
-## Verify the migration
+### Verify the migration
 
-The project can now be built, and the operator can be deployed on cluster by running the command:
+The project can now be deployed on cluster by running the command:
 
 ```sh
-make deploy IMG=<some-registry>/<project-name>:<tag>
+make deploy IMG=example.com/memcached-operator:v0.0.1
 ```
 
-For further steps regarding the deployment of the operator, creation of custom resources, and cleaning up of resources, see the [quickstart guide][quickstart].
+You can troubleshoot your deployment by checking container logs:
+```sh
+kubectl logs deployment.apps/memcached-operator-controller-manager -n memcached-operator-system -c manager
+```
 
-Note that, you can also troubleshoot by checking the container logs.
-E.g `kubectl logs deployment.apps/memcached-operator-controller-manager -n memcached-operator-system -c manager`  
+For further steps regarding the deployment of the operator, creation of custom resources, and cleaning up of resources, see the [tutorial][tutorial-deploy].
 
-[quickstart-legacy]: https://v0-19-x.sdk.operatorframework.io/docs/golang/legacy/quickstart/
-[integration-doc]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/integrating-kubebuilder-and-osdk.md
-[quickstart]: /docs/building-operators/golang/quickstart/
+
+[install-guide]: /docs/building-operators/ansible/installation
+[k8s-image-pull-sec]:https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 [metrics]: https://book.kubebuilder.io/reference/metrics.html?highlight=metr#metrics
 [memcached_controller]: https://github.com/operator-framework/operator-sdk/tree/master/testdata/go/v3/memcached-operator
 [rbac_markers]: https://book.kubebuilder.io/reference/markers/rbac.html
@@ -433,3 +448,4 @@ E.g `kubectl logs deployment.apps/memcached-operator-controller-manager -n memca
 [component-config-tutorial]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/docs/book/src/component-config-tutorial/tutorial.md
 [plugins-phase1-design-doc]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/extensible-cli-and-scaffolding-plugins-phase-1.md
 [migration-doc]: /docs/upgrading-sdk-version/
+[tutorial-deploy]: /docs/building-operators/golang/tutorial/#run-the-operator

--- a/website/content/en/docs/building-operators/helm/migration.md
+++ b/website/content/en/docs/building-operators/helm/migration.md
@@ -9,7 +9,7 @@ description: Instructions for migrating an Helm-based operator built prior to `v
 
 The v1.0 release improves upon prior `operator-sdk` releases with a new project structure and CLI, each of which enhances project extensibility and customizability. These design changes are influenced by [`kubebuilder`](https://book.kubebuilder.io/).
 
-**Note:** It is recommended that you have your project upgraded to the latest SDK release version (0.19.x+) before following the steps in this guide to migrate to the new layout. However, the steps might work from previous versions as well. In this case, if you find an issue which is not covered here then check the previous [Migration Guides][migration-doc] which might help out.
+**Note:** It is recommended that you have your project upgraded to the latest SDK v1.y release version before following the steps in this guide to migrate to the new layout. However, the steps might work from previous versions as well. In this case, if you find an issue which is not covered here then check the previous [Migration Guides][migration-doc] which might help out.
 
 ### What was changed
 
@@ -40,6 +40,17 @@ Generated files with the default API versions:
 
 The easy migration path is to initialize a new project, re-recreate APIs, then copy pre-v1.0.0 configuration files into the new project.
 
+### Prerequisites
+
+- Go through the [installation guide][install-guide].
+- User authorized with `cluster-admin` permissions.
+- An accessible image registry for various operator images (ex. [hub.docker.com](https://hub.docker.com/signup),
+[quay.io](https://quay.io/)) and be logged in in your command line environment.
+  - `example.com` is used as the registry Docker Hub namespace in these examples.
+  Replace it with another value if using a different registry or namespace.
+  - The registry/namespace must be public, or the cluster must be provisioned with an
+  [image pull secret][k8s-image-pull-sec] if the image namespace is private.
+
 ### Creating a new project
 
 In Kubebuilder-style projects, CRD groups are defined using two different flags
@@ -52,7 +63,7 @@ domain we're using for the APIs in our existing project.
 To determine the domain, look at the `spec.group` field in your CRDs in the
 `deploy/crds` directory.
 
-The domain is everything after the first DNS segment. Using `cache.example.com` as an
+The domain is everything after the first DNS segment. Using `demo.example.com` as an
 example, the `--domain` would be `example.com`.
 
 So let's create a new project with the same domain (`example.com`):
@@ -64,7 +75,7 @@ operator-sdk init --plugins=helm --domain=example.com
 ```
 
 Now that we have our new project initialized, we need to re-create each of our APIs.
-Using our API example from earlier (`cache.example.com`), we'll use `cache` for the
+Using our API example from earlier (`demo.example.com`), we'll use `demo` for the
 `--group` flag.
 
 For `--version` and `--kind`, we use `spec.versions[0].name` and `spec.names.kind`, respectively.
@@ -72,7 +83,7 @@ For `--version` and `--kind`, we use `spec.versions[0].name` and `spec.names.kin
 For each API in the existing project, run:
 ```sh
 operator-sdk create api \
-    --group=cache \
+    --group=demo \
     --version=<version> \
     --kind=<Kind> \
     --helm-chart=<path_to_existing_project>/helm-charts/<chart>
@@ -97,7 +108,7 @@ Check if you have custom options in the `watches.yaml` file of your existing pro
 
 **NOTE**: Do not remove the `+kubebuilder:scaffold:watch` [marker][marker]. It allows the tool to update the watches file when new APIs are created.
 
-### Checking the Permissions (RBAC)
+### Checking RBAC Permissions
 
 In your new project, roles are automatically generated in `config/rbac/role.yaml`.
 If you modified these permissions manually in `deploy/role.yaml` in your existing
@@ -123,7 +134,7 @@ The following rules were used in earlier versions of helm-operator to automatica
   - apiGroups:
     - apps
     resourceNames:
-    - memcached-operator
+    - nginx-operator
     resources:
     - deployments/finalizers
     verbs:
@@ -149,22 +160,33 @@ Note that the following environment variables are no longer used.
 - `OPERATOR_NAME` is deprecated. It is used to define the name for a leader election config map. Operator authors should begin using `--leader-election-id` instead.
 - `POD_NAME` was used to enable a particular pod to hold the leader election lock when the Helm operator used the leader for life mechanism. Helm operator now uses controller-runtime's leader with lease mechanism, and `POD_NAME` is no longer necessary.
 
-## Exporting metrics
+### Exporting metrics
 
 If you are using metrics and would like to keep them exported you will need to configure
 it in the `config/default/kustomization.yaml`. Please see the [metrics][metrics] doc to know how you can perform this setup.
 
 The default port used by the metric endpoint binds to was changed from `:8383` to `:8080`. To continue using port `8383`, specify `--metrics-addr=:8383` when you start the operator.
 
-## Checking the changes
+### Verify the migration
 
-Finally, follow the steps in the ["run the Operator"][run-the-operator] section to verify your project is running.
+The project can now be deployed on cluster by running the command:
 
-[quickstart]: /docs/building-operators/helm/quickstart
-[integration-doc]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/integrating-kubebuilder-and-osdk.md
-[run-the-operator]: /docs/building-operators/helm/tutorial#run-the-operator
+```sh
+make deploy IMG=example.com/nginx-operator:v0.0.1
+```
+
+You can troubleshoot your deployment by checking container logs:
+```sh
+kubectl logs deployment.apps/nginx-operator-controller-manager -n nginx-operator-system -c manager
+```
+
+For further steps regarding the deployment of the operator, creation of custom resources, and cleaning up of resources, see the [tutorial][tutorial-deploy].
+
+[install-guide]: /docs/building-operators/helm/installation
+[k8s-image-pull-sec]:https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 [kustomize]: https://github.com/kubernetes-sigs/kustomize
 [kube-auth-proxy]: https://github.com/brancz/kube-rbac-proxy
 [metrics]: https://book.kubebuilder.io/reference/metrics.html?highlight=metr#metrics
 [marker]: https://book.kubebuilder.io/reference/markers.html?highlight=markers#marker-syntax
 [migration-doc]: /docs/upgrading-sdk-version/
+[tutorial-deploy]: /docs/building-operators/helm/tutorial/#run-the-operator


### PR DESCRIPTION
**Description of the change:**
- docs/building-operators/*/migration.md: make sure these are aligned and have prerequisites

**Motivation for the change:** migration guides should all have prerequisites. Follows up on #4665.

/kind documentation

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
