### PR TITLE
bump java plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/ginkgo v1.15.2
 	github.com/onsi/gomega v1.11.0
 	github.com/operator-framework/api v0.8.1
-	github.com/operator-framework/java-operator-plugins v0.0.0-20210430183738-736a20a43674
+	github.com/operator-framework/java-operator-plugins v0.0.0-20210524125824-b8f7ac135e76
 	github.com/operator-framework/operator-lib v0.4.1
 	github.com/operator-framework/operator-registry v1.15.3
 	github.com/prometheus/client_golang v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -770,8 +770,8 @@ github.com/operator-framework/api v0.3.22/go.mod h1:GVNiB6AQucwdZz3ZFXNv9HtcLOzc
 github.com/operator-framework/api v0.5.2/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
 github.com/operator-framework/api v0.8.1 h1:eFWAV70bvnQfNFM1dmBOY4y5u/WGZHV/SVDDl5WNsMk=
 github.com/operator-framework/api v0.8.1/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
-github.com/operator-framework/java-operator-plugins v0.0.0-20210430183738-736a20a43674 h1:ObJh5IfxKjbZw3u34mRRRLWnGzJ4Ry96oF1ujP2d89c=
-github.com/operator-framework/java-operator-plugins v0.0.0-20210430183738-736a20a43674/go.mod h1:QFcG224Nx8VMwBEqxpZbT17LkISNzlOjY1/r4OQBYic=
+github.com/operator-framework/java-operator-plugins v0.0.0-20210524125824-b8f7ac135e76 h1:Q5DKpohFF8aMvP4PHCvJ/FV1Pt1LKFZCmZ/3kJNIu5E=
+github.com/operator-framework/java-operator-plugins v0.0.0-20210524125824-b8f7ac135e76/go.mod h1:QFcG224Nx8VMwBEqxpZbT17LkISNzlOjY1/r4OQBYic=
 github.com/operator-framework/operator-lib v0.4.1 h1:Eh4JHs+LAWeC85ZMHXJ9RXg7G5grYx8J29TkOw8003s=
 github.com/operator-framework/operator-lib v0.4.1/go.mod h1:2dszbSeSo/472Ea8zIAcjEJhgzXKxzAGG24MgIP+13c=
 github.com/operator-framework/operator-registry v1.15.3 h1:C+u+zjDh6yQAKN+DbUvPeLjojZtJftvp/J28rRqiWWU=


### PR DESCRIPTION
**Description of the change:**
Bump the java plugin so that it picks up the recent `Makefile` changes.

**Motivation for the change:**
The java plugin now has a `Makefile` which we'd like to include in the first release of the plugin with the SDK.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
