### PR TITLE
docs/olm-integration: fix example Go code for OLM < 0.17

### DIFF
--- a/website/content/en/docs/olm-integration/generation.md
+++ b/website/content/en/docs/olm-integration/generation.md
@@ -102,32 +102,28 @@ import (
 func main() {
   ...
 
-  // Standard Manager setup.
+  // Configure a webhook.Server with the correct path and file names.
+  // If webhookServer is nil, which will be the case of OLM >= 0.17 is available,
+  // the manager will create a server for you using Host, Port,
+  // and the default CertDir, KeyName, and CertName.
+  var webhookServer *webhook.Server
+  const legacyOLMCertDir = "/apiserver.local.config/certificates"
+  if info, err := os.Stat(legacyOLMCertDir); err == nil && info.IsDir() {
+    webhookServer = &webhook.Server{
+      Host:     <some host>, // Set this only if normally set in ctrl.Options below.
+      Port:     <some port>, // Set this only if normally set in ctrl.Options below.
+      CertDir:  legacyOLMCertDir,
+      CertName: "apiserver.crt",
+      KeyName:  "apiserver.key",
+    }
+  }
+
   mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-    Host: <some host>, // May not be configured explicitly.
-    Port: <some port>, // May not be configured explicitly.
+    Host:          <some host>,
+    Port:          <some port>,
+    WebhookServer: webhookServer, // Host/Port will not be used if webhookServer is nil.
   })
-
-  ...
-
-  // Before any webhooks are registered:
-  var certDir, certName, keyName string
-  if info, err := os.Stat("/apiserver.local.config/certificates"); err == nil && info.IsDir() {
-    certDir = "/apiserver.local.config/certificates"
-    certName = "apiserver.crt"
-    keyName = "apiserver.key"
-  }
-  if err = mgr.Add(webhook.Server{
-    Host:     <some host>, // Set this only if set in ctrl.Options above.
-    Port:     <some port>, // Set this only if set in ctrl.Options above.
-    CertDir:  certDir,     // Defaults to the correct path if unset.
-    CertName: certName,    // Defaults to the correct path if unset.
-    KeyName:  keyName,     // Defaults to the correct path if unset.
-  }); err != nil {
-    setupLog.Error(err, "unable to add webhook server")
-    os.Exit(1)
-  }
-
+ 
   // Now you can register webhooks.
   ...
 }


### PR DESCRIPTION
**Description of the change:**
- docs/olm-integration/generation.md: fix example Go code to get webhooks working with OLM < 0.17

**Motivation for the change:** see https://github.com/kubernetes-sigs/controller-runtime/pull/1500

/kind documentation

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
