### PR TITLE
website/context: Fix the Patch function signature in the Go client documentation

### DIFF
--- a/website/content/en/docs/building-operators/golang/references/client.md
+++ b/website/content/en/docs/building-operators/golang/references/client.md
@@ -275,7 +275,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 ```Go
 // Patch patches the given obj in the Kubernetes cluster. obj must be a
 // struct pointer so that obj can be updated with the content returned by the Server.
-func (c Client) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.UpdateOption) error
+func (c Client) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error
 ```
 
 A `client.PatchOption` is an interface that sets [`client.PatchOptions`][patch-options] fields. A `client.PatchOption` is created by using one of the provided implementations: [`DryRunAll`][dry-run-all], [`ForceOwnership`][force-ownership]. Generally these options are not needed.
@@ -496,7 +496,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
             }
             return ctrl.Result{Requeue: true}, nil
         } else {
-            return ctrl.Result{}, err            
+            return ctrl.Result{}, err
         }
     }
 


### PR DESCRIPTION
Update the client.md documentation and change the function signature
documented from client.UpdateOption to client.PatchOption for the patch
method header.

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
