### PR TITLE
*: pin internally used images to specific versions, add TODO's for others

### DIFF
--- a/hack/check-links.sh
+++ b/hack/check-links.sh
@@ -11,7 +11,7 @@ docker run --rm -v "$(pwd):/src" -v sdk-html:/src/website/public klakegg/hugo:0.
 
 header_text "Checking links"
 # For config explanation: https://github.com/gjtorikian/html-proofer#special-cases-for-the-command-line
-docker run --rm -v sdk-html:/target klakegg/html-proofer:latest /target \
+docker run --rm -v sdk-html:/target klakegg/html-proofer:3.18.8 /target \
   --empty-alt-ignore \
   --http-status-ignore 429 \
   --allow_hash_href \

--- a/internal/olm/operator/bundleupgrade/upgrade.go
+++ b/internal/olm/operator/bundleupgrade/upgrade.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/operator-framework/operator-sdk/internal/olm/operator"
 	"github.com/operator-framework/operator-sdk/internal/olm/operator/registry"
-	"github.com/operator-framework/operator-sdk/internal/olm/operator/registry/index"
 )
 
 type Upgrade struct {
@@ -84,7 +83,7 @@ func (u *Upgrade) setup(ctx context.Context) error {
 	// defer defaulting the bundle add mode to after the existing CatalogSource is retrieved.
 	u.IndexImageCatalogCreator.PackageName = u.OperatorInstaller.PackageName
 	u.IndexImageCatalogCreator.BundleImage = u.BundleImage
-	u.IndexImageCatalogCreator.IndexImage = index.DefaultIndexImage
+	u.IndexImageCatalogCreator.IndexImage = registry.DefaultIndexImage
 
 	return nil
 }

--- a/internal/olm/operator/registry/index/registry_pod.go
+++ b/internal/olm/operator/registry/index/registry_pod.go
@@ -36,9 +36,6 @@ import (
 )
 
 const (
-	// DefaultIndexImage is the index base image used if none is specified. It contains no bundles.
-	DefaultIndexImage = "quay.io/operator-framework/upstream-opm-builder:latest"
-
 	// defaultGRPCPort is the default grpc container port that the registry pod exposes
 	defaultGRPCPort = 50051
 	defaultDBPath   = "/database/index.db"
@@ -84,9 +81,6 @@ func (rp *RegistryPod) init(cfg *operator.Configuration) error {
 	}
 	if rp.DBPath == "" {
 		rp.DBPath = defaultDBPath
-	}
-	if rp.IndexImage == "" {
-		rp.IndexImage = DefaultIndexImage
 	}
 	rp.cfg = cfg
 
@@ -169,6 +163,10 @@ func (rp *RegistryPod) validate() error {
 		if err := item.AddMode.Validate(); err != nil {
 			return fmt.Errorf("invalid bundle add mode: %v", err)
 		}
+	}
+
+	if rp.IndexImage == "" {
+		return errors.New("index image cannot be empty")
 	}
 
 	return nil

--- a/internal/olm/operator/registry/index/registry_pod_test.go
+++ b/internal/olm/operator/registry/index/registry_pod_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/olm/operator"
 )
 
+const testIndexImageTag = "some-image:v1.2.3"
+
 // newFakeClient() returns a fake controller runtime client
 func newFakeClient() client.Client {
 	return fakeclient.NewClientBuilder().Build()
@@ -59,7 +61,10 @@ var _ = Describe("RegistryPod", func() {
 					Client:    newFakeClient(),
 					Namespace: "test-default",
 				}
-				rp = &RegistryPod{BundleItems: []BundleItem{defaultBundleItem}}
+				rp = &RegistryPod{
+					BundleItems: []BundleItem{defaultBundleItem},
+					IndexImage:  testIndexImageTag,
+				}
 				By("initializing the RegistryPod")
 				Expect(rp.init(cfg)).To(Succeed())
 			})
@@ -150,6 +155,7 @@ var _ = Describe("RegistryPod", func() {
 			It("checkPodStatus should return error when pod check is false and context is done", func() {
 				rp := &RegistryPod{
 					BundleItems: []BundleItem{defaultBundleItem},
+					IndexImage:  testIndexImageTag,
 				}
 				Expect(rp.init(cfg)).To(Succeed())
 

--- a/internal/scorecard/testpod.go
+++ b/internal/scorecard/testpod.go
@@ -30,6 +30,10 @@ import (
 const (
 	// PodBundleRoot is the directory containing all bundle data within a test pod.
 	PodBundleRoot = "/bundle"
+
+	// The image used to untar bundles prior to running tests within a runner Pod.
+	// This image tag should always be pinned to a specific version.
+	scorecardUntarImage = "docker.io/busybox:1.33.0"
 )
 
 // getPodDefinition fills out a Pod definition based on
@@ -75,7 +79,7 @@ func getPodDefinition(configMapName string, test v1alpha3.TestConfiguration, r P
 			InitContainers: []v1.Container{
 				{
 					Name:            "scorecard-untar",
-					Image:           "busybox",
+					Image:           scorecardUntarImage,
 					ImagePullPolicy: v1.PullIfNotPresent,
 					Args: []string{
 						"tar",


### PR DESCRIPTION
**Description of the change:**
- *: pin internally used images to specific versions, add TODO(v2.0.0)'s for public images

**Motivation for the change:** all images should be pinned for reproducibility and backwards-compatibility.

/area dependency

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
