### PR TITLE
config3alphato3: Default domain to empty string

### DIFF
--- a/internal/cmd/operator-sdk/alpha/config3alphato3/convert_config_3-alpha_to_3.go
+++ b/internal/cmd/operator-sdk/alpha/config3alphato3/convert_config_3-alpha_to_3.go
@@ -66,7 +66,12 @@ func convertConfig3AlphaTo3(cfgBytes []byte) (_ []byte, err error) {
 	isMultigroup := hasMultigroup && multigroupObj.(bool)
 
 	if obj, hasRes := cfgObj["resources"]; hasRes {
-		domain := cfgObj["domain"].(string)
+		// Default to empty domain if no domain information is found.
+		domain := ""
+		if domainObj, ok := cfgObj["domain"]; ok {
+			domain = domainObj.(string)
+		}
+
 		resObjs := obj.([]interface{})
 		resources := make([]resource.Resource, len(resObjs))
 

--- a/internal/cmd/operator-sdk/alpha/config3alphato3/convert_config_3-alpha_to_3_test.go
+++ b/internal/cmd/operator-sdk/alpha/config3alphato3/convert_config_3-alpha_to_3_test.go
@@ -36,6 +36,7 @@ var _ = Describe("ConvertConfig3AlphaTo3", func() {
 		Entry("no resources", noResourcesConfig, noResourcesConfigExp),
 		Entry("basic", basicConfig, basicConfigExp),
 		Entry("complex", complexConfig, complexConfigExp),
+		Entry("no domain", noDomainConfig, noDomainConfigExp),
 	)
 })
 
@@ -66,6 +67,30 @@ resources:
   version: v1alpha1
 version: "3"
 `
+)
+
+const (
+	noDomainConfig = `layout: ansible.sdk.operatorframework.io/v1
+projectName: memcached-operator
+resources:
+- crdVersion: v1
+  group: cache
+  kind: Memcached
+  version: v1alpha1
+version: 3-alpha`
+	noDomainConfigExp = `layout: ansible.sdk.operatorframework.io/v1
+projectName: memcached-operator
+resources:
+- api:
+    crdVersion: v1
+    # TODO(user): Uncomment the below line if this resource's CRD is namespace scoped, else delete it.
+    # namespaced: true
+  # TODO(user): Uncomment the below line if this resource implements a controller, else delete it.
+  # controller: true
+  group: cache
+  kind: Memcached
+  version: v1alpha1
+version: "3"`
 )
 
 const (


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

Update `convertConfig3AlphaTo3()` to use an empty string as a domain name
when the read config has no domain information.

Check the existence of "domain" field in the config before attempting a
type assertion. This helps avoid panic:

```
panic: interface conversion: interface {} is nil, not string
```

**Motivation for the change:**

I've an old project which was created with `3-alpha` PROJECT version a few months ago. It is based on an old operator-sdk project, before operator-sdk started using kubebuilder for project scaffold. The project's api version is of the format `group/v1`. All the new projects based on kubebuilder seem to use a domain name, resulting in the api version of the format `group.domain/v1`. Setting the domain to an empty string seems to work well with `kubebuilder/operator-sdk init --domain=""` to not break the CRD APIs of the old project. Found some tests in kubebuilder that ensures projects are valid without any domain.
When I tried to convert 3-alpha to 3 project, I got the following failure:

```console
$ operator-sdk alpha config-3alpha-to-3
WARN[0000] Config version 3-alpha has been stabilized as 3, and 3-alpha is no longer supported. Run `operator-sdk alpha config-3alpha-to-3` to upgrade your PROJECT config
 file to version 3
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
github.com/operator-framework/operator-sdk/internal/cmd/operator-sdk/alpha/config3alphato3.convertConfig3AlphaTo3(0xc00096c400, 0x123, 0x200, 0x1db5401, 0xc00057baf0, 0x0
, 0x0, 0x0)
        internal/cmd/operator-sdk/alpha/config3alphato3/convert_config_3-alpha_to_3.go:69 +0x171f
github.com/operator-framework/operator-sdk/internal/cmd/operator-sdk/alpha/config3alphato3.NewCmd.func1(0xc00094e000, 0x3538108, 0x0, 0x0, 0x0, 0x0)
        internal/cmd/operator-sdk/alpha/config3alphato3/cmd.go:48 +0x1b2
github.com/spf13/cobra.(*Command).execute(0xc00094e000, 0x3538108, 0x0, 0x0, 0xc00094e000, 0x3538108)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:850 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0xc00094e2c0, 0xc00094e2c0, 0x40d4aa, 0x7f006a977b00)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
sigs.k8s.io/kubebuilder/v3/pkg/cli.CLI.Run(...)
        /home/runner/go/pkg/mod/sigs.k8s.io/kubebuilder/v3@v3.0.0-alpha.0.0.20210518234629-191170994550/pkg/cli/cli.go:463
github.com/operator-framework/operator-sdk/internal/cmd/operator-sdk/cli.Run(0xc000182058, 0x41ad01)
        internal/cmd/operator-sdk/cli/cli.go:68 +0x65
main.main()
        cmd/operator-sdk/main.go:28 +0x25

```

Tried this with version v1.9.0 and a build from the master branch.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

I believe this is not a user-facing change, don't think the above check boxes need to be ticked.