### PR TITLE
Remove community.kubernetes dependency for ansible-operator

### DIFF
--- a/testdata/ansible/memcached-operator/roles/memcached/tasks/main.yml
+++ b/testdata/ansible/memcached-operator/roles/memcached/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for Memcached
 - name: start memcached
-  community.kubernetes.k8s:
+  k8s:
     definition:
       kind: Deployment
       apiVersion: apps/v1


### PR DESCRIPTION

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Remove` community.kubernetes` dependency for `ansible-operator`

**Motivation for the change:**
Cannot test the ansible-operator with the `kubernetes.core` collection.

