### PR TITLE
[v1.5.x] hack/check-links.sh: pin klakegg/html-proofer image to 3.18.8 to fix dep issue

### DIFF
--- a/hack/check-links.sh
+++ b/hack/check-links.sh
@@ -11,7 +11,7 @@ docker run --rm -v "$(pwd):/src" -v sdk-html:/src/website/public klakegg/hugo:0.
 
 header_text "Checking links"
 # For config explanation: https://github.com/gjtorikian/html-proofer#special-cases-for-the-command-line
-docker run --rm -v sdk-html:/target klakegg/html-proofer:latest /target \
+docker run --rm -v sdk-html:/target klakegg/html-proofer:3.18.8 /target \
   --empty-alt-ignore \
   --http-status-ignore 429 \
   --allow_hash_href \


### PR DESCRIPTION
**Description of the change:**
- hack/check-links.sh: pin klakegg/html-proofer image to 3.18.8 to fix dep issue

**Motivation for the change:** latest image is broken


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
