### PR TITLE
workflows/deploy: only build master and v* branches on push event

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,12 +3,14 @@ name: deploy
 on:
   push:
     branches:
-    - '**'
+    - 'master'
+    - 'v*.*.x'
     tags:
     - 'v*'
     - 'scorecard-kuttl/v*'
   pull_request:
-    branches: [ master ]
+    branches:
+    - master
 
 jobs:
   check_docs_only:


### PR DESCRIPTION
**Description of the change:** workflows/deploy: only build master and v* branches on push event

**Motivation for the change:** all PRs are already tested, so skip `push` events for those branches

/area testing

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
