### PR TITLE
Add logs that allow users to see what events the controller is receiving

### DIFF
--- a/changelog/fragments/ansible_log_events.yaml
+++ b/changelog/fragments/ansible_log_events.yaml
@@ -1,0 +1,10 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For Ansible-based operators, adds log messages for each event that is received.
+      This will make debugging excessive reconciliations much more straightforward.
+
+    kind: "addition"
+
+    breaking: false

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/operator-framework/operator-lib v0.4.0
 	github.com/operator-framework/operator-registry v1.15.3
 	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
 	github.com/sergi/go-diff v1.1.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/afero v1.2.2

--- a/internal/ansible/controller/controller.go
+++ b/internal/ansible/controller/controller.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/operator-framework/operator-lib/handler"
 	libpredicate "github.com/operator-framework/operator-lib/predicate"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -33,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/operator-framework/operator-sdk/internal/ansible/events"
+	"github.com/operator-framework/operator-sdk/internal/ansible/handler"
 	"github.com/operator-framework/operator-sdk/internal/ansible/predicate"
 	"github.com/operator-framework/operator-sdk/internal/ansible/runner"
 )
@@ -112,7 +112,7 @@ func Add(mgr manager.Manager, options Options) *controller.Controller {
 
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(options.GVK)
-	err = c.Watch(&source.Kind{Type: u}, &handler.InstrumentedEnqueueRequestForObject{}, predicates...)
+	err = c.Watch(&source.Kind{Type: u}, &handler.LoggingEnqueueRequestForObject{}, predicates...)
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)

--- a/internal/ansible/handler/handler_suite_test.go
+++ b/internal/ansible/handler/handler_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Operator-SDK Authors
+// Copyright 2021 The Operator-SDK Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/ansible/handler/handler_suite_test.go
+++ b/internal/ansible/handler/handler_suite_test.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"bytes"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var logBuffer bytes.Buffer
+
+func TestEventhandler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Handler Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(&logBuffer), zap.UseDevMode(true)))
+})

--- a/internal/ansible/handler/logging_enqueue_annotation.go
+++ b/internal/ansible/handler/logging_enqueue_annotation.go
@@ -27,6 +27,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
+const (
+	nilString = "<nil>"
+)
+
 // LoggingEnqueueRequestForAnnotation wraps operator-lib handler for
 // "InstrumentedEnqueueRequestForObject", and logs the events as they occur
 //		&handler.LoggingEnqueueRequestForAnnotation{}
@@ -64,12 +68,12 @@ func (h LoggingEnqueueRequestForAnnotation) logEvent(eventType string, object, n
 		typeString, name, namespace = extractTypedOwnerAnnotations(h.EnqueueRequestForAnnotation.Type, newObject)
 	}
 	if namespace == "" {
-		namespace = "<nil>"
+		namespace = nilString
 	}
 
 	objectNs := object.GetNamespace()
 	if objectNs == "" {
-		objectNs = "<nil>"
+		objectNs = nilString
 	}
 
 	if name != "" && typeString != "" {

--- a/internal/ansible/handler/logging_enqueue_annotation.go
+++ b/internal/ansible/handler/logging_enqueue_annotation.go
@@ -80,7 +80,7 @@ func (h LoggingEnqueueRequestForAnnotation) logEvent(eventType string, object, n
 			kvs = append(kvs, "Owner Namespace", namespace)
 		}
 
-		log.Info("Annotation handler event", kvs...)
+		log.V(1).Info("Annotation handler event", kvs...)
 	}
 }
 

--- a/internal/ansible/handler/logging_enqueue_annotation.go
+++ b/internal/ansible/handler/logging_enqueue_annotation.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package handler
 
 import (

--- a/internal/ansible/handler/logging_enqueue_annotation.go
+++ b/internal/ansible/handler/logging_enqueue_annotation.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 
 	"github.com/operator-framework/operator-lib/handler"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -86,8 +85,12 @@ func (h LoggingEnqueueRequestForAnnotation) logEvent(eventType string, object, n
 }
 
 func extractTypedOwnerAnnotations(ownerGK schema.GroupKind, object metav1.Object) (string, string, string) {
-	if typeString, ok := object.GetAnnotations()[handler.TypeAnnotation]; ok && typeString == ownerGK.String() {
-		if namespacedNameString, ok := object.GetAnnotations()[handler.NamespacedNameAnnotation]; ok {
+	annotations := object.GetAnnotations()
+	if len(annotations) == 0 {
+		return "", "", ""
+	}
+	if typeString, ok := annotations[handler.TypeAnnotation]; ok && typeString == ownerGK.String() {
+		if namespacedNameString, ok := annotations[handler.NamespacedNameAnnotation]; ok {
 			parsed := parseNamespacedName(namespacedNameString)
 			return typeString, parsed.Name, parsed.Namespace
 		}

--- a/internal/ansible/handler/logging_enqueue_annotation.go
+++ b/internal/ansible/handler/logging_enqueue_annotation.go
@@ -1,0 +1,95 @@
+package handler
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/operator-framework/operator-lib/handler"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+// LoggingEnqueueRequestForAnnotation wraps operator-lib handler for
+// "InstrumentedEnqueueRequestForObject", and logs the events as they occur
+//		&handler.LoggingEnqueueRequestForAnnotation{}
+type LoggingEnqueueRequestForAnnotation struct {
+	handler.EnqueueRequestForAnnotation
+}
+
+// Create implements EventHandler, and emits a log message.
+func (h LoggingEnqueueRequestForAnnotation) Create(e event.CreateEvent, q workqueue.RateLimitingInterface) {
+	h.logEvent("Create", e.Object, nil)
+	h.EnqueueRequestForAnnotation.Create(e, q)
+}
+
+// Update implements EventHandler, and emits a log message.
+func (h LoggingEnqueueRequestForAnnotation) Update(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	h.logEvent("Update", e.ObjectOld, e.ObjectNew)
+	h.EnqueueRequestForAnnotation.Update(e, q)
+}
+
+// Delete implements EventHandler, and emits a log message.
+func (h LoggingEnqueueRequestForAnnotation) Delete(e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	h.logEvent("Delete", e.Object, nil)
+	h.EnqueueRequestForAnnotation.Delete(e, q)
+}
+
+// Generic implements EventHandler, and emits a log message.
+func (h LoggingEnqueueRequestForAnnotation) Generic(e event.GenericEvent, q workqueue.RateLimitingInterface) {
+	h.logEvent("Generic", e.Object, nil)
+	h.EnqueueRequestForAnnotation.Generic(e, q)
+}
+
+func (h LoggingEnqueueRequestForAnnotation) logEvent(eventType string, object, newObject client.Object) {
+	typeString, name, namespace := extractTypedOwnerAnnotations(h.EnqueueRequestForAnnotation.Type, object)
+	if newObject != nil && typeString == "" {
+		typeString, name, namespace = extractTypedOwnerAnnotations(h.EnqueueRequestForAnnotation.Type, newObject)
+	}
+	if namespace == "" {
+		namespace = "<nil>"
+	}
+
+	objectNs := object.GetNamespace()
+	if objectNs == "" {
+		objectNs = "<nil>"
+	}
+
+	if name != "" && typeString != "" {
+		log.Info(fmt.Sprintf("Received %s event for dependent resource with GVK %s with name %s in namespace %s, mapped to owner GK %s with name %s in namespace %s",
+			eventType,
+			object.GetObjectKind().GroupVersionKind().String(),
+			object.GetName(),
+			objectNs,
+			typeString,
+			name,
+			namespace))
+	}
+}
+
+func extractTypedOwnerAnnotations(ownerGK schema.GroupKind, object metav1.Object) (string, string, string) {
+	if typeString, ok := object.GetAnnotations()[handler.TypeAnnotation]; ok && typeString == ownerGK.String() {
+		if namespacedNameString, ok := object.GetAnnotations()[handler.NamespacedNameAnnotation]; ok {
+			parsed := parseNamespacedName(namespacedNameString)
+			return typeString, parsed.Name, parsed.Namespace
+		}
+	}
+	return "", "", ""
+}
+
+// parseNamespacedName parses the provided string to extract the namespace and name into a
+// types.NamespacedName. The edge case of empty string is handled prior to calling this function.
+func parseNamespacedName(namespacedNameString string) types.NamespacedName {
+	values := strings.SplitN(namespacedNameString, "/", 2)
+
+	switch len(values) {
+	case 1:
+		return types.NamespacedName{Name: values[0]}
+	default:
+		return types.NamespacedName{Namespace: values[0], Name: values[1]}
+	}
+}

--- a/internal/ansible/handler/logging_enqueue_annotation_test.go
+++ b/internal/ansible/handler/logging_enqueue_annotation_test.go
@@ -227,7 +227,7 @@ var _ = Describe("LoggingEnqueueRequestForAnnotation", func() {
 			logBuffer.Reset()
 			instance.Create(evt, q)
 			Expect(logBuffer.String()).To(MatchRegexp(
-				`ansible.handler.*Create.*/v1.*Node.*node-1.*<nil>.*ReplicaSet.apps.*myapp.*<nil>`,
+				`ansible.handler.*Create.*/v1.*Node.*node-1.*ReplicaSet.apps.*myapp.*`,
 			))
 			Expect(q.Len()).To(Equal(1))
 

--- a/internal/ansible/handler/logging_enqueue_annotation_test.go
+++ b/internal/ansible/handler/logging_enqueue_annotation_test.go
@@ -54,8 +54,7 @@ var _ = Describe("LoggingEnqueueRequestForAnnotation", func() {
 		pod.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
 		podOwner.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
 
-		err := handler.SetOwnerAnnotations(podOwner, pod)
-		Expect(err).To(BeNil())
+		Expect(handler.SetOwnerAnnotations(podOwner, pod)).To(Succeed())
 		instance = LoggingEnqueueRequestForAnnotation{
 			handler.EnqueueRequestForAnnotation{
 				Type: schema.GroupKind{

--- a/internal/ansible/handler/logging_enqueue_annotation_test.go
+++ b/internal/ansible/handler/logging_enqueue_annotation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Operator-SDK Authors
+// Copyright 2021 The Operator-SDK Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/ansible/handler/logging_enqueue_annotation_test.go
+++ b/internal/ansible/handler/logging_enqueue_annotation_test.go
@@ -1,0 +1,447 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/operator-lib/handler"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+var _ = Describe("LoggingEnqueueRequestForAnnotation", func() {
+	var q workqueue.RateLimitingInterface
+	var instance LoggingEnqueueRequestForAnnotation
+	var pod *corev1.Pod
+	var podOwner *corev1.Pod
+
+	BeforeEach(func() {
+		q = controllertest.Queue{Interface: workqueue.New()}
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "biz",
+				Name:      "biz",
+			},
+		}
+		podOwner = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "podOwnerNs",
+				Name:      "podOwnerName",
+			},
+		}
+
+		pod.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
+		podOwner.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
+
+		err := handler.SetOwnerAnnotations(podOwner, pod)
+		Expect(err).To(BeNil())
+		instance = LoggingEnqueueRequestForAnnotation{
+			handler.EnqueueRequestForAnnotation{
+				Type: schema.GroupKind{
+					Group: "",
+					Kind:  "Pod",
+				}}}
+	})
+
+	Describe("Create", func() {
+		It("should emit a log and enqueue a Request with the annotations of the object in case of CreateEvent", func() {
+			evt := event.CreateEvent{
+				Object: pod,
+			}
+
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Create.*/v1.*Pod.*biz.*biz.*Pod.*podOwnerName.*podOwnerNs`,
+			))
+			Expect(q.Len()).To(Equal(1))
+
+			i, _ := q.Get()
+			Expect(i).To(Equal(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: podOwner.Namespace,
+					Name:      podOwner.Name,
+				},
+			}))
+		})
+
+		It("should enqueue a Request to the owner resource when the annotations are applied in child object"+
+			" in the Create Event", func() {
+			repl := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "faz",
+				},
+			}
+			repl.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"})
+
+			err := handler.SetOwnerAnnotations(podOwner, repl)
+			Expect(err).To(BeNil())
+
+			evt := event.CreateEvent{
+				Object: repl,
+			}
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Create.*apps/v1.*ReplicaSet.*faz.*foo.*Pod.*podOwnerName.*podOwnerNs`,
+			))
+			Expect(q.Len()).To(Equal(1))
+
+			i, _ := q.Get()
+			Expect(i).To(Equal(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: podOwner.Namespace,
+					Name:      podOwner.Name,
+				},
+			}))
+		})
+		It("should not emit a log or enqueue a request if there are no annotations matching with the object", func() {
+			repl := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "faz",
+				},
+			}
+			repl.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"})
+
+			evt := event.CreateEvent{
+				Object: repl,
+			}
+
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(Not(ContainSubstring("ansible.handler")))
+			Expect(q.Len()).To(Equal(0))
+		})
+		It("should not emit a log or enqueue a Request if there is no Namespace and name annotation matching the specified object are found", func() {
+			repl := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "faz",
+					Annotations: map[string]string{
+						handler.TypeAnnotation: schema.GroupKind{Group: "", Kind: "Pod"}.String(),
+					},
+				},
+			}
+			repl.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"})
+
+			evt := event.CreateEvent{
+				Object: repl,
+			}
+
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(Not(ContainSubstring("ansible.handler")))
+			Expect(q.Len()).To(Equal(0))
+		})
+		It("should not emit a log or enqueue a Request if there is no TypeAnnotation matching the specified Group and Kind", func() {
+			repl := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "faz",
+
+					Annotations: map[string]string{
+						handler.NamespacedNameAnnotation: "AppService",
+					},
+				},
+			}
+			repl.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"})
+
+			evt := event.CreateEvent{
+				Object: repl,
+			}
+
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(Not(ContainSubstring("ansible.handler")))
+			Expect(q.Len()).To(Equal(0))
+		})
+		It("should emit a log and enqueue a Request if there are no Namespace annotation matching the object", func() {
+			repl := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "faz",
+					Annotations: map[string]string{
+						handler.NamespacedNameAnnotation: "AppService",
+						handler.TypeAnnotation:           schema.GroupKind{Group: "", Kind: "Pod"}.String(),
+					},
+				},
+			}
+			repl.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"})
+
+			evt := event.CreateEvent{
+				Object: repl,
+			}
+
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Create.*apps/v1.*ReplicaSet.*faz.*foo.*Pod.*AppService`,
+			))
+			Expect(q.Len()).To(Equal(1))
+
+			i, _ := q.Get()
+			Expect(i).To(Equal(reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: "", Name: "AppService"}}))
+		})
+		It("should emit a log and enqueue a Request for an object that is cluster scoped which has the annotations", func() {
+			nd := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-1",
+					Annotations: map[string]string{
+						handler.NamespacedNameAnnotation: "myapp",
+						handler.TypeAnnotation:           schema.GroupKind{Group: "apps", Kind: "ReplicaSet"}.String(),
+					},
+				},
+			}
+			nd.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"})
+
+			instance = LoggingEnqueueRequestForAnnotation{handler.EnqueueRequestForAnnotation{Type: schema.GroupKind{Group: "apps", Kind: "ReplicaSet"}}}
+
+			evt := event.CreateEvent{
+				Object: nd,
+			}
+
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Create.*/v1.*Node.*node-1.*<nil>.*ReplicaSet.apps.*myapp.*<nil>`,
+			))
+			Expect(q.Len()).To(Equal(1))
+
+			i, _ := q.Get()
+			Expect(i).To(Equal(reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: "", Name: "myapp"}}))
+		})
+		It("should not emit a log or enqueue a Request for an object that is cluster scoped which does not have annotations", func() {
+			nd := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+			}
+			nd.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"})
+
+			instance = LoggingEnqueueRequestForAnnotation{handler.EnqueueRequestForAnnotation{Type: nd.GetObjectKind().GroupVersionKind().GroupKind()}}
+			evt := event.CreateEvent{
+				Object: nd,
+			}
+
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(Not(ContainSubstring("ansible.handler")))
+			Expect(q.Len()).To(Equal(0))
+		})
+	})
+
+	Describe("Delete", func() {
+		It("should emit a log and enqueue a Request with the annotations of the object in case of DeleteEvent", func() {
+			evt := event.DeleteEvent{
+				Object: pod,
+			}
+			logBuffer.Reset()
+			instance.Delete(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Delete.*/v1.*Pod.*biz.*biz.*Pod.*podOwnerName.*podOwnerNs`,
+			))
+			Expect(q.Len()).To(Equal(1))
+
+			i, _ := q.Get()
+			Expect(i).To(Equal(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: podOwner.Namespace,
+					Name:      podOwner.Name,
+				},
+			}))
+		})
+	})
+
+	Describe("Update", func() {
+		It("should emit a log and enqueue a Request with annotations applied to both objects in UpdateEvent", func() {
+			newPod := pod.DeepCopy()
+			newPod.Name = pod.Name + "2"
+			newPod.Namespace = pod.Namespace + "2"
+
+			err := handler.SetOwnerAnnotations(podOwner, pod)
+			Expect(err).To(BeNil())
+
+			evt := event.UpdateEvent{
+				ObjectOld: pod,
+				ObjectNew: newPod,
+			}
+
+			logBuffer.Reset()
+			instance.Update(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Update.*/v1.*Pod.*biz.*biz.*Pod.*podOwnerName.*podOwnerNs`,
+			))
+			Expect(q.Len()).To(Equal(1))
+
+			i, _ := q.Get()
+			Expect(i).To(Equal(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: podOwner.Namespace,
+					Name:      podOwner.Name,
+				},
+			}))
+		})
+		It("should emit a log and enqueue a Request with the annotations applied in one of the objects in case of UpdateEvent", func() {
+			newPod := pod.DeepCopy()
+			newPod.Name = pod.Name + "2"
+			newPod.Namespace = pod.Namespace + "2"
+			newPod.Annotations = map[string]string{}
+
+			evt := event.UpdateEvent{
+				ObjectOld: pod,
+				ObjectNew: newPod,
+			}
+
+			logBuffer.Reset()
+			instance.Update(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Update.*/v1.*Pod.*biz.*biz.*Pod.*podOwnerName.*podOwnerNs`,
+			))
+			Expect(q.Len()).To(Equal(1))
+			i, _ := q.Get()
+
+			Expect(i).To(Equal(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: podOwner.Namespace,
+					Name:      podOwner.Name,
+				},
+			}))
+		})
+		It("should emit a log and enqueue a Request when the annotations are applied in a different resource in case of UpdateEvent", func() {
+			repl := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "faz",
+				},
+			}
+			repl.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"})
+
+			instance = LoggingEnqueueRequestForAnnotation{
+				handler.EnqueueRequestForAnnotation{
+					Type: schema.GroupKind{
+						Group: "apps",
+						Kind:  "ReplicaSet",
+					}}}
+
+			evt := event.CreateEvent{
+				Object: repl,
+			}
+
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(Not(ContainSubstring("ansible.handler")))
+			Expect(q.Len()).To(Equal(0))
+
+			newRepl := repl.DeepCopy()
+			newRepl.Name = pod.Name + "2"
+			newRepl.Namespace = pod.Namespace + "2"
+
+			newRepl.Annotations = map[string]string{
+				handler.TypeAnnotation:           schema.GroupKind{Group: "apps", Kind: "ReplicaSet"}.String(),
+				handler.NamespacedNameAnnotation: "foo/faz",
+			}
+
+			instance2 := LoggingEnqueueRequestForAnnotation{
+				handler.EnqueueRequestForAnnotation{
+					Type: schema.GroupKind{
+						Group: "apps",
+						Kind:  "ReplicaSet",
+					}}}
+
+			evt2 := event.UpdateEvent{
+				ObjectOld: repl,
+				ObjectNew: newRepl,
+			}
+
+			logBuffer.Reset()
+			instance2.Update(evt2, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Update.*apps/v1.*ReplicaSet.*faz.*foo.*ReplicaSet.apps.*faz.*foo`,
+			))
+			Expect(q.Len()).To(Equal(1))
+
+			i, _ := q.Get()
+			Expect(i).To(Equal(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "foo",
+					Name:      "faz",
+				},
+			}))
+		})
+		It("should emit a log and enqueue multiple Update Requests when different annotations are applied to multiple objects", func() {
+			newPod := pod.DeepCopy()
+			newPod.Name = pod.Name + "2"
+			newPod.Namespace = pod.Namespace + "2"
+
+			err := handler.SetOwnerAnnotations(podOwner, pod)
+			Expect(err).To(BeNil())
+
+			var podOwner2 = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "podOwnerNsTest",
+					Name:      "podOwnerNameTest",
+				},
+			}
+			podOwner2.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Kind: "Pod"})
+
+			err = handler.SetOwnerAnnotations(podOwner2, newPod)
+			Expect(err).To(BeNil())
+
+			evt := event.UpdateEvent{
+				ObjectOld: pod,
+				ObjectNew: newPod,
+			}
+			logBuffer.Reset()
+			instance.Update(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Update.*/v1.*Pod.*biz.*biz.*Pod.*podOwnerName.*podOwnerNs`,
+			))
+			Expect(q.Len()).To(Equal(2))
+		})
+	})
+
+	Describe("Generic", func() {
+		It("should enqueue a Request with the annotations of the object in case of GenericEvent", func() {
+			evt := event.GenericEvent{
+				Object: pod,
+			}
+			logBuffer.Reset()
+			instance.Generic(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Generic.*/v1.*Pod.*biz.*biz.*Pod.*podOwnerName.*podOwnerNs`,
+			))
+			Expect(q.Len()).To(Equal(1))
+
+			i, _ := q.Get()
+			Expect(i).To(Equal(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: podOwner.Namespace,
+					Name:      podOwner.Name,
+				},
+			}))
+		})
+	})
+})

--- a/internal/ansible/handler/logging_enqueue_object.go
+++ b/internal/ansible/handler/logging_enqueue_object.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package handler
 
 import (
@@ -52,5 +65,4 @@ func (h LoggingEnqueueRequestForObject) logEvent(eventType string, object client
 		eventType,
 		object.GetObjectKind().GroupVersionKind().String(),
 		object.GetName(), objectNs))
-
 }

--- a/internal/ansible/handler/logging_enqueue_object.go
+++ b/internal/ansible/handler/logging_enqueue_object.go
@@ -1,0 +1,56 @@
+package handler
+
+import (
+	"fmt"
+
+	"github.com/operator-framework/operator-lib/handler"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var log = logf.Log.WithName("ansible").WithName("handler")
+
+// LoggingEnqueueRequestForObject wraps operator-lib handler for
+// "InstrumentedEnqueueRequestForObject", and logs the events as they occur
+//		&handler.LoggingEnqueueRequestForObject{}
+type LoggingEnqueueRequestForObject struct {
+	handler.InstrumentedEnqueueRequestForObject
+}
+
+// Create implements EventHandler, and emits a log message.
+func (h LoggingEnqueueRequestForObject) Create(e event.CreateEvent, q workqueue.RateLimitingInterface) {
+	h.logEvent("Create", e.Object)
+	h.InstrumentedEnqueueRequestForObject.Create(e, q)
+}
+
+// Update implements EventHandler, and emits a log message.
+func (h LoggingEnqueueRequestForObject) Update(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	h.logEvent("Update", e.ObjectOld)
+	h.InstrumentedEnqueueRequestForObject.Update(e, q)
+}
+
+// Delete implements EventHandler, and emits a log message.
+func (h LoggingEnqueueRequestForObject) Delete(e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	h.logEvent("Delete", e.Object)
+	h.InstrumentedEnqueueRequestForObject.Delete(e, q)
+}
+
+// Generic implements EventHandler, and emits a log message.
+func (h LoggingEnqueueRequestForObject) Generic(e event.GenericEvent, q workqueue.RateLimitingInterface) {
+	h.logEvent("Generic", e.Object)
+	h.EnqueueRequestForObject.Generic(e, q)
+}
+
+func (h LoggingEnqueueRequestForObject) logEvent(eventType string, object client.Object) {
+	objectNs := object.GetNamespace()
+	if objectNs == "" {
+		objectNs = "<nil>"
+	}
+	log.Info(fmt.Sprintf("Received %s event for GVK %s with name %s in namespace %s",
+		eventType,
+		object.GetObjectKind().GroupVersionKind().String(),
+		object.GetName(), objectNs))
+
+}

--- a/internal/ansible/handler/logging_enqueue_object.go
+++ b/internal/ansible/handler/logging_enqueue_object.go
@@ -14,8 +14,6 @@
 package handler
 
 import (
-	"fmt"
-
 	"github.com/operator-framework/operator-lib/handler"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,7 +55,7 @@ func (h LoggingEnqueueRequestForObject) Generic(e event.GenericEvent, q workqueu
 }
 
 func (h LoggingEnqueueRequestForObject) logEvent(eventType string, object client.Object) {
-	kvs := []string{
+	kvs := []interface{}{
 		"Event type", eventType,
 		"GroupVersionKind", object.GetObjectKind().GroupVersionKind().String(),
 		"Name", object.GetName(),
@@ -65,5 +63,6 @@ func (h LoggingEnqueueRequestForObject) logEvent(eventType string, object client
 	if objectNs := object.GetNamespace(); objectNs != "" {
 		kvs = append(kvs, "Namespace", objectNs)
 	}
-	log.Info("Metrics handler event", kvs...))
+
+	log.Info("Metrics handler event", kvs...)
 }

--- a/internal/ansible/handler/logging_enqueue_object.go
+++ b/internal/ansible/handler/logging_enqueue_object.go
@@ -64,5 +64,5 @@ func (h LoggingEnqueueRequestForObject) logEvent(eventType string, object client
 		kvs = append(kvs, "Namespace", objectNs)
 	}
 
-	log.Info("Metrics handler event", kvs...)
+	log.V(1).Info("Metrics handler event", kvs...)
 }

--- a/internal/ansible/handler/logging_enqueue_object.go
+++ b/internal/ansible/handler/logging_enqueue_object.go
@@ -57,12 +57,13 @@ func (h LoggingEnqueueRequestForObject) Generic(e event.GenericEvent, q workqueu
 }
 
 func (h LoggingEnqueueRequestForObject) logEvent(eventType string, object client.Object) {
-	objectNs := object.GetNamespace()
-	if objectNs == "" {
-		objectNs = "<nil>"
+	kvs := []string{
+		"Event type", eventType,
+		"GroupVersionKind", object.GetObjectKind().GroupVersionKind().String(),
+		"Name", object.GetName(),
 	}
-	log.Info(fmt.Sprintf("Received %s event for GVK %s with name %s in namespace %s",
-		eventType,
-		object.GetObjectKind().GroupVersionKind().String(),
-		object.GetName(), objectNs))
+	if objectNs := object.GetNamespace(); objectNs != "" {
+		kvs = append(kvs, "Namespace", objectNs)
+	}
+	log.Info("Metrics handler event", kvs...))
 }

--- a/internal/ansible/handler/logging_enqueue_object_test.go
+++ b/internal/ansible/handler/logging_enqueue_object_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Operator-SDK Authors
+// Copyright 2021 The Operator-SDK Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/ansible/handler/logging_enqueue_object_test.go
+++ b/internal/ansible/handler/logging_enqueue_object_test.go
@@ -1,0 +1,230 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	dto "github.com/prometheus/client_model/go"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+var _ = Describe("LoggingEnqueueRequestForObject", func() {
+	var q workqueue.RateLimitingInterface
+	var instance LoggingEnqueueRequestForObject
+	var pod *corev1.Pod
+
+	BeforeEach(func() {
+		logBuffer.Reset()
+		q = controllertest.Queue{Interface: workqueue.New()}
+		instance = LoggingEnqueueRequestForObject{}
+		pod = &corev1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Pod",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         "biznamespace",
+				Name:              "bizname",
+				CreationTimestamp: metav1.Now(),
+			},
+		}
+	})
+	Describe("Create", func() {
+		It("should emit a log, enqueue a request & emit a metric on a CreateEvent", func() {
+			evt := event.CreateEvent{
+				Object: pod,
+			}
+
+			// test the create
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Create.*/v1.*Pod.*bizname.*biznamespace`,
+			))
+
+			// verify workqueue
+			Expect(q.Len()).To(Equal(1))
+			i, _ := q.Get()
+			Expect(i).To(Equal(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: pod.Namespace,
+					Name:      pod.Name,
+				},
+			}))
+
+			// verify metrics
+			gauges, err := metrics.Registry.Gather()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(gauges)).To(Equal(1))
+			assertMetrics(gauges[0], 1, []*corev1.Pod{pod})
+		})
+	})
+
+	Describe("Delete", func() {
+		Context("when a gauge already exists", func() {
+			BeforeEach(func() {
+				evt := event.CreateEvent{
+					Object: pod,
+				}
+				logBuffer.Reset()
+				instance.Create(evt, q)
+				Expect(logBuffer.String()).To(MatchRegexp(
+					`ansible.handler.*Create.*/v1.*Pod.*bizname.*biznamespace`,
+				))
+				Expect(q.Len()).To(Equal(1))
+			})
+			It("should emit a log, enqueue a request & remove the metric on a DeleteEvent", func() {
+				evt := event.DeleteEvent{
+					Object: pod,
+				}
+
+				logBuffer.Reset()
+				// test the delete
+				instance.Delete(evt, q)
+				Expect(logBuffer.String()).To(MatchRegexp(
+					`ansible.handler.*Delete.*/v1.*Pod.*bizname.*biznamespace`,
+				))
+
+				// verify workqueue
+				Expect(q.Len()).To(Equal(1))
+				i, _ := q.Get()
+				Expect(i).To(Equal(reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: pod.Namespace,
+						Name:      pod.Name,
+					},
+				}))
+
+				// verify metrics
+				gauges, err := metrics.Registry.Gather()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(gauges)).To(Equal(0))
+			})
+		})
+		Context("when a gauge does not exist", func() {
+			It("should emit a log, enqueue a request & there should be no new metric on a DeleteEvent", func() {
+				evt := event.DeleteEvent{
+					Object: pod,
+				}
+
+				logBuffer.Reset()
+				// test the delete
+				instance.Delete(evt, q)
+				Expect(logBuffer.String()).To(MatchRegexp(
+					`ansible.handler.*Delete.*/v1.*Pod.*bizname.*biznamespace`,
+				))
+
+				// verify workqueue
+				Expect(q.Len()).To(Equal(1))
+				i, _ := q.Get()
+				Expect(i).To(Equal(reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: pod.Namespace,
+						Name:      pod.Name,
+					},
+				}))
+
+				// verify metrics
+				gauges, err := metrics.Registry.Gather()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(gauges)).To(Equal(0))
+			})
+		})
+
+	})
+
+	Describe("Update", func() {
+		It("should emit a log and enqueue a request in case of UpdateEvent", func() {
+			newpod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "baznamespace",
+					Name:      "bazname",
+				},
+			}
+			evt := event.UpdateEvent{
+				ObjectOld: pod,
+				ObjectNew: newpod,
+			}
+
+			logBuffer.Reset()
+			// test the update
+			instance.Update(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Update.*/v1.*Pod.*bizname.*biznamespace`,
+			))
+
+			// verify workqueue
+			Expect(q.Len()).To(Equal(2))
+			i, _ := q.Get()
+			Expect(i).To(Equal(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: pod.Namespace,
+					Name:      pod.Name,
+				},
+			}))
+			i, _ = q.Get()
+			Expect(i).To(Equal(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: newpod.Namespace,
+					Name:      newpod.Name,
+				},
+			}))
+
+			// verify metrics
+			gauges, err := metrics.Registry.Gather()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(gauges)).To(Equal(1))
+			assertMetrics(gauges[0], 2, []*corev1.Pod{newpod, pod})
+		})
+	})
+})
+
+func assertMetrics(gauge *dto.MetricFamily, count int, pods []*corev1.Pod) {
+	// need variables to compare the pointers
+	name := "name"
+	namespace := "namespace"
+	g := "group"
+	v := "version"
+	k := "kind"
+
+	Expect(len(gauge.Metric)).To(Equal(count))
+	for i := 0; i < count; i++ {
+		Expect(*gauge.Metric[i].Gauge.Value).To(Equal(float64(pods[i].GetObjectMeta().GetCreationTimestamp().UTC().Unix())))
+
+		for _, l := range gauge.Metric[i].Label {
+			switch l.Name {
+			case &name:
+				Expect(l.Value).To(Equal(pods[i].GetObjectMeta().GetName()))
+			case &namespace:
+				Expect(l.Value).To(Equal(pods[i].GetObjectMeta().GetNamespace()))
+			case &g:
+				Expect(l.Value).To(Equal(pods[i].GetObjectKind().GroupVersionKind().Group))
+			case &v:
+				Expect(l.Value).To(Equal(pods[i].GetObjectKind().GroupVersionKind().Version))
+			case &k:
+				Expect(l.Value).To(Equal(pods[i].GetObjectKind().GroupVersionKind().Kind))
+			}
+		}
+	}
+}

--- a/internal/ansible/handler/logging_enqueue_owner.go
+++ b/internal/ansible/handler/logging_enqueue_owner.go
@@ -14,8 +14,6 @@
 package handler
 
 import (
-	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/util/workqueue"
@@ -63,14 +61,21 @@ func (h LoggingEnqueueRequestForOwner) logEvent(eventType string, object, newObj
 
 	// If no ownerReference was found then it's probably not an event we care about
 	if ownerReference != nil {
-		log.Info(fmt.Sprintf("Received %s event for dependent resource with GVK %s with name %s in namespace %s, mapped to owner GVK %s, Kind=%s with name %s",
-			eventType,
-			object.GetObjectKind().GroupVersionKind().String(),
-			object.GetName(),
-			object.GetNamespace(),
-			ownerReference.APIVersion,
-			ownerReference.Kind,
-			ownerReference.Name))
+		kvs := []interface{}{
+			"Event type", eventType,
+			"GroupVersionKind", object.GetObjectKind().GroupVersionKind().String(),
+			"Name", object.GetName(),
+		}
+		if objectNs := object.GetNamespace(); objectNs != "" {
+			kvs = append(kvs, "Namespace", objectNs)
+		}
+		kvs = append(kvs,
+			"Owner APIVersion", ownerReference.APIVersion,
+			"Owner Kind", ownerReference.Kind,
+			"Owner Name", ownerReference.Name,
+		)
+
+		log.Info("OwnerReference handler event", kvs...)
 	}
 }
 

--- a/internal/ansible/handler/logging_enqueue_owner.go
+++ b/internal/ansible/handler/logging_enqueue_owner.go
@@ -1,0 +1,78 @@
+package handler
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	crHandler "sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+// LoggingEnqueueRequestForOwner wraps operator-lib handler for
+// "InstrumentedEnqueueRequestForObject", and logs the events as they occur
+//		&handler.LoggingEnqueueRequestForOwner{}
+type LoggingEnqueueRequestForOwner struct {
+	crHandler.EnqueueRequestForOwner
+}
+
+// Create implements EventHandler, and emits a log message.
+func (h LoggingEnqueueRequestForOwner) Create(e event.CreateEvent, q workqueue.RateLimitingInterface) {
+	h.logEvent("Create", e.Object, nil)
+	h.EnqueueRequestForOwner.Create(e, q)
+}
+
+// Update implements EventHandler, and emits a log message.
+func (h LoggingEnqueueRequestForOwner) Update(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	h.logEvent("Update", e.ObjectOld, e.ObjectNew)
+	h.EnqueueRequestForOwner.Update(e, q)
+}
+
+// Delete implements EventHandler, and emits a log message.
+func (h LoggingEnqueueRequestForOwner) Delete(e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	h.logEvent("Delete", e.Object, nil)
+	h.EnqueueRequestForOwner.Delete(e, q)
+}
+
+// Generic implements EventHandler, and emits a log message.
+func (h LoggingEnqueueRequestForOwner) Generic(e event.GenericEvent, q workqueue.RateLimitingInterface) {
+	h.logEvent("Generic", e.Object, nil)
+	h.EnqueueRequestForOwner.Generic(e, q)
+}
+
+func (h LoggingEnqueueRequestForOwner) logEvent(eventType string, object, newObject client.Object) {
+	ownerReference := extractTypedOwnerReference(h.EnqueueRequestForOwner.OwnerType.GetObjectKind().GroupVersionKind(), object.GetOwnerReferences())
+	if ownerReference == nil && newObject != nil {
+		ownerReference = extractTypedOwnerReference(h.EnqueueRequestForOwner.OwnerType.GetObjectKind().GroupVersionKind(), newObject.GetOwnerReferences())
+	}
+
+	// If no ownerReference was found then it's probably not an event we care about
+	if ownerReference != nil {
+		log.Info(fmt.Sprintf("Received %s event for dependent resource with GVK %s with name %s in namespace %s, mapped to owner GVK %s, Kind=%s with name %s",
+			eventType,
+			object.GetObjectKind().GroupVersionKind().String(),
+			object.GetName(),
+			object.GetNamespace(),
+			ownerReference.APIVersion,
+			ownerReference.Kind,
+			ownerReference.Name))
+	}
+}
+
+func extractTypedOwnerReference(ownerGVK schema.GroupVersionKind, ownerReferences []metav1.OwnerReference) *metav1.OwnerReference {
+	for _, ownerRef := range ownerReferences {
+		refGV, err := schema.ParseGroupVersion(ownerRef.APIVersion)
+		if err != nil {
+			log.Error(err, "Could not parse OwnerReference APIVersion",
+				"api version", ownerRef.APIVersion)
+		}
+
+		if ownerGVK.Group == refGV.Group &&
+			ownerGVK.Kind == ownerRef.Kind {
+			return &ownerRef
+		}
+	}
+	return nil
+}

--- a/internal/ansible/handler/logging_enqueue_owner.go
+++ b/internal/ansible/handler/logging_enqueue_owner.go
@@ -75,7 +75,7 @@ func (h LoggingEnqueueRequestForOwner) logEvent(eventType string, object, newObj
 			"Owner Name", ownerReference.Name,
 		)
 
-		log.Info("OwnerReference handler event", kvs...)
+		log.V(1).Info("OwnerReference handler event", kvs...)
 	}
 }
 

--- a/internal/ansible/handler/logging_enqueue_owner.go
+++ b/internal/ansible/handler/logging_enqueue_owner.go
@@ -1,3 +1,16 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package handler
 
 import (

--- a/internal/ansible/handler/logging_enqueue_owner_test.go
+++ b/internal/ansible/handler/logging_enqueue_owner_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Operator-SDK Authors
+// Copyright 2021 The Operator-SDK Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/ansible/handler/logging_enqueue_owner_test.go
+++ b/internal/ansible/handler/logging_enqueue_owner_test.go
@@ -1,0 +1,269 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	crHandler "sigs.k8s.io/controller-runtime/pkg/handler"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+var _ = Describe("LoggingEnqueueRequestForOwner", func() {
+	var q workqueue.RateLimitingInterface
+	var instance LoggingEnqueueRequestForOwner
+	var pod *corev1.Pod
+	var podOwner *metav1.OwnerReference
+
+	BeforeEach(func() {
+		q = controllertest.Queue{Interface: workqueue.New()}
+		podOwner = &metav1.OwnerReference{
+			Kind:       "Pod",
+			APIVersion: "v1",
+			Name:       "podOwnerName",
+		}
+
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       "biz",
+				Name:            "biz",
+				OwnerReferences: []metav1.OwnerReference{*podOwner},
+			},
+		}
+
+		pod.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
+
+		instance = LoggingEnqueueRequestForOwner{
+			crHandler.EnqueueRequestForOwner{
+				OwnerType: pod,
+			}}
+	})
+
+	Describe("Create", func() {
+		It("should emit a log with the ownerReference of the object in case of CreateEvent", func() {
+			evt := event.CreateEvent{
+				Object: pod,
+			}
+
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Create.*/v1.*Pod.*biz.*biz.*v1.*Pod.*podOwnerName`,
+			))
+		})
+
+		It("emit a log when the ownerReferences are applied in child object"+
+			" in the Create Event", func() {
+			repl := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "foo",
+					Name:            "faz",
+					OwnerReferences: []metav1.OwnerReference{*podOwner},
+				},
+			}
+			repl.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"})
+
+			evt := event.CreateEvent{
+				Object: repl,
+			}
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Create.*apps/v1.*ReplicaSet.*faz.*foo.*Pod.*podOwnerName`,
+			))
+		})
+		It("should not emit a log or there are no ownerReferences matching with the object", func() {
+			repl := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "faz",
+				},
+			}
+			repl.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"})
+
+			evt := event.CreateEvent{
+				Object: repl,
+			}
+
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(Not(ContainSubstring("ansible.handler")))
+			Expect(q.Len()).To(Equal(0))
+		})
+		It("should not emit a log if the ownerReference does not match the OwnerType", func() {
+			repl := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "faz",
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "v1",
+						Kind:       "ConfigMap",
+						Name:       "podOwnerName",
+					}},
+				},
+			}
+			repl.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"})
+
+			evt := event.CreateEvent{
+				Object: repl,
+			}
+
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(Not(ContainSubstring("ansible.handler")))
+		})
+
+		It("should not emit a log for an object which does not have ownerReferences", func() {
+			repl := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "faz",
+				},
+			}
+			repl.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"})
+
+			evt := event.CreateEvent{
+				Object: repl,
+			}
+
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(Not(ContainSubstring("ansible.handler")))
+		})
+	})
+
+	Describe("Delete", func() {
+		It("should emit a log with the ownerReferenc of the object in case of DeleteEvent", func() {
+			evt := event.DeleteEvent{
+				Object: pod,
+			}
+			logBuffer.Reset()
+			instance.Delete(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Delete.*/v1.*Pod.*biz.*biz.*Pod.*podOwnerName`,
+			))
+		})
+	})
+
+	Describe("Update", func() {
+		It("should emit a log and enqueue a Request with annotations applied to both objects in UpdateEvent", func() {
+			newPod := pod.DeepCopy()
+			newPod.Name = pod.Name + "2"
+			newPod.Namespace = pod.Namespace + "2"
+
+			evt := event.UpdateEvent{
+				ObjectOld: pod,
+				ObjectNew: newPod,
+			}
+
+			logBuffer.Reset()
+			instance.Update(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Update.*/v1.*Pod.*biz.*biz.*Pod.*podOwnerName`,
+			))
+		})
+		It("should emit a log with the ownerReferences applied in one of the objects in case of UpdateEvent", func() {
+			noOwnerPod := pod.DeepCopy()
+			noOwnerPod.Name = pod.Name + "2"
+			noOwnerPod.Namespace = pod.Namespace + "2"
+			noOwnerPod.OwnerReferences = []metav1.OwnerReference{}
+
+			evt := event.UpdateEvent{
+				ObjectOld: pod,
+				ObjectNew: noOwnerPod,
+			}
+
+			logBuffer.Reset()
+			instance.Update(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Update.*/v1.*Pod.*biz.*biz.*Pod.*podOwnerName`,
+			))
+
+			evt = event.UpdateEvent{
+				ObjectOld: noOwnerPod,
+				ObjectNew: pod,
+			}
+
+			logBuffer.Reset()
+			instance.Update(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Update.*/v1.*Pod.*biz.*biz.*Pod.*podOwnerName`,
+			))
+		})
+		It("should emit a log when the OwnerReference is applied after creation in case of UpdateEvent", func() {
+			repl := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "faz",
+				},
+			}
+			repl.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"})
+
+			instance = LoggingEnqueueRequestForOwner{
+				crHandler.EnqueueRequestForOwner{
+					OwnerType: repl,
+				}}
+
+			evt := event.CreateEvent{
+				Object: repl,
+			}
+
+			logBuffer.Reset()
+			instance.Create(evt, q)
+			Expect(logBuffer.String()).To(Not(ContainSubstring("ansible.handler")))
+
+			newRepl := repl.DeepCopy()
+			newRepl.Name = pod.Name + "2"
+			newRepl.Namespace = pod.Namespace + "2"
+
+			newRepl.OwnerReferences = []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "ReplicaSet",
+				Name:       "faz",
+			}}
+
+			evt2 := event.UpdateEvent{
+				ObjectOld: repl,
+				ObjectNew: newRepl,
+			}
+
+			logBuffer.Reset()
+			instance.Update(evt2, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Update.*apps/v1.*ReplicaSet.*faz.*foo.*apps/v1.*ReplicaSet.*faz`,
+			))
+		})
+	})
+
+	Describe("Generic", func() {
+		It("should emit a log with the OwnerReference of the object in case of GenericEvent", func() {
+			evt := event.GenericEvent{
+				Object: pod,
+			}
+			logBuffer.Reset()
+			instance.Generic(evt, q)
+			Expect(logBuffer.String()).To(MatchRegexp(
+				`ansible.handler.*Generic.*/v1.*Pod.*biz.*biz.*Pod.*podOwnerName`,
+			))
+		})
+	})
+})

--- a/internal/ansible/proxy/proxy.go
+++ b/internal/ansible/proxy/proxy.go
@@ -242,7 +242,9 @@ func addWatchToController(owner kubeconfig.NamespacedOwnerReference, cMap *contr
 			log.Info("Watching child resource", "kind", resource.GroupVersionKind(),
 				"enqueue_kind", u.GroupVersionKind())
 			err := contents.Controller.Watch(&source.Kind{Type: resource},
-				&handler.LoggingEnqueueRequestForOwner{crHandler.EnqueueRequestForOwner{OwnerType: u}}, predicate.DependentPredicate{})
+				&handler.LoggingEnqueueRequestForOwner{
+					EnqueueRequestForOwner: crHandler.EnqueueRequestForOwner{OwnerType: u},
+				}, predicate.DependentPredicate{})
 			// Store watch in map
 			if err != nil {
 				log.Error(err, "Failed to watch child resource",
@@ -263,7 +265,9 @@ func addWatchToController(owner kubeconfig.NamespacedOwnerReference, cMap *contr
 			log.Info("Watching child resource", "kind", resource.GroupVersionKind(),
 				"enqueue_annotation_type", ownerGK.String())
 			err = contents.Controller.Watch(&source.Kind{Type: resource},
-				&handler.LoggingEnqueueRequestForAnnotation{libhandler.EnqueueRequestForAnnotation{Type: ownerGK}}, predicate.DependentPredicate{})
+				&handler.LoggingEnqueueRequestForAnnotation{
+					EnqueueRequestForAnnotation: libhandler.EnqueueRequestForAnnotation{Type: ownerGK},
+				}, predicate.DependentPredicate{})
 			if err != nil {
 				log.Error(err, "Failed to watch child resource",
 					"kind", resource.GroupVersionKind(), "enqueue_kind", u.GroupVersionKind())

--- a/internal/ansible/proxy/proxy.go
+++ b/internal/ansible/proxy/proxy.go
@@ -36,9 +36,10 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
+	crHandler "sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/operator-framework/operator-sdk/internal/ansible/handler"
 	"github.com/operator-framework/operator-sdk/internal/ansible/proxy/controllermap"
 	"github.com/operator-framework/operator-sdk/internal/ansible/proxy/kubeconfig"
 	k8sRequest "github.com/operator-framework/operator-sdk/internal/ansible/proxy/requestfactory"
@@ -241,7 +242,7 @@ func addWatchToController(owner kubeconfig.NamespacedOwnerReference, cMap *contr
 			log.Info("Watching child resource", "kind", resource.GroupVersionKind(),
 				"enqueue_kind", u.GroupVersionKind())
 			err := contents.Controller.Watch(&source.Kind{Type: resource},
-				&handler.EnqueueRequestForOwner{OwnerType: u}, predicate.DependentPredicate{})
+				&handler.LoggingEnqueueRequestForOwner{crHandler.EnqueueRequestForOwner{OwnerType: u}}, predicate.DependentPredicate{})
 			// Store watch in map
 			if err != nil {
 				log.Error(err, "Failed to watch child resource",
@@ -262,7 +263,7 @@ func addWatchToController(owner kubeconfig.NamespacedOwnerReference, cMap *contr
 			log.Info("Watching child resource", "kind", resource.GroupVersionKind(),
 				"enqueue_annotation_type", ownerGK.String())
 			err = contents.Controller.Watch(&source.Kind{Type: resource},
-				&libhandler.EnqueueRequestForAnnotation{Type: ownerGK}, predicate.DependentPredicate{})
+				&handler.LoggingEnqueueRequestForAnnotation{libhandler.EnqueueRequestForAnnotation{Type: ownerGK}}, predicate.DependentPredicate{})
 			if err != nil {
 				log.Error(err, "Failed to watch child resource",
 					"kind", resource.GroupVersionKind(), "enqueue_kind", u.GroupVersionKind())


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Adds event handlers that emit a log signaling what events are coming in and what primary resource it will map to.

This is currently just for the ansible-operator specifically, it may be that these changes are better suited to `operator-lib` or `controller-runtime`, but I wanted people to be able to work with a basic implementation before I started working on a more complete solution.

**Motivation for the change:**
For Ansible-based Operators specifically, we've frequently had issues with infinite reconciliation loops caused by controllers wrestling over a resource, but what resource is causing the issue is completely opaque to the user. This should make debugging those kinds of issues significantly easier.

Fixes #3945

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
