### PR TITLE
Return actual olm client error

### DIFF
--- a/internal/olm/installer/manager.go
+++ b/internal/olm/installer/manager.go
@@ -45,13 +45,13 @@ func (m *Manager) initialize() (err error) {
 		if m.Client == nil {
 			cfg, cerr := config.GetConfig()
 			if cerr != nil {
-				err = fmt.Errorf("failed to get Kubernetes config: %v", err)
+				err = fmt.Errorf("failed to get Kubernetes config: %v", cerr)
 				return
 			}
 
 			client, cerr := ClientForConfig(cfg)
 			if cerr != nil {
-				err = fmt.Errorf("failed to create manager client: %v", err)
+				err = fmt.Errorf("failed to create manager client: %v", cerr)
 				return
 			}
 			m.Client = client


### PR DESCRIPTION
Signed-off-by: jesus m. rodriguez <jesusr@redhat.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Return actual error returned by olm client

**Motivation for the change:**
Error installing OLM resulted in `nil` error:
```
Failed to install OLM version "latest": failed to create manager client: <nil>
```

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
