### PR TITLE
ansible-operator: bump base image to `ansible-operator-base:b187f86157fbdc115da60d275628b3dd633e55c2`

### DIFF
--- a/changelog/fragments/urllib3-1.26.4.yaml
+++ b/changelog/fragments/urllib3-1.26.4.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Bumped urllib3 in ansible-operator-base and ansible-operator images to 1.26.4
+      for a security fix.
+    kind: change

--- a/images/ansible-operator/Dockerfile
+++ b/images/ansible-operator/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/ansible-operator
 
 # Final image.
-FROM quay.io/operator-framework/ansible-operator-base:c6796de9b29ace4f4c737325c9037f6f715ce6d1
+FROM quay.io/operator-framework/ansible-operator-base:b187f86157fbdc115da60d275628b3dd633e55c2
 
 ENV HOME=/opt/ansible \
     USER_NAME=ansible \


### PR DESCRIPTION
**Description of the change:**
- images/ansible-operator/Dockerfile: bump base image to `ansible-operator-base:b187f86157fbdc115da60d275628b3dd633e55c2`

**Motivation for the change:** [security fix](https://github.com/urllib3/urllib3/releases/tag/1.26.4)

/area dependency


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
