### PR TITLE
[v1.5.x] ansible-operator: bump base image to `ansible-operator-base:v1.5.0-2-g052de7c858de99f224d26b80959c0cc6805e53a3`

### DIFF
--- a/images/ansible-operator/Dockerfile
+++ b/images/ansible-operator/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/ansible-operator
 
 # Final image.
-FROM quay.io/operator-framework/ansible-operator-base:v1.4.0-45-g65af4898a1cbeb032954979c68bba0d422454b6d
+FROM quay.io/operator-framework/ansible-operator-base:v1.5.0-2-g052de7c858de99f224d26b80959c0cc6805e53a3
 
 ENV HOME=/opt/ansible \
     USER_NAME=ansible \


### PR DESCRIPTION
**Description of the change:**
-  images/ansible-operator/Dockerfile: bump base image to `ansible-operator-base:v1.5.0-2-g052de7c858de99f224d26b80959c0cc6805e53a3`

**Motivation for the change:** see #4723


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
