### PR TITLE
[v1.5.x]  images/ansible-operator: bumped base to ansible-operator-base:v1.5.x-61a9e03de149f6b9d3c7f192e1f303ce97a42420

### DIFF
--- a/images/ansible-operator/Dockerfile
+++ b/images/ansible-operator/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/ansible-operator
 
 # Final image.
-FROM quay.io/operator-framework/ansible-operator-base:v1.5.0-2-g052de7c858de99f224d26b80959c0cc6805e53a3
+FROM quay.io/operator-framework/ansible-operator-base:v1.5.x-61a9e03de149f6b9d3c7f192e1f303ce97a42420
 
 ENV HOME=/opt/ansible \
     USER_NAME=ansible \


### PR DESCRIPTION
**Description of the change:**
- images/ansible-operator: bumped base to ansible-operator-base:v1.5.x-61a9e03de149f6b9d3c7f192e1f303ce97a42420

**Motivation for the change:** see #4799 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
