### PR TITLE
generate bundle: add --extra-service-accounts flag to consider extra-Deployment SAs

### DIFF
--- a/changelog/fragments/extra-service-accounts.yaml
+++ b/changelog/fragments/extra-service-accounts.yaml
@@ -1,0 +1,10 @@
+entries:
+  - description: >
+      Added --extra-service-accounts flag to `generate bundle` to consider roles bound to
+      service accounts not specified in the operator's Deployment.
+    kind: addition
+  - description: >
+      `generate bundle` adds ClusterRoles bound by RoleBindings to a CSV's `.spec.permissions`,
+      since these become namespace-scoped at runtime. They will also be added to `.spec.clusterPermissions`
+      if bound by a ClusterRoleBinding.
+    kind: change

--- a/internal/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/internal/cmd/operator-sdk/generate/bundle/bundle.go
@@ -197,16 +197,17 @@ func (c bundleCmd) runManifests() (err error) {
 	}
 
 	csvGen := gencsv.Generator{
-		OperatorName: c.packageName,
-		Version:      c.version,
-		Collector:    col,
-		Annotations:  metricsannotations.MakeBundleObjectAnnotations(c.layout),
+		OperatorName:         c.packageName,
+		Version:              c.version,
+		Collector:            col,
+		Annotations:          metricsannotations.MakeBundleObjectAnnotations(c.layout),
+		ExtraServiceAccounts: c.extraServiceAccounts,
 	}
 	if err := csvGen.Generate(opts...); err != nil {
 		return fmt.Errorf("error generating ClusterServiceVersion: %v", err)
 	}
 
-	objs := genutil.GetManifestObjects(col)
+	objs := genutil.GetManifestObjects(col, c.extraServiceAccounts)
 	if c.stdout {
 		if err := genutil.WriteObjects(stdout, objs...); err != nil {
 			return err

--- a/internal/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/generate/bundle/cmd.go
@@ -38,6 +38,8 @@ type bundleCmd struct {
 	crdsDir      string
 	stdout       bool
 	quiet        bool
+	// ServiceAccount names to consider outside of the operator's service account.
+	extraServiceAccounts []string
 
 	// Metadata options.
 	channels       string
@@ -129,6 +131,9 @@ func (c *bundleCmd) addFlagsTo(fs *pflag.FlagSet) {
 		"Directory containing kustomize bases in a \"bases\" dir and a kustomization.yaml for operator-framework manifests")
 	fs.StringVar(&c.channels, "channels", "alpha", "A comma-separated list of channels the bundle belongs to")
 	fs.StringVar(&c.defaultChannel, "default-channel", "", "The default channel for the bundle")
+	fs.StringSliceVar(&c.extraServiceAccounts, "extra-service-accounts", nil,
+		"Names of service accounts, outside of the operator's Deployment account, "+
+			"that have bindings to {Cluster}Roles that should be added to the CSV")
 	fs.BoolVar(&c.overwrite, "overwrite", true, "Overwrite the bundle's metadata and Dockerfile if they exist")
 	fs.BoolVarP(&c.quiet, "quiet", "q", false, "Run in quiet mode")
 	fs.BoolVar(&c.stdout, "stdout", false, "Write bundle manifest to stdout")

--- a/internal/cmd/operator-sdk/generate/internal/manifests.go
+++ b/internal/cmd/operator-sdk/generate/internal/manifests.go
@@ -22,7 +22,7 @@ import (
 )
 
 // GetManifestObjects returns all objects to be written to a manifests directory from collector.Manifests.
-func GetManifestObjects(c *collector.Manifests) (objs []client.Object) {
+func GetManifestObjects(c *collector.Manifests, extraSAs []string) (objs []client.Object) {
 	// All CRDs passed in should be written.
 	for i := range c.V1CustomResourceDefinitions {
 		objs = append(objs, &c.V1CustomResourceDefinitions[i])
@@ -50,9 +50,9 @@ func GetManifestObjects(c *collector.Manifests) (objs []client.Object) {
 	}
 
 	// RBAC objects that are not a part of the CSV should be written.
-	_, roleObjs := c.SplitCSVPermissionsObjects()
+	_, roleObjs := c.SplitCSVPermissionsObjects(extraSAs)
 	objs = append(objs, roleObjs...)
-	_, clusterRoleObjs := c.SplitCSVClusterPermissionsObjects()
+	_, clusterRoleObjs := c.SplitCSVClusterPermissionsObjects(extraSAs)
 	objs = append(objs, clusterRoleObjs...)
 
 	removeNamespace(objs)

--- a/internal/cmd/operator-sdk/generate/internal/manifests_test.go
+++ b/internal/cmd/operator-sdk/generate/internal/manifests_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GetManifestObjects", func() {
 				{ObjectMeta: metav1.ObjectMeta{Namespace: "bar"}},
 			},
 		}
-		objs := GetManifestObjects(&m)
+		objs := GetManifestObjects(&m, nil)
 		Expect(objs).To(HaveLen(len(m.Roles) + len(m.ClusterRoles) + len(m.ServiceAccounts) + len(m.V1CustomResourceDefinitions) + len(m.V1beta1CustomResourceDefinitions)))
 		for _, obj := range objs {
 			Expect(obj.GetNamespace()).To(BeEmpty())

--- a/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
+++ b/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests.go
@@ -207,7 +207,8 @@ func (c packagemanifestsCmd) run() error {
 	}
 
 	if c.updateObjects {
-		objs := genutil.GetManifestObjects(col)
+		// Extra ServiceAccounts not supported by this command.
+		objs := genutil.GetManifestObjects(col, nil)
 		if c.stdout {
 			if err := genutil.WriteObjects(stdout, objs...); err != nil {
 				return err

--- a/internal/generate/clusterserviceversion/clusterserviceversion.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion.go
@@ -53,6 +53,9 @@ type Generator struct {
 	Collector *collector.Manifests
 	// Annotations are applied to the resulting CSV.
 	Annotations map[string]string
+	// ExtraServiceAccounts are ServiceAccount names to consider when matching
+	// {Cluster}Roles to include in a CSV via their Bindings.
+	ExtraServiceAccounts []string
 
 	// Func that returns the writer the generated CSV's bytes are written to.
 	getWriter func() (io.Writer, error)
@@ -163,7 +166,7 @@ func (g *Generator) generate() (base *operatorsv1alpha1.ClusterServiceVersion, e
 		base.Spec.Replaces = genutil.MakeCSVName(g.OperatorName, g.FromVersion)
 	}
 
-	if err := ApplyTo(g.Collector, base); err != nil {
+	if err := ApplyTo(g.Collector, base, g.ExtraServiceAccounts); err != nil {
 		return nil, err
 	}
 

--- a/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
@@ -30,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/operator-framework/operator-sdk/internal/generate/collector"
 	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
@@ -54,8 +55,9 @@ func apply(c *collector.Manifests, csv *operatorsv1alpha1.ClusterServiceVersion,
 	strategy := getCSVInstallStrategy(csv)
 	switch strategy.StrategyName {
 	case operatorsv1alpha1.InstallStrategyNameDeployment:
-		applyRoles(c, &strategy.StrategySpec, extraSAs)
-		applyClusterRoles(c, &strategy.StrategySpec, extraSAs)
+		inPerms, inCPerms, _ := c.SplitCSVPermissionsObjects(extraSAs)
+		applyRoles(c, inPerms, &strategy.StrategySpec, extraSAs)
+		applyClusterRoles(c, inCPerms, &strategy.StrategySpec, extraSAs)
 		applyDeployments(c, &strategy.StrategySpec)
 	}
 	csv.Spec.InstallStrategy = strategy
@@ -82,37 +84,46 @@ const defaultServiceAccountName = "default"
 
 // applyRoles applies Roles to strategy's permissions field by combining Roles bound to ServiceAccounts
 // into one set of permissions.
-func applyRoles(c *collector.Manifests, strategy *operatorsv1alpha1.StrategyDetailsDeployment, extraSAs []string) { //nolint:dupl
-	objs, _ := c.SplitCSVPermissionsObjects(extraSAs)
-	roleSet := make(map[string]*rbacv1.Role)
+func applyRoles(c *collector.Manifests, objs []client.Object, strategy *operatorsv1alpha1.StrategyDetailsDeployment, extraSAs []string) { //nolint:dupl
+	roleSet := make(map[string]rbacv1.Role)
+	cRoleSet := make(map[string]rbacv1.ClusterRole)
 	for i := range objs {
 		switch t := objs[i].(type) {
 		case *rbacv1.Role:
-			roleSet[t.GetName()] = t
+			roleSet[t.GetName()] = *t
+		case *rbacv1.ClusterRole:
+			cRoleSet[t.GetName()] = *t
 		}
 	}
 
-	saToPermissions := make(map[string]operatorsv1alpha1.StrategyDeploymentPermissions)
-	for _, dep := range c.Deployments {
-		saName := dep.Spec.Template.Spec.ServiceAccountName
-		if saName == "" {
-			saName = defaultServiceAccountName
-		}
-		saToPermissions[saName] = operatorsv1alpha1.StrategyDeploymentPermissions{ServiceAccountName: saName}
-	}
-	for _, extraSA := range extraSAs {
-		saToPermissions[extraSA] = operatorsv1alpha1.StrategyDeploymentPermissions{ServiceAccountName: extraSA}
-	}
-
-	// Collect all role names by their corresponding service accounts via bindings. This lets us
+	// Collect all role and cluster role names by their corresponding service accounts via bindings. This lets us
 	// look up all service accounts a role is bound to and create one set of permissions per service account.
+	saToPermissions := initPermissionSet(c.Deployments, extraSAs)
 	for _, binding := range c.RoleBindings {
-		if role, hasRole := roleSet[binding.RoleRef.Name]; hasRole {
-			for _, subject := range binding.Subjects {
-				if perm, hasSA := saToPermissions[subject.Name]; hasSA && subject.Kind == "ServiceAccount" {
-					perm.Rules = append(perm.Rules, role.Rules...)
-					saToPermissions[subject.Name] = perm
-				}
+		for _, subject := range binding.Subjects {
+			perm, hasSA := saToPermissions[subject.Name]
+			if subject.Kind != "ServiceAccount" || !hasSA {
+				continue
+			}
+			var (
+				rules   []rbacv1.PolicyRule
+				hasRole bool
+			)
+			switch binding.RoleRef.Kind {
+			case "Role":
+				role, has := roleSet[binding.RoleRef.Name]
+				rules = role.Rules
+				hasRole = has
+			case "ClusterRole":
+				role, has := cRoleSet[binding.RoleRef.Name]
+				rules = role.Rules
+				hasRole = has
+			default:
+				continue
+			}
+			if hasRole {
+				perm.Rules = append(perm.Rules, rules...)
+				saToPermissions[subject.Name] = perm
 			}
 		}
 	}
@@ -124,42 +135,35 @@ func applyRoles(c *collector.Manifests, strategy *operatorsv1alpha1.StrategyDeta
 			perms = append(perms, perm)
 		}
 	}
+	sort.Slice(perms, func(i, j int) bool {
+		return perms[i].ServiceAccountName < perms[j].ServiceAccountName
+	})
 	strategy.Permissions = perms
 }
 
 // applyClusterRoles applies ClusterRoles to strategy's clusterPermissions field by combining ClusterRoles
 // bound to ServiceAccounts into one set of clusterPermissions.
-func applyClusterRoles(c *collector.Manifests, strategy *operatorsv1alpha1.StrategyDetailsDeployment, extraSAs []string) { //nolint:dupl
-	objs, _ := c.SplitCSVClusterPermissionsObjects(extraSAs)
-	roleSet := make(map[string]*rbacv1.ClusterRole)
+func applyClusterRoles(c *collector.Manifests, objs []client.Object, strategy *operatorsv1alpha1.StrategyDetailsDeployment, extraSAs []string) { //nolint:dupl
+	roleSet := make(map[string]rbacv1.ClusterRole)
 	for i := range objs {
 		switch t := objs[i].(type) {
 		case *rbacv1.ClusterRole:
-			roleSet[t.GetName()] = t
+			roleSet[t.GetName()] = *t
 		}
-	}
-
-	saToPermissions := make(map[string]operatorsv1alpha1.StrategyDeploymentPermissions)
-	for _, dep := range c.Deployments {
-		saName := dep.Spec.Template.Spec.ServiceAccountName
-		if saName == "" {
-			saName = defaultServiceAccountName
-		}
-		saToPermissions[saName] = operatorsv1alpha1.StrategyDeploymentPermissions{ServiceAccountName: saName}
-	}
-	for _, extraSA := range extraSAs {
-		saToPermissions[extraSA] = operatorsv1alpha1.StrategyDeploymentPermissions{ServiceAccountName: extraSA}
 	}
 
 	// Collect all role names by their corresponding service accounts via bindings. This lets us
 	// look up all service accounts a role is bound to and create one set of permissions per service account.
+	saToPermissions := initPermissionSet(c.Deployments, extraSAs)
 	for _, binding := range c.ClusterRoleBindings {
-		if role, hasRole := roleSet[binding.RoleRef.Name]; hasRole {
-			for _, subject := range binding.Subjects {
-				if perm, hasSA := saToPermissions[subject.Name]; hasSA && subject.Kind == "ServiceAccount" {
-					perm.Rules = append(perm.Rules, role.Rules...)
-					saToPermissions[subject.Name] = perm
-				}
+		for _, subject := range binding.Subjects {
+			perm, hasSA := saToPermissions[subject.Name]
+			if !hasSA || subject.Kind != "ServiceAccount" {
+				continue
+			}
+			if role, hasRole := roleSet[binding.RoleRef.Name]; hasRole {
+				perm.Rules = append(perm.Rules, role.Rules...)
+				saToPermissions[subject.Name] = perm
 			}
 		}
 	}
@@ -171,7 +175,26 @@ func applyClusterRoles(c *collector.Manifests, strategy *operatorsv1alpha1.Strat
 			perms = append(perms, perm)
 		}
 	}
+	sort.Slice(perms, func(i, j int) bool {
+		return perms[i].ServiceAccountName < perms[j].ServiceAccountName
+	})
 	strategy.ClusterPermissions = perms
+}
+
+// initPermissionSet initializes a map of ServiceAccount name to permissions, which are empty.
+func initPermissionSet(deps []appsv1.Deployment, extraSAs []string) map[string]operatorsv1alpha1.StrategyDeploymentPermissions {
+	saToPermissions := make(map[string]operatorsv1alpha1.StrategyDeploymentPermissions)
+	for _, dep := range deps {
+		saName := dep.Spec.Template.Spec.ServiceAccountName
+		if saName == "" {
+			saName = defaultServiceAccountName
+		}
+		saToPermissions[saName] = operatorsv1alpha1.StrategyDeploymentPermissions{ServiceAccountName: saName}
+	}
+	for _, extraSA := range extraSAs {
+		saToPermissions[extraSA] = operatorsv1alpha1.StrategyDeploymentPermissions{ServiceAccountName: extraSA}
+	}
+	return saToPermissions
 }
 
 // applyDeployments updates strategy's deployments with the Deployments

--- a/internal/generate/clusterserviceversion/clusterserviceversion_updaters_test.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_updaters_test.go
@@ -24,6 +24,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/operator-framework/operator-sdk/internal/generate/collector"
 )
@@ -47,48 +48,88 @@ var _ = Describe("apply functions", func() {
 			strategy = &operatorsv1alpha1.StrategyDetailsDeployment{}
 		})
 
-		Context("collector contains Roles", func() {
+		Context("collector contains {Cluster}Roles", func() {
 			It("adds one Role's rules to the CSV deployment strategy", func() {
 				c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount(depName1, saName1)}
 				c.ServiceAccounts = []corev1.ServiceAccount{newServiceAccount(saName1)}
 				rules := []rbacv1.PolicyRule{{Verbs: []string{"create"}}}
-				c.Roles = []rbacv1.Role{newRole(roleName1, rules...)}
+				perms := []client.Object{newRole(roleName1, rules...)}
 				c.RoleBindings = []rbacv1.RoleBinding{newRoleBinding("role-binding", newRoleRef(roleName1), newServiceAccountSubject(saName1))}
-				applyRoles(c, strategy, nil)
+				applyRoles(c, perms, strategy, nil)
 				Expect(strategy.Permissions).To(Equal([]operatorsv1alpha1.StrategyDeploymentPermissions{
 					{ServiceAccountName: saName1, Rules: rules},
 				}))
 			})
-		})
-		Context("collector contains no Roles", func() {
-			It("adds no Permissions to the CSV deployment strategy", func() {
-				c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount(depName1, saName1)}
-				c.ServiceAccounts = []corev1.ServiceAccount{newServiceAccount(saName1)}
-				c.RoleBindings = []rbacv1.RoleBinding{newRoleBinding("role-binding", newRoleRef(roleName1), newServiceAccountSubject(saName1))}
-				applyRoles(c, strategy, nil)
-				Expect(strategy.Permissions).To(Equal([]operatorsv1alpha1.StrategyDeploymentPermissions{}))
-			})
-		})
-
-		Context("collector contains ClusterRoles", func() {
 			It("adds one ClusterRole's rules to the CSV deployment strategy", func() {
 				c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount(depName1, saName1)}
 				c.ServiceAccounts = []corev1.ServiceAccount{newServiceAccount(saName1)}
 				rules := []rbacv1.PolicyRule{{Verbs: []string{"create"}}}
-				c.ClusterRoles = []rbacv1.ClusterRole{newClusterRole(cRoleName1, rules...)}
+				perms := []client.Object{newClusterRole(cRoleName1, rules...)}
 				c.ClusterRoleBindings = []rbacv1.ClusterRoleBinding{newClusterRoleBinding("cluster-role-binding", newClusterRoleRef(cRoleName1), newServiceAccountSubject(saName1))}
-				applyClusterRoles(c, strategy, nil)
+				applyClusterRoles(c, perms, strategy, nil)
 				Expect(strategy.ClusterPermissions).To(Equal([]operatorsv1alpha1.StrategyDeploymentPermissions{
 					{ServiceAccountName: saName1, Rules: rules},
 				}))
 			})
+			It("adds multiple bound {Cluster}Roles to the CSV deployment strategy with extra service account", func() {
+				roleName2, roleName3 := "role-2", "role-3"
+				cRoleName2, cRoleName3 := "cluster-role-2", "cluster-role-3"
+				extraSAName := "service-account-extra"
+				c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount(depName1, saName1)}
+				c.ServiceAccounts = []corev1.ServiceAccount{
+					newServiceAccount(saName1),
+					newServiceAccount(extraSAName),
+				}
+				rules := []rbacv1.PolicyRule{{Verbs: []string{"create"}}}
+				role3Rules := []rbacv1.PolicyRule{{APIGroups: []string{"my.group"}, Verbs: []string{"update"}}}
+				cRole3Rules := []rbacv1.PolicyRule{{APIGroups: []string{"my.group"}, Verbs: []string{"list", "watch"}}}
+				perms := []client.Object{
+					newRole(roleName1, rules...),
+					newRole(roleName2, rules...),
+					newRole(roleName3, role3Rules...),
+					newClusterRole(cRoleName1, rules...),
+					newClusterRole(cRoleName2, rules...),
+				}
+				cperms := []client.Object{
+					newClusterRole(cRoleName1, rules...),
+					newClusterRole(cRoleName3, cRole3Rules...),
+				}
+				c.RoleBindings = []rbacv1.RoleBinding{
+					newRoleBinding("role-binding", newRoleRef(roleName1), newServiceAccountSubject(saName1)),
+					newRoleBinding("role-binding-2", newRoleRef(roleName2), newServiceAccountSubject(extraSAName)),
+					newRoleBinding("role-binding-3", newClusterRoleRef(cRoleName3), newServiceAccountSubject(extraSAName)),
+				}
+				c.ClusterRoleBindings = []rbacv1.ClusterRoleBinding{
+					newClusterRoleBinding("cluster-role-binding", newClusterRoleRef(cRoleName1), newServiceAccountSubject(saName1)),
+					newClusterRoleBinding("cluster-role-binding-2", newClusterRoleRef(cRoleName2), newServiceAccountSubject(extraSAName)),
+					newClusterRoleBinding("cluster-role-binding-3", newClusterRoleRef(cRoleName3), newServiceAccountSubject(extraSAName)),
+				}
+				applyRoles(c, perms, strategy, []string{extraSAName})
+				applyClusterRoles(c, cperms, strategy, []string{extraSAName})
+				Expect(strategy.Permissions).To(Equal([]operatorsv1alpha1.StrategyDeploymentPermissions{
+					{ServiceAccountName: saName1, Rules: rules},
+					{ServiceAccountName: extraSAName, Rules: rules},
+				}))
+				Expect(strategy.ClusterPermissions).To(Equal([]operatorsv1alpha1.StrategyDeploymentPermissions{
+					{ServiceAccountName: saName1, Rules: rules},
+					{ServiceAccountName: extraSAName, Rules: cRole3Rules},
+				}))
+			})
 		})
-		Context("collector contains no ClusterRoles", func() {
+
+		Context("collector contains no {Cluster}Roles", func() {
+			It("adds no Permissions to the CSV deployment strategy", func() {
+				c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount(depName1, saName1)}
+				c.ServiceAccounts = []corev1.ServiceAccount{newServiceAccount(saName1)}
+				c.RoleBindings = []rbacv1.RoleBinding{newRoleBinding("role-binding", newRoleRef(roleName1), newServiceAccountSubject(saName1))}
+				applyRoles(c, nil, strategy, nil)
+				Expect(strategy.Permissions).To(Equal([]operatorsv1alpha1.StrategyDeploymentPermissions{}))
+			})
 			It("adds no ClusterPermissions to the CSV deployment strategy", func() {
 				c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount(depName1, saName1)}
 				c.ServiceAccounts = []corev1.ServiceAccount{newServiceAccount(saName1)}
 				c.ClusterRoleBindings = []rbacv1.ClusterRoleBinding{newClusterRoleBinding("cluster-role-binding", newClusterRoleRef(cRoleName1), newServiceAccountSubject(saName1))}
-				applyClusterRoles(c, strategy, nil)
+				applyClusterRoles(c, nil, strategy, nil)
 				Expect(strategy.ClusterPermissions).To(Equal([]operatorsv1alpha1.StrategyDeploymentPermissions{}))
 			})
 		})
@@ -405,14 +446,16 @@ func newDeploymentWithServiceAccount(name, saName string) (d appsv1.Deployment) 
 	return d
 }
 
-func newRole(name string, rules ...rbacv1.PolicyRule) (r rbacv1.Role) {
+func newRole(name string, rules ...rbacv1.PolicyRule) (r *rbacv1.Role) {
+	r = &rbacv1.Role{}
 	r.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("Role"))
 	r.SetName(name)
 	r.Rules = rules
 	return r
 }
 
-func newClusterRole(name string, rules ...rbacv1.PolicyRule) (r rbacv1.ClusterRole) {
+func newClusterRole(name string, rules ...rbacv1.PolicyRule) (r *rbacv1.ClusterRole) {
+	r = &rbacv1.ClusterRole{}
 	r.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("ClusterRole"))
 	r.SetName(name)
 	r.Rules = rules

--- a/internal/generate/clusterserviceversion/clusterserviceversion_updaters_test.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_updaters_test.go
@@ -54,7 +54,7 @@ var _ = Describe("apply functions", func() {
 				rules := []rbacv1.PolicyRule{{Verbs: []string{"create"}}}
 				c.Roles = []rbacv1.Role{newRole(roleName1, rules...)}
 				c.RoleBindings = []rbacv1.RoleBinding{newRoleBinding("role-binding", newRoleRef(roleName1), newServiceAccountSubject(saName1))}
-				applyRoles(c, strategy)
+				applyRoles(c, strategy, nil)
 				Expect(strategy.Permissions).To(Equal([]operatorsv1alpha1.StrategyDeploymentPermissions{
 					{ServiceAccountName: saName1, Rules: rules},
 				}))
@@ -65,7 +65,7 @@ var _ = Describe("apply functions", func() {
 				c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount(depName1, saName1)}
 				c.ServiceAccounts = []corev1.ServiceAccount{newServiceAccount(saName1)}
 				c.RoleBindings = []rbacv1.RoleBinding{newRoleBinding("role-binding", newRoleRef(roleName1), newServiceAccountSubject(saName1))}
-				applyRoles(c, strategy)
+				applyRoles(c, strategy, nil)
 				Expect(strategy.Permissions).To(Equal([]operatorsv1alpha1.StrategyDeploymentPermissions{}))
 			})
 		})
@@ -77,7 +77,7 @@ var _ = Describe("apply functions", func() {
 				rules := []rbacv1.PolicyRule{{Verbs: []string{"create"}}}
 				c.ClusterRoles = []rbacv1.ClusterRole{newClusterRole(cRoleName1, rules...)}
 				c.ClusterRoleBindings = []rbacv1.ClusterRoleBinding{newClusterRoleBinding("cluster-role-binding", newClusterRoleRef(cRoleName1), newServiceAccountSubject(saName1))}
-				applyClusterRoles(c, strategy)
+				applyClusterRoles(c, strategy, nil)
 				Expect(strategy.ClusterPermissions).To(Equal([]operatorsv1alpha1.StrategyDeploymentPermissions{
 					{ServiceAccountName: saName1, Rules: rules},
 				}))
@@ -88,7 +88,7 @@ var _ = Describe("apply functions", func() {
 				c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount(depName1, saName1)}
 				c.ServiceAccounts = []corev1.ServiceAccount{newServiceAccount(saName1)}
 				c.ClusterRoleBindings = []rbacv1.ClusterRoleBinding{newClusterRoleBinding("cluster-role-binding", newClusterRoleRef(cRoleName1), newServiceAccountSubject(saName1))}
-				applyClusterRoles(c, strategy)
+				applyClusterRoles(c, strategy, nil)
 				Expect(strategy.ClusterPermissions).To(Equal([]operatorsv1alpha1.StrategyDeploymentPermissions{}))
 			})
 		})

--- a/internal/generate/collector/clusterserviceversion.go
+++ b/internal/generate/collector/clusterserviceversion.go
@@ -31,8 +31,11 @@ const (
 	cRoleKind          = "ClusterRole"
 )
 
-// SplitCSVPermissionsObjects splits roles that should be written to a CSV as permissions (in)
-// from roles and role bindings that should be written directly to the bundle (out).
+// SplitCSVPermissionsObjects splits Roles and ClusterRoles bound to ServiceAccounts in Deployments and extraSA's.
+// Roles and ClusterRoles bound to RoleBindings associated with ServiceAccounts are added to inPerms.
+// ClusterRoles bound to ClusterRoleBindings associated with ServiceAccounts are added to inCPerms.
+// All unassociated Roles, ClusterRoles, and bindings are added to out.
+// Any bindings with some associations, but with non-associations, are added to out unmodified.
 func (c *Manifests) SplitCSVPermissionsObjects(extraSAs []string) (inPerms, inCPerms, out []client.Object) { //nolint:gocyclo
 	// Create a set of ServiceAccount names to match against below.
 	saNameSet := make(map[string]struct{})

--- a/internal/generate/collector/clusterserviceversion_test.go
+++ b/internal/generate/collector/clusterserviceversion_test.go
@@ -1,12 +1,12 @@
 // Copyright 2020 The Operator-SDK Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except inPerm compliance with the License.
+// you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to inPerm writing, software
+// Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and

--- a/internal/generate/collector/clusterserviceversion_test.go
+++ b/internal/generate/collector/clusterserviceversion_test.go
@@ -37,14 +37,14 @@ var _ = Describe("ClusterServiceVersion", func() {
 
 		It("should return empty lists for an empty Manifests", func() {
 			c.Roles = []rbacv1.Role{}
-			in, out = c.SplitCSVPermissionsObjects()
+			in, out = c.SplitCSVPermissionsObjects(nil)
 			Expect(in).To(HaveLen(0))
 			Expect(out).To(HaveLen(0))
 		})
 		It("should return non-empty lists", func() {
 			By("splitting 1 Role no RoleBinding")
 			c.Roles = []rbacv1.Role{newRole("my-role")}
-			in, out = c.SplitCSVPermissionsObjects()
+			in, out = c.SplitCSVPermissionsObjects(nil)
 			Expect(in).To(HaveLen(0))
 			Expect(out).To(HaveLen(1))
 			Expect(getRoleNames(out)).To(ContainElement("my-role"))
@@ -55,7 +55,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			c.RoleBindings = []rbacv1.RoleBinding{
 				newRoleBinding("my-role-binding", newRoleRef("my-role"), newServiceAccountSubject("my-other-account")),
 			}
-			in, out = c.SplitCSVPermissionsObjects()
+			in, out = c.SplitCSVPermissionsObjects(nil)
 			Expect(in).To(HaveLen(0))
 			Expect(out).To(HaveLen(2))
 			Expect(getRoleNames(out)).To(ContainElement("my-role"))
@@ -67,7 +67,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			c.RoleBindings = []rbacv1.RoleBinding{
 				newRoleBinding("my-role-binding", newRoleRef("my-role"), newServiceAccountSubject("my-dep-account")),
 			}
-			in, out = c.SplitCSVPermissionsObjects()
+			in, out = c.SplitCSVPermissionsObjects(nil)
 			Expect(in).To(HaveLen(1))
 			Expect(getRoleNames(in)).To(ContainElement("my-role"))
 			Expect(out).To(HaveLen(0))
@@ -80,7 +80,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					newRoleRef("my-role"),
 					newServiceAccountSubject("my-dep-account"), newServiceAccountSubject("my-other-account")),
 			}
-			in, out = c.SplitCSVPermissionsObjects()
+			in, out = c.SplitCSVPermissionsObjects(nil)
 			Expect(in).To(HaveLen(1))
 			Expect(getRoleNames(in)).To(ContainElement("my-role"))
 			Expect(out).To(HaveLen(2))
@@ -98,7 +98,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					newRoleRef("my-role-2"),
 					newServiceAccountSubject("my-other-account")),
 			}
-			in, out = c.SplitCSVPermissionsObjects()
+			in, out = c.SplitCSVPermissionsObjects(nil)
 			Expect(in).To(HaveLen(1))
 			Expect(getRoleNames(in)).To(ContainElement("my-role-1"))
 			Expect(out).To(HaveLen(4))
@@ -124,7 +124,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					newRoleRef("my-role-3"),
 					newServiceAccountSubject("my-dep-account-2")),
 			}
-			in, out = c.SplitCSVPermissionsObjects()
+			in, out = c.SplitCSVPermissionsObjects(nil)
 			Expect(in).To(HaveLen(2))
 			Expect(getRoleNames(in)).To(ContainElement("my-role-1"))
 			Expect(getRoleNames(in)).To(ContainElement("my-role-3"))
@@ -139,14 +139,14 @@ var _ = Describe("ClusterServiceVersion", func() {
 	Describe("SplitCSVClusterPermissionsObjects", func() {
 		It("should return empty lists for an empty Manifests", func() {
 			c.ClusterRoles = []rbacv1.ClusterRole{}
-			in, out = c.SplitCSVClusterPermissionsObjects()
+			in, out = c.SplitCSVClusterPermissionsObjects(nil)
 			Expect(in).To(HaveLen(0))
 			Expect(out).To(HaveLen(0))
 		})
 		It("should return non-empty lists", func() {
 			By("splitting 1 ClusterRole no ClusterRoleBinding")
 			c.ClusterRoles = []rbacv1.ClusterRole{newClusterRole("my-role")}
-			in, out = c.SplitCSVClusterPermissionsObjects()
+			in, out = c.SplitCSVClusterPermissionsObjects(nil)
 			Expect(in).To(HaveLen(0))
 			Expect(out).To(HaveLen(1))
 			Expect(getClusterRoleNames(out)).To(ContainElement("my-role"))
@@ -157,7 +157,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			c.ClusterRoleBindings = []rbacv1.ClusterRoleBinding{
 				newClusterRoleBinding("my-role-binding", newClusterRoleRef("my-role"), newServiceAccountSubject("my-other-account")),
 			}
-			in, out = c.SplitCSVClusterPermissionsObjects()
+			in, out = c.SplitCSVClusterPermissionsObjects(nil)
 			Expect(in).To(HaveLen(0))
 			Expect(out).To(HaveLen(2))
 			Expect(getClusterRoleNames(out)).To(ContainElement("my-role"))
@@ -169,7 +169,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 			c.ClusterRoleBindings = []rbacv1.ClusterRoleBinding{
 				newClusterRoleBinding("my-role-binding", newClusterRoleRef("my-role"), newServiceAccountSubject("my-dep-account")),
 			}
-			in, out = c.SplitCSVClusterPermissionsObjects()
+			in, out = c.SplitCSVClusterPermissionsObjects(nil)
 			Expect(in).To(HaveLen(1))
 			Expect(getClusterRoleNames(in)).To(ContainElement("my-role"))
 			Expect(out).To(HaveLen(0))
@@ -182,7 +182,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					newClusterRoleRef("my-role"),
 					newServiceAccountSubject("my-dep-account"), newServiceAccountSubject("my-other-account")),
 			}
-			in, out = c.SplitCSVClusterPermissionsObjects()
+			in, out = c.SplitCSVClusterPermissionsObjects(nil)
 			Expect(in).To(HaveLen(1))
 			Expect(getClusterRoleNames(in)).To(ContainElement("my-role"))
 			Expect(out).To(HaveLen(2))
@@ -200,7 +200,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					newClusterRoleRef("my-role-2"),
 					newServiceAccountSubject("my-other-account")),
 			}
-			in, out = c.SplitCSVClusterPermissionsObjects()
+			in, out = c.SplitCSVClusterPermissionsObjects(nil)
 			Expect(in).To(HaveLen(1))
 			Expect(getClusterRoleNames(in)).To(ContainElement("my-role-1"))
 			Expect(out).To(HaveLen(4))
@@ -230,7 +230,7 @@ var _ = Describe("ClusterServiceVersion", func() {
 					newClusterRoleRef("my-role-3"),
 					newServiceAccountSubject("my-dep-account-2")),
 			}
-			in, out = c.SplitCSVClusterPermissionsObjects()
+			in, out = c.SplitCSVClusterPermissionsObjects(nil)
 			Expect(in).To(HaveLen(2))
 			Expect(getClusterRoleNames(in)).To(ContainElement("my-role-1"))
 			Expect(getClusterRoleNames(in)).To(ContainElement("my-role-3"))

--- a/internal/generate/collector/clusterserviceversion_test.go
+++ b/internal/generate/collector/clusterserviceversion_test.go
@@ -1,12 +1,12 @@
 // Copyright 2020 The Operator-SDK Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// you may not use this file except inPerm compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
+// Unless required by applicable law or agreed to inPerm writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
@@ -16,6 +16,8 @@
 package collector
 
 import (
+	"sort"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -23,225 +25,196 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("ClusterServiceVersion", func() {
-	var (
-		c       *Manifests
-		in, out []client.Object
-	)
+var _ = Describe("SplitCSVPermissionsObjects", func() {
+	var c *Manifests
+	var inPerm, inCPerm, out []client.Object
 
 	BeforeEach(func() {
 		c = &Manifests{}
 	})
 
-	Describe("SplitCSVPermissionsObjects", func() {
-
-		It("should return empty lists for an empty Manifests", func() {
-			c.Roles = []rbacv1.Role{}
-			in, out = c.SplitCSVPermissionsObjects(nil)
-			Expect(in).To(HaveLen(0))
-			Expect(out).To(HaveLen(0))
-		})
-		It("should return non-empty lists", func() {
-			By("splitting 1 Role no RoleBinding")
-			c.Roles = []rbacv1.Role{newRole("my-role")}
-			in, out = c.SplitCSVPermissionsObjects(nil)
-			Expect(in).To(HaveLen(0))
-			Expect(out).To(HaveLen(1))
-			Expect(getRoleNames(out)).To(ContainElement("my-role"))
-
-			By("splitting 1 Role 1 RoleBinding with 1 Subject not containing Deployment serviceAccountName")
-			c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount("my-dep-account")}
-			c.Roles = []rbacv1.Role{newRole("my-role")}
-			c.RoleBindings = []rbacv1.RoleBinding{
-				newRoleBinding("my-role-binding", newRoleRef("my-role"), newServiceAccountSubject("my-other-account")),
-			}
-			in, out = c.SplitCSVPermissionsObjects(nil)
-			Expect(in).To(HaveLen(0))
-			Expect(out).To(HaveLen(2))
-			Expect(getRoleNames(out)).To(ContainElement("my-role"))
-			Expect(getRoleBindingNames(out)).To(ContainElement("my-role-binding"))
-
-			By("splitting 1 Role 1 RoleBinding with 1 Subject containing Deployment serviceAccountName")
-			c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount("my-dep-account")}
-			c.Roles = []rbacv1.Role{newRole("my-role")}
-			c.RoleBindings = []rbacv1.RoleBinding{
-				newRoleBinding("my-role-binding", newRoleRef("my-role"), newServiceAccountSubject("my-dep-account")),
-			}
-			in, out = c.SplitCSVPermissionsObjects(nil)
-			Expect(in).To(HaveLen(1))
-			Expect(getRoleNames(in)).To(ContainElement("my-role"))
-			Expect(out).To(HaveLen(0))
-
-			By("splitting 1 Role 1 RoleBinding with 2 Subjects containing a Deployment serviceAccountName")
-			c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount("my-dep-account")}
-			c.Roles = []rbacv1.Role{newRole("my-role")}
-			c.RoleBindings = []rbacv1.RoleBinding{
-				newRoleBinding("my-role-binding",
-					newRoleRef("my-role"),
-					newServiceAccountSubject("my-dep-account"), newServiceAccountSubject("my-other-account")),
-			}
-			in, out = c.SplitCSVPermissionsObjects(nil)
-			Expect(in).To(HaveLen(1))
-			Expect(getRoleNames(in)).To(ContainElement("my-role"))
-			Expect(out).To(HaveLen(2))
-			Expect(getRoleNames(out)).To(ContainElement("my-role"))
-			Expect(getRoleBindingNames(out)).To(ContainElement("my-role-binding"))
-
-			By("splitting 2 Roles 2 RoleBinding, one with 1 Subject not containing and the other with 2 Subjects containing a Deployment serviceAccountName")
-			c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount("my-dep-account")}
-			c.Roles = []rbacv1.Role{newRole("my-role-1"), newRole("my-role-2")}
-			c.RoleBindings = []rbacv1.RoleBinding{
-				newRoleBinding("my-role-binding-1",
-					newRoleRef("my-role-1"),
-					newServiceAccountSubject("my-dep-account"), newServiceAccountSubject("my-other-account")),
-				newRoleBinding("my-role-binding-2",
-					newRoleRef("my-role-2"),
-					newServiceAccountSubject("my-other-account")),
-			}
-			in, out = c.SplitCSVPermissionsObjects(nil)
-			Expect(in).To(HaveLen(1))
-			Expect(getRoleNames(in)).To(ContainElement("my-role-1"))
-			Expect(out).To(HaveLen(4))
-			Expect(getRoleNames(out)).To(ContainElement("my-role-1"))
-			Expect(getRoleNames(out)).To(ContainElement("my-role-2"))
-			Expect(getRoleBindingNames(out)).To(ContainElement("my-role-binding-1"))
-			Expect(getRoleBindingNames(out)).To(ContainElement("my-role-binding-2"))
-
-			By("splitting on 2 different Deployments")
-			c.Deployments = []appsv1.Deployment{
-				newDeploymentWithServiceAccount("my-dep-account-1"),
-				newDeploymentWithServiceAccount("my-dep-account-2"),
-			}
-			c.Roles = []rbacv1.Role{newRole("my-role-1"), newRole("my-role-2"), newRole("my-role-3")}
-			c.RoleBindings = []rbacv1.RoleBinding{
-				newRoleBinding("my-role-binding-1",
-					newRoleRef("my-role-1"),
-					newServiceAccountSubject("my-dep-account-1"), newServiceAccountSubject("my-other-account")),
-				newRoleBinding("my-role-binding-2",
-					newRoleRef("my-role-2"),
-					newServiceAccountSubject("my-other-account")),
-				newRoleBinding("my-role-binding-3",
-					newRoleRef("my-role-3"),
-					newServiceAccountSubject("my-dep-account-2")),
-			}
-			in, out = c.SplitCSVPermissionsObjects(nil)
-			Expect(in).To(HaveLen(2))
-			Expect(getRoleNames(in)).To(ContainElement("my-role-1"))
-			Expect(getRoleNames(in)).To(ContainElement("my-role-3"))
-			Expect(out).To(HaveLen(4))
-			Expect(getRoleNames(out)).To(ContainElement("my-role-1"))
-			Expect(getRoleNames(out)).To(ContainElement("my-role-2"))
-			Expect(getRoleBindingNames(out)).To(ContainElement("my-role-binding-1"))
-			Expect(getRoleBindingNames(out)).To(ContainElement("my-role-binding-2"))
-		})
+	It("returns empty lists for an empty Manifests", func() {
+		c.Roles = []rbacv1.Role{}
+		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
+		Expect(inPerm).To(HaveLen(0))
+		Expect(inCPerm).To(HaveLen(0))
+		Expect(out).To(HaveLen(0))
 	})
 
-	Describe("SplitCSVClusterPermissionsObjects", func() {
-		It("should return empty lists for an empty Manifests", func() {
-			c.ClusterRoles = []rbacv1.ClusterRole{}
-			in, out = c.SplitCSVClusterPermissionsObjects(nil)
-			Expect(in).To(HaveLen(0))
-			Expect(out).To(HaveLen(0))
-		})
-		It("should return non-empty lists", func() {
-			By("splitting 1 ClusterRole no ClusterRoleBinding")
-			c.ClusterRoles = []rbacv1.ClusterRole{newClusterRole("my-role")}
-			in, out = c.SplitCSVClusterPermissionsObjects(nil)
-			Expect(in).To(HaveLen(0))
-			Expect(out).To(HaveLen(1))
-			Expect(getClusterRoleNames(out)).To(ContainElement("my-role"))
-
-			By("splitting 1 ClusterRole 1 ClusterRoleBinding with 1 Subject not containing Deployment serviceAccountName")
-			c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount("my-dep-account")}
-			c.ClusterRoles = []rbacv1.ClusterRole{newClusterRole("my-role")}
-			c.ClusterRoleBindings = []rbacv1.ClusterRoleBinding{
-				newClusterRoleBinding("my-role-binding", newClusterRoleRef("my-role"), newServiceAccountSubject("my-other-account")),
-			}
-			in, out = c.SplitCSVClusterPermissionsObjects(nil)
-			Expect(in).To(HaveLen(0))
-			Expect(out).To(HaveLen(2))
-			Expect(getClusterRoleNames(out)).To(ContainElement("my-role"))
-			Expect(getClusterRoleBindingNames(out)).To(ContainElement("my-role-binding"))
-
-			By("splitting 1 ClusterRole 1 ClusterRoleBinding with 1 Subject containing Deployment serviceAccountName")
-			c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount("my-dep-account")}
-			c.ClusterRoles = []rbacv1.ClusterRole{newClusterRole("my-role")}
-			c.ClusterRoleBindings = []rbacv1.ClusterRoleBinding{
-				newClusterRoleBinding("my-role-binding", newClusterRoleRef("my-role"), newServiceAccountSubject("my-dep-account")),
-			}
-			in, out = c.SplitCSVClusterPermissionsObjects(nil)
-			Expect(in).To(HaveLen(1))
-			Expect(getClusterRoleNames(in)).To(ContainElement("my-role"))
-			Expect(out).To(HaveLen(0))
-
-			By("splitting 1 ClusterRole 1 ClusterRoleBinding with 2 Subjects containing a Deployment serviceAccountName")
-			c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount("my-dep-account")}
-			c.ClusterRoles = []rbacv1.ClusterRole{newClusterRole("my-role")}
-			c.ClusterRoleBindings = []rbacv1.ClusterRoleBinding{
-				newClusterRoleBinding("my-role-binding",
-					newClusterRoleRef("my-role"),
-					newServiceAccountSubject("my-dep-account"), newServiceAccountSubject("my-other-account")),
-			}
-			in, out = c.SplitCSVClusterPermissionsObjects(nil)
-			Expect(in).To(HaveLen(1))
-			Expect(getClusterRoleNames(in)).To(ContainElement("my-role"))
-			Expect(out).To(HaveLen(2))
-			Expect(getClusterRoleNames(out)).To(ContainElement("my-role"))
-			Expect(getClusterRoleBindingNames(out)).To(ContainElement("my-role-binding"))
-
-			By("splitting 2 ClusterRoles 2 ClusterRoleBindings, one with 1 Subject not containing and the other with 2 Subjects containing a Deployment serviceAccountName")
-			c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount("my-dep-account")}
-			c.ClusterRoles = []rbacv1.ClusterRole{newClusterRole("my-role-1"), newClusterRole("my-role-2")}
-			c.ClusterRoleBindings = []rbacv1.ClusterRoleBinding{
-				newClusterRoleBinding("my-role-binding-1",
-					newClusterRoleRef("my-role-1"),
-					newServiceAccountSubject("my-dep-account"), newServiceAccountSubject("my-other-account")),
-				newClusterRoleBinding("my-role-binding-2",
-					newClusterRoleRef("my-role-2"),
-					newServiceAccountSubject("my-other-account")),
-			}
-			in, out = c.SplitCSVClusterPermissionsObjects(nil)
-			Expect(in).To(HaveLen(1))
-			Expect(getClusterRoleNames(in)).To(ContainElement("my-role-1"))
-			Expect(out).To(HaveLen(4))
-			Expect(getClusterRoleNames(out)).To(ContainElement("my-role-1"))
-			Expect(getClusterRoleNames(out)).To(ContainElement("my-role-2"))
-			Expect(getClusterRoleBindingNames(out)).To(ContainElement("my-role-binding-1"))
-			Expect(getClusterRoleBindingNames(out)).To(ContainElement("my-role-binding-2"))
-
-			By("splitting on 2 different Deployments")
-			c.Deployments = []appsv1.Deployment{
-				newDeploymentWithServiceAccount("my-dep-account-1"),
-				newDeploymentWithServiceAccount("my-dep-account-2"),
-			}
-			c.ClusterRoles = []rbacv1.ClusterRole{
-				newClusterRole("my-role-1"),
-				newClusterRole("my-role-2"),
-				newClusterRole("my-role-3"),
-			}
-			c.ClusterRoleBindings = []rbacv1.ClusterRoleBinding{
-				newClusterRoleBinding("my-role-binding-1",
-					newClusterRoleRef("my-role-1"),
-					newServiceAccountSubject("my-dep-account-1"), newServiceAccountSubject("my-other-account")),
-				newClusterRoleBinding("my-role-binding-2",
-					newClusterRoleRef("my-role-2"),
-					newServiceAccountSubject("my-other-account")),
-				newClusterRoleBinding("my-role-binding-3",
-					newClusterRoleRef("my-role-3"),
-					newServiceAccountSubject("my-dep-account-2")),
-			}
-			in, out = c.SplitCSVClusterPermissionsObjects(nil)
-			Expect(in).To(HaveLen(2))
-			Expect(getClusterRoleNames(in)).To(ContainElement("my-role-1"))
-			Expect(getClusterRoleNames(in)).To(ContainElement("my-role-3"))
-			Expect(out).To(HaveLen(4))
-			Expect(getClusterRoleNames(out)).To(ContainElement("my-role-1"))
-			Expect(getClusterRoleNames(out)).To(ContainElement("my-role-2"))
-			Expect(getClusterRoleBindingNames(out)).To(ContainElement("my-role-binding-1"))
-			Expect(getClusterRoleBindingNames(out)).To(ContainElement("my-role-binding-2"))
-		})
+	It("splitting 1 Role no RoleBinding", func() {
+		c.Roles = []rbacv1.Role{newRole("my-role")}
+		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
+		Expect(inPerm).To(HaveLen(0))
+		Expect(inCPerm).To(HaveLen(0))
+		Expect(out).To(HaveLen(1))
+		Expect(getRoleNames(out)).To(Equal([]string{"my-role"}))
 	})
 
+	It("splitting 1 Role 1 RoleBinding with 1 Subject not containing Deployment serviceAccountName", func() {
+		c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount("my-dep-account")}
+		c.Roles = []rbacv1.Role{newRole("my-role")}
+		c.RoleBindings = []rbacv1.RoleBinding{
+			newRoleBinding("my-role-binding", newRoleRef("my-role"), newServiceAccountSubject("my-other-account")),
+		}
+		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
+		Expect(inPerm).To(HaveLen(0))
+		Expect(inCPerm).To(HaveLen(0))
+		Expect(out).To(HaveLen(2))
+		Expect(getRoleNames(out)).To(Equal([]string{"my-role"}))
+		Expect(getRoleBindingNames(out)).To(Equal([]string{"my-role-binding"}))
+	})
+
+	It("splitting 1 ClusterRole 1 RoleBinding with 1 Subject not containing Deployment serviceAccountName", func() {
+		c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount("my-dep-account")}
+		c.ClusterRoles = []rbacv1.ClusterRole{newClusterRole("my-role")}
+		c.RoleBindings = []rbacv1.RoleBinding{
+			newRoleBinding("my-role-binding", newClusterRoleRef("my-role"), newServiceAccountSubject("my-other-account")),
+		}
+		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
+		Expect(inPerm).To(HaveLen(0))
+		Expect(inCPerm).To(HaveLen(0))
+		Expect(out).To(HaveLen(2))
+		Expect(getClusterRoleNames(out)).To(Equal([]string{"my-role"}))
+		Expect(getRoleBindingNames(out)).To(Equal([]string{"my-role-binding"}))
+	})
+
+	It("splitting 1 Role 1 ClusterRole 1 RoleBinding with 1 Subject not containing Deployment serviceAccountName", func() {
+		c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount("my-dep-account")}
+		c.Roles = []rbacv1.Role{newRole("my-role")}
+		c.ClusterRoles = []rbacv1.ClusterRole{newClusterRole("my-role")}
+		c.RoleBindings = []rbacv1.RoleBinding{
+			newRoleBinding("my-role-binding-1", newRoleRef("my-role"), newServiceAccountSubject("my-other-account")),
+			newRoleBinding("my-role-binding-2", newClusterRoleRef("my-role"), newServiceAccountSubject("my-other-account")),
+		}
+		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
+		Expect(inPerm).To(HaveLen(0))
+		Expect(inCPerm).To(HaveLen(0))
+		Expect(out).To(HaveLen(4))
+		Expect(getRoleNames(out)).To(Equal([]string{"my-role"}))
+		Expect(getClusterRoleNames(out)).To(Equal([]string{"my-role"}))
+		Expect(getRoleBindingNames(out)).To(Equal([]string{"my-role-binding-1", "my-role-binding-2"}))
+	})
+
+	It("splitting 1 Role 1 RoleBinding with 1 Subject containing a Deployment serviceAccountName", func() {
+		c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount("my-dep-account")}
+		c.Roles = []rbacv1.Role{newRole("my-role")}
+		c.RoleBindings = []rbacv1.RoleBinding{
+			newRoleBinding("my-role-binding", newRoleRef("my-role"), newServiceAccountSubject("my-dep-account")),
+		}
+		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
+		Expect(inPerm).To(HaveLen(1))
+		Expect(getRoleNames(inPerm)).To(Equal([]string{"my-role"}))
+		Expect(inCPerm).To(HaveLen(0))
+		Expect(out).To(HaveLen(0))
+	})
+
+	It("splitting 1 ClusterRole 1 RoleBinding with 1 Subject containing a Deployment serviceAccountName", func() {
+		c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount("my-dep-account")}
+		c.ClusterRoles = []rbacv1.ClusterRole{newClusterRole("my-role")}
+		c.RoleBindings = []rbacv1.RoleBinding{
+			newRoleBinding("my-role-binding", newClusterRoleRef("my-role"), newServiceAccountSubject("my-dep-account")),
+		}
+		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
+		Expect(inPerm).To(HaveLen(1))
+		Expect(getClusterRoleNames(inPerm)).To(Equal([]string{"my-role"}))
+		Expect(inCPerm).To(HaveLen(0))
+		Expect(out).To(HaveLen(0))
+	})
+
+	It("splitting 1 Role 1 ClusterRole 1 RoleBinding with 1 Subject containing a Deployment serviceAccountName", func() {
+		c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount("my-dep-account")}
+		c.Roles = []rbacv1.Role{newRole("my-role")}
+		c.ClusterRoles = []rbacv1.ClusterRole{newClusterRole("my-role")}
+		c.RoleBindings = []rbacv1.RoleBinding{
+			newRoleBinding("my-role-binding-1", newRoleRef("my-role"), newServiceAccountSubject("my-dep-account")),
+			newRoleBinding("my-role-binding-2", newClusterRoleRef("my-role"), newServiceAccountSubject("my-dep-account")),
+		}
+		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
+		Expect(inPerm).To(HaveLen(2))
+		Expect(getRoleNames(inPerm)).To(Equal([]string{"my-role"}))
+		Expect(getClusterRoleNames(inPerm)).To(Equal([]string{"my-role"}))
+		Expect(inCPerm).To(HaveLen(0))
+		Expect(out).To(HaveLen(0))
+	})
+
+	It("splitting 1 Role 1 ClusterRole 1 RoleBinding with 2 Subjects containing a Deployment serviceAccountName", func() {
+		c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount("my-dep-account")}
+		c.Roles = []rbacv1.Role{newRole("my-role")}
+		c.ClusterRoles = []rbacv1.ClusterRole{newClusterRole("my-role")}
+		c.RoleBindings = []rbacv1.RoleBinding{
+			newRoleBinding("my-role-binding-1", newRoleRef("my-role"), newServiceAccountSubject("my-other-account"), newServiceAccountSubject("my-dep-account")),
+			newRoleBinding("my-role-binding-2", newClusterRoleRef("my-role"), newServiceAccountSubject("my-dep-account")),
+		}
+		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
+		Expect(inPerm).To(HaveLen(2))
+		Expect(getRoleNames(inPerm)).To(Equal([]string{"my-role"}))
+		Expect(getClusterRoleNames(inPerm)).To(Equal([]string{"my-role"}))
+		Expect(out).To(HaveLen(1))
+		Expect(getRoleBindingNames(out)).To(Equal([]string{"my-role-binding-1"}))
+	})
+
+	Context("multiple relationship RBAC", func() {
+		depSA, extraSA := "my-dep-account", "my-other-account"
+		roleName1, roleName2 := "my-role-1", "my-role-2"
+		bindingName1, bindingName2, bindingName3 := "my-role-binding-1", "my-role-binding-2", "my-role-binding-3"
+
+		complexTestSetup := func() {
+			c.Deployments = []appsv1.Deployment{newDeploymentWithServiceAccount(depSA)}
+			role1, role2 := newRole(roleName1), newRole(roleName2)
+			c.Roles = []rbacv1.Role{role1, role2}
+			// Use the same names as for Roles to make sure Kind is respected
+			cRole1, cRole2 := newClusterRole(roleName1), newClusterRole(roleName2)
+			c.ClusterRoles = []rbacv1.ClusterRole{cRole1, cRole2}
+
+			// Binds role 1 to depSA,extraSA, role 2 to extraSA, and clusterrole 1 to depSA.
+			c.RoleBindings = []rbacv1.RoleBinding{
+				newRoleBinding(bindingName1,
+					newRoleRef(role1.Name),
+					newServiceAccountSubject(depSA), newServiceAccountSubject(extraSA)),
+				newRoleBinding(bindingName2,
+					newRoleRef(role2.Name),
+					newServiceAccountSubject(extraSA)),
+				newRoleBinding(bindingName3,
+					newClusterRoleRef(cRole1.Name),
+					newServiceAccountSubject(depSA)),
+			}
+
+			// Binds clusterrole 1 to depSA and clusterrole 2 to extraSA.
+			c.ClusterRoleBindings = []rbacv1.ClusterRoleBinding{
+				newClusterRoleBinding(bindingName1,
+					newClusterRoleRef(cRole1.Name),
+					newServiceAccountSubject(depSA)),
+				newClusterRoleBinding(bindingName2,
+					newClusterRoleRef(cRole2.Name),
+					newServiceAccountSubject(extraSA)),
+			}
+		}
+
+		It("contains a Deployment serviceAccountName only", func() {
+			complexTestSetup()
+			inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
+			Expect(inPerm).To(HaveLen(2))
+			Expect(getRoleNames(inPerm)).To(Equal([]string{roleName1}))
+			Expect(getClusterRoleNames(inPerm)).To(Equal([]string{roleName1}))
+			Expect(inCPerm).To(HaveLen(1))
+			Expect(getClusterRoleNames(inCPerm)).To(Equal([]string{roleName1}))
+			Expect(out).To(HaveLen(5))
+			Expect(getRoleNames(out)).To(Equal([]string{roleName2}))
+			Expect(getClusterRoleNames(out)).To(Equal([]string{roleName2}))
+			Expect(getRoleBindingNames(out)).To(Equal([]string{bindingName1, bindingName2}))
+			Expect(getClusterRoleBindingNames(out)).To(Equal([]string{bindingName2}))
+		})
+		It("contains a Deployment serviceAccountName and extra ServiceAccount", func() {
+			complexTestSetup()
+			inPerm, inCPerm, out = c.SplitCSVPermissionsObjects([]string{extraSA})
+			Expect(inPerm).To(HaveLen(3))
+			Expect(getRoleNames(inPerm)).To(Equal([]string{roleName1, roleName2}))
+			Expect(getClusterRoleNames(inPerm)).To(Equal([]string{roleName1}))
+			Expect(inCPerm).To(HaveLen(2))
+			Expect(getClusterRoleNames(inCPerm)).To(Equal([]string{roleName1, roleName2}))
+			Expect(out).To(HaveLen(0))
+		})
+	})
 })
 
 func getRoleNames(objs []client.Object) []string {
@@ -266,6 +239,7 @@ func getNamesForKind(kind string, objs []client.Object) (names []string) {
 			names = append(names, obj.GetName())
 		}
 	}
+	sort.Strings(names)
 	return
 }
 

--- a/website/content/en/docs/cli/operator-sdk_generate_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_bundle.md
@@ -88,21 +88,22 @@ operator-sdk generate bundle [flags]
 ### Options
 
 ```
-      --channels string          A comma-separated list of channels the bundle belongs to (default "alpha")
-      --crds-dir string          Directory to read cluster-ready CustomResoureDefinition manifests from. This option can only be used if --deploy-dir is set
-      --default-channel string   The default channel for the bundle
-      --deploy-dir string        Directory to read cluster-ready operator manifests from. If --crds-dir is not set, CRDs are ready from this directory. This option is mutually exclusive with --input-dir and piping to stdin
-  -h, --help                     help for bundle
-      --input-dir string         Directory to read cluster-ready operator manifests from. This option is mutually exclusive with --deploy-dir/--crds-dir and piping to stdin. This option should not be passed an existing bundle directory, as this bundle will not contain the correct set of manifests required to generate a CSV. Use --kustomize-dir to pass a base CSV
-      --kustomize-dir string     Directory containing kustomize bases in a "bases" dir and a kustomization.yaml for operator-framework manifests (default "config/manifests")
-      --manifests                Generate bundle manifests
-      --metadata                 Generate bundle metadata and Dockerfile
-      --output-dir string        Directory to write the bundle to
-      --overwrite                Overwrite the bundle's metadata and Dockerfile if they exist (default true)
-      --package string           Bundle's package name
-  -q, --quiet                    Run in quiet mode
-      --stdout                   Write bundle manifest to stdout
-  -v, --version string           Semantic version of the operator in the generated bundle. Only set if creating a new bundle or upgrading your operator
+      --channels string                  A comma-separated list of channels the bundle belongs to (default "alpha")
+      --crds-dir string                  Directory to read cluster-ready CustomResoureDefinition manifests from. This option can only be used if --deploy-dir is set
+      --default-channel string           The default channel for the bundle
+      --deploy-dir string                Directory to read cluster-ready operator manifests from. If --crds-dir is not set, CRDs are ready from this directory. This option is mutually exclusive with --input-dir and piping to stdin
+      --extra-service-accounts strings   Names of service accounts, outside of the operator's Deployment account, that have bindings to {Cluster}Roles that should be added to the CSV
+  -h, --help                             help for bundle
+      --input-dir string                 Directory to read cluster-ready operator manifests from. This option is mutually exclusive with --deploy-dir/--crds-dir and piping to stdin. This option should not be passed an existing bundle directory, as this bundle will not contain the correct set of manifests required to generate a CSV. Use --kustomize-dir to pass a base CSV
+      --kustomize-dir string             Directory containing kustomize bases in a "bases" dir and a kustomization.yaml for operator-framework manifests (default "config/manifests")
+      --manifests                        Generate bundle manifests
+      --metadata                         Generate bundle metadata and Dockerfile
+      --output-dir string                Directory to write the bundle to
+      --overwrite                        Overwrite the bundle's metadata and Dockerfile if they exist (default true)
+      --package string                   Bundle's package name
+  -q, --quiet                            Run in quiet mode
+      --stdout                           Write bundle manifest to stdout
+  -v, --version string                   Semantic version of the operator in the generated bundle. Only set if creating a new bundle or upgrading your operator
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
**Description of the change:**
- generate bundle: add --extra-service-accounts flag to consider extra-Deployment SAsFeature/extra service accounts
- generate bundle: include both Roles and ClusterRoles in `.spec.permissions`, if ClusterRoles are bound by RoleBindings

**Motivation for the change:** see https://github.com/operator-framework/operator-sdk/issues/4751#issuecomment-821574461

/kind feature

Closes #4751 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>