### PR TITLE
test/integration: bump tested OLM version to 0.18.0, remove old test code

### DIFF
--- a/internal/testutils/utils.go
+++ b/internal/testutils/utils.go
@@ -41,8 +41,6 @@ type TestContext struct {
 	BundleImageName string
 	// ProjectName store the project name
 	ProjectName string
-	// Kubectx stores the k8s context from where the tests are running
-	Kubectx string
 	// isPrometheusManagedBySuite is true when the suite tests is installing/uninstalling the Prometheus
 	isPrometheusManagedBySuite bool
 	// isOLMManagedBySuite is true when the suite tests is installing/uninstalling the OLM
@@ -254,8 +252,12 @@ func (tc TestContext) InstallPrerequisites() {
 }
 
 // IsRunningOnKind returns true when the tests are executed in a Kind Cluster
-func (tc TestContext) IsRunningOnKind() bool {
-	return strings.Contains(tc.Kubectx, "kind")
+func (tc TestContext) IsRunningOnKind() (bool, error) {
+	kubectx, err := tc.Kubectl.Command("config", "current-context")
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(kubectx, "kind"), nil
 }
 
 // UninstallPrerequisites will uninstall all prerequisites installed via InstallPrerequisites()

--- a/test/e2e/ansible/suite_test.go
+++ b/test/e2e/ansible/suite_test.go
@@ -67,10 +67,6 @@ var _ = BeforeSuite(func() {
 		"- \"--leader-elect\"", "- \"--zap-log-level=2\"\n        - \"--leader-elect\"")
 	Expect(err).NotTo(HaveOccurred())
 
-	By("fetching the current-context")
-	tc.Kubectx, err = tc.Kubectl.Command("config", "current-context")
-	Expect(err).NotTo(HaveOccurred())
-
 	By("preparing the prerequisites on cluster")
 	tc.InstallPrerequisites()
 
@@ -122,7 +118,9 @@ var _ = BeforeSuite(func() {
 	err = tc.Make("docker-build", "IMG="+tc.ImageName)
 	Expect(err).NotTo(HaveOccurred())
 
-	if tc.IsRunningOnKind() {
+	onKind, err := tc.IsRunningOnKind()
+	Expect(err).NotTo(HaveOccurred())
+	if onKind {
 		By("loading the required images into Kind cluster")
 		Expect(tc.LoadImageToKindCluster()).To(Succeed())
 		Expect(tc.LoadImageToKindClusterWithName("quay.io/operator-framework/scorecard-test:dev")).To(Succeed())

--- a/test/e2e/go/suite_test.go
+++ b/test/e2e/go/suite_test.go
@@ -58,10 +58,6 @@ var _ = BeforeSuite(func() {
 	By("copying sample to a temporary e2e directory")
 	Expect(exec.Command("cp", "-r", "../../../testdata/go/v3/memcached-operator", tc.Dir).Run()).To(Succeed())
 
-	By("fetching the current-context")
-	tc.Kubectx, err = tc.Kubectl.Command("config", "current-context")
-	Expect(err).NotTo(HaveOccurred())
-
 	By("preparing the prerequisites on cluster")
 	tc.InstallPrerequisites()
 
@@ -77,7 +73,9 @@ var _ = BeforeSuite(func() {
 	err = tc.Make("docker-build", "IMG="+tc.ImageName)
 	Expect(err).NotTo(HaveOccurred())
 
-	if tc.IsRunningOnKind() {
+	onKind, err := tc.IsRunningOnKind()
+	Expect(err).NotTo(HaveOccurred())
+	if onKind {
 		By("loading the required images into Kind cluster")
 		Expect(tc.LoadImageToKindCluster()).To(Succeed())
 		Expect(tc.LoadImageToKindClusterWithName("quay.io/operator-framework/scorecard-test:dev")).To(Succeed())

--- a/test/e2e/helm/suite_test.go
+++ b/test/e2e/helm/suite_test.go
@@ -60,10 +60,6 @@ var _ = BeforeSuite(func() {
 	By("copying sample to a temporary e2e directory")
 	Expect(exec.Command("cp", "-r", "../../../testdata/helm/memcached-operator", tc.Dir).Run()).To(Succeed())
 
-	By("fetching the current-context")
-	tc.Kubectx, err = tc.Kubectl.Command("config", "current-context")
-	Expect(err).NotTo(HaveOccurred())
-
 	By("preparing the prerequisites on cluster")
 	tc.InstallPrerequisites()
 
@@ -83,7 +79,9 @@ var _ = BeforeSuite(func() {
 	err = tc.Make("docker-build", "IMG="+tc.ImageName)
 	Expect(err).NotTo(HaveOccurred())
 
-	if tc.IsRunningOnKind() {
+	onKind, err := tc.IsRunningOnKind()
+	Expect(err).NotTo(HaveOccurred())
+	if onKind {
 		By("loading the required images into Kind cluster")
 		Expect(tc.LoadImageToKindCluster()).To(Succeed())
 		Expect(tc.LoadImageToKindClusterWithName("quay.io/operator-framework/scorecard-test:dev")).To(Succeed())

--- a/test/integration/packagemanifests_test.go
+++ b/test/integration/packagemanifests_test.go
@@ -62,7 +62,7 @@ var _ = Describe("run packagemanifests", func() {
 				break
 			}
 		}
-		Expect(writeCSV(csv)).To(Succeed())
+		Expect(writeCSV(csv, "0.0.1")).To(Succeed())
 		Expect(runPackageManifests("--install-mode", "OwnNamespace", "--version", "0.0.1")).To(Succeed())
 	})
 
@@ -73,7 +73,7 @@ var _ = Describe("run packagemanifests", func() {
 			imageTag := fmt.Sprintf("integration/%s:%s", tc.ProjectName, version)
 			By("building the manager image " + imageTag)
 			Expect(tc.Make("docker-build", "IMG="+imageTag)).To(Succeed())
-			if tc.IsRunningOnKind() {
+			if onKind {
 				Expect(tc.LoadImageToKindClusterWithName(imageTag)).To(Succeed())
 			}
 			makeArgs := []string{"packagemanifests", "IMG=" + imageTag, "VERSION=" + version, "CHANNEL=" + channels[i]}


### PR DESCRIPTION
**Description of the change:** bump OLM version tested, remove code.

**Motivation for the change:** This PR bumps the tested OLM version to 0.18.0 and removes integration test code necessary for project to work with prior OLM versions following #4832

/area testing

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
