### PR TITLE
operator-sdk: run bundle{-upgrade} support insecure registry server

### DIFF
--- a/changelog/fragments/run-bundle-from-insecure-registry.yaml
+++ b/changelog/fragments/run-bundle-from-insecure-registry.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: >
+       Add new optional flag `--skip-tls` to the commands `operator-sdk run bundle` and `operator-sdk run bundle-upgrade`. This option allow to install the operator from a bundle image stored at an insecure docker registry. (e.g. `operator-sdk run bundle localhost:5000/my-operator-bundle:latest --skip-tls`)
+    kind: "addition"

--- a/internal/cmd/operator-sdk/scorecard/cmd.go
+++ b/internal/cmd/operator-sdk/scorecard/cmd.go
@@ -211,5 +211,5 @@ func extractBundleImage(bundleImage string) (string, error) {
 		logger = log.WithFields(log.Fields{"bundle": bundleImage})
 	}
 	// FEAT: enable explicit local image extraction.
-	return registryutil.ExtractBundleImage(context.TODO(), logger, bundleImage, false)
+	return registryutil.ExtractBundleImage(context.TODO(), logger, bundleImage, false, false)
 }

--- a/internal/olm/operator/bundle/install.go
+++ b/internal/olm/operator/bundle/install.go
@@ -72,7 +72,7 @@ func (i *Install) setup(ctx context.Context) error {
 	}
 
 	// Load bundle labels and set label-dependent values.
-	labels, bundle, err := operator.LoadBundle(ctx, i.BundleImage)
+	labels, bundle, err := operator.LoadBundle(ctx, i.BundleImage, i.SkipTLS)
 	if err != nil {
 		return err
 	}

--- a/internal/olm/operator/bundleupgrade/upgrade.go
+++ b/internal/olm/operator/bundleupgrade/upgrade.go
@@ -69,7 +69,7 @@ func (u *Upgrade) setup(ctx context.Context) error {
 		}
 	}
 
-	labels, bundle, err := operator.LoadBundle(ctx, u.BundleImage)
+	labels, bundle, err := operator.LoadBundle(ctx, u.BundleImage, u.SkipTLS)
 	if err != nil {
 		return err
 	}

--- a/internal/olm/operator/helpers.go
+++ b/internal/olm/operator/helpers.go
@@ -34,8 +34,8 @@ func CatalogNameForPackage(pkg string) string {
 }
 
 // LoadBundle returns metadata and manifests from within bundleImage.
-func LoadBundle(ctx context.Context, bundleImage string) (registryutil.Labels, *apimanifests.Bundle, error) {
-	bundlePath, err := registryutil.ExtractBundleImage(ctx, nil, bundleImage, false)
+func LoadBundle(ctx context.Context, bundleImage string, skipTLS bool) (registryutil.Labels, *apimanifests.Bundle, error) {
+	bundlePath, err := registryutil.ExtractBundleImage(ctx, nil, bundleImage, false, skipTLS)
 	if err != nil {
 		return nil, nil, fmt.Errorf("pull bundle image: %v", err)
 	}

--- a/internal/olm/operator/registry/index/registry_pod.go
+++ b/internal/olm/operator/registry/index/registry_pod.go
@@ -77,6 +77,9 @@ type RegistryPod struct {
 	// The secret's key for this file must be "cert.pem".
 	CASecretName string
 
+	// SkipTLS controls wether to ignore SSL errors while pulling bundle image from registry server.
+	SkipTLS bool `json:"SkipTLS"`
+
 	// pod represents a kubernetes *corev1.pod that will be created on a cluster using an index image
 	pod *corev1.Pod
 
@@ -302,7 +305,7 @@ func newBool(b bool) *bool {
 
 const cmdTemplate = `/bin/mkdir -p {{ dirname .DBPath }} && \
 {{- range $i, $item := .BundleItems }}
-/bin/opm registry add -d {{ $.DBPath }} -b {{ $item.ImageTag }} --mode={{ $item.AddMode }}{{ if $.CASecretName }} --ca-file=/certs/cert.pem{{ end }} && \
+/bin/opm registry add -d {{ $.DBPath }} -b {{ $item.ImageTag }} --mode={{ $item.AddMode }}{{ if $.CASecretName }} --ca-file=/certs/cert.pem{{ end }} --skip-tls={{ $.SkipTLS }} && \
 {{- end }}
 /bin/opm registry serve -d {{ .DBPath }} -p {{ .GRPCPort }}
 `

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -62,6 +62,7 @@ type IndexImageCatalogCreator struct {
 	PackageName   string
 	IndexImage    string
 	BundleImage   string
+	SkipTLS       bool
 	BundleAddMode index.BundleAddMode
 	SecretName    string
 	CASecretName  string
@@ -87,6 +88,8 @@ func (c *IndexImageCatalogCreator) BindFlags(fs *pflag.FlagSet) {
 		"Name of a generic secret containing a PEM root certificate file required to pull bundle images. "+
 			"This secret *must* be in the namespace that this command is configured to run in, "+
 			"and the file *must* be encoded under the key \"cert.pem\"")
+	fs.BoolVar(&c.SkipTLS, "skip-tls", false, "skip authentication of image registry TLS "+
+		"certificate when pulling a bundle image in-cluster")
 }
 
 func (c IndexImageCatalogCreator) CreateCatalog(ctx context.Context, name string) (*v1alpha1.CatalogSource, error) {
@@ -191,6 +194,7 @@ func (c IndexImageCatalogCreator) createAnnotatedRegistry(ctx context.Context, c
 		IndexImage:   c.IndexImage,
 		SecretName:   c.SecretName,
 		CASecretName: c.CASecretName,
+		SkipTLS:      c.SkipTLS,
 	}
 	if registryPod.DBPath, err = c.getDBPath(ctx); err != nil {
 		return fmt.Errorf("get database path: %v", err)

--- a/internal/registry/image.go
+++ b/internal/registry/image.go
@@ -28,7 +28,7 @@ import (
 
 // ExtractBundleImage returns a bundle directory containing files extracted
 // from image. If local is true, the image will not be pulled.
-func ExtractBundleImage(ctx context.Context, logger *log.Entry, image string, local bool) (string, error) {
+func ExtractBundleImage(ctx context.Context, logger *log.Entry, image string, local bool, skipTLS bool) (string, error) {
 	if logger == nil {
 		logger = DiscardLogger()
 	}
@@ -51,7 +51,7 @@ func ExtractBundleImage(ctx context.Context, logger *log.Entry, image string, lo
 	logger = logger.WithFields(log.Fields{"dir": bundleDir})
 
 	// Use a containerd registry instead of shelling out to a container tool.
-	reg, err := containerdregistry.NewRegistry(containerdregistry.WithLog(logger))
+	reg, err := containerdregistry.NewRegistry(containerdregistry.WithLog(logger), containerdregistry.SkipTLS(skipTLS))
 	if err != nil {
 		return "", err
 	}

--- a/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
@@ -23,6 +23,7 @@ operator-sdk run bundle-upgrade <bundle-image> [flags]
   -n, --namespace string          If present, namespace scope for this CLI request
       --pull-secret-name string   Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
       --service-account string    Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
+      --skip-tls                  skip authentication of image registry TLS certificate when pulling a bundle image in-cluster
       --timeout duration          Duration to wait for the command to complete before failing (default 2m0s)
 ```
 

--- a/website/content/en/docs/cli/operator-sdk_run_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle.md
@@ -25,6 +25,7 @@ operator-sdk run bundle <bundle-image> [flags]
   -n, --namespace string                If present, namespace scope for this CLI request
       --pull-secret-name string         Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
       --service-account string          Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
+      --skip-tls                        skip authentication of image registry TLS certificate when pulling a bundle image in-cluster
       --timeout duration                Duration to wait for the command to complete before failing (default 2m0s)
 ```
 


### PR DESCRIPTION
Supporting insecure registry is useful for testing operator installation
from a bundle image stored at the local registry.

Closes #4815

**Description of the change:**

Add a new boolean command-line option(defaults to false) named `--allow-insecure` for both `operator-sdk run bundle` and `operator-sdk run bundle-upgrade`. When enabled this argument the commands ignores the SSL errors that occurred while communicating the docker registry. This allows pulling the bundle images from insecure(usually local) docker registries.

**Motivation for the change:**

Using a local insecure registry is a possible case for storing the generated bundle image, and test the operator installation.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
