### PR TITLE
`run bundle(-upgrade)`: configure service account and secret

### DIFF
--- a/changelog/fragments/run-bundle-with-secret.yaml
+++ b/changelog/fragments/run-bundle-with-secret.yaml
@@ -1,0 +1,10 @@
+entries:
+  - description: >
+      Added `--service-account` to `run bundle` and `run bundle-upgrade` to bind
+      registry objects to a non-default service account.
+    kind: addition
+  - description: >
+      Added `--secret-name` to `run bundle` and `run bundle-upgrade` to configure
+      the registry Pod with an in-cluster docker config Secret
+      to pull bundle images from private registries.
+    kind: addition

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.6.1
+	github.com/thoas/go-funk v0.8.0
 	golang.org/x/mod v0.3.0
 	golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e
 	gomodules.xyz/jsonpatch/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -964,6 +964,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/thoas/go-funk v0.8.0 h1:JP9tKSvnpFVclYgDM0Is7FD9M4fhPvqA0s0BsXmzSRQ=
+github.com/thoas/go-funk v0.8.0/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/internal/cmd/operator-sdk/run/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/run/bundle/cmd.go
@@ -16,7 +16,6 @@ package bundle
 
 import (
 	"context"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -26,18 +25,14 @@ import (
 )
 
 func NewCmd(cfg *operator.Configuration) *cobra.Command {
-	var timeout time.Duration
-
 	i := bundle.NewInstall(cfg)
 	cmd := &cobra.Command{
-		Use:   "bundle <bundle-image>",
-		Short: "Deploy an Operator in the bundle format with OLM",
-		Args:  cobra.ExactArgs(1),
-		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
-			return cfg.Load()
-		},
+		Use:     "bundle <bundle-image>",
+		Short:   "Deploy an Operator in the bundle format with OLM",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: func(*cobra.Command, []string) error { return cfg.Load() },
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
+			ctx, cancel := context.WithTimeout(cmd.Context(), cfg.Timeout)
 			defer cancel()
 
 			i.BundleImage = args[0]
@@ -49,10 +44,9 @@ func NewCmd(cfg *operator.Configuration) *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().SortFlags = false
-	cfg.BindFlags(cmd.PersistentFlags())
+
+	cfg.BindFlags(cmd.Flags())
 	i.BindFlags(cmd.Flags())
 
-	cmd.Flags().DurationVar(&timeout, "timeout", 2*time.Minute, "install timeout")
 	return cmd
 }

--- a/internal/cmd/operator-sdk/run/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/run/bundle/cmd.go
@@ -27,8 +27,10 @@ import (
 func NewCmd(cfg *operator.Configuration) *cobra.Command {
 	i := bundle.NewInstall(cfg)
 	cmd := &cobra.Command{
-		Use:     "bundle <bundle-image>",
-		Short:   "Deploy an Operator in the bundle format with OLM",
+		Use:   "bundle <bundle-image>",
+		Short: "Deploy an Operator in the bundle format with OLM",
+		Long: `The single argument to this command is a bundle image, with the full registry path specified.
+If using a docker.io image, you must specify docker.io(/<namespace>)?/<bundle-image-name>:<tag>.`,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: func(*cobra.Command, []string) error { return cfg.Load() },
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/cmd/operator-sdk/run/bundleupgrade/cmd.go
+++ b/internal/cmd/operator-sdk/run/bundleupgrade/cmd.go
@@ -27,8 +27,10 @@ import (
 func NewCmd(cfg *operator.Configuration) *cobra.Command {
 	u := bundleupgrade.NewUpgrade(cfg)
 	cmd := &cobra.Command{
-		Use:     "bundle-upgrade <bundle-image>",
-		Short:   "Upgrade an Operator previously installed in the bundle format with OLM",
+		Use:   "bundle-upgrade <bundle-image>",
+		Short: "Upgrade an Operator previously installed in the bundle format with OLM",
+		Long: `The single argument to this command is a bundle image, with the full registry path specified.
+If using a docker.io image, you must specify docker.io(/<namespace>)?/<bundle-image-name>:<tag>.`,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: func(*cobra.Command, []string) error { return cfg.Load() },
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/cmd/operator-sdk/run/packagemanifests/packagemanifests.go
+++ b/internal/cmd/operator-sdk/run/packagemanifests/packagemanifests.go
@@ -16,7 +16,6 @@ package packagemanifests
 
 import (
 	"context"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -26,8 +25,6 @@ import (
 )
 
 func NewCmd(cfg *operator.Configuration) *cobra.Command {
-	var timeout time.Duration
-
 	i := packagemanifests.NewInstall(cfg)
 	cmd := &cobra.Command{
 		Use:   "packagemanifests [packagemanifests-root-dir]",
@@ -35,11 +32,11 @@ func NewCmd(cfg *operator.Configuration) *cobra.Command {
 		Long: `'run packagemanifests' deploys an Operator's package manifests with OLM. The command's argument
 will default to './packagemanifests' if unset; if set, the argument must be a package manifests root directory,
 ex. '<project-root>/packagemanifests'.`,
-		Aliases:           []string{"pm"},
-		Args:              cobra.MaximumNArgs(1),
-		PersistentPreRunE: func(_ *cobra.Command, _ []string) error { return cfg.Load() },
+		Aliases: []string{"pm"},
+		Args:    cobra.MaximumNArgs(1),
+		PreRunE: func(*cobra.Command, []string) error { return cfg.Load() },
 		Run: func(cmd *cobra.Command, args []string) {
-			ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
+			ctx, cancel := context.WithTimeout(cmd.Context(), cfg.Timeout)
 			defer cancel()
 
 			if len(args) == 0 {
@@ -55,10 +52,13 @@ ex. '<project-root>/packagemanifests'.`,
 			}
 		},
 	}
-	cmd.Flags().SortFlags = false
-	cfg.BindFlags(cmd.PersistentFlags())
-	i.BindFlags(cmd.Flags())
 
-	cmd.Flags().DurationVar(&timeout, "timeout", 2*time.Minute, "install timeout")
+	cfg.BindFlags(cmd.Flags())
+	i.BindFlags(cmd.Flags())
+	// Not implemented.
+	if err := cmd.Flags().MarkHidden("service-account"); err != nil {
+		log.Fatal(err)
+	}
+
 	return cmd
 }

--- a/internal/olm/operator/bundle/install.go
+++ b/internal/olm/operator/bundle/install.go
@@ -52,6 +52,8 @@ func (i *Install) BindFlags(fs *pflag.FlagSet) {
 	// --mode is hidden so only users who know what they're doing can alter add mode.
 	fs.StringVar((*string)(&i.BundleAddMode), "mode", "", "mode to use for adding bundle to index")
 	_ = fs.MarkHidden("mode")
+
+	i.IndexImageCatalogCreator.BindFlags(fs)
 }
 
 func (i Install) Run(ctx context.Context) (*v1alpha1.ClusterServiceVersion, error) {

--- a/internal/olm/operator/bundleupgrade/upgrade.go
+++ b/internal/olm/operator/bundleupgrade/upgrade.go
@@ -49,6 +49,8 @@ func (u *Upgrade) BindFlags(fs *pflag.FlagSet) {
 	// --mode is hidden so only users who know what they're doing can alter add mode.
 	fs.StringVar((*string)(&u.BundleAddMode), "mode", "", "mode to use for adding new bundle version to index")
 	_ = fs.MarkHidden("mode")
+
+	u.IndexImageCatalogCreator.BindFlags(fs)
 }
 
 func (u Upgrade) Run(ctx context.Context) (*v1alpha1.ClusterServiceVersion, error) {

--- a/internal/olm/operator/config.go
+++ b/internal/olm/operator/config.go
@@ -16,6 +16,7 @@ package operator
 
 import (
 	"context"
+	"time"
 
 	v1 "github.com/operator-framework/api/pkg/operators/v1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -30,10 +31,12 @@ import (
 
 type Configuration struct {
 	Namespace      string
+	ServiceAccount string
 	KubeconfigPath string
 	RESTConfig     *rest.Config
 	Client         client.Client
 	Scheme         *runtime.Scheme
+	Timeout        time.Duration
 
 	overrides *clientcmd.ConfigOverrides
 }
@@ -54,6 +57,11 @@ func (c *Configuration) BindFlags(fs *pflag.FlagSet) {
 	})
 	fs.StringVar(&c.KubeconfigPath, "kubeconfig", "",
 		"Path to the kubeconfig file to use for CLI requests.")
+	fs.StringVar(&c.ServiceAccount, "service-account", "",
+		"Service account name to bind registry objects to. If unset, the default service account is used. "+
+			"This value does not override the operator's service account")
+	fs.DurationVar(&c.Timeout, "timeout", 2*time.Minute,
+		"Duration to wait for the command to complete before failing")
 }
 
 func (c *Configuration) Load() error {

--- a/internal/olm/operator/registry/olm_resources.go
+++ b/internal/olm/operator/registry/olm_resources.go
@@ -81,6 +81,14 @@ func withSDKPublisher(pkgName string) func(*v1alpha1.CatalogSource) {
 	}
 }
 
+// withSecrets adds secretNames to a CatalogSource's secrets. Secrets are
+// assumed to be image pull secrets ("type: kubernetes.io/dockerconfigjson").
+func withSecrets(secretNames ...string) func(*v1alpha1.CatalogSource) {
+	return func(cs *v1alpha1.CatalogSource) {
+		cs.Spec.Secrets = append(cs.Spec.Secrets, secretNames...)
+	}
+}
+
 // newCatalogSource creates a new CatalogSource with a name derived from
 // pkgName, the package manifest's packageName, in namespace. opts will
 // be applied to the CatalogSource object.

--- a/website/content/en/docs/building-operators/ansible/quickstart.md
+++ b/website/content/en/docs/building-operators/ansible/quickstart.md
@@ -57,9 +57,13 @@ This guide walks through an example of building a simple memcached-operator powe
   ```
 
 1. Run your bundle. If your bundle image is hosted in a private registry,
-set `--secret-name` to the image pull secret name for that registry host:
+add the image pull secret for that registry host to the service account in use
+and set `--secret-name` to the secret name:
+<!-- TODO(estroz): remove the service account requirement once OLM releases a patch or new
+minor release containing https://github.com/operator-framework/operator-lifecycle-manager/pull/1941 -->
 
   ```sh
+  kubectl patch serviceaccount default -p '{"imagePullSecrets":[{"name":"<reg secret name>"}]}'
   operator-sdk run bundle example.com/memcached-operator-bundle:v0.0.1
   ```
 

--- a/website/content/en/docs/building-operators/ansible/quickstart.md
+++ b/website/content/en/docs/building-operators/ansible/quickstart.md
@@ -56,7 +56,8 @@ This guide walks through an example of building a simple memcached-operator powe
   make bundle-build bundle-push
   ```
 
-1. Run your bundle:
+1. Run your bundle. If your bundle image is hosted in a private registry,
+set `--secret-name` to the image pull secret name for that registry host:
 
   ```sh
   operator-sdk run bundle example.com/memcached-operator-bundle:v0.0.1

--- a/website/content/en/docs/building-operators/ansible/tutorial.md
+++ b/website/content/en/docs/building-operators/ansible/tutorial.md
@@ -209,7 +209,8 @@ in the `bundle` directory containing manifests and metadata defining your operat
 make bundle bundle-build bundle-push
 ```
 
-Finally, run your bundle:
+Finally, run your bundle. If your bundle image is hosted in a private registry,
+set `--secret-name` to the image pull secret name for that registry host.
 
 ```sh
 operator-sdk run bundle example.com/memcached-operator-bundle:v0.0.1

--- a/website/content/en/docs/building-operators/ansible/tutorial.md
+++ b/website/content/en/docs/building-operators/ansible/tutorial.md
@@ -210,9 +210,13 @@ make bundle bundle-build bundle-push
 ```
 
 Finally, run your bundle. If your bundle image is hosted in a private registry,
-set `--secret-name` to the image pull secret name for that registry host.
+add the image pull secret for that registry host to the service account in use
+and set `--secret-name` to the secret name:
+<!-- TODO(estroz): remove the service account requirement once OLM releases a patch or new
+minor release containing https://github.com/operator-framework/operator-lifecycle-manager/pull/1941 -->
 
 ```sh
+kubectl patch serviceaccount default -p '{"imagePullSecrets":[{"name":"<reg secret name>"}]}'
 operator-sdk run bundle example.com/memcached-operator-bundle:v0.0.1
 ```
 

--- a/website/content/en/docs/building-operators/golang/quickstart.md
+++ b/website/content/en/docs/building-operators/golang/quickstart.md
@@ -57,9 +57,13 @@ This guide walks through an example of building a simple memcached-operator usin
   ```
 
 1. Run your bundle. If your bundle image is hosted in a private registry,
-set `--secret-name` to the image pull secret name for that registry host:
+add the image pull secret for that registry host to the service account in use
+and set `--secret-name` to the secret name:
+<!-- TODO(estroz): remove the service account requirement once OLM releases a patch or new
+minor release containing https://github.com/operator-framework/operator-lifecycle-manager/pull/1941 -->
 
   ```sh
+  kubectl patch serviceaccount default -p '{"imagePullSecrets":[{"name":"<reg secret name>"}]}'
   operator-sdk run bundle example.com/memcached-operator-bundle:v0.0.1
   ```
 

--- a/website/content/en/docs/building-operators/golang/quickstart.md
+++ b/website/content/en/docs/building-operators/golang/quickstart.md
@@ -56,7 +56,8 @@ This guide walks through an example of building a simple memcached-operator usin
   make bundle-build bundle-push
   ```
 
-1. Run your bundle:
+1. Run your bundle. If your bundle image is hosted in a private registry,
+set `--secret-name` to the image pull secret name for that registry host:
 
   ```sh
   operator-sdk run bundle example.com/memcached-operator-bundle:v0.0.1

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -340,9 +340,13 @@ make bundle bundle-build bundle-push
 ```
 
 Finally, run your bundle. If your bundle image is hosted in a private registry,
-set `--secret-name` to the image pull secret name for that registry host.
+add the image pull secret for that registry host to the service account in use
+and set `--secret-name` to the secret name:
+<!-- TODO(estroz): remove the service account requirement once OLM releases a patch or new
+minor release containing https://github.com/operator-framework/operator-lifecycle-manager/pull/1941 -->
 
 ```sh
+kubectl patch serviceaccount default -p '{"imagePullSecrets":[{"name":"<reg secret name>"}]}'
 operator-sdk run bundle example.com/memcached-operator-bundle:v0.0.1
 ```
 

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -339,7 +339,8 @@ in the `bundle` directory containing manifests and metadata defining your operat
 make bundle bundle-build bundle-push
 ```
 
-Finally, run your bundle:
+Finally, run your bundle. If your bundle image is hosted in a private registry,
+set `--secret-name` to the image pull secret name for that registry host.
 
 ```sh
 operator-sdk run bundle example.com/memcached-operator-bundle:v0.0.1

--- a/website/content/en/docs/building-operators/helm/quickstart.md
+++ b/website/content/en/docs/building-operators/helm/quickstart.md
@@ -57,7 +57,8 @@ This guide walks through an example of building a simple nginx-operator powered 
   make bundle-build bundle-push
   ```
 
-1. Run your bundle:
+1. Run your bundle. If your bundle image is hosted in a private registry,
+set `--secret-name` to the image pull secret name for that registry host:
 
   ```sh
   operator-sdk run bundle example.com/nginx-operator-bundle:v0.0.1

--- a/website/content/en/docs/building-operators/helm/quickstart.md
+++ b/website/content/en/docs/building-operators/helm/quickstart.md
@@ -58,10 +58,14 @@ This guide walks through an example of building a simple nginx-operator powered 
   ```
 
 1. Run your bundle. If your bundle image is hosted in a private registry,
-set `--secret-name` to the image pull secret name for that registry host:
+add the image pull secret for that registry host to the service account in use
+and set `--secret-name` to the secret name:
+<!-- TODO(estroz): remove the service account requirement once OLM releases a patch or new
+minor release containing https://github.com/operator-framework/operator-lifecycle-manager/pull/1941 -->
 
   ```sh
-  operator-sdk run bundle example.com/nginx-operator-bundle:v0.0.1
+  kubectl patch serviceaccount default -p '{"imagePullSecrets":[{"name":"<reg secret name>"}]}'
+  operator-sdk run bundle example.com/memcached-operator-bundle:v0.0.1
   ```
 
 1. Create a sample Nginx custom resource:

--- a/website/content/en/docs/building-operators/helm/tutorial.md
+++ b/website/content/en/docs/building-operators/helm/tutorial.md
@@ -243,10 +243,14 @@ make bundle bundle-build bundle-push
 ```
 
 Finally, run your bundle. If your bundle image is hosted in a private registry,
-set `--secret-name` to the image pull secret name for that registry host.
+add the image pull secret for that registry host to the service account in use
+and set `--secret-name` to the secret name:
+<!-- TODO(estroz): remove the service account requirement once OLM releases a patch or new
+minor release containing https://github.com/operator-framework/operator-lifecycle-manager/pull/1941 -->
 
 ```sh
-operator-sdk run bundle example.com/nginx-operator-bundle:v0.0.1
+kubectl patch serviceaccount default -p '{"imagePullSecrets":[{"name":"<reg secret name>"}]}'
+operator-sdk run bundle example.com/memcached-operator-bundle:v0.0.1
 ```
 
 Check out the [docs][quickstart-bundle] for a deep dive into `operator-sdk`'s OLM integration.

--- a/website/content/en/docs/building-operators/helm/tutorial.md
+++ b/website/content/en/docs/building-operators/helm/tutorial.md
@@ -242,7 +242,8 @@ in the `bundle` directory containing manifests and metadata defining your operat
 make bundle bundle-build bundle-push
 ```
 
-Finally, run your bundle:
+Finally, run your bundle. If your bundle image is hosted in a private registry,
+set `--secret-name` to the image pull secret name for that registry host.
 
 ```sh
 operator-sdk run bundle example.com/nginx-operator-bundle:v0.0.1

--- a/website/content/en/docs/cli/operator-sdk_cleanup.md
+++ b/website/content/en/docs/cli/operator-sdk_cleanup.md
@@ -22,7 +22,7 @@ operator-sdk cleanup <operatorPackageName> [flags]
   -h, --help                     help for cleanup
       --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string         If present, namespace scope for this CLI request
-      --timeout duration         Time to wait for the command to complete before failing (default 2m0s)
+      --timeout duration         Duration to wait for the command to complete before failing (default 2m0s)
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
@@ -12,10 +12,12 @@ operator-sdk run bundle-upgrade <bundle-image> [flags]
 ### Options
 
 ```
-      --timeout duration    upgrade timeout (default 2m0s)
-      --kubeconfig string   Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string    If present, namespace scope for this CLI request
-  -h, --help                help for bundle-upgrade
+  -h, --help                     help for bundle-upgrade
+      --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string         If present, namespace scope for this CLI request
+      --secret-name string       Name of image pull secret required to pull bundle images. This secret must be in docker config format, and tied to the namespace, and optionally service account, that this command is configured to run in
+      --service-account string   Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
+      --timeout duration         Duration to wait for the command to complete before failing (default 2m0s)
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
@@ -5,6 +5,11 @@ title: "operator-sdk run bundle-upgrade"
 
 Upgrade an Operator previously installed in the bundle format with OLM
 
+### Synopsis
+
+The single argument to this command is a bundle image, with the full registry path specified.
+If using a docker.io image, you must specify docker.io(/&lt;namespace&gt;)?/&lt;bundle-image-name&gt;:&lt;tag&gt;.
+
 ```
 operator-sdk run bundle-upgrade <bundle-image> [flags]
 ```
@@ -15,7 +20,7 @@ operator-sdk run bundle-upgrade <bundle-image> [flags]
   -h, --help                     help for bundle-upgrade
       --kubeconfig string        Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string         If present, namespace scope for this CLI request
-      --secret-name string       Name of image pull secret required to pull bundle images. This secret must be in docker config format, and tied to the namespace, and optionally service account, that this command is configured to run in
+      --secret-name string       Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
       --service-account string   Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
       --timeout duration         Duration to wait for the command to complete before failing (default 2m0s)
 ```

--- a/website/content/en/docs/cli/operator-sdk_run_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle.md
@@ -12,12 +12,14 @@ operator-sdk run bundle <bundle-image> [flags]
 ### Options
 
 ```
+  -h, --help                            help for bundle
       --index-image string              index image in which to inject bundle (default "quay.io/operator-framework/upstream-opm-builder:latest")
       --install-mode InstallModeValue   install mode
-      --timeout duration                install timeout (default 2m0s)
       --kubeconfig string               Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string                If present, namespace scope for this CLI request
-  -h, --help                            help for bundle
+      --secret-name string              Name of image pull secret required to pull bundle images. This secret must be in docker config format, and tied to the namespace, and optionally service account, that this command is configured to run in
+      --service-account string          Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
+      --timeout duration                Duration to wait for the command to complete before failing (default 2m0s)
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/cli/operator-sdk_run_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle.md
@@ -5,6 +5,11 @@ title: "operator-sdk run bundle"
 
 Deploy an Operator in the bundle format with OLM
 
+### Synopsis
+
+The single argument to this command is a bundle image, with the full registry path specified.
+If using a docker.io image, you must specify docker.io(/&lt;namespace&gt;)?/&lt;bundle-image-name&gt;:&lt;tag&gt;.
+
 ```
 operator-sdk run bundle <bundle-image> [flags]
 ```
@@ -17,7 +22,7 @@ operator-sdk run bundle <bundle-image> [flags]
       --install-mode InstallModeValue   install mode
       --kubeconfig string               Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string                If present, namespace scope for this CLI request
-      --secret-name string              Name of image pull secret required to pull bundle images. This secret must be in docker config format, and tied to the namespace, and optionally service account, that this command is configured to run in
+      --secret-name string              Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
       --service-account string          Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
       --timeout duration                Duration to wait for the command to complete before failing (default 2m0s)
 ```

--- a/website/content/en/docs/cli/operator-sdk_run_packagemanifests.md
+++ b/website/content/en/docs/cli/operator-sdk_run_packagemanifests.md
@@ -18,12 +18,12 @@ operator-sdk run packagemanifests [packagemanifests-root-dir] [flags]
 ### Options
 
 ```
+  -h, --help                            help for packagemanifests
       --install-mode InstallModeValue   install mode
-      --version string                  Packaged version of the operator to deploy
-      --timeout duration                install timeout (default 2m0s)
       --kubeconfig string               Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string                If present, namespace scope for this CLI request
-  -h, --help                            help for packagemanifests
+      --timeout duration                Duration to wait for the command to complete before failing (default 2m0s)
+      --version string                  Packaged version of the operator to deploy
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/olm-integration/quickstart-bundle.md
+++ b/website/content/en/docs/olm-integration/quickstart-bundle.md
@@ -110,6 +110,14 @@ to ensure the on-disk bundle representation is correct.
 At this point in development we've generated all files necessary to build the memcached-operator bundle.
 Now we're ready to test and deploy the Operator with OLM.
 
+**Note:** if testing a bundle hosted in a private registry, set the `--secret-name` flag to
+the name of the appropriate in-cluster image pull secret. If the index image being tested
+is in a private registry, add that secret [to a service account][add-sa-secret] and set
+`--service-account` to that service account's name; you may have to set `--namespace`
+if the service account is in a different namespace than that configured in your kubeconfig.
+
+[add-sa-secret]:https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
+
 ### Testing bundles
 
 Before proceeding, make sure you've [Installed OLM](#enabling-olm) onto your

--- a/website/content/en/docs/olm-integration/quickstart-bundle.md
+++ b/website/content/en/docs/olm-integration/quickstart-bundle.md
@@ -110,11 +110,12 @@ to ensure the on-disk bundle representation is correct.
 At this point in development we've generated all files necessary to build the memcached-operator bundle.
 Now we're ready to test and deploy the Operator with OLM.
 
-**Note:** if testing a bundle hosted in a private registry, set the `--secret-name` flag to
-the name of the appropriate in-cluster image pull secret. If the index image being tested
-is in a private registry, add that secret [to a service account][add-sa-secret] and set
-`--service-account` to that service account's name; you may have to set `--namespace`
+**Note:** if testing a bundle hosted in a private registry, add the image pull
+secret for that registry host [to the service account][add-sa-secret] in use
+and set `--secret-name` to the secret name. You may have to set `--namespace`
 if the service account is in a different namespace than that configured in your kubeconfig.
+<!-- TODO(estroz): remove the service account requirement once OLM releases a patch or new
+minor release containing https://github.com/operator-framework/operator-lifecycle-manager/pull/1941 -->
 
 [add-sa-secret]:https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
 

--- a/website/content/en/docs/olm-integration/testing-deployment.md
+++ b/website/content/en/docs/olm-integration/testing-deployment.md
@@ -18,10 +18,12 @@ to inform OLM of that registry and which Operator versions it can deploy and whe
 and `run bundle-upgrade` can only upgrade one Operator and one version of that Operator at a time, 
 hence their intended purpose being testing only.
 - If testing a bundle hosted in a private registry, set the `--secret-name` flag to
-the name of the appropriate in-cluster image pull secret.
-- If testing an index image hosted in a private registry, add the appropriate image pull secret
+the name of the appropriate in-cluster image pull secret, and add the same secret
 [to a service account][add-sa-secret] and set `--service-account` to that service account's name;
-you may have to set `--namespace` if the service account is in a different namespace than that configured in your kubeconfig.
+you may have to set `--namespace` if the service account is in a different namespace
+than that configured in your kubeconfig.
+<!-- TODO(estroz): remove the service account requirement once OLM releases a patch or new
+minor release containing https://github.com/operator-framework/operator-lifecycle-manager/pull/1941 -->
 
 
 ## `operator-sdk run bundle` command overview

--- a/website/content/en/docs/olm-integration/testing-deployment.md
+++ b/website/content/en/docs/olm-integration/testing-deployment.md
@@ -8,9 +8,24 @@ This document discusses the behavior of `operator-sdk <run|cleanup>` subcommands
 and assumes you are familiar with [OLM][olm], related terminology,
 and have read the SDK-OLM integration [design proposal][sdk-olm-design].
 
-**Note:** before continuing, please read the [caveats](#caveats) section below.
+### Caveats
+
+- `run bundle`, `run bundle-upgrade`, `run packagemanifests`, and `cleanup` are intended to be used for testing purposes only,
+since these commands create a transient image registry that should not be used in production.
+Typically a registry is deployed separately and a set of catalog manifests are created in the cluster
+to inform OLM of that registry and which Operator versions it can deploy and where to deploy the Operator.
+- `run bundle` and `run packagemanifests` can only deploy one Operator and one version of that Operator at a time, 
+and `run bundle-upgrade` can only upgrade one Operator and one version of that Operator at a time, 
+hence their intended purpose being testing only.
+- If testing a bundle hosted in a private registry, set the `--secret-name` flag to
+the name of the appropriate in-cluster image pull secret.
+- If testing an index image hosted in a private registry, add the appropriate image pull secret
+[to a service account][add-sa-secret] and set `--service-account` to that service account's name;
+you may have to set `--namespace` if the service account is in a different namespace than that configured in your kubeconfig.
+
 
 ## `operator-sdk run bundle` command overview
+
 `operator-sdk run bundle` assumes OLM is already installed and running on your
 cluster. It also assumes that your Operator has a valid [bundle][bundle-format].
 See the [creating a bundle][creating-bundle] guide for more information. See the
@@ -103,6 +118,7 @@ Let's look at the anatomy of the `run packagemanifests` configuration model:
   SDK project.
 
 ## `operator-sdk run bundle-upgrade` command overview
+
 `operator-sdk run bundle-upgrade` assumes OLM is already installed and running on your 
 cluster and that the Operator has a valid [bundle][bundle-format]. It also assumes that 
 the previous version of the Operator was deployed on the cluster using `run bundle` command 
@@ -149,16 +165,6 @@ Let's look at the anatomy of the `cleanup` configuration model:
 - **delete-operator-groups**: a boolean indicating to delete all operator groups. This is an optional field
   which will default to false if not provided. If set to true, operator groups will be deleted.
 
-### Caveats
-
-- `run bundle`, `run bundle-upgrade`, `run packagemanifests`, and `cleanup` are intended to be used for testing purposes only,
-since these commands create a transient image registry that should not be used in production.
-Typically a registry is deployed separately and a set of catalog manifests are created in the cluster
-to inform OLM of that registry and which Operator versions it can deploy and where to deploy the Operator.
-- `run bundle` and `run packagemanifests` can only deploy one Operator and one version of that Operator at a time, 
-and `run bundle-upgrade` can only upgrade one Operator and one version of that Operator at a time, 
-hence their intended purpose being testing only.
-
 
 [olm]:https://github.com/operator-framework/operator-lifecycle-manager/
 [sdk-olm-design]:https://github.com/operator-framework/operator-sdk/blob/master/proposals/sdk-integration-with-olm.md
@@ -169,3 +175,4 @@ hence their intended purpose being testing only.
 [cli-olm-install]:/docs/cli/operator-sdk_olm_install
 [cli-olm-status]:/docs/cli/operator-sdk_olm_status
 [creating-bundles]:/docs/olm-integration/quickstart-bundle/#creating-a-bundle
+[add-sa-secret]:https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account

--- a/website/content/en/docs/overview/cheat-sheet.md
+++ b/website/content/en/docs/overview/cheat-sheet.md
@@ -32,12 +32,13 @@ For further information check [Operator SDK Integration with Operator Lifecycle 
 |-------|-----------|
 | `make bundle`          | Create/update the [bundle][bundle] based on the project manifests in the `bundle/` directory. More info [Create a bundle][creating-a-bundle].      |
 | `operator-sdk bundle validate ./bundle`          | To validate your [bundle][bundle] spec definition.      |
-| `operator-sdk bundle validate ./bundle --select-optional suite=operatorframework` | Validate your bundle against [OperatorHub.io][operatorhub-io] criteria. For further information use the flag.`--help`. |
+| `operator-sdk bundle validate ./bundle --select-optional suite=operatorframework` | Validate your bundle against [OperatorHub.io][operatorhub-io] criteria. For further information use the flag`--help`. |
 | `operator-sdk olm install` | To install OLM on your cluster for development purposes. |
 | `operator-sdk olm uninstall` | To uninstall OLM from your cluster. |
 | `make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>` | To build your bundle operator image. |
 | `make bundle-build bundle-push BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>` | To build and push your bundle operator image. |
-| `operator-sdk run bundle <some-registry>/<project-name-bundle>:<tag>.` | To deploy your bundle operator using OLM on your cluster for development purposes. |
+| `operator-sdk run bundle <some-registry>/<project-name-bundle>:<tag>` | To deploy your bundle operator using OLM on your cluster for development purposes. |
+| `operator-sdk run bundle --service-account test-sa --secret-name registry-pull-secret private-registry.org/bundle:v1.2.3` | Configure `run bundle` (and `run bundle-upgrade`) to use a bundle image pull secret and non-default service account |
 
 ### Updating bundle channels
  

--- a/website/content/en/docs/overview/cheat-sheet.md
+++ b/website/content/en/docs/overview/cheat-sheet.md
@@ -32,13 +32,15 @@ For further information check [Operator SDK Integration with Operator Lifecycle 
 |-------|-----------|
 | `make bundle`          | Create/update the [bundle][bundle] based on the project manifests in the `bundle/` directory. More info [Create a bundle][creating-a-bundle].      |
 | `operator-sdk bundle validate ./bundle`          | To validate your [bundle][bundle] spec definition.      |
-| `operator-sdk bundle validate ./bundle --select-optional suite=operatorframework` | Validate your bundle against [OperatorHub.io][operatorhub-io] criteria. For further information use the flag`--help`. |
+| `operator-sdk bundle validate ./bundle --select-optional suite=operatorframework` | Validate your bundle against [OperatorHub.io][operatorhub-io] criteria. For further information use the flag `--help`. |
 | `operator-sdk olm install` | To install OLM on your cluster for development purposes. |
 | `operator-sdk olm uninstall` | To uninstall OLM from your cluster. |
 | `make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>` | To build your bundle operator image. |
 | `make bundle-build bundle-push BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>` | To build and push your bundle operator image. |
 | `operator-sdk run bundle <some-registry>/<project-name-bundle>:<tag>` | To deploy your bundle operator using OLM on your cluster for development purposes. |
-| `operator-sdk run bundle --service-account test-sa --secret-name registry-pull-secret private-registry.org/bundle:v1.2.3` | Configure `run bundle` (and `run bundle-upgrade`) to use a bundle image pull secret and non-default service account |
+| `operator-sdk run bundle --service-account sa-with-secret --secret-name registry-pull-secret private-registry.org/bundle:v1.2.3` | Configure `run bundle` (and `run bundle-upgrade`) to use an image pull secret and non-default service account configured with that secret |
+<!-- TODO(estroz): remove the service account requirement once OLM releases a patch or new
+minor release containing https://github.com/operator-framework/operator-lifecycle-manager/pull/1941 -->
 
 ### Updating bundle channels
  


### PR DESCRIPTION
**Description of the change:** This PR adds `--service-account` to `run bundle` and `run bundle-upgrade` to bind registry objects to a non-default service account. It also adds `--secret-name` to `run bundle` and `run bundle-upgrade` to configure the registry Pod with an in-cluster docker config Secret to pull bundle images from private registries.

**Motivation for the change:** private registries containing bundles should be accessible by `opm` within the ephemeral registry pod. The service account can be used to configure image pull secrets for private index images.

Relates to #4650

/kind feature

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
