### PR TITLE
bump github.com/operator-framework/api from 0.5.3 to 0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/markbates/inflect v1.0.4
 	github.com/onsi/ginkgo v1.15.0
 	github.com/onsi/gomega v1.10.5
-	github.com/operator-framework/api v0.5.3
+	github.com/operator-framework/api v0.8.0
 	github.com/operator-framework/operator-lib v0.4.0
 	github.com/operator-framework/operator-registry v1.15.3
 	github.com/prometheus/client_golang v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -802,8 +802,8 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/operator-framework/api v0.3.22/go.mod h1:GVNiB6AQucwdZz3ZFXNv9HtcLOzcFnr6O/QldzKG93g=
 github.com/operator-framework/api v0.5.2 h1:NLgOoi70+iyz4vVJeeJUKaFT8wZaCbCHzS1eExCqX7A=
 github.com/operator-framework/api v0.5.2/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
-github.com/operator-framework/api v0.5.3 h1:1RDw2FbuEDtSC7ONKLKgAxtq+iRsV7rRTumD4RLQfSI=
-github.com/operator-framework/api v0.5.3/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
+github.com/operator-framework/api v0.8.0 h1:S1R5BaPKeZoACbu0913mPnG33s7GOA2VrT9gvOeBjbU=
+github.com/operator-framework/api v0.8.0/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
 github.com/operator-framework/operator-lib v0.4.0 h1:g7tGRo+FikHgFZDmRdHkOxyTv3sViI+Ujiqbfd9Tfsk=
 github.com/operator-framework/operator-lib v0.4.0/go.mod h1:kOjV7h01DCSw3RZAqYdHyHyVwuJL8hvG53tSZoDZfsQ=
 github.com/operator-framework/operator-registry v1.15.3 h1:C+u+zjDh6yQAKN+DbUvPeLjojZtJftvp/J28rRqiWWU=

--- a/internal/cmd/operator-sdk/generate/kustomize/manifests.go
+++ b/internal/cmd/operator-sdk/generate/kustomize/manifests.go
@@ -15,6 +15,7 @@
 package kustomize
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -210,6 +211,11 @@ func (c manifestsCmd) run(cfg config.Config) error {
 	if err != nil {
 		return fmt.Errorf("error marshaling CSV base: %v", err)
 	}
+
+	// todo: remove it when the OLM starts to support https://github.com/operator-framework/api/pull/100
+	const cleanup = "cleanup:\n    enabled: false\n  "
+	csvBytes = bytes.ReplaceAll(csvBytes, []byte(cleanup), []byte(""))
+
 	if err = os.MkdirAll(filepath.Join(c.outputDir, "bases"), 0755); err != nil {
 		return err
 	}

--- a/internal/generate/internal/genutil.go
+++ b/internal/generate/internal/genutil.go
@@ -15,6 +15,7 @@
 package genutil
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -61,6 +62,11 @@ func WriteObject(w io.Writer, obj interface{}) error {
 	if err != nil {
 		return err
 	}
+
+	// todo: remove it when the OLM starts to support https://github.com/operator-framework/api/pull/100
+	const cleanup = "cleanup:\n    enabled: false\n  "
+	b = bytes.ReplaceAll(b, []byte(cleanup), []byte(""))
+
 	return write(w, b)
 }
 


### PR DESCRIPTION
**Description**

bump github.com/operator-framework/api from 0.5.3 to 0.8.0
More info: https://github.com/operator-framework/api/compare/v0.5.3...v0.8.0

**Motivation**

- Solve tech debts
- Unblock https://github.com/operator-framework/operator-sdk/pull/4693