### PR TITLE
generate: correct error message when package name is missing

### DIFF
--- a/internal/cmd/operator-sdk/generate/internal/genutil.go
+++ b/internal/cmd/operator-sdk/generate/internal/genutil.go
@@ -192,14 +192,14 @@ func GetPackageNameAndLayout(defaultPackageName string) (packageName string, lay
 			default:
 				packageName = cfg.GetProjectName()
 				if packageName == "" {
-					return "", "", errors.New("--package-name must be set if \"projectName\" is not set in the PROJECT config file")
+					return "", "", errors.New("--package <name> must be set if \"projectName\" is not set in the PROJECT config file")
 				}
 			}
 		}
 		layout = projutil.GetProjectLayout(cfg)
 	} else {
 		if packageName == "" {
-			return "", "", errors.New("--package-name must be set if PROJECT config file is not present")
+			return "", "", errors.New("--package <name> must be set if PROJECT config file is not present")
 		}
 		layout = "unknown"
 	}

--- a/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests_test.go
+++ b/internal/cmd/operator-sdk/generate/packagemanifests/packagemanifests_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Running a generate packagemanifests command", func() {
 			It("fails if no correct operator name can be found", func() {
 				err := c.setDefaults()
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("package-name must be set if PROJECT config file is not present"))
+				Expect(err.Error()).To(ContainSubstring("--package <name> must be set if PROJECT config file is not present"))
 			})
 			It("sets fields on the command to default values", func() {
 				c.packageName = "apricot"


### PR DESCRIPTION
**Description of the change:**

Fix tthe error message when generating a bundle. It should mention `--package` instead of `--package-name` since `--package-name` is not a valid parameter.
