### PR TITLE
workflows/deploy-manual: automate ansible-operator base image bump PR creation

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -51,3 +51,20 @@ jobs:
         platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
         push: true
         tags: ${{ steps.tag.outputs.tag }}
+
+    # This change will be staged and committed in the PR pushed below.
+    # The script below will fail if no change was made.
+    - name: update ansible-operator base
+      run: |
+        set -e
+        sed -i -E 's|FROM quay\.io/operator-framework/ansible-operator-base:.+|FROM '"${{ steps.tag.outputs.tag }}"'|' images/ansible-operator/Dockerfile
+        git diff --exit-code --quiet && echo "Failed to update images/ansible-operator/Dockerfile" && exit 1
+
+    - name: create PR
+      uses: peter-evans/create-pull-request@v3
+      with:
+        title: "[auto] image(ansible-operator): bump base to ${{ steps.tag.outputs.tag }}"
+        commit-message: "[auto] image(ansible-operator): bump base to ${{ steps.tag.outputs.tag }}"
+        body: "New ansible-operator-base image built by https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        delete-branch: true
+        branch-suffix: -ansible-operator-base


### PR DESCRIPTION
**Description of the change:**
- .github/workflows/deploy-manual.yml: patch ansible-operator Dockerfile with new base image tag and create a PR on successful base image build

**Motivation for the change:** automates a step that needs doing on each ansible-operator-base image build.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
