### PR TITLE
Run generate before prerelease

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ release: ## Release target. See 'make -f release/Makefile help' for more informa
 	$(MAKE) -f release/Makefile $@
 
 .PHONY: prerelease
-prerelease: ## Write release commit changes. See 'make -f release/Makefile help' for more information.
+prerelease: generate ## Write release commit changes. See 'make -f release/Makefile help' for more information.
 ifneq ($(RELEASE_VERSION),$(IMAGE_VERSION))
 	$(error "IMAGE_VERSION "$(IMAGE_VERSION)" must be updated to match RELEASE_VERSION "$(RELEASE_VERSION)" prior to creating a release commit")
 endif

--- a/website/content/en/docs/contribution-guidelines/releasing.md
+++ b/website/content/en/docs/contribution-guidelines/releasing.md
@@ -76,15 +76,17 @@ make prerelease
 
 The following changes should be present:
 
+- `Makefile`: IMAGE_VERSION should be modified to the upcoming release tag. (This variable ensures sampleprojects have been tagged correctpy prior to the release commit.)
 - `changelog/generated/v1.3.0.md`: commit changes (created by changelog generation).
 - `changelog/fragments/*`: commit deleted fragment files (deleted by changelog generation).
 - `website/content/en/docs/upgrading-sdk-version/v1.3.0.md`: commit changes (created by changelog generation).
 - `website/config.toml`: commit changes (modified by release script).
+- `testdata/*`: Generated sample code.
 
 Commit these changes and push to your remote (assuming your remote is named `origin`):
 
 ```sh
-git add --all
+git add Makefile changelog website testdata
 git commit -m "Release $RELEASE_VERSION"
 git push -u origin release-$RELEASE_VERSION
 ```
@@ -171,9 +173,6 @@ following commands from the root of the project.
 sed -i -E 's/(IMAGE_VERSION = ).+/\1v1\.3\.1/g' Makefile
 #  Run the pre-release `make` target:
 make prerelease
-# Regenerate testdata (samples).
-# NOTE: The sanity test will fail but scaffolding should complete.
-make test-sanity
 ```
 
 All of the following changes should be present (and no others).
@@ -186,7 +185,7 @@ All of the following changes should be present (and no others).
 Commit these changes and push these changes **to your fork**:
 
 ```sh
-git add --all
+git add Makefile changelog website testdata
 git commit -sm "Release $RELEASE_VERSION"
 git push -u origin release-$RELEASE_VERSION
 ```

--- a/website/content/en/docs/contribution-guidelines/releasing.md
+++ b/website/content/en/docs/contribution-guidelines/releasing.md
@@ -76,7 +76,7 @@ make prerelease
 
 The following changes should be present:
 
-- `Makefile`: IMAGE_VERSION should be modified to the upcoming release tag. (This variable ensures sampleprojects have been tagged correctpy prior to the release commit.)
+- `Makefile`: IMAGE_VERSION should be modified to the upcoming release tag. (This variable ensures sampleprojects have been tagged correctly prior to the release commit.)
 - `changelog/generated/v1.3.0.md`: commit changes (created by changelog generation).
 - `changelog/fragments/*`: commit deleted fragment files (deleted by changelog generation).
 - `website/content/en/docs/upgrading-sdk-version/v1.3.0.md`: commit changes (created by changelog generation).


### PR DESCRIPTION
**Description of the change:**
`make generate` is now run before `make prerelease`, and the documentation is updated to match.

**Motivation for the change:**
This is a necessary step in the release process.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
