### PR TITLE
Closes #4446: Logging to Stdout based on verbosity

### DIFF
--- a/internal/ansible/events/log_events.go
+++ b/internal/ansible/events/log_events.go
@@ -66,9 +66,15 @@ func (l loggingEventHandler) Handle(ident string, u *unstructured.Unstructured, 
 
 	// Parse verbosity from CR
 	verbosityAnnotation := 0
-	verbosityAnnotation, err := strconv.Atoi(u.UnstructuredContent()["metadata"].(map[string]interface{})["annotations"].(map[string]interface{})["ansible.sdk.operatorframework.io/verbosity"].(string))
-	if err != nil {
-		logger.Error(err, "Unable to parse verbosity value from custom resource.")
+	if annot, exists := u.UnstructuredContent()["metadata"].(map[string]interface{})["annotations"]; exists {
+		if verbosityField, present := annot.(map[string]interface{})["ansible.sdk.operatorframework.io/verbosity"]; present {
+			verbosityValue, err := strconv.Atoi(verbosityField.(string))
+			if err != nil {
+				logger.Error(err, "Unable to parse verbosity value from CR.")
+			} else {
+				verbosityAnnotation = verbosityValue
+			}
+		}
 	}
 
 	// Parse verbosity from environment variable

--- a/internal/ansible/events/log_events.go
+++ b/internal/ansible/events/log_events.go
@@ -50,6 +50,9 @@ type loggingEventHandler struct {
 }
 
 func (l loggingEventHandler) Handle(ident string, u *unstructured.Unstructured, e eventapi.JobEvent) {
+	// Prints StdOut based on verbosity
+	fmt.Printf("%s\n", e.StdOut)
+
 	if l.LogLevel == Nothing {
 		return
 	}


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Printed log events to stdout, based on verbosity set in CR.

**Motivation for the change:**
To no longer ignore the verbosity at stdout while running Ansible-based operators, as mentioned in #4446.