### PR TITLE
docs: fix scorecard patches path.

### DIFF
--- a/website/content/en/docs/advanced-topics/scorecard/custom-tests.md
+++ b/website/content/en/docs/advanced-topics/scorecard/custom-tests.md
@@ -97,7 +97,7 @@ func CustomTest1(bundle registry.Bundle) scapiv1alpha3.TestStatus {
 The [configuration file][config_yaml] includes test definitions and metadata to run the test.
 This file is constructed using a kustomization under `config/scorecard`, with overlays for test sets.
 
-For the example `CustomTest1` function, add the following to `config/scorecard/customtest1.config.yaml`.
+For the example `CustomTest1` function, add the following to `config/scorecard/patches/customtest1.config.yaml`.
 
 ```yaml
 - op: add


### PR DESCRIPTION
**Description of the change:**

The path for the custom test configuration file should be located in the patches directory as indicated later in the patchesJson6902.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
