### PR TITLE
fix: skip adding unserved CRDs to CSV

### DIFF
--- a/changelog/fragments/skip-adding-deprecard-crds.yaml
+++ b/changelog/fragments/skip-adding-deprecard-crds.yaml
@@ -1,0 +1,13 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      The `generate kustomize manifests` command no longer adds non-served CRD versions to a CSV's `.spec.customresourcedefinitions.owned`.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"

--- a/internal/util/k8sutil/api.go
+++ b/internal/util/k8sutil/api.go
@@ -112,6 +112,10 @@ func GetCustomResourceDefinitions(crdsDir string) (
 func DefinitionsForV1CustomResourceDefinitions(crds ...apiextv1.CustomResourceDefinition) (keys []registry.DefinitionKey) {
 	for _, crd := range crds {
 		for _, ver := range crd.Spec.Versions {
+			if !ver.Served {
+				log.Debugf("Not adding unserved CRD %q version %q to set of owned keys", crd.GetName(), ver.Name)
+				continue
+			}
 			keys = append(keys, registry.DefinitionKey{
 				Name:    crd.GetName(),
 				Group:   crd.Spec.Group,
@@ -136,6 +140,10 @@ func DefinitionsForV1beta1CustomResourceDefinitions(crds ...apiextv1beta1.Custom
 			})
 		}
 		for _, ver := range crd.Spec.Versions {
+			if !ver.Served {
+				log.Debugf("Not adding unserved CRD %q version %q to set of owned keys", crd.GetName(), ver.Name)
+				continue
+			}
 			keys = append(keys, registry.DefinitionKey{
 				Name:    crd.GetName(),
 				Group:   crd.Spec.Group,


### PR DESCRIPTION
Signed-off-by: varshaprasad96 <varshaprasad96@gmail.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Currently CSV generator adds the unserved crd versions
to the `ownedCRD` section of CSV. This PR fixes the same.

Closes: #4722 

**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [X] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
