### PR TITLE
Changed arch with uname for finding the architecture in macOS

### DIFF
--- a/website/content/en/docs/installation/_index.md
+++ b/website/content/en/docs/installation/_index.md
@@ -29,7 +29,7 @@ brew install operator-sdk
 Set platform information:
 
 ```sh
-export ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac)
+export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
 export OS=$(uname | awk '{print tolower($0)}')
 ```
 


### PR DESCRIPTION
**Description of the change:**
Updated the `arch` command with `uname` for more accurate architecture identification. 

**Motivation for the change:**
The `arch` command in macOS due to [legacy reasons](https://stackoverflow.com/a/12763379) reports whether the Intel arches are capable of 32-bit.

For example, in my MBP 16" (Intel):
```
$ arch
i386
$ uname -m
x86_64
```
Consequently, the snippet for downloading `operator-sdk` manually. That's why I chose `uname -m` as a replacement.

**Checklist**
If the pull request includes user-facing changes, extra documentation is required:
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

PTAL