### PR TITLE
Bugfix: log actual error during client initialization

### DIFF
--- a/internal/olm/installer/manager.go
+++ b/internal/olm/installer/manager.go
@@ -45,13 +45,13 @@ func (m *Manager) initialize() (err error) {
 		if m.Client == nil {
 			cfg, cerr := config.GetConfig()
 			if cerr != nil {
-				err = fmt.Errorf("failed to get Kubernetes config: %v", err)
+				err = fmt.Errorf("failed to get Kubernetes config: %v", cerr)
 				return
 			}
 
 			client, cerr := ClientForConfig(cfg)
 			if cerr != nil {
-				err = fmt.Errorf("failed to create manager client: %v", err)
+				err = fmt.Errorf("failed to create manager client: %v", cerr)
 				return
 			}
 			m.Client = client


### PR DESCRIPTION
Signed-off-by: rashmigottipati <chowdary.grashmi@gmail.com>

**Description of the change:**
Log the actual error cerr and not err while initializing the client 

**Motivation for the change:**


If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
