### PR TITLE
Modify channels for previous versions of manifests

### DIFF
--- a/changelog/fragments/modify-default-channel.yaml
+++ b/changelog/fragments/modify-default-channel.yaml
@@ -1,0 +1,17 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      In the `pkgman-to-bundle` command, changed the default channel name used for CSV's
+      not specified in `package.yaml` to `defaultChannel` instead of "candidate". 
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/cmd/operator-sdk/pkgmantobundle/cmd.go
+++ b/internal/cmd/operator-sdk/pkgmantobundle/cmd.go
@@ -182,7 +182,7 @@ func (p *pkgManToBundleCmd) run() (err error) {
 	for _, dir := range directories {
 		if dir.IsDir() {
 			// this is required to extract project layout and SDK version information.
-			otherLabels, channels, err := getSDKStampsAndChannels(filepath.Join(p.pkgmanifestDir, dir.Name()), channelsByCSV)
+			otherLabels, channels, err := getSDKStampsAndChannels(filepath.Join(p.pkgmanifestDir, dir.Name()), defaultChannel, channelsByCSV)
 			if err != nil {
 				return fmt.Errorf("error getting CSV from provided packagemanifest %v", err)
 			}
@@ -268,7 +268,7 @@ func getScorecardConfigPath(inputDir string) (string, error) {
 	return scorecardConfigPath, nil
 }
 
-func getSDKStampsAndChannels(path string, channelsByCSV map[string][]string) (map[string]string, string, error) {
+func getSDKStampsAndChannels(path, defaultChannel string, channelsByCSV map[string][]string) (map[string]string, string, error) {
 	bundle, err := apimanifests.GetBundleFromDir(path)
 	if err != nil {
 		return nil, "", err
@@ -280,7 +280,7 @@ func getSDKStampsAndChannels(path string, channelsByCSV map[string][]string) (ma
 	}
 
 	// Find channels matching the CSV names
-	channels := getChannelsByCSV(bundle, channelsByCSV)
+	channels := getChannelsByCSV(bundle, channelsByCSV, defaultChannel)
 
 	return sdkLabels, channels, nil
 }
@@ -308,23 +308,18 @@ func getSDKStamps(bundle *apimanifests.Bundle) (map[string]string, error) {
 	return sdkLabels, nil
 }
 
-// getChannelsByCSV creates a list for channels for the currentCSV,
-func getChannelsByCSV(bundle *apimanifests.Bundle, channelsByCSV map[string][]string) (channels string) {
+// getChannelsByCSV creates a list for channels for the currentCSV. For other versions of manifests which
+// are not present in the manifest, the defaultChannel is added.
+func getChannelsByCSV(bundle *apimanifests.Bundle, channelsByCSV map[string][]string, defaultChannel string) (channels string) {
 	// Find channels matching the CSV names
-	var channelNames []string
-	for csv, ch := range channelsByCSV {
-		if csv == bundle.CSV.GetName() {
-			channelNames = ch
-			break
-		}
-	}
+	channelNames := channelsByCSV[bundle.CSV.GetName()]
 	channels = strings.Join(channelNames, ",")
 
 	// TODO: verify if we have to add this validation since while building bundles if channel is not specified
 	// we add the default channel.
 	if channels == "" {
-		channels = "candidate"
-		log.Infof("Supported channels cannot be identified from CSV %s, using default channel 'preview'", bundle.CSV.GetName())
+		channels = defaultChannel
+		log.Infof("Supported channels cannot be identified from CSV %s, using default channel %s", bundle.CSV.GetName(), defaultChannel)
 	}
 
 	return channels
@@ -339,7 +334,8 @@ func getPackageMetadata(pkg *apimanifests.PackageManifest) (packagename, default
 
 	defaultChannel = pkg.DefaultChannelName
 	if defaultChannel == "" {
-		defaultChannel = "candidate"
+		err = fmt.Errorf("cannot find the default channel for package %q", packagename)
+		return
 	}
 
 	channelsByCSV = make(map[string][]string)

--- a/internal/cmd/operator-sdk/pkgmantobundle/pkgmantobundle_test.go
+++ b/internal/cmd/operator-sdk/pkgmantobundle/pkgmantobundle_test.go
@@ -164,19 +164,21 @@ var _ = Describe("Running pkgmanToBundle command", func() {
 				},
 			}
 
+			defaultChannel := "gamma"
+
 			It("should get the list of channels for corresponding CSV", func() {
 				channels := map[string][]string{
 					"memcached-operator:0.0.1": {"alpha", "beta"},
 				}
 
-				ch := getChannelsByCSV(&bundle, channels)
+				ch := getChannelsByCSV(&bundle, channels, defaultChannel)
 				Expect(ch).To(BeEquivalentTo("alpha,beta"))
 			})
 
 			It("if no channel is provided, default to candidate", func() {
 				channels := map[string][]string{}
-				ch := getChannelsByCSV(&bundle, channels)
-				Expect(ch).To(BeEquivalentTo("candidate"))
+				ch := getChannelsByCSV(&bundle, channels, defaultChannel)
+				Expect(ch).To(BeEquivalentTo(defaultChannel))
 			})
 		})
 	})
@@ -224,11 +226,11 @@ var _ = Describe("Running pkgmanToBundle command", func() {
 			Expect(err.Error()).To(ContainSubstring("cannot find packagename from the manifest directory"))
 		})
 
-		It("should assign default channel name of not provided", func() {
+		It("should error when defaultChannel name is empty", func() {
 			pkg.DefaultChannelName = ""
-			_, defaultChannel, _, err := getPackageMetadata(&pkg)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(defaultChannel).To(BeEquivalentTo("candidate"))
+			_, _, _, err := getPackageMetadata(&pkg)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot find the default channel for package"))
 		})
 	})
 })


### PR DESCRIPTION
Previously, the versions of manifests other than the latest version,
used to have the channel as `candidate`. This caused errors
while running the bundle. With this commit, the channels for those
manifests would be the defaultchannel specified in package.yaml.

Signed-off-by: varshaprasad96 <varshaprasad96@gmail.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->


**Motivation for the change:**
Previous versions of pkgman bundles used to error.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
