### PR TITLE
add new optional for bundle validate

### DIFF
--- a/changelog/fragments/new-option-validate.yaml
+++ b/changelog/fragments/new-option-validate.yaml
@@ -1,0 +1,13 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Add new optional flag `--optional-values` to the command `operator-sdk bundle validate`. This option allow to inform a list of key and values to the validators. (e.g. `operator-sdk bundle validate ./bundle --optional-values=k8s-version=1.22 --select-optional suite=operatorframework`)
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/markbates/inflect v1.0.4
 	github.com/onsi/ginkgo v1.15.0
 	github.com/onsi/gomega v1.10.5
-	github.com/operator-framework/api v0.8.0
+	github.com/operator-framework/api v0.8.1-0.20210414192051-b51286920978
 	github.com/operator-framework/operator-lib v0.4.0
 	github.com/operator-framework/operator-registry v1.15.3
 	github.com/prometheus/client_golang v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -802,8 +802,8 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/operator-framework/api v0.3.22/go.mod h1:GVNiB6AQucwdZz3ZFXNv9HtcLOzcFnr6O/QldzKG93g=
 github.com/operator-framework/api v0.5.2 h1:NLgOoi70+iyz4vVJeeJUKaFT8wZaCbCHzS1eExCqX7A=
 github.com/operator-framework/api v0.5.2/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
-github.com/operator-framework/api v0.8.0 h1:S1R5BaPKeZoACbu0913mPnG33s7GOA2VrT9gvOeBjbU=
-github.com/operator-framework/api v0.8.0/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
+github.com/operator-framework/api v0.8.1-0.20210414192051-b51286920978 h1:I7bA53PwWaCr5x64vIjYNt384D0zQUwsZ8TA2DttRhQ=
+github.com/operator-framework/api v0.8.1-0.20210414192051-b51286920978/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
 github.com/operator-framework/operator-lib v0.4.0 h1:g7tGRo+FikHgFZDmRdHkOxyTv3sViI+Ujiqbfd9Tfsk=
 github.com/operator-framework/operator-lib v0.4.0/go.mod h1:kOjV7h01DCSw3RZAqYdHyHyVwuJL8hvG53tSZoDZfsQ=
 github.com/operator-framework/operator-registry v1.15.3 h1:C+u+zjDh6yQAKN+DbUvPeLjojZtJftvp/J28rRqiWWU=

--- a/internal/cmd/operator-sdk/bundle/validate/optional.go
+++ b/internal/cmd/operator-sdk/bundle/validate/optional.go
@@ -47,8 +47,8 @@ var optionalValidators = validators{
 }
 
 // runOptionalValidators runs optional validators selected by sel on bundle.
-func runOptionalValidators(bundle *apimanifests.Bundle, sel labels.Selector) []apierrors.ManifestResult {
-	return optionalValidators.run(bundle, sel)
+func runOptionalValidators(bundle *apimanifests.Bundle, sel labels.Selector, optionalValues map[string]string) []apierrors.ManifestResult {
+	return optionalValidators.run(bundle, sel, optionalValues)
 }
 
 // listOptionalValidators lists all optional validators.
@@ -101,7 +101,7 @@ func (vals validators) checkMatches(sel labels.Selector) error {
 }
 
 // run runs optional validators selected by sel on bundle.
-func (vals validators) run(bundle *apimanifests.Bundle, sel labels.Selector) (results []apierrors.ManifestResult) {
+func (vals validators) run(bundle *apimanifests.Bundle, sel labels.Selector, optionalValues map[string]string) (results []apierrors.ManifestResult) {
 	// No selector set, do not run any optional validators.
 	if sel == nil || sel.String() == "" {
 		return results
@@ -115,6 +115,9 @@ func (vals validators) run(bundle *apimanifests.Bundle, sel labels.Selector) (re
 	for _, obj := range bundle.Objects {
 		objs = append(objs, obj)
 	}
+
+	// Pass the --optional-values. e.g. --optional-values="k8s-version=1.22"
+	objs = append(objs, optionalValues)
 
 	for _, v := range vals {
 		if sel.Matches(labels.Set(v.labels)) {

--- a/internal/cmd/operator-sdk/bundle/validate/optional_test.go
+++ b/internal/cmd/operator-sdk/bundle/validate/optional_test.go
@@ -46,14 +46,14 @@ var _ = Describe("Running optional validators", func() {
 		It("runs no validators for an empty selector", func() {
 			bundle = &apimanifests.Bundle{}
 			sel = labels.SelectorFromSet(map[string]string{})
-			Expect(vals.run(bundle, sel)).To(HaveLen(0))
+			Expect(vals.run(bundle, sel, nil)).To(HaveLen(0))
 		})
 		It("runs a validator for one selector on an empty bundle", func() {
 			bundle = &apimanifests.Bundle{}
 			sel = labels.SelectorFromSet(map[string]string{
 				nameKey: "operatorhub",
 			})
-			results = vals.run(bundle, sel)
+			results = vals.run(bundle, sel, map[string]string{"k8s-version": "1.22"})
 			Expect(results).To(HaveLen(1))
 			Expect(results[0].Errors).To(HaveLen(1))
 		})
@@ -63,7 +63,7 @@ var _ = Describe("Running optional validators", func() {
 			sel = labels.SelectorFromSet(map[string]string{
 				nameKey: "operatorhub",
 			})
-			results = vals.run(bundle, sel)
+			results = vals.run(bundle, sel, nil)
 			Expect(results).To(HaveLen(1))
 			// Only test that more than one error was returned than the empty bundle case, which
 			// indicates validation happening.

--- a/website/content/en/docs/cli/operator-sdk_bundle_validate.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle_validate.md
@@ -68,11 +68,12 @@ To validate a bundle against the validator for operatorhub.io specifically, in a
 ### Options
 
 ```
-  -h, --help                     help for validate
-  -b, --image-builder string     Tool to pull and unpack bundle images. Only used when validating a bundle image. One of: [docker, podman, none] (default "docker")
-      --list-optional            List all optional validators available. When set, no validators will be run
-  -o, --output string            Result format for results. One of: [text, json-alpha1]. Note: output format types containing "alphaX" are subject to change and not covered by guarantees of stable APIs. (default "text")
-      --select-optional string   Label selector to select optional validators to run. Run this command with '--list-optional' to list available optional validators
+  -h, --help                                                 help for validate
+  -b, --image-builder string                                 Tool to pull and unpack bundle images. Only used when validating a bundle image. One of: [docker, podman, none] (default "docker")
+      --list-optional                                        List all optional validators available. When set, no validators will be run
+      --optional-values --optional-values=k8s-version=1.22   Inform a []string map of key=values which can be used by the validator. e.g. to check the operator bundle against an Kubernetes version that it is intended to be distributed use --optional-values=k8s-version=1.22 (default [])
+  -o, --output string                                        Result format for results. One of: [text, json-alpha1]. Note: output format types containing "alphaX" are subject to change and not covered by guarantees of stable APIs. (default "text")
+      --select-optional string                               Label selector to select optional validators to run. Run this command with '--list-optional' to list available optional validators
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/olm-integration/generation.md
+++ b/website/content/en/docs/olm-integration/generation.md
@@ -237,6 +237,18 @@ bundle: ...
   operator-sdk bundle validate ./bundle --select-optional name=operatorhub
 ```
 
+Also, see that you can test the bundle against the suite of test to ensure it against all criteria:
+
+```sh 
+operator-sdk bundle validate ./bundle --select-optional suite=operatorframework 
+```  
+
+**Note**: The `OperatorHub.io` validator in the `operatorframework` optional suite allows you to validate that your manifests can work with a Kubernetes cluster of a particular version using the `k8s-version` optional key value:
+
+```sh 
+operator-sdk bundle validate ./bundle --select-optional suite=operatorframework --optional-values=k8s-version=1.22
+```
+
 Documentation on optional validators:
 - [`operatorhub`][operatorhub_validator]
 


### PR DESCRIPTION
**Description of the change:**

- Add a new optional flag to pass optional values to the validators.  For more info see the EP: https://github.com/operator-framework/enhancements/blob/master/enhancements/operator-hub-check.md

<img width="1067" alt="Screen Shot 2021-03-24 at 01 43 43" src="https://user-images.githubusercontent.com/7708031/112242908-8f9c9300-8c44-11eb-9a03-8297a3be470f.png">
<img width="1068" alt="Screen Shot 2021-03-24 at 01 44 06" src="https://user-images.githubusercontent.com/7708031/112242917-93301a00-8c44-11eb-83a4-782e40a5ec2e.png">

**Motivation for the change:**

Allow SDK to use the new checks added for OperatorHub.io

**NOTE** This PR is using my fork. We need to get merged first: https://github.com/operator-framework/api/pull/103 and follow-up: https://github.com/operator-framework/api/pull/111

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
