### PR TITLE
[v1.5.x] images/ansible-operator: pin urllib3 to 1.26.4

### DIFF
--- a/changelog/fragments/urllib3-1.26.4.yaml
+++ b/changelog/fragments/urllib3-1.26.4.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Bumped urllib3 in ansible-operator-base and ansible-operator images to 1.26.4
+      for a security fix.
+    kind: change

--- a/images/ansible-operator/base.Dockerfile
+++ b/images/ansible-operator/base.Dockerfile
@@ -26,6 +26,7 @@ RUN yum clean all && rm -rf /var/cache/yum/* \
     openshift==0.10.3 \
     ansible==2.9.15 \
     jmespath==0.10.0 \
+    urllib3==1.26.4 \
   && yum remove -y gcc libffi-devel openssl-devel python38-devel \
   && yum clean all \
   && rm -rf /var/cache/yum


### PR DESCRIPTION
Security fix