### PR TITLE
internal/cmd/operator-sdk/generate: print warning correctly

### DIFF
--- a/internal/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/internal/cmd/operator-sdk/generate/bundle/bundle.go
@@ -180,13 +180,13 @@ func (c bundleCmd) runManifests() (err error) {
 	// If no CSV was initially read, a kustomize base can be used at the default base path.
 	// Only read from kustomizeDir if a base exists so users can still generate a barebones CSV.
 	baseCSVPath := filepath.Join(c.kustomizeDir, "bases", c.packageName+".clusterserviceversion.yaml")
-	if len(col.ClusterServiceVersions) == 0 && genutil.IsExist(baseCSVPath) {
+	if noCSVStdin := len(col.ClusterServiceVersions) == 0; noCSVStdin && genutil.IsExist(baseCSVPath) {
 		base, err := bases.ClusterServiceVersion{BasePath: baseCSVPath}.GetBase()
 		if err != nil {
 			return fmt.Errorf("error reading CSV base: %v", err)
 		}
 		col.ClusterServiceVersions = append(col.ClusterServiceVersions, *base)
-	} else {
+	} else if noCSVStdin {
 		c.println("Building a ClusterServiceVersion without an existing base")
 	}
 

--- a/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
+++ b/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
@@ -180,13 +180,13 @@ func (c packagemanifestsCmd) run() error {
 	// If no CSV was initially read, a kustomize base can be used at the default base path.
 	// Only read from kustomizeDir if a base exists so users can still generate a barebones CSV.
 	baseCSVPath := filepath.Join(c.kustomizeDir, "bases", c.packageName+".clusterserviceversion.yaml")
-	if len(col.ClusterServiceVersions) == 0 && genutil.IsExist(baseCSVPath) {
+	if noCSVStdin := len(col.ClusterServiceVersions) == 0; noCSVStdin && genutil.IsExist(baseCSVPath) {
 		base, err := bases.ClusterServiceVersion{BasePath: baseCSVPath}.GetBase()
 		if err != nil {
 			return fmt.Errorf("error reading CSV base: %v", err)
 		}
 		col.ClusterServiceVersions = append(col.ClusterServiceVersions, *base)
-	} else {
+	} else if noCSVStdin {
 		c.println("Building a ClusterServiceVersion without an existing base")
 	}
 


### PR DESCRIPTION
**Description of the change:**
- internal/cmd/operator-sdk/generate: print 'without an existing base' only if no base was provided

**Motivation for the change:** message was printed even when a base was provided.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
