### PR TITLE
Identify downstream SDK in metrics annotations

### DIFF
--- a/internal/annotations/metrics/metrics.go
+++ b/internal/annotations/metrics/metrics.go
@@ -69,6 +69,11 @@ func parseVersion(input string) string {
 		return "unknown"
 	}
 
+	if strings.Contains(input, "ocp") {
+		version = version + "-ocp"
+		input = strings.Replace(input, "-ocp", "", 1)
+	}
+
 	if isUnreleased(input) {
 		version = version + "+git"
 	}

--- a/internal/annotations/metrics/metrics_test.go
+++ b/internal/annotations/metrics/metrics_test.go
@@ -15,6 +15,8 @@
 package metrics
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -36,6 +38,26 @@ var _ = Describe("SDK Label helper functions", func() {
 			output := parseVersion(version)
 			Expect(output).To(Equal("v0.18.0+git"))
 		})
+		It("should extract the right downstream sdk version", func() {
+			version := "v1.3.0-ocp"
+			output := parseVersion(version)
+			Expect(output).To(Equal("v1.3.0-ocp"))
+		})
+		It("should extract the right downstream sdk version", func() {
+			version := "v1.3.0-ocp-ge87627f4"
+			output := parseVersion(version)
+			Expect(output).To(Equal("v1.3.0-ocp+git"))
+		})
+		It("should extract the right downstream sdk version", func() {
+			version := "v1.3.0-ocp-ge87627f4-dirty"
+			output := parseVersion(version)
+			Expect(output).To(Equal("v1.3.0-ocp+git"))
+		})
 
 	})
 })
+
+func TestVersion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "metrics Suite")
+}


### PR DESCRIPTION


<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
- Support identification of downstream SDK metrics. Initially downstream SDK version tag (eg: `v1.3.0-ocp`) was considered to be an unreleased version and appeared as `v1.3.0+git` in CSV.
- Register Ginko handler. Since this wasn't done, the tests in `metrics` package were not being run.

Signed-off-by: varshaprasad96 <varshaprasad96@gmail.com>

**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
