### PR TITLE
docs/olm-integration: fix broken link for cm-patch

### DIFF
--- a/website/content/en/docs/olm-integration/generation.md
+++ b/website/content/en/docs/olm-integration/generation.md
@@ -143,7 +143,7 @@ in case other Operator resources require routing. Feel free to remove it otherwi
 [crd-wh-serviceref]:https://pkg.go.dev/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1?utm_source=godoc#ServiceReference
 [wh-serviceref]:https://pkg.go.dev/k8s.io/api/admissionregistration/v1?utm_source=godoc#ServiceReference
 [olm-cert-support]:https://olm.operatorframework.io/docs/advanced-tasks/adding-admission-and-conversion-webhooks/#certificate-authority-requirements
-[cm-patch]:https://github.com/operator-framework/operator-sdk/blob/master/testdata/go/v3/memcached-operator/config/manifests/kustomization.yaml#L12
+[cm-patch]:https://github.com/operator-framework/operator-sdk/blob/163c657/testdata/go/v3/memcached-operator/config/manifests/kustomization.yaml#L12
 
 ## Generate your first release
 

--- a/website/content/en/docs/olm-integration/generation.md
+++ b/website/content/en/docs/olm-integration/generation.md
@@ -143,7 +143,7 @@ in case other Operator resources require routing. Feel free to remove it otherwi
 [crd-wh-serviceref]:https://pkg.go.dev/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1?utm_source=godoc#ServiceReference
 [wh-serviceref]:https://pkg.go.dev/k8s.io/api/admissionregistration/v1?utm_source=godoc#ServiceReference
 [olm-cert-support]:https://olm.operatorframework.io/docs/advanced-tasks/adding-admission-and-conversion-webhooks/#certificate-authority-requirements
-[cm-patch]:https://github.com/operator-framework/operator-sdk/blob/163c657/go/v3/memcached-operator/config/manifests/kustomization.yaml#L12
+[cm-patch]:https://github.com/operator-framework/operator-sdk/blob/master/testdata/go/v3/memcached-operator/config/manifests/kustomization.yaml#L12
 
 ## Generate your first release
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
The link to "JSON patch" was added to remove the volume containing TLS cert data by Cert manager is broken.

**Motivation for the change:**
Broken markdown link.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
