### PR TITLE
fix: ensure labels are ordered in generated bundle

### DIFF
--- a/internal/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/internal/cmd/operator-sdk/generate/bundle/bundle.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -286,6 +287,7 @@ func (c bundleCmd) runMetadata() error {
 	for key, value := range metricsannotations.MakeBundleMetadataLabels(c.layout) {
 		values.OtherLabels = append(values.OtherLabels, fmt.Sprintf("%s=%s", key, value))
 	}
+	sort.Strings(values.OtherLabels)
 
 	// Write each file.
 	metadataDir := filepath.Join(c.outputDir, "metadata")


### PR DESCRIPTION
**Description of the change:**

Sorting the OtherLabels in bundle command.

**Motivation for the change:**

OtherLabels stem from a map and will have random order between
executions causing the generated bundle Dockerfile to potentially
result in a dirty git state.
