### PR TITLE
workflows: add freshen-images cronjob to rebuild tagged images

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -38,10 +38,12 @@ jobs:
         set -e
         IMG=quay.io/${{ github.repository_owner }}/ansible-operator-base
         TAG="${{ github.event.inputs.ansible_operator_base_tag }}"
+        GIT_COMMIT=$(git rev-parse HEAD)
         if [[ "$TAG" == "" ]]; then
-          TAG="$(git branch --show-current)-$(git rev-parse HEAD)"
+          TAG="$(git branch --show-current)-${GIT_COMMIT}"
         fi
         echo ::set-output name=tag::${IMG}:${TAG}
+        echo ::set-output name=git_commit::${GIT_COMMIT}
 
     - name: build and push
       uses: docker/build-push-action@v2
@@ -51,6 +53,8 @@ jobs:
         platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
         push: true
         tags: ${{ steps.tag.outputs.tag }}
+        build-args: |
+          GIT_COMMIT=${{ steps.tag.outputs.git_commit }}
 
     # This change will be staged and committed in the PR pushed below.
     # The script below will fail if no change was made.

--- a/.github/workflows/freshen-images.yml
+++ b/.github/workflows/freshen-images.yml
@@ -1,0 +1,53 @@
+name: freshen-images
+
+on:
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Force rebuild of all images.
+        default: ''
+        required: false
+  schedule:
+  # Run at 11 am UTC every day.
+  - cron: '0 11 * * *'
+
+jobs:
+  git_tags:
+    runs-on: ubuntu-18.04
+    outputs:
+      git_tags: steps.tags.outputs.git_tags
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - id: tags
+      run: echo ::set-output name=git_tags::$(.github/workflows/freshen-images/tags.sh)
+
+  images:
+    name: images
+    needs: git_tags
+    runs-on: ubuntu-18.04
+    environment: deploy
+    strategy:
+      matrix:
+        # TODO(estroz): support scorecard-test-kuttl rebuilds.
+        id: ["operator-sdk", "ansible-operator", "helm-operator", "scorecard-test"]
+    steps:
+    - name: set up qemu
+      uses: docker/setup-qemu-action@v1
+    - name: set up buildx
+      uses: docker/setup-buildx-action@v1
+    - name: quay.io login
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+        registry: quay.io
+    - name: get build IDs
+      id: build_ids
+      run: |
+        .github/workflows/freshen-images/build.sh --push \
+          --image-id ${{ matrix.id }} \
+          --tags ${{ needs.git_tags.outputs.git_tags }} \
+          ${{ github.event.inputs.force != '' && '--force' || '' }}

--- a/.github/workflows/freshen-images.yml
+++ b/.github/workflows/freshen-images.yml
@@ -15,7 +15,7 @@ jobs:
   git_tags:
     runs-on: ubuntu-18.04
     outputs:
-      git_tags: steps.tags.outputs.git_tags
+      git_tags: ${{ steps.tags.outputs.git_tags }}
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -24,8 +24,8 @@ jobs:
     - id: tags
       run: echo ::set-output name=git_tags::$(.github/workflows/freshen-images/tags.sh)
 
-  images:
-    name: images
+  build:
+    name: build
     needs: git_tags
     runs-on: ubuntu-18.04
     environment: deploy
@@ -44,7 +44,11 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
         registry: quay.io
-    - name: get build IDs
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - name: build and push
       id: build_ids
       run: |
         .github/workflows/freshen-images/build.sh --push \

--- a/.github/workflows/freshen-images/build.sh
+++ b/.github/workflows/freshen-images/build.sh
@@ -7,7 +7,7 @@ source ${DIR}/lib.sh
 set -eu
 set -o pipefail
 
-# Comman-separated list of build platforms, ex. linux/s390x.
+# Comma-separated list of build platforms, ex. linux/s390x.
 # See 'docker buildx build --help' for --platform flag info.
 DEFAULT_PLATFORMS="linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
 # TODO(estroz): support scorecard-test-kuttl rebuilds.

--- a/.github/workflows/freshen-images/build.sh
+++ b/.github/workflows/freshen-images/build.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+
+# _buildx runs "docker buildx build" in CI-output mode.
+function _buildx() {
+  echo -e "\n$ docker buildx build --progress plain $@"
+  docker buildx build --progress plain $@
+}
+
+# _pull runs "docker pull".
+function _pull() {
+  echo -e "\n$ docker pull $@"
+  docker pull $@
+}
+
+# cmp_times returns false if $2 occurred within some timespan relative to $1.
+# The TIMESPAN variable
+function cmp_times() {
+  local base_seconds=$(date -d "$1" +%s)
+  local img_time_seconds=$(date -d "$2" +%s)
+  if (( $base_seconds - $TIMESPAN < $img_time_seconds )) || (( $FORCE )); then
+    return 1
+  fi
+  return 0
+}
+
+# is_dockerfile_fresh returns false if at least one image in a "FROM" directive
+# in the Dockerfile at $1 has been freshly built within TIMESPAN relative to now,
+# or FORCE=1.
+function is_dockerfile_fresh() {
+  local dockerfile=$1
+  # Strip flag from FROM to get image, which always precedes this flag if set.
+  local docker_images=$(grep -oP "FROM (--platform=[^ ]+ )?\K([^ ]+)" $dockerfile)
+
+  for img in $docker_images; do
+    _pull $img
+    local img_create_time=$(docker inspect --format '{{.Created}}' $img)
+    if [[ "$img_create_time" == "0001-01-01T00:00:00Z" ]]; then 
+      echo "image creation time could be found for $img"
+      exit 1
+    fi
+    if ! cmp_times "$(date)" "$img_create_time"; then
+      return 1
+    fi
+  done
+}
+
+# Build an image at path ./images/ansible-operator/base.Dockerfile checked out at git tag $1
+# for all platforms in $2. Semantics are otherwise the same as build_generic.
+function build_ansible_base() {
+  local tag=$1
+  local platforms=$2
+  local dockerfile=./images/ansible-operator/base.Dockerfile
+
+  git checkout refs/tags/$tag
+  local ansible_base_image_tag=$(grep -oP 'FROM \K(quay\.io/estroz/ansible-operator-base:.+)' ./images/ansible-operator/Dockerfile)
+  # Attempt to get the git ref that built this image from the git_commit image label,
+  # falling back to parsing it from the image tag, which typically contains a git ref
+  # as the last hyphen-delimit element.
+  local ansible_base_git_ref=$(docker inspect --format '{{ index .Config.Labels "git_commit" }}' $ansible_base_image_tag)
+  if [[ $ansible_base_git_ref == "devel" || $ansible_base_git_ref == "" ]]; then
+    ansible_base_git_ref=$(echo $ansible_base_image_tag | sed -E 's|.+:.+-(.+)|\1|')
+  fi
+  git checkout $ansible_base_git_ref
+  if ! is_dockerfile_fresh "$dockerfile"; then
+    _buildx --tag $ansible_base_image_tag --platform "$platforms" --file "$dockerfile" $IMAGE_DO --build-arg GIT_COMMIT=$ansible_base_git_ref ./images/ansible-operator
+  fi
+}
+
+# Build an image at path ./images/$2/Dockerfile checked out at git tag $1
+# for all platforms in $3. Tag is assumed to be "v"+semver; the image is tagged
+# with the full semver string and with "v${major}.${minor}".
+# The build will only run if the Dockerfile is not fresh.
+function build_generic() {
+  local tag=$1
+  local id=$2
+  local platforms=$3
+  local tag_maj_min="quay.io/estroz/${id}:$(echo $tag | grep -Eo "v[1-9]+\.[0-9]+")"
+  local tag_full="quay.io/estroz/${id}:${tag}"
+  local dockerfile=./images/${id}/Dockerfile
+
+  git checkout refs/tags/$tag
+  if ! is_dockerfile_fresh "$dockerfile"; then
+    _buildx --tag "$tag_maj_min" --tag "$tag_full"  --platform "$platforms" --file "$dockerfile" $IMAGE_DO .
+  fi
+}
+
+set -eu
+set -o pipefail
+
+# Comman-separated list of build platforms, ex. linux/s390x.
+# See 'docker buildx build --help' for --platform flag info.
+DEFAULT_PLATFORMS="linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
+# TODO(estroz): support scorecard-test-kuttl rebuilds.
+# DEFAULT_SCORECARD_KUTTL_PLATFORMS="linux/amd64,linux/arm64,linux/ppc64le"
+PLATFORMS=
+# Time window to compare image creation times against, relative to now.
+DEFAULT_TIMESPAN=86400 # 24 hours in seconds
+# What to do with the image, either load (default) or push.
+IMAGE_DO=--load
+# Space-separated list of git tags.
+# The --tags arg can be comma-separated.
+TAGS=
+# ID of the image, ex. operator-sdk, ansible-operator.
+IMAGE_ID=
+# Update all images.
+FORCE=0
+while [[ $# -gt 0 ]]; do
+  case $1 in
+  --push)
+  IMAGE_DO=$1
+  ;;
+  --force)
+  FORCE=1
+  ;;
+  --tags)
+  TAGS=$(echo $2 | sed -E 's/,/ /g')
+  shift
+  ;;
+  --image-id)
+  IMAGE_ID=$2
+  shift
+  ;;
+  --platforms)
+  PLATFORMS=$2
+  shift
+  ;;
+  *) echo "Invalid flag $1"; exit 1 ;;
+  esac
+  shift
+done
+
+: ${IMAGE_ID:?--image-id is required}
+: ${TAGS:?--tags is required}
+
+# Set defaults.
+case $IMAGE_ID in
+scorecard-test-kuttl)
+  # TODO(estroz): support scorecard-test-kuttl rebuilds.
+  # PLATFORMS=${PLATFORMS:-$DEFAULT_SCORECARD_KUTTL_PLATFORMS}
+  echo "$IMAGE_ID is not supported"
+  exit 1
+;;
+*)
+  PLATFORMS=${PLATFORMS:-$DEFAULT_PLATFORMS}
+;;
+esac
+TIMESPAN=${TIMESPAN:-$DEFAULT_TIMESPAN}
+
+# Clone the operator-sdk repo into a temp dir with cleanup.
+tmp=$(mktemp -d --tmpdir freshen-images-tmp.XXXXXX)
+git clone https://github.com/operator-framework/operator-sdk.git $tmp
+trap "rm -rf $tmp" EXIT
+pushd $tmp
+
+set -x
+
+case $IMAGE_ID in
+ansible-operator)
+  # ansible-operator has a base image that must be rebuilt in advance if necessary.
+  # This script will detect that the base is fresh when inspecting ansible-operator's
+  # Dockerfile and build it.
+  for tag in $TAGS; do
+    build_ansible_base $tag "$PLATFORMS"
+  done
+;;
+esac
+
+# Build the image defined by IMAGE_ID for each tag for a set of platforms.
+for tag in $TAGS; do
+  build_generic $tag $IMAGE_ID "$PLATFORMS"
+done
+
+popd

--- a/.github/workflows/freshen-images/build.sh
+++ b/.github/workflows/freshen-images/build.sh
@@ -1,88 +1,8 @@
 #!/usr/bin/env bash
 
-# _buildx runs "docker buildx build" in CI-output mode.
-function _buildx() {
-  echo -e "\n$ docker buildx build --progress plain $@"
-  docker buildx build --progress plain $@
-}
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-# _pull runs "docker pull".
-function _pull() {
-  echo -e "\n$ docker pull $@"
-  docker pull $@
-}
-
-# cmp_times returns false if $2 occurred within some timespan relative to $1.
-# The TIMESPAN variable
-function cmp_times() {
-  local base_seconds=$(date -d "$1" +%s)
-  local img_time_seconds=$(date -d "$2" +%s)
-  if (( $base_seconds - $TIMESPAN < $img_time_seconds )) || (( $FORCE )); then
-    return 1
-  fi
-  return 0
-}
-
-# is_dockerfile_fresh returns false if at least one image in a "FROM" directive
-# in the Dockerfile at $1 has been freshly built within TIMESPAN relative to now,
-# or FORCE=1.
-function is_dockerfile_fresh() {
-  local dockerfile=$1
-  # Strip flag from FROM to get image, which always precedes this flag if set.
-  local docker_images=$(grep -oP "FROM (--platform=[^ ]+ )?\K([^ ]+)" $dockerfile)
-
-  for img in $docker_images; do
-    _pull $img
-    local img_create_time=$(docker inspect --format '{{.Created}}' $img)
-    if [[ "$img_create_time" == "0001-01-01T00:00:00Z" ]]; then 
-      echo "image creation time could be found for $img"
-      exit 1
-    fi
-    if ! cmp_times "$(date)" "$img_create_time"; then
-      return 1
-    fi
-  done
-}
-
-# Build an image at path ./images/ansible-operator/base.Dockerfile checked out at git tag $1
-# for all platforms in $2. Semantics are otherwise the same as build_generic.
-function build_ansible_base() {
-  local tag=$1
-  local platforms=$2
-  local dockerfile=./images/ansible-operator/base.Dockerfile
-
-  git checkout refs/tags/$tag
-  local ansible_base_image_tag=$(grep -oP 'FROM \K(quay\.io/estroz/ansible-operator-base:.+)' ./images/ansible-operator/Dockerfile)
-  # Attempt to get the git ref that built this image from the git_commit image label,
-  # falling back to parsing it from the image tag, which typically contains a git ref
-  # as the last hyphen-delimit element.
-  local ansible_base_git_ref=$(docker inspect --format '{{ index .Config.Labels "git_commit" }}' $ansible_base_image_tag)
-  if [[ $ansible_base_git_ref == "devel" || $ansible_base_git_ref == "" ]]; then
-    ansible_base_git_ref=$(echo $ansible_base_image_tag | sed -E 's|.+:.+-(.+)|\1|')
-  fi
-  git checkout $ansible_base_git_ref
-  if ! is_dockerfile_fresh "$dockerfile"; then
-    _buildx --tag $ansible_base_image_tag --platform "$platforms" --file "$dockerfile" $IMAGE_DO --build-arg GIT_COMMIT=$ansible_base_git_ref ./images/ansible-operator
-  fi
-}
-
-# Build an image at path ./images/$2/Dockerfile checked out at git tag $1
-# for all platforms in $3. Tag is assumed to be "v"+semver; the image is tagged
-# with the full semver string and with "v${major}.${minor}".
-# The build will only run if the Dockerfile is not fresh.
-function build_generic() {
-  local tag=$1
-  local id=$2
-  local platforms=$3
-  local tag_maj_min="quay.io/estroz/${id}:$(echo $tag | grep -Eo "v[1-9]+\.[0-9]+")"
-  local tag_full="quay.io/estroz/${id}:${tag}"
-  local dockerfile=./images/${id}/Dockerfile
-
-  git checkout refs/tags/$tag
-  if ! is_dockerfile_fresh "$dockerfile"; then
-    _buildx --tag "$tag_maj_min" --tag "$tag_full"  --platform "$platforms" --file "$dockerfile" $IMAGE_DO .
-  fi
-}
+source ${DIR}/lib.sh
 
 set -eu
 set -o pipefail
@@ -94,7 +14,9 @@ DEFAULT_PLATFORMS="linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
 # DEFAULT_SCORECARD_KUTTL_PLATFORMS="linux/amd64,linux/arm64,linux/ppc64le"
 PLATFORMS=
 # Time window to compare image creation times against, relative to now.
+# --timespan should be set to this duration in seconds.
 DEFAULT_TIMESPAN=86400 # 24 hours in seconds
+TIMESPAN=
 # What to do with the image, either load (default) or push.
 IMAGE_DO=--load
 # Space-separated list of git tags.
@@ -124,6 +46,10 @@ while [[ $# -gt 0 ]]; do
   PLATFORMS=$2
   shift
   ;;
+  --timespan)
+  TIMESPAN=$2
+  shift
+  ;;
   *) echo "Invalid flag $1"; exit 1 ;;
   esac
   shift
@@ -151,8 +77,6 @@ tmp=$(mktemp -d --tmpdir freshen-images-tmp.XXXXXX)
 git clone https://github.com/operator-framework/operator-sdk.git $tmp
 trap "rm -rf $tmp" EXIT
 pushd $tmp
-
-set -x
 
 case $IMAGE_ID in
 ansible-operator)

--- a/.github/workflows/freshen-images/lib.sh
+++ b/.github/workflows/freshen-images/lib.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# _buildx runs "docker buildx build" in CI-output mode.
+function _buildx() {
+  echo -e "\n$ docker buildx build --progress plain $@"
+  docker buildx build --progress plain $@
+}
+
+# _pull runs "docker pull".
+function _pull() {
+  echo -e "\n$ docker pull $@"
+  docker pull $@
+}
+
+# cmp_times returns false if time $2 occurred within some timespan defined by TIMESPAN
+# relative to time $1.
+function cmp_times() {
+  local base_seconds=$(date -d "$1" +%s)
+  local img_time_seconds=$(date -d "$2" +%s)
+  if (( $base_seconds - $TIMESPAN < $img_time_seconds )) || (( $FORCE )); then
+    return 1
+  fi
+  return 0
+}
+
+# is_dockerfile_fresh returns false if at least one image in a "FROM" directive
+# in the Dockerfile at $1 has been freshly built within TIMESPAN relative to now,
+# or FORCE=1.
+function is_dockerfile_fresh() {
+  local dockerfile=$1
+  # Strip flag from FROM to get image, which always precedes this flag if set.
+  local docker_images=$(grep -oP "FROM (--platform=[^ ]+ )?\K([^ ]+)" $dockerfile)
+
+  for img in $docker_images; do
+    _pull $img
+    local img_create_time=$(docker inspect --format '{{.Created}}' $img)
+    if [[ "$img_create_time" == "0001-01-01T00:00:00Z" ]]; then 
+      echo "image creation time could be found for $img"
+      exit 1
+    fi
+    if ! cmp_times "$(date)" "$img_create_time"; then
+      return 1
+    fi
+  done
+}
+
+# Build an image at path ./images/ansible-operator/base.Dockerfile checked out at git tag $1
+# for all platforms in $2. Semantics are otherwise the same as build_generic.
+function build_ansible_base() {
+  local tag=$1
+  local platforms=$2
+  local dockerfile=./images/ansible-operator/base.Dockerfile
+
+  git checkout refs/tags/$tag
+  local ansible_base_image_tag=$(grep -oP 'FROM \K(quay\.io/operator-framework/ansible-operator-base:.+)' ./images/ansible-operator/Dockerfile)
+  # Attempt to get the git ref that built this image from the git_commit image label,
+  # falling back to parsing it from the image tag, which typically contains a git ref
+  # as the last hyphen-delimit element.
+  local ansible_base_git_ref=$(docker inspect --format '{{ index .Config.Labels "git_commit" }}' $ansible_base_image_tag)
+  if [[ $ansible_base_git_ref == "devel" || $ansible_base_git_ref == "" ]]; then
+    ansible_base_git_ref=$(echo $ansible_base_image_tag | sed -E 's|.+:.+-(.+)|\1|')
+  fi
+  git checkout $ansible_base_git_ref
+  if ! is_dockerfile_fresh "$dockerfile"; then
+    _buildx --tag $ansible_base_image_tag --platform "$platforms" --file "$dockerfile" $IMAGE_DO --build-arg GIT_COMMIT=$ansible_base_git_ref ./images/ansible-operator
+  fi
+}
+
+# Build an image at path ./images/$2/Dockerfile checked out at git tag $1
+# for all platforms in $3. Tag is assumed to be "v"+semver; the image is tagged
+# with the full semver string and with "v${major}.${minor}".
+# The build will only run if the Dockerfile is not fresh.
+function build_generic() {
+  local tag=$1
+  local id=$2
+  local platforms=$3
+  local tag_maj_min="quay.io/operator-framework/${id}:$(echo $tag | grep -Eo "v[1-9]+\.[0-9]+")"
+  local tag_full="quay.io/operator-framework/${id}:${tag}"
+  local dockerfile=./images/${id}/Dockerfile
+
+  git checkout refs/tags/$tag
+  if ! is_dockerfile_fresh "$dockerfile"; then
+    _buildx --tag "$tag_maj_min" --tag "$tag_full"  --platform "$platforms" --file "$dockerfile" $IMAGE_DO .
+  fi
+}

--- a/.github/workflows/freshen-images/tags.sh
+++ b/.github/workflows/freshen-images/tags.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+# Major version to select (default 1).
+MAJ=${1:-1}
+# Number of minor versions to select (default 2).
+NUM_MINORS=${2:-2}
+
+# Get unique "v${major}.${minor}" tags, then add the greatest patch version for each
+# to a list.
+declare -a LATEST_GIT_TAGS
+for tag in $(git tag --sort=-v:refname -l "v${MAJ}.*" | grep -Eo "v${MAJ}\.[^\.]+" | uniq | head -n $NUM_MINORS); do
+  LATEST_GIT_TAGS+=( $(git tag --sort=-v:refname -l "$tag*" | head -n 1) )
+done
+# Print tags in comma-separated form.
+echo ${LATEST_GIT_TAGS[@]} | sed -E 's/[ ]+/,/g'

--- a/changelog/fragments/freshen-images.yaml
+++ b/changelog/fragments/freshen-images.yaml
@@ -1,0 +1,7 @@
+entries:
+  - description: >
+      Images built from the operator-sdk repository for the latest two minor version's
+      latest patch version will now be rebuilt whenever a constituent base image has a new patch version published.
+      For example, running `docker pull quay.io/operator-framework/ansible-operator:v1.7.2` after a rebuild
+      will result in a fully compatible, patched image.
+    kind: change

--- a/images/ansible-operator/base.Dockerfile
+++ b/images/ansible-operator/base.Dockerfile
@@ -2,8 +2,12 @@
 # It is built with dependencies that take a while to download, thus speeding
 # up ansible deploy jobs.
 
-FROM registry.access.redhat.com/ubi8/ubi:8.3-297.1618432833
+FROM registry.access.redhat.com/ubi8/ubi:8.3
 ARG TARGETARCH
+
+# Label this image with the repo and commit that built it, for freshmaking purposes.
+ARG GIT_COMMIT=devel
+LABEL git_commit=$GIT_COMMIT
 
 RUN mkdir -p /etc/ansible \
   && echo "localhost ansible_connection=local" > /etc/ansible/hosts \

--- a/images/custom-scorecard-tests/Dockerfile
+++ b/images/custom-scorecard-tests/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/custom-scorecard-tests
 
 # Final image.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-298.1618432845
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 ENV HOME=/opt/custom-scorecard-tests \
     USER_NAME=custom-scorecard-tests \

--- a/images/helm-operator/Dockerfile
+++ b/images/helm-operator/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/helm-operator
 
 # Final image.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-298.1618432845
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 ENV HOME=/opt/helm \
     USER_NAME=helm \

--- a/images/operator-sdk/Dockerfile
+++ b/images/operator-sdk/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/operator-sdk
 
 # Final image.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-298.1618432845
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 RUN microdnf install -y golang make which
 

--- a/images/scorecard-test/Dockerfile
+++ b/images/scorecard-test/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/scorecard-test
 
 # Final image.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-298.1618432845
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 ENV HOME=/opt/scorecard-test \
     USER_NAME=scorecard-test \


### PR DESCRIPTION
**Description of the change:**
- images/: remove patch info from base images in Dockerfiles, add git_commit label to ansible-operator-base for getting git info in freshen-images job.
- .github/workflows: add freshen-images job and scripts, and update ansible-operator-base build with GIT_COMMIT build arg

**Motivation for the change:** This PR adds the freshen-images workflow, which checks for newer base images used by any Dockerfile in images/ and rebuilds them if found. These Dockerfiles now specify patch-less base image tags so newer base images can be pulled if they exist.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
