### PR TITLE
test/integration: use local registry for bundle tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ubuntu-18.04
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
+    strategy:
+      matrix:
+        type: [olm, bundle, pkgman]
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -32,4 +35,4 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: make test-e2e-integration
+      - run: make test-integration-${{ matrix.type }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 
 # Test artifacts
 **/testbin/
+/test/artifacts/
+/test/integration/e2e-*
 
 # CI GPG keyring
 /.ci/gpg/keyring

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ test-integration-cluster:: ## Set up cluster for integration tests.
 ifeq ($(CLUSTER),kind)
 	$(SCRIPTS_DIR)/create_kind_cluster -c $(TEST_ARTIFACTS)/registry-certs -k $(K8S_VERSION)
 endif
-	go test ./test/integration -v -ginkgo.v -ginkgo.focus="$(FOCUS)" $(if ($(CLUSTER),kind),-cert-dir $(shell pwd)/$(TEST_ARTIFACTS)/registry-certs)
+	go test ./test/integration -v -ginkgo.v -ginkgo.focus="$(FOCUS)" -timeout 20m $(if ($(CLUSTER),kind),-cert-dir $(shell pwd)/$(TEST_ARTIFACTS)/registry-certs)
 
 .DEFAULT_GOAL := help
 .PHONY: help

--- a/internal/olm/operator/bundle/install.go
+++ b/internal/olm/operator/bundle/install.go
@@ -28,6 +28,7 @@ import (
 
 type Install struct {
 	BundleImage string
+	LocalBundle string
 
 	*registry.IndexImageCatalogCreator
 	*registry.OperatorInstaller
@@ -46,6 +47,7 @@ func NewInstall(cfg *operator.Configuration) Install {
 }
 
 func (i *Install) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&i.LocalBundle, "local-bundle", "", "bundle directory or image to extract package information from. If unset, the bundle image arg is used")
 	fs.StringVar(&i.IndexImage, "index-image", registry.DefaultIndexImage, "index image in which to inject bundle")
 	fs.Var(&i.InstallMode, "install-mode", "install mode")
 
@@ -71,8 +73,12 @@ func (i *Install) setup(ctx context.Context) error {
 		}
 	}
 
+	bundleRef := i.LocalBundle
+	if bundleRef == "" {
+		bundleRef = i.BundleImage
+	}
 	// Load bundle labels and set label-dependent values.
-	labels, bundle, err := operator.LoadBundle(ctx, i.BundleImage, i.SkipTLS)
+	labels, bundle, err := operator.LoadBundle(ctx, bundleRef, i.SkipTLS)
 	if err != nil {
 		return err
 	}

--- a/internal/olm/operator/registry/index/registry_pod.go
+++ b/internal/olm/operator/registry/index/registry_pod.go
@@ -78,7 +78,7 @@ type RegistryPod struct { //nolint:maligned
 	CASecretName string
 
 	// SkipTLS controls wether to ignore SSL errors while pulling bundle image from registry server.
-	SkipTLS bool `json:"SkipTLS"`
+	SkipTLS bool
 
 	// pod represents a kubernetes *corev1.pod that will be created on a cluster using an index image
 	pod *corev1.Pod

--- a/internal/olm/operator/registry/index/registry_pod_test.go
+++ b/internal/olm/operator/registry/index/registry_pod_test.go
@@ -232,13 +232,16 @@ var _ = Describe("RegistryPod", func() {
 
 // containerCommandFor returns the expected container command for a db path and set of bundle items.
 func containerCommandFor(dbPath string, items []BundleItem, hasCA, skipTLS bool) string { //nolint:unparam
-	var caFlag string
+	var extraFlags string
 	if hasCA {
-		caFlag = " --ca-file=/certs/cert.pem"
+		extraFlags += " --ca-file=/certs/cert.pem"
+	}
+	if skipTLS {
+		extraFlags += " --skip-tls"
 	}
 	additions := &strings.Builder{}
 	for _, item := range items {
-		additions.WriteString(fmt.Sprintf("opm registry add -d %s -b %s --mode=%s%s --skip-tls=%v && \\\n", dbPath, item.ImageTag, item.AddMode, caFlag, skipTLS))
+		additions.WriteString(fmt.Sprintf("opm registry add -d %s -b %s --mode=%s%s && \\\n", dbPath, item.ImageTag, item.AddMode, extraFlags))
 	}
 	return fmt.Sprintf("mkdir -p /database && \\\n%sopm registry serve -d /database/index.db -p 50051\n", additions.String())
 }

--- a/internal/olm/operator/uninstall.go
+++ b/internal/olm/operator/uninstall.go
@@ -25,6 +25,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -214,7 +215,7 @@ func (u *Uninstall) deleteObjects(ctx context.Context, waitForDelete bool, objs 
 			return err
 		}
 		lowerKind := strings.ToLower(gvks[0].Kind)
-		if err := u.config.Client.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+		if err := u.config.Client.Delete(ctx, obj, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("delete %s %q: %v", lowerKind, obj.GetName(), err)
 		} else if err == nil {
 			u.Logf("%s %q deleted", lowerKind, obj.GetName())

--- a/test/integration/bundle_test.go
+++ b/test/integration/bundle_test.go
@@ -1,0 +1,88 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/operator-framework/operator-sdk/internal/testutils"
+)
+
+var _ = Describe("run bundle", func() {
+
+	var (
+		err    error
+		output string
+	)
+
+	AfterEach(func() {
+		By("cleaning up")
+		_, err = cleanup(&tc)
+		Expect(err).NotTo(HaveOccurred())
+		output, err := tc.Kubectl.Wait(true, "pods", "--all", "--for=delete", "--timeout=2m")
+		if err != nil && !strings.Contains(output, "no matching resources found") {
+			Fail(err.Error())
+		}
+	})
+
+	It("should handle existing operator deployments correctly", func() {
+		output, err = cleanup(&tc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(ContainSubstring(`package \"memcached-operator\" not found`))
+		Expect(runBundle(&tc, "integration/memcached-operator-bundle:v0.0.1")).To(Succeed())
+		Expect(runBundle(&tc, "integration/memcached-operator-bundle:v0.0.1")).NotTo(Succeed())
+		_, err = cleanup(&tc)
+		Expect(err).NotTo(HaveOccurred())
+		output, err = cleanup(&tc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(ContainSubstring(`package \"memcached-operator\" not found`))
+	})
+
+	It("should succeed with a single operator version in OwnNamespace mode", func() {
+		Expect(runBundle(&tc, "integration/memcached-operator-bundle:v0.0.1", "--install-mode", "OwnNamespace")).To(Succeed())
+	})
+
+	It("should successfully deploy the second of two operator versions", func() {
+		Skip("currently broken")
+		By("building a v0.0.1 catalog and v0.2.0 bundle")
+		Expect(tc.Make("catalog-build", "catalog-push", "IMAGE_TAG_BASE="+localImageBase)).To(Succeed())
+		if onKind {
+			inClusterCatalogImage := inClusterImageBase + "-catalog:v0.0.1"
+			ExpectWithOffset(1, dockerTag(tc, localImageBase+"-catalog:v0.0.1", inClusterCatalogImage)).To(Succeed())
+			ExpectWithOffset(1, tc.LoadImageToKindClusterWithName(inClusterCatalogImage)).To(Succeed())
+		}
+
+		inClusterBundleImage := inClusterImageBase + "-bundle:v0.2.0"
+		Expect(tc.Make("bundle", "bundle-build", "bundle-push", "VERSION="+"0.2.0", "CHANNELS=stable", "IMG="+inClusterBundleImage, "IMAGE_TAG_BASE="+localImageBase)).To(Succeed())
+		if onKind {
+			ExpectWithOffset(1, dockerTag(tc, localImageBase+"-bundle:v0.2.0", inClusterBundleImage)).To(Succeed())
+			ExpectWithOffset(1, tc.LoadImageToKindClusterWithName(inClusterBundleImage)).To(Succeed())
+		}
+
+		Expect(runBundle(&tc, "integration/memcached-operator-bundle:v0.2.0", "--index-image", inClusterImageBase+"-catalog:v0.0.1")).To(Succeed())
+	})
+})
+
+func runBundle(tc *testutils.TestContext, args ...string) (err error) {
+	args = append(args,
+		inClusterRegistryHost+"/"+args[0],
+		"--local-bundle", localRegistryHost+"/"+args[0],
+		"--ca-secret-name", caSecretName,
+	)
+	return runCmd(tc, "bundle", args[1:]...)
+}

--- a/test/integration/registry_test.go
+++ b/test/integration/registry_test.go
@@ -1,0 +1,46 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Adapted from https://github.com/operator-framework/operator-registry/blob/v1.17.1/test/e2e/e2e_suite_test.go
+package integration
+
+import (
+	"os"
+
+	"github.com/operator-framework/operator-sdk/internal/testutils"
+)
+
+const (
+	defaultLocalRegistryName     = "localhost"
+	defaultInClusterRegistryName = "kind-registry"
+)
+
+var (
+	localRegistryHost     = os.Getenv("DOCKER_REGISTRY_LOCAL_HOST")
+	inClusterRegistryHost = os.Getenv("DOCKER_REGISTRY_IN_CLUSTER_HOST")
+
+	registryPort = "443"
+)
+
+func configureRegistry(testutils.TestContext) func() {
+	if localRegistryHost == "" {
+		localRegistryHost = defaultLocalRegistryName + ":" + registryPort
+	}
+	if inClusterRegistryHost == "" {
+		inClusterRegistryHost = defaultInClusterRegistryName + ":" + registryPort
+	}
+
+	return func() {
+	}
+}

--- a/tools/scripts/create_kind_cluster
+++ b/tools/scripts/create_kind_cluster
@@ -96,8 +96,9 @@ CERT="${CERT_DIR}/cert.pem"
 KEY="${CERT_DIR}/key.pem"
 
 function installMkcert() {
+  local mkcert_ver="v1.4.3"
   if ! mkcert --version &>/dev/null; then
-    curl -sSLo "$MKCERT" https://github.com/FiloSottile/mkcert/releases/download/v1.4.3/mkcert-v1.4.3-$(go env GOOS)-$(go env GOARCH)
+    curl -sSLo "$MKCERT" "https://github.com/FiloSottile/mkcert/releases/download/${mkcert_ver}/mkcert-${mkcert_ver}-$(go env GOOS)-$(go env GOARCH)"
     chmod +x "$MKCERT"
   else
     MKCERT=$(command -v mkcert)
@@ -106,14 +107,15 @@ function installMkcert() {
 
 function createCerts() {
   # create destination for certs
-  mkdir -p "${CERT_DIR}"
   # check if CAROOT is installed or not
   if [[ ! -d $("$MKCERT" -CAROOT) ]]; then
+    export TRUST_STORES=system
     if ! "$MKCERT" -install; then
       err_exit "Unable to install CAROOT"
     fi
   fi
   # check if the certs were already created from a previous run of this script
+  mkdir -p "${CERT_DIR}"
   if [[ ! -f "${CERT}" ]] && [[ ! -f "${KEY}" ]]; then
     if ! "$MKCERT" -cert-file "${CERT}" -key-file "${KEY}" localhost 127.0.0.1 ::1 "$REGISTRY_NAME" ; then
       err_exit "Unable to create cert and key files"
@@ -121,37 +123,45 @@ function createCerts() {
   fi
 }
 
-running="$(docker inspect -f '{{.State.Running}}' "${REGISTRY_NAME}" 2>/dev/null || true)"
-if [ "${running}" = 'true' ]; then
-  echo "Registry is already running. Nothing to do."
-  exit 0
+function registry_running() {
+  local value="$(docker inspect -f '{{.State.Running}}' "$1" 2>/dev/null || true)"
+  if [[ "$value" == "true" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+if registry_running "$REGISTRY_NAME"; then
+  echo "Registry $REGISTRY_NAME is already running."
+else
+
+  # use mkcert tool for simple cross platform setup/configuration
+  installMkcert
+  createCerts
+
+  ABS_CERT_DIR="$(cd "$(dirname "${CERT_DIR}")"; pwd -P)/$(basename "${CERT_DIR}")"
+  docker run \
+    -d \
+    --restart=always \
+    --name "${REGISTRY_NAME}" \
+    -v "${ABS_CERT_DIR}":/certs \
+    -e REGISTRY_HTTP_ADDR=0.0.0.0:${REGISTRY_PORT} \
+    -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/cert.pem \
+    -e REGISTRY_HTTP_TLS_KEY=/certs/key.pem \
+    -p "127.0.0.1:${REGISTRY_PORT}:${REGISTRY_PORT}" \
+    registry:2
 fi
-
-# use mkcert tool for simple cross platform setup/configuration
-installMkcert
-createCerts
-
-ABS_CERT_DIR="$(cd "$(dirname "${CERT_DIR}")"; pwd -P)/$(basename "${CERT_DIR}")"
-docker run \
-  -d \
-  --restart=always \
-  --name "${REGISTRY_NAME}" \
-  -v "${ABS_CERT_DIR}":/certs \
-  -e REGISTRY_HTTP_ADDR=0.0.0.0:${REGISTRY_PORT} \
-  -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/cert.pem \
-  -e REGISTRY_HTTP_TLS_KEY=/certs/key.pem \
-  -p "127.0.0.1:${REGISTRY_PORT}:${REGISTRY_PORT}" \
-  registry:2
 
 if [[ "`$KIND get clusters`" =~ "$CLUSTER_NAME" ]]; then
-  echo "Cluster operator-sdk-e2e already exists."
+  echo "Cluster $CLUSTER_NAME already exists."
   exit 0
 fi
 
+# create a cluster with the local registry enabled in containerd
 if [[ "$SKIP_TLS" == "false" ]]; then
+
   echo "Creating kind cluster with an insecure registry client config."
-  # create a cluster with the local registry enabled in containerd
-  cat <<EOF | $KIND create cluster --name operator-sdk-e2e --image kindest/node:v${K8S_VERSION} --config=-
+  cat <<EOF | $KIND create cluster --name $CLUSTER_NAME --image kindest/node:v${K8S_VERSION} --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
@@ -167,15 +177,15 @@ else
 
   # TODO: get secure registry client working.
   echo "Creating kind cluster with a secure registry client config."
-  # create a cluster with the local registry enabled in containerd
-  cat <<EOF | $KIND create cluster --name operator-sdk-e2e --image kindest/node:v${K8S_VERSION} --config=-
+
+  cat <<EOF | $KIND create cluster --name $CLUSTER_NAME --image kindest/node:v${K8S_VERSION} --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
   extraMounts:
   - containerPath: /etc/docker/certs.d/localhost
-    hostPath: $(pwd)/test/integration/registry/certs
+    hostPath: "$CERT_DIR"
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${REGISTRY_PORT}"]

--- a/tools/scripts/create_kind_cluster
+++ b/tools/scripts/create_kind_cluster
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+
+# Adapted from https://github.com/operator-framework/operator-registry/blob/v1.17.1/scripts/start_registry.sh
+
+set -o errexit
+set -o pipefail
+
+# defaults
+CERT_DIR=certs
+
+TOOLS_DIR=tools/bin
+
+CLUSTER_NAME="operator-sdk-e2e"
+REGISTRY_NAME=kind-registry
+REGISTRY_PORT=443
+# TODO: get secure registry client working.
+SKIP_TLS=false
+
+K8S_VERSION=
+
+function usage() {
+  echo -n "$(basename "$0") [OPTIONS]
+
+Creates a local kind cluster reading from a local named docker registry.
+This registry always serves over TLS; this script generates TLS certs.
+
+ Options:
+  -k,--k8s-ver     Kubernetes version (required)
+  --tools-dir      Directory containing kind and kubectl (defaults to ${TOOLS_DIR})
+  --reg-name       Image registry container and in-cluster name (defaults to ${REGISTRY_NAME})
+  -p, --reg-port   Port the image registry will listen on (defaults to ${REGISTRY_PORT})
+  -c, --cert-dir   Output directory for cert and key files (defaults to ${CERT_DIR})
+  -h, --help       Display this help and exit
+"
+  exit 0
+}
+
+function err_exit() {
+  echo >&2 "[ERROR] $1"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  -k|--k8s-ver)
+    K8S_VERSION="$2"
+    shift 2
+  ;;
+  --tools-dir)
+    TOOLS_DIR="$2"
+    shift 2
+  ;;
+  --reg-name)
+    REGISTRY_NAME="$2"
+    shift 2
+  ;;
+  -p|--reg-port)
+    REGISTRY_PORT="$2"
+    shift 2
+  ;;
+  -c|--cert-dir)
+    CERT_DIR="$2"
+    shift 2
+  ;;
+  -h|--help)
+    usage
+    shift
+  ;;
+  --) # end argument parsing
+    shift
+    break
+  ;;
+  --*=|-*) # unsupported flags
+    err_exit "Unsupported flag $1"
+  ;;
+  *)
+    POSITIONAL+=("$1") # save it in an array for later
+    shift # past argument
+  ;;
+  esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+: ${K8S_VERSION:?"Kubernetes version must be set"}
+
+KIND=${TOOLS_DIR}/kind
+KUBECTL=${TOOLS_DIR}/kubectl
+
+# Install this globally since its version does not really matter.
+LOCAL_BIN="${XGD_CONFIG_HOME:-$HOME}/.local/bin"
+mkdir -p "$LOCAL_BIN"
+export PATH="${PATH}:${LOCAL_BIN}"
+MKCERT="${LOCAL_BIN}/mkcert"
+
+CERT="${CERT_DIR}/cert.pem"
+KEY="${CERT_DIR}/key.pem"
+
+function installMkcert() {
+  if ! mkcert --version &>/dev/null; then
+    curl -sSLo "$MKCERT" https://github.com/FiloSottile/mkcert/releases/download/v1.4.3/mkcert-v1.4.3-$(go env GOOS)-$(go env GOARCH)
+    chmod +x "$MKCERT"
+  else
+    MKCERT=$(command -v mkcert)
+  fi
+}
+
+function createCerts() {
+  # create destination for certs
+  mkdir -p "${CERT_DIR}"
+  # check if CAROOT is installed or not
+  if [[ ! -d $("$MKCERT" -CAROOT) ]]; then
+    if ! "$MKCERT" -install; then
+      err_exit "Unable to install CAROOT"
+    fi
+  fi
+  # check if the certs were already created from a previous run of this script
+  if [[ ! -f "${CERT}" ]] && [[ ! -f "${KEY}" ]]; then
+    if ! "$MKCERT" -cert-file "${CERT}" -key-file "${KEY}" localhost 127.0.0.1 ::1 "$REGISTRY_NAME" ; then
+      err_exit "Unable to create cert and key files"
+    fi
+  fi
+}
+
+running="$(docker inspect -f '{{.State.Running}}' "${REGISTRY_NAME}" 2>/dev/null || true)"
+if [ "${running}" = 'true' ]; then
+  echo "Registry is already running. Nothing to do."
+  exit 0
+fi
+
+# use mkcert tool for simple cross platform setup/configuration
+installMkcert
+createCerts
+
+ABS_CERT_DIR="$(cd "$(dirname "${CERT_DIR}")"; pwd -P)/$(basename "${CERT_DIR}")"
+docker run \
+  -d \
+  --restart=always \
+  --name "${REGISTRY_NAME}" \
+  -v "${ABS_CERT_DIR}":/certs \
+  -e REGISTRY_HTTP_ADDR=0.0.0.0:${REGISTRY_PORT} \
+  -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/cert.pem \
+  -e REGISTRY_HTTP_TLS_KEY=/certs/key.pem \
+  -p "127.0.0.1:${REGISTRY_PORT}:${REGISTRY_PORT}" \
+  registry:2
+
+if [[ "`$KIND get clusters`" =~ "$CLUSTER_NAME" ]]; then
+  echo "Cluster operator-sdk-e2e already exists."
+  exit 0
+fi
+
+if [[ "$SKIP_TLS" == "false" ]]; then
+  echo "Creating kind cluster with an insecure registry client config."
+  # create a cluster with the local registry enabled in containerd
+  cat <<EOF | $KIND create cluster --name operator-sdk-e2e --image kindest/node:v${K8S_VERSION} --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${REGISTRY_PORT}"]
+    endpoint = ["http://${REGISTRY_NAME}:${REGISTRY_PORT}"]
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.configs."${REGISTRY_NAME}:${REGISTRY_PORT}".tls]
+    insecure_skip_verify = true
+EOF
+
+else
+
+  # TODO: get secure registry client working.
+  echo "Creating kind cluster with a secure registry client config."
+  # create a cluster with the local registry enabled in containerd
+  cat <<EOF | $KIND create cluster --name operator-sdk-e2e --image kindest/node:v${K8S_VERSION} --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+  - containerPath: /etc/docker/certs.d/localhost
+    hostPath: $(pwd)/test/integration/registry/certs
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${REGISTRY_PORT}"]
+    endpoint = ["https://${REGISTRY_NAME}:${REGISTRY_PORT}"]
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.configs."${REGISTRY_NAME}:${REGISTRY_PORT}".tls]
+    cert_file = "/etc/docker/certs.d/localhost/cert.pem"
+    key_file  = "/etc/docker/certs.d/localhost/key.pem"
+EOF
+
+fi
+
+# Connect the registry to kind's network so the registry name is resolvable.
+docker network connect kind $REGISTRY_NAME || true
+
+# Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | $KUBECTL apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${REGISTRY_PORT}"
+    hostFromClusterNetwork: "${REGISTRY_NAME}:${REGISTRY_PORT}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF

--- a/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
@@ -20,6 +20,7 @@ operator-sdk run bundle-upgrade <bundle-image> [flags]
       --ca-secret-name string     Name of a generic secret containing a PEM root certificate file required to pull bundle images. This secret *must* be in the namespace that this command is configured to run in, and the file *must* be encoded under the key "cert.pem"
   -h, --help                      help for bundle-upgrade
       --kubeconfig string         Path to the kubeconfig file to use for CLI requests.
+      --local-bundle string       bundle directory or image to extract package information from. If unset, the bundle image arg is used
   -n, --namespace string          If present, namespace scope for this CLI request
       --pull-secret-name string   Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
       --service-account string    Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account

--- a/website/content/en/docs/cli/operator-sdk_run_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle.md
@@ -22,6 +22,7 @@ operator-sdk run bundle <bundle-image> [flags]
       --index-image string              index image in which to inject bundle (default "quay.io/operator-framework/opm:latest")
       --install-mode InstallModeValue   install mode
       --kubeconfig string               Path to the kubeconfig file to use for CLI requests.
+      --local-bundle string             bundle directory or image to extract package information from. If unset, the bundle image arg is used
   -n, --namespace string                If present, namespace scope for this CLI request
       --pull-secret-name string         Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
       --service-account string          Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account


### PR DESCRIPTION
**Description of the change:** run a local docker registry to push/pull bundle and catalog images for bundle integration tests

**Motivation for the change:** `run bundle` is not tested yet

/area testing

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
