### PR TITLE
Fix: Spelling mistake in packagemanifests deprecation message

### DIFF
--- a/internal/cmd/operator-sdk/generate/packagemanifests/cmd.go
+++ b/internal/cmd/operator-sdk/generate/packagemanifests/cmd.go
@@ -57,7 +57,7 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "packagemanifests",
 		Deprecated: "support for the packagemanifests format will be removed in operator-sdk v2.0.0. Use bundles " +
-			"to package your operator instead. Migrate your packagemanifes to a bundle using " +
+			"to package your operator instead. Migrate your packagemanifest to a bundle using " +
 			"'operator-sdk pkgman-to-bundle' command. Run 'operator-sdk pkgman-to-bundle --help' " +
 			"for more details.",
 		Short:   "Generates package manifests data for the operator",

--- a/internal/cmd/operator-sdk/run/packagemanifests/packagemanifests.go
+++ b/internal/cmd/operator-sdk/run/packagemanifests/packagemanifests.go
@@ -29,7 +29,7 @@ func NewCmd(cfg *operator.Configuration) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "packagemanifests [packagemanifests-root-dir]",
 		Deprecated: "support for the packagemanifests format will be removed in operator-sdk v2.0.0. Use bundles to " +
-			"package your operator instead. Migrate your packagemanifes to a bundle using " +
+			"package your operator instead. Migrate your packagemanifest to a bundle using " +
 			"'operator-sdk pkgman-to-bundle' command. Run 'operator-sdk pkgman-to-bundle --help' " +
 			"for more details.",
 		Short: "Deploy an Operator in the package manifests format with OLM",


### PR DESCRIPTION

**Description of the change:**
A spelling mistake "packagemanifes" has been fixed in two places

**Motivation for the change:**
The spelling was incorrect
