### PR TITLE
update image name in "operator-sdk run bundle" cmd

### DIFF
--- a/website/content/en/docs/building-operators/helm/tutorial.md
+++ b/website/content/en/docs/building-operators/helm/tutorial.md
@@ -245,7 +245,7 @@ Finally, run your bundle. If your bundle image is hosted in a registry that is p
 has a custom CA, these [configuration steps][image-reg-config] must be complete.
 
 ```sh
-operator-sdk run bundle example.com/memcached-operator-bundle:v0.0.1
+operator-sdk run bundle example.com/nginx-operator-bundle:v0.0.1
 ```
 
 Check out the [docs][quickstart-bundle] for a deep dive into `operator-sdk`'s OLM integration.


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
[Tutorial for building helm-based operator](https://sdk.operatorframework.io/docs/building-operators/helm/tutorial/) has instructions to build a Nginx operator bundle. However, when running the `operator-sdk run bundle` command, it shows the `memcached-operator-bundle` instead of `nginx-operator-bundle`.


**Motivation for the change:**
Incorrect documentation

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
