### PR TITLE
fix: build-cmd arg in pkgman-to-bundle

### DIFF
--- a/internal/cmd/operator-sdk/pkgmantobundle/cmd.go
+++ b/internal/cmd/operator-sdk/pkgmantobundle/cmd.go
@@ -183,7 +183,7 @@ func (p *pkgManToBundleCmd) run() (err error) {
 			}
 
 			bundleMetaData := bundleutil.BundleMetaData{
-				BundleDir:       filepath.Join(p.outputDir, "bundle-"+dir.Name()),
+				BundleDir:       filepath.Join(p.outputDir, "bundle-"+dir.Name(), "bundle"),
 				PackageName:     packageName,
 				Channels:        channels,
 				DefaultChannel:  defaultChannel,

--- a/internal/cmd/operator-sdk/pkgmantobundle/cmd.go
+++ b/internal/cmd/operator-sdk/pkgmantobundle/cmd.go
@@ -74,35 +74,36 @@ INFO[0000] Creating bundle/bundle-0.0.1/bundle.Dockerfile
 INFO[0000] Creating bundle/bundle-0.0.1/metadata/annotations.yaml
 ...
 
-# After running the above command, the bundles will be generated in 'bundle/' directory.
-$ tree bundle/
-bundle/
+# After running the above command, the bundles will be generated in 'bundles/' directory.
+$ tree bundles/
+bundles/
 ├── bundle-0.0.1
-│   ├── bundle.Dockerfile
-│   ├── manifests
-│   │   ├── etcdcluster.crd.yaml
-│   │   ├── etcdoperator.clusterserviceversion.yaml
-│   ├── metadata
-│   │   └── annotations.yaml
-│   └── tests
-│       └── scorecard
-│           └── config.yaml
+│   ├── bundle
+│   │   ├── manifests
+│   │   │   ├── etcdcluster.crd.yaml
+│   │   │   ├── etcdoperator.clusterserviceversion.yaml
+│   │   ├── metadata
+│   │   │   └── annotations.yaml
+│   │   └── tests
+│   │       └── scorecard
+│   │           └── config.yaml
+│   └── bundle.Dockerfile
 └── bundle-0.0.2
-    ├── bundle.Dockerfile
-    ├── manifests
-    │   ├── etcdbackup.crd.yaml
-    │   ├── etcdcluster.crd.yaml
-    │   ├── etcdoperator.v0.0.2.clusterserviceversion.yaml
-    │   ├── etcdrestore.crd.yaml
-    ├── metadata
-    │   └── annotations.yaml
-    └── tests
-        └── scorecard
-            └── config.yaml
+    ├── bundle
+    │   ├── manifests
+    │   │   ├── etcdbackup.crd.yaml
+    │   │   ├── etcdcluster.crd.yaml
+    │   │   ├── etcdoperator.v0.0.2.clusterserviceversion.yaml
+    │   │   ├── etcdrestore.crd.yaml
+    │   └── metadata
+    │       └── annotations.yaml
+    └── bundle.Dockerfile
 
 Also, images for the both the bundles will be built with the following names: quay.io/example/etcd:0.0.1 and quay.io/example/etcd:0.0.2.
 `
 )
+
+var defaultSubBundleDir = "bundle"
 
 type pkgManToBundleCmd struct {
 	// Input packagemanifest directory.
@@ -183,7 +184,7 @@ func (p *pkgManToBundleCmd) run() (err error) {
 			}
 
 			bundleMetaData := bundleutil.BundleMetaData{
-				BundleDir:       filepath.Join(p.outputDir, "bundle-"+dir.Name(), "bundle"),
+				BundleDir:       filepath.Join(p.outputDir, "bundle-"+dir.Name(), defaultSubBundleDir),
 				PackageName:     packageName,
 				Channels:        channels,
 				DefaultChannel:  defaultChannel,

--- a/internal/cmd/operator-sdk/pkgmantobundle/cmd.go
+++ b/internal/cmd/operator-sdk/pkgmantobundle/cmd.go
@@ -99,7 +99,11 @@ bundles/
     │       └── annotations.yaml
     └── bundle.Dockerfile
 
-Also, images for the both the bundles will be built with the following names: quay.io/example/etcd:0.0.1 and quay.io/example/etcd:0.0.2.
+A custom command to build bundle images can also be specified using the '--build-cmd' flag. For example,
+
+$ operator-sdk pkgman-to-bundle packagemanifests --image-tag-base quay.io/example/etcd --build-cmd "podman build -f bundle.Dockerfile . -t"
+
+Images for the both the bundles will be built with the following names: quay.io/example/etcd:0.0.1 and quay.io/example/etcd:0.0.2.
 `
 )
 

--- a/internal/cmd/operator-sdk/pkgmantobundle/pkgmantobundle_test.go
+++ b/internal/cmd/operator-sdk/pkgmantobundle/pkgmantobundle_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Running pkgmanToBundle command", func() {
 			p.pkgmanifestDir = pkgManDir
 			p.outputDir = outputDir
 			p.baseImg = "quay.io/example/memcached-operator"
-			p.buildCmd = "docker build -f bundle.Dockerfile"
+			p.buildCmd = "docker build -f bundle.Dockerfile . -t"
 
 			err := p.run()
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/cmd/operator-sdk/pkgmantobundle/pkgmantobundle_test.go
+++ b/internal/cmd/operator-sdk/pkgmantobundle/pkgmantobundle_test.go
@@ -88,15 +88,29 @@ var _ = Describe("Running pkgmanToBundle command", func() {
 
 				// Verifying that bundle contains required files
 				Expect(fileExists(filepath.Join(p.outputDir, bundle.Name(), "bundle.Dockerfile"))).To(BeTrue())
-				Expect(fileExists(filepath.Join(p.outputDir, bundle.Name(), "metadata", "annotations.yaml"))).To(BeTrue())
+				Expect(fileExists(filepath.Join(p.outputDir, bundle.Name(), "bundle", "metadata", "annotations.yaml"))).To(BeTrue())
 				Expect(b.CSV).NotTo(BeNil())
 				Expect(b.V1CRDs).NotTo(BeNil())
 
 				// Verify if scorecard config exiss in the bundle
 				if bundle.Name() == "bundle-0.0.1" {
-					Expect(fileExists(filepath.Join(p.outputDir, bundle.Name(), "tests", "scorecard", "config.yaml"))).To(BeTrue())
+					Expect(fileExists(filepath.Join(p.outputDir, bundle.Name(), "bundle", "tests", "scorecard", "config.yaml"))).To(BeTrue())
 				}
 			}
+		})
+
+		It("should build image when build command is provided", func() {
+			// Specify input package manifest directory and output directory
+			pkgManDir = filepath.Join("testdata", "packagemanifests")
+			outputDir = "bundles-output"
+
+			p.pkgmanifestDir = pkgManDir
+			p.outputDir = outputDir
+			p.baseImg = "quay.io/example/memcached-operator"
+			p.buildCmd = "docker build -f bundle.Dockerfile -t quay.io/example/memcached ."
+
+			err := p.run()
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should error when output directory already exists", func() {

--- a/internal/cmd/operator-sdk/pkgmantobundle/pkgmantobundle_test.go
+++ b/internal/cmd/operator-sdk/pkgmantobundle/pkgmantobundle_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Running pkgmanToBundle command", func() {
 	var (
 		p         pkgManToBundleCmd
 		pkgManDir string
-		outputDir string
+		outputDir string = "bundle-output"
 	)
 
 	BeforeEach(func() {
@@ -65,7 +65,6 @@ var _ = Describe("Running pkgmanToBundle command", func() {
 		It("should generate multiple bundles for each version of manifests", func() {
 			// Specify input package manifest directory and output directory
 			pkgManDir = filepath.Join("testdata", "packagemanifests")
-			outputDir = "bundles-output"
 
 			p.pkgmanifestDir = pkgManDir
 			p.outputDir = outputDir
@@ -88,13 +87,13 @@ var _ = Describe("Running pkgmanToBundle command", func() {
 
 				// Verifying that bundle contains required files
 				Expect(fileExists(filepath.Join(p.outputDir, bundle.Name(), "bundle.Dockerfile"))).To(BeTrue())
-				Expect(fileExists(filepath.Join(p.outputDir, bundle.Name(), "bundle", "metadata", "annotations.yaml"))).To(BeTrue())
+				Expect(fileExists(filepath.Join(p.outputDir, bundle.Name(), defaultSubBundleDir, "metadata", "annotations.yaml"))).To(BeTrue())
 				Expect(b.CSV).NotTo(BeNil())
 				Expect(b.V1CRDs).NotTo(BeNil())
 
 				// Verify if scorecard config exiss in the bundle
 				if bundle.Name() == "bundle-0.0.1" {
-					Expect(fileExists(filepath.Join(p.outputDir, bundle.Name(), "bundle", "tests", "scorecard", "config.yaml"))).To(BeTrue())
+					Expect(fileExists(filepath.Join(p.outputDir, bundle.Name(), defaultSubBundleDir, "tests", "scorecard", "config.yaml"))).To(BeTrue())
 				}
 			}
 		})
@@ -102,19 +101,17 @@ var _ = Describe("Running pkgmanToBundle command", func() {
 		It("should build image when build command is provided", func() {
 			// Specify input package manifest directory and output directory
 			pkgManDir = filepath.Join("testdata", "packagemanifests")
-			outputDir = "bundles-output"
 
 			p.pkgmanifestDir = pkgManDir
 			p.outputDir = outputDir
 			p.baseImg = "quay.io/example/memcached-operator"
-			p.buildCmd = "docker build -f bundle.Dockerfile -t quay.io/example/memcached ."
+			p.buildCmd = "docker build -f bundle.Dockerfile"
 
 			err := p.run()
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should error when output directory already exists", func() {
-			outputDir = "bundles-output"
 			err := os.Mkdir(outputDir, projutil.DirMode)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/internal/util/bundleutil/bundleutil.go
+++ b/internal/util/bundleutil/bundleutil.go
@@ -221,10 +221,12 @@ func (meta *BundleMetaData) BuildBundleImage(tag string) error {
 		commandArg := strings.Split(meta.BuildCommand, " ")
 
 		// append the tag and build context to the command
-		commandArg = append(commandArg, "-t", img, ".")
-		cmd := exec.Command(commandArg[0], commandArg[1:]...)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			fmt.Println(string(out))
+		cmd := exec.Command(commandArg[0], append(commandArg[1:], img)...)
+		output, err := cmd.CombinedOutput()
+		if err != nil || viper.GetBool(flags.VerboseOpt) {
+			fmt.Println(string(output))
+		}
+		if err != nil {
 			return err
 		}
 	} else {

--- a/internal/util/bundleutil/bundleutil.go
+++ b/internal/util/bundleutil/bundleutil.go
@@ -204,8 +204,10 @@ func (meta *BundleMetaData) BuildBundleImage(tag string) error {
 		return err
 	}
 
-	defer func() error {
-		return os.Chdir(cwd)
+	defer func() {
+		if err := os.Chdir(cwd); err != nil {
+			log.Error(cwd)
+		}
 	}()
 
 	if err := os.Chdir(filepath.Dir(meta.BundleDir)); err != nil {
@@ -218,8 +220,11 @@ func (meta *BundleMetaData) BuildBundleImage(tag string) error {
 		log.Infof("Using the specified command to build image")
 		commandArg := strings.Split(meta.BuildCommand, " ")
 
+		// append the tag and build context to the command
+		commandArg = append(commandArg, "-t", img, ".")
 		cmd := exec.Command(commandArg[0], commandArg[1:]...)
-		if err := cmd.Run(); err != nil {
+		if out, err := cmd.CombinedOutput(); err != nil {
+			fmt.Println(string(out))
 			return err
 		}
 	} else {

--- a/internal/util/bundleutil/bundleutil.go
+++ b/internal/util/bundleutil/bundleutil.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 	"text/template"
 
 	log "github.com/sirupsen/logrus"
@@ -87,7 +88,7 @@ func (meta *BundleMetaData) GenerateMetadata() error {
 	// Create annotation values for both bundle.Dockerfile and annotations.yaml, which should
 	// hold the same set of values always.
 	values := annotationsValues{
-		BundleDir:                meta.BundleDir,
+		BundleDir:                filepath.Base(meta.BundleDir),
 		PackageName:              meta.PackageName,
 		Channels:                 meta.Channels,
 		DefaultChannel:           meta.DefaultChannel,
@@ -110,7 +111,7 @@ func (meta *BundleMetaData) GenerateMetadata() error {
 	// inside bundleDir, else its in the project directory.
 	// Remmove this, when pkgman-to-bundle migrate command is removed.
 	if len(meta.PkgmanifestPath) != 0 {
-		dockerfilePath = filepath.Join(meta.BundleDir, "bundle.Dockerfile")
+		dockerfilePath = filepath.Join(filepath.Dir(meta.BundleDir), "bundle.Dockerfile")
 	}
 
 	templateMap := map[string]*template.Template{
@@ -196,16 +197,33 @@ func (meta *BundleMetaData) BuildBundleImage(tag string) error {
 
 	img := fmt.Sprintf("%s:%s", meta.BaseImage, tag)
 
+	// switch back to current working directory, so that subsequent
+	// bundle version images can be built.
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	defer func() error {
+		return os.Chdir(cwd)
+	}()
+
+	if err := os.Chdir(filepath.Dir(meta.BundleDir)); err != nil {
+		return err
+	}
+
 	if len(meta.BuildCommand) != 0 {
 		// TODO(varsha): Make this more user friendly by accepting a template which
 		// can executed in each bundle subdirectory.
-		log.Infof("Using the specified command to build image %s", img)
-		cmd := exec.Command(meta.BuildCommand, img)
+		log.Infof("Using the specified command to build image")
+		commandArg := strings.Split(meta.BuildCommand, " ")
+
+		cmd := exec.Command(commandArg[0], commandArg[1:]...)
 		if err := cmd.Run(); err != nil {
 			return err
 		}
 	} else {
-		output, err := exec.Command("docker", "build", "-f", filepath.Join(meta.BundleDir, "bundle.Dockerfile"), "-t", img, ".").CombinedOutput()
+		output, err := exec.Command("docker", "build", "-f", "bundle.Dockerfile", "-t", img, ".").CombinedOutput()
 		if err != nil || viper.GetBool(flags.VerboseOpt) {
 			fmt.Println(string(output))
 		}

--- a/website/content/en/docs/cli/operator-sdk_pkgman-to-bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_pkgman-to-bundle.md
@@ -55,31 +55,30 @@ INFO[0000] Creating bundle/bundle-0.0.1/bundle.Dockerfile
 INFO[0000] Creating bundle/bundle-0.0.1/metadata/annotations.yaml
 ...
 
-# After running the above command, the bundles will be generated in 'bundle/' directory.
-$ tree bundle/
-bundle/
+# After running the above command, the bundles will be generated in 'bundles/' directory.
+$ tree bundles/
+bundles/
 ├── bundle-0.0.1
-│   ├── bundle.Dockerfile
-│   ├── manifests
-│   │   ├── etcdcluster.crd.yaml
-│   │   ├── etcdoperator.clusterserviceversion.yaml
-│   ├── metadata
-│   │   └── annotations.yaml
-│   └── tests
-│       └── scorecard
-│           └── config.yaml
+│   ├── bundle
+│   │   ├── manifests
+│   │   │   ├── etcdcluster.crd.yaml
+│   │   │   ├── etcdoperator.clusterserviceversion.yaml
+│   │   ├── metadata
+│   │   │   └── annotations.yaml
+│   │   └── tests
+│   │       └── scorecard
+│   │           └── config.yaml
+│   └── bundle.Dockerfile
 └── bundle-0.0.2
-    ├── bundle.Dockerfile
-    ├── manifests
-    │   ├── etcdbackup.crd.yaml
-    │   ├── etcdcluster.crd.yaml
-    │   ├── etcdoperator.v0.0.2.clusterserviceversion.yaml
-    │   ├── etcdrestore.crd.yaml
-    ├── metadata
-    │   └── annotations.yaml
-    └── tests
-        └── scorecard
-            └── config.yaml
+    ├── bundle
+    │   ├── manifests
+    │   │   ├── etcdbackup.crd.yaml
+    │   │   ├── etcdcluster.crd.yaml
+    │   │   ├── etcdoperator.v0.0.2.clusterserviceversion.yaml
+    │   │   ├── etcdrestore.crd.yaml
+    │   └── metadata
+    │       └── annotations.yaml
+    └── bundle.Dockerfile
 
 Also, images for the both the bundles will be built with the following names: quay.io/example/etcd:0.0.1 and quay.io/example/etcd:0.0.2.
 

--- a/website/content/en/docs/cli/operator-sdk_pkgman-to-bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_pkgman-to-bundle.md
@@ -80,7 +80,11 @@ bundles/
     │       └── annotations.yaml
     └── bundle.Dockerfile
 
-Also, images for the both the bundles will be built with the following names: quay.io/example/etcd:0.0.1 and quay.io/example/etcd:0.0.2.
+A custom command to build bundle images can also be specified using the '--build-cmd' flag. For example,
+
+$ operator-sdk pkgman-to-bundle packagemanifests --image-tag-base quay.io/example/etcd --build-cmd "podman build -f bundle.Dockerfile . -t"
+
+Images for the both the bundles will be built with the following names: quay.io/example/etcd:0.0.1 and quay.io/example/etcd:0.0.2.
 
 ```
 

--- a/website/content/en/docs/olm-integration/quickstart-package-manifests.md
+++ b/website/content/en/docs/olm-integration/quickstart-package-manifests.md
@@ -125,22 +125,28 @@ INFO[0000] Creating etcd-bundle/bundle-0.0.1/metadata/annotations.yaml
 This will create output bundles in the directory `etcd-bundle`. The output directory will look like:
 
 ```
+etcd-bundle/
 ├── bundle-0.0.1
-│   ├── bundle.Dockerfile
-│   ├── manifests
-│   │   ├── etcdcluster.crd.yaml
-│   │   ├── etcdoperator.clusterserviceversion.yaml
-│   ├── metadata
-│   │   └── annotations.yaml
+│   ├── bundle
+│   │   ├── manifests
+│   │   │   ├── etcdcluster.crd.yaml
+│   │   │   ├── etcdoperator.clusterserviceversion.yaml
+│   │   ├── metadata
+│   │   │   └── annotations.yaml
+│   │   └── tests
+│   │       └── scorecard
+│   │           └── config.yaml
+│   └── bundle.Dockerfile
 └── bundle-0.0.2
-    ├── bundle.Dockerfile
-    ├── manifests
-    │   ├── etcdbackup.crd.yaml
-    │   ├── etcdcluster.crd.yaml
-    │   ├── etcdoperator.v0.0.2.clusterserviceversion.yaml
-    │   ├── etcdrestore.crd.yaml
-    ├── metadata
-        └── annotations.yaml
+    ├── bundle
+    │   ├── manifests
+    │   │   ├── etcdbackup.crd.yaml
+    │   │   ├── etcdcluster.crd.yaml
+    │   │   ├── etcdoperator.v0.0.2.clusterserviceversion.yaml
+    │   │   ├── etcdrestore.crd.yaml
+    │   └── metadata
+    │       └── annotations.yaml
+    └── bundle.Dockerfile
 ```
 
 To build images for the bundles, the base container image name can be provided using `--image-tag-base` flag. This name should be provided without the tag (`:` and characters following), as the command will tag each bundle image with its packagemanifests directory name, i.e. `<image-tag-base>:<dir-name>`. For example, the following command for the above `packagemnifests` directory would build the bundles `quay.io/example/etcd-bundle:0.0.1` and `quay.io/example/etcd-bundle:0.0.2`.
@@ -151,12 +157,11 @@ operator-sdk pkgman-to-bundle packagemanifests --image-tag-base quay.io/example/
 
 A custom command can also be specified to build images, using the `--build-cmd` flag. The default command is `docker build`. However, if using a custom command, it needs to be made sure that the command is in the `PATH` or a fully qualified path name is provided as input to the flag.
 
-Once the command has finished building your bundle images and they have been added to a catalog image, delete all bundle directories except for the latest one. This directory will contain manifests for your operator's head bundle, and should be versioned with version control system like git. Rename this directory to `bundle`, and move `bundle.Dockerfile` to your project's root:
+Once the command has finished building your bundle images and they have been added to a catalog image, delete all bundle directories except for the latest one. This directory will contain manifests for your operator's head bundle, and should be versioned with version control system like git. Move this directory and its `bundle.Dockerfile` to your project's root:
 
 ```console
-$ mv ./etcd-bundle/bundle-0.0.2 ./bundle
+$ cp -r ./etcd-bundle/bundle-0.0.2/* .
 $ rm -rf ./etcd-bundle
-$ mv bundle/bundle.Dockerfile .
 ```
 
 Try building then running your bundle on a live cluster to make sure it works as expected:

--- a/website/content/en/docs/olm-integration/quickstart-package-manifests.md
+++ b/website/content/en/docs/olm-integration/quickstart-package-manifests.md
@@ -155,7 +155,13 @@ To build images for the bundles, the base container image name can be provided u
 operator-sdk pkgman-to-bundle packagemanifests --image-tag-base quay.io/example/etcd-bundle
 ```
 
-A custom command can also be specified to build images, using the `--build-cmd` flag. The default command is `docker build`. However, if using a custom command, it needs to be made sure that the command is in the `PATH` or a fully qualified path name is provided as input to the flag.
+A custom command can also be specified to build images, using the `--build-cmd` flag. The default command is `docker build`. For example:
+
+```console
+$ operator-sdk pkgman-to-bundle packagemanifests --output-dir etcd-bundle/ --image-tag-base quay.io/example/etcd --build-cmd "podman build -f bundle.Dockerfile . -t"
+```
+
+However, if using a custom command, it needs to be made sure that the command is in the `PATH` or a fully qualified path name is provided as input to the flag.
 
 Once the command has finished building your bundle images and they have been added to a catalog image, delete all bundle directories except for the latest one. This directory will contain manifests for your operator's head bundle, and should be versioned with version control system like git. Move this directory and its `bundle.Dockerfile` to your project's root:
 


### PR DESCRIPTION
The custom build command in pkgman-to-bundle accepts the input and
executes it using [`exec.Command()`](https://github.com/operator-framework/operator-sdk/blob/d3bd87c6900f70b7df618340e1d63329c7cd651e/internal/util/bundleutil/bundleutil.go#L203). However, `exec.Command()` requires that the
first argument is the name or path of the command. This change separates
the user input and considers first argument as the path and then appends the rest of the args to execute the command in all the sub directories. 

Example:
```
/Users/vnarsing/go/bin/operator-sdk pkgman-to-bundle packagemanifests --image-tag-base quay.io/example/memcached --build-cmd "docker build -f bundle.Dockerfile . -t"
INFO[0001] Packagemanifests will be migrated to bundles in bundles directory
INFO[0001] Creating bundles/bundle-0.0.1/bundle.Dockerfile
INFO[0001] Creating bundles/bundle-0.0.1/metadata/annotations.yaml
INFO[0001] Bundle metadata generated suceessfully
INFO[0001] Using the specified command to build image quay.io/example/memcached:0.0.1
INFO[0003] Successfully built image quay.io/example/memcached:0.0.1
```

This also modifies the output directory structure. The output directory will look like:
```sh
├── bundle-0.0.1
│   ├── bundle
│   │   ├── manifests
│   │   │   ├── cache.example.com_memcacheds.yaml
│   │   │   ├── memcached-operator-controller-manager-metrics-service_v1_service.yaml
│   │   │   ├── memcached-operator-controller-manager_v1_serviceaccount.yaml
│   │   │   ├── memcached-operator-manager-config_v1_configmap.yaml
│   │   │   ├── memcached-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
│   │   │   └── memcached-operator.clusterserviceversion.yaml
│   │   ├── metadata
│   │   │   └── annotations.yaml
│   │   └── tests
│   │       └── scorecard
│   │           └── config.yaml
│   └── bundle.Dockerfile
└── bundle-0.0.2
    ├── bundle
    │   ├── manifests
    │   │   ├── cache.example.com_memcacheds.yaml
    │   │   ├── memcached-operator-controller-manager-metrics-service_v1_service.yaml
    │   │   ├── memcached-operator-controller-manager_v1_serviceaccount.yaml
    │   │   ├── memcached-operator-manager-config_v1_configmap.yaml
    │   │   ├── memcached-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
    │   │   └── memcached-operator.clusterserviceversion.yaml
    │   └── metadata
    │       └── annotations.yaml
    └── bundle.Dockerfile
```
Each of the bundles will in turn have a `bundle/` directory. 

Signed-off-by: varshaprasad96 <varshaprasad96@gmail.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
