### PR TITLE
workflows/deploy-manual: set branch suffix to valid enum

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -70,4 +70,4 @@ jobs:
         commit-message: "[${{ steps.update.outputs.branch_name }}] image(ansible-operator): bump base to ${{ steps.tag.outputs.tag }}"
         body: "New ansible-operator-base image built by https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         delete-branch: true
-        branch-suffix: -ansible-operator-base
+        branch-suffix: short-commit-hash


### PR DESCRIPTION
**Description of the change:**
- workflows/deploy-manual: set branch suffix to valid enum

**Motivation for the change:** apparently `branch-suffix` is an enum not an arbitrary string, whoops.


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
