### PR TITLE
fix(helm-operator): do not send empty patch requests to kube apiserver

### DIFF
--- a/changelog/fragments/empty-patch-requests.yaml
+++ b/changelog/fragments/empty-patch-requests.yaml
@@ -1,4 +1,4 @@
 entries:
   - description: >
-      Filtering out empty patch requests generated from the 3-way merge to avoid unnecessary load on kube apiserver.
+      For helm-based operators, empty patch requests generated from the 3-way merge are filtered to avoid unnecessary requests to the kube apiserver.
     kind: bugfix

--- a/changelog/fragments/empty-patch-requests.yaml
+++ b/changelog/fragments/empty-patch-requests.yaml
@@ -1,0 +1,4 @@
+entries:
+  - description: >
+      Filtering out empty patch requests generated from the 3-way merge to avoid unnecessary load on kube apiserver.
+    kind: bugfix

--- a/internal/helm/release/manager_test.go
+++ b/internal/helm/release/manager_test.go
@@ -163,7 +163,7 @@ func TestManagerGenerateStrategicMergePatch(t *testing.T) {
 			o2: newTestDeployment([]v1.Container{
 				{Name: "test1", LivenessProbe: nil},
 			}),
-			patch:     `{}`,
+			patch:     ``,
 			patchType: apitypes.StrategicMergePatchType,
 		},
 		{
@@ -196,7 +196,7 @@ func TestManagerGenerateStrategicMergePatch(t *testing.T) {
 				},
 				Spec: appsv1.DeploymentSpec{},
 			},
-			patch:     `{}`,
+			patch:     ``,
 			patchType: apitypes.StrategicMergePatchType,
 		},
 	}


### PR DESCRIPTION
**Description of the change:**
This change is in the helm operator when generating patch requests during each reconcile cycle.  The change filters out empty patches generated from the 3-way merge, which could be in the form of the "{}" byte array that represents an empty map.  This byte array is neither nil or zero-length, so the release reconciler sees it as non-empty and sends out a patch request to the kube apiserver.

This addresses https://github.com/operator-framework/operator-sdk/issues/4956.

**Motivation for the change:**
We have a deployment scenario with hundreds of helm operators, each generating ~60 empty patch requests even there are no changes.  That caused heavy traffic onto the kube apiserver.

**Testing done:**
- Built the operator with this change and confirmed no more such empty requests reported in #4956.
- Also tested a normal reconciliation scenario, by manually modifying a resource and observing that the operator still picks up the modification and reverts it upon the reconcile event.
- Updated the unit tests as well.