### PR TITLE
feat: add kustomize plugin

### DIFF
--- a/changelog/fragments/add-plugins.yaml
+++ b/changelog/fragments/add-plugins.yaml
@@ -1,0 +1,7 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Added `kustomize.common/v1` plugin which scaffolds the a commonly used project base that leverages `kustomize`.
+    kind: "addition"
+    breaking: false

--- a/internal/cmd/operator-sdk/cli/cli.go
+++ b/internal/cmd/operator-sdk/cli/cli.go
@@ -102,6 +102,7 @@ func GetPluginsCLIAndRoot() (*cli.CLI, *cobra.Command) {
 			gov2Bundle,
 			gov3Bundle,
 			helmBundle,
+			kustomizev1.Plugin{},
 		),
 		cli.WithDefaultPlugins(cfgv2.Version, gov2Bundle),
 		cli.WithDefaultPlugins(cfgv3.Version, gov3Bundle),

--- a/website/content/en/docs/cli/operator-sdk.md
+++ b/website/content/en/docs/cli/operator-sdk.md
@@ -29,6 +29,7 @@ and <PROJECT VERSION> a supported project version for these plugins.
                 go.kubebuilder.io/v2 |                       2, 3
                 go.kubebuilder.io/v3 |                          3
     helm.sdk.operatorframework.io/v1 |                          3
+  kustomize.common.kubebuilder.io/v1 |                          3
 
 For more specific help for the init command of a certain plugins and project version
 configuration please run:


### PR DESCRIPTION
**Description**
Add kustomize plugin

**Motivation**
Allow using the SDK tool to only scaffold the default common base. 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)