### PR TITLE
docs/olm-integration: add docs on relatedImages and skips fields

### DIFF
--- a/website/content/en/docs/olm-integration/generation.md
+++ b/website/content/en/docs/olm-integration/generation.md
@@ -42,6 +42,7 @@ Comma-separated list of keywords for your operator (required):
 ```
 
 Once this base is written, you may modify any of the fields labeled _user_ in the [fields section](#csv-fields) below.
+These values will persist when generating a bundle, so make necessary metadata changes here and not the generated bundle.
 
 **For Go Operators only:** the command parses [CSV markers][csv-markers] from Go API type definitions, located
 in `./api` for single group projects and `./apis` for multigroup projects, to populate certain CSV fields.
@@ -189,6 +190,9 @@ $ tree ./bundle
     └── scorecard
         └── config.yaml
 ```
+
+**Important:** bundle generation is supposed to be idempotent, so any changes to CSV fields able to be persisted
+(marked _(user)_ or _(marker)_ [below](#csv-fields)) must be made to the base set of manifests, typically found in `config/`.
 
 Bundle metadata in `bundle/metadata/annotations.yaml` contains information about a particular Operator version
 available in a registry. OLM uses this information to install specific Operator versions and resolve dependencies.
@@ -385,8 +389,8 @@ Currently all but `MultiNamespace` are supported by SDK Operators.
 - `spec.customresourcedefinitions`: any CRDs the Operator uses. Certain fields in elements of `owned` will be filled by the SDK.
     - `owned`: all CRDs the Operator deploys itself from it's bundle.
         - `name`: CRD's `metadata.name`.
-        - `kind`: CRD's `metadata.spec.names.kind`.
-        - `version`: CRD's `metadata.spec.version`.
+        - `kind`: CRD's `spec.names.kind`.
+        - `version`: CRD's `spec.version`.
         - `description` _(marker)_ : description of the CRD.
         - `displayName` _(marker)_ : display name of the CRD.
         - `resources` _(marker)_ : any Kubernetes resources used by the CRD, ex. `Pod`'s and `ConfigMap`'s.
@@ -412,6 +416,11 @@ being managed, each with a `name` and `url`.
 - `spec.icon` _(user)_ : a base64-encoded icon unique to the Operator, set in a `base64data` field with a `mediatype`.
 - `spec.maturity` _(user)_: the Operator's maturity, ex. `alpha`.
 - `spec.webhookdefinitions`: any webhooks the Operator uses.
+- `spec.relatedImages` _(user)_: a list of image tags containing SHA digests [mapped to in-CSV names][relatedimages]
+that your Operator might require to perform their functions.
+    - To get the correct tag for an image available in some remote registry, run `docker inspect --format='{{range $i, $d := .RepoDigests}}{{$d}}{{"\n"}}{{end}}'`
+    and choose the tag for the desired registry.
+- `spec.skips` _(user)_: the names of one or more CSVs that should be skipped in a catalog's upgrade graph.
 
 **\*** `metadata.name` and `spec.version` will only be automatically updated from the base CSV
 when you set `--version` when running `generate <bundle|packagemanifests>`.
@@ -429,3 +438,4 @@ when you set `--version` when running `generate <bundle|packagemanifests>`.
 [operatorhub]:https://operatorhub.io/
 [scorecard]:/docs/advanced-topics/scorecard
 [operatorhub_validator]:https://olm.operatorframework.io/docs/tasks/creating-operator-bundle/#validating-your-bundle
+[relatedimages]:https://pkg.go.dev/github.com/operator-framework/api@v0.8.1/pkg/operators/v1alpha1#RelatedImage


### PR DESCRIPTION
**Description of the change:** add docs on `.spec.relatedImages` and `.spec.skips` in a CSV

**Motivation for the change:** see #4884

/kind documentation

Closes #4884 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
