### PR TITLE
images/ansible-operator/base.Dockerfile: pin `pip3~=21.1`

### DIFF
--- a/changelog/fragments/pip3-21.1.yaml
+++ b/changelog/fragments/pip3-21.1.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: >
+      Pinned pip3 to 21.1 in the ansible-operator image to fix https://github.com/pypa/pip/pull/9827
+    kind: bugfix

--- a/images/ansible-operator/base.Dockerfile
+++ b/images/ansible-operator/base.Dockerfile
@@ -21,9 +21,11 @@ ENV PIP_NO_CACHE_DIR=1 \
     PIPENV_CLEAR=1
 # Ensure fresh metadata rather than cached metadata, install system and pip python deps,
 # and remove those not needed at runtime.
+# pip3~=21.1 fixes a vulnerability described in https://github.com/pypa/pip/pull/9827.
 RUN yum clean all && rm -rf /var/cache/yum/* \
   && yum update -y \
   && yum install -y libffi-devel openssl-devel python38-devel gcc python38-pip python38-setuptools \
+  && pip3 install --upgrade pip~=21.1.0 \
   && pip3 install pipenv==2020.11.15 \
   && pipenv install --deploy \
   && pipenv check \


### PR DESCRIPTION
**Description of the change:**
- images/ansible-operator/base.Dockerfile: pin pip3~=21.1

**Motivation for the change:** fix unicode split vuln that `pipenv check` complains about

/area dependency

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
