### PR TITLE
fix: specify the right path of metadata in bundle.Dockerfile

### DIFF
--- a/changelog/fragments/generate-bundle-fix.yaml
+++ b/changelog/fragments/generate-bundle-fix.yaml
@@ -1,0 +1,17 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Fixed the `operator-sdk generate bundle` command to specify the right path of bundle
+      metadata in bundle.Dcokerfile.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: bugfix
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/util/bundleutil/bundleutil.go
+++ b/internal/util/bundleutil/bundleutil.go
@@ -88,7 +88,7 @@ func (meta *BundleMetaData) GenerateMetadata() error {
 	// Create annotation values for both bundle.Dockerfile and annotations.yaml, which should
 	// hold the same set of values always.
 	values := annotationsValues{
-		BundleDir:                filepath.Base(meta.BundleDir),
+		BundleDir:                meta.BundleDir,
 		PackageName:              meta.PackageName,
 		Channels:                 meta.Channels,
 		DefaultChannel:           meta.DefaultChannel,
@@ -107,11 +107,13 @@ func (meta *BundleMetaData) GenerateMetadata() error {
 	}
 
 	dockerfilePath := defaultBundleDockerfilePath
-	// If migrating from packagemanifests to bundle, bundle.Docker file is present
-	// inside bundleDir, else its in the project directory.
+	// If migrating from packagemanifests to bundle, bundle.Dockerfile is present
+	// inside bundleDir, else its in the project directory. Hence dockerfile
+	// should have the path specified with respect to output directory of resulting bundles.
 	// Remmove this, when pkgman-to-bundle migrate command is removed.
 	if len(meta.PkgmanifestPath) != 0 {
 		dockerfilePath = filepath.Join(filepath.Dir(meta.BundleDir), "bundle.Dockerfile")
+		values.BundleDir = filepath.Base(meta.BundleDir)
 	}
 
 	templateMap := map[string]*template.Template{


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Specify the right path of metadata in bundle.Dockerfile when `output-dir` is specified.

**Motivation for the change:**
closes #5021 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
