### PR TITLE
internal/cmd: format log.Info messages correctly

### DIFF
--- a/changelog/fragments/fmt-info-logs.yaml
+++ b/changelog/fragments/fmt-info-logs.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: >
+      Format ansible-operator and helm-operator `run` command logs correctly.
+    kind: bugfix

--- a/internal/cmd/ansible-operator/run/cmd.go
+++ b/internal/cmd/ansible-operator/run/cmd.go
@@ -139,7 +139,7 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 	namespace, found := os.LookupEnv(k8sutil.WatchNamespaceEnvVar)
 	log = log.WithValues("Namespace", namespace)
 	if found {
-		log.V(1).Info("Setting namespace with value in %s", k8sutil.WatchNamespaceEnvVar)
+		log.V(1).Info(fmt.Sprintf("Setting namespace with value in %s", k8sutil.WatchNamespaceEnvVar))
 		if namespace == metav1.NamespaceAll {
 			log.Info("Watching all namespaces.")
 			options.Namespace = metav1.NamespaceAll

--- a/internal/cmd/helm-operator/run/cmd.go
+++ b/internal/cmd/helm-operator/run/cmd.go
@@ -135,7 +135,7 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 	namespace, found := os.LookupEnv(k8sutil.WatchNamespaceEnvVar)
 	log = log.WithValues("Namespace", namespace)
 	if found {
-		log.V(1).Info("Setting namespace with value in %s", k8sutil.WatchNamespaceEnvVar)
+		log.V(1).Info(fmt.Sprintf("Setting namespace with value in %s", k8sutil.WatchNamespaceEnvVar))
 		if namespace == metav1.NamespaceAll {
 			log.Info("Watching all namespaces.")
 			options.Namespace = metav1.NamespaceAll


### PR DESCRIPTION
**Description of the change:**
- internal/cmd: format log.Info messages correctly

**Motivation for the change:** panic caused by odd number of keys

/kind bug 

Closes #4841 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
