### PR TITLE
Ansible fix: align template with ansible-operator cmd flags

### DIFF
--- a/testdata/ansible/memcached-operator/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/ansible/memcached-operator/config/default/manager_auth_proxy_patch.yaml
@@ -22,6 +22,6 @@ spec:
       - name: manager
         args:
         - "--health-probe-bind-address=:6789"
-        - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"
+        - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election"
         - "--leader-election-id=memcached-operator"


### PR DESCRIPTION
## Problem

I scaffolded a new ansible-based operator using master (1ab5feda490014ac4729d70417d300b8afa7f039) but the deployment failed. 

### Errors in the Log

`Error: unknown flag: --metrics-bind-address
Usage:
  ansible-operator run [flags]
`
`Error: unknown flag: --leader-elect
Usage:
  ansible-operator run [flags]
`
Looks like these flags changed recently and we just missed a couple instances. https://github.com/operator-framework/operator-sdk/pull/4654/
