### PR TITLE
[1.8.x] modify default channels for previous versions of manifests

### DIFF
--- a/changelog/fragments/modify-default-channel.yaml
+++ b/changelog/fragments/modify-default-channel.yaml
@@ -1,0 +1,15 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+ - description: >
+     In the `pkgman-to-bundle` command, changed the default channel name used for CSV's
+     not specified in `package.yaml` to `defaultChannel` instead of "candidate". 
+   # kind is one of:
+   # - addition
+   # - change
+   # - deprecation
+   # - removal
+   # - bugfix
+   kind: "bugfix"
+   # Is this a breaking change?
+   breaking: false

--- a/internal/cmd/operator-sdk/pkgmantobundle/pkgmantobundle_test.go
+++ b/internal/cmd/operator-sdk/pkgmantobundle/pkgmantobundle_test.go
@@ -153,19 +153,21 @@ var _ = Describe("Running pkgmanToBundle command", func() {
 				},
 			}
 
+			defaultChannel := "gamma"
+
 			It("should get the list of channels for corresponding CSV", func() {
 				channels := map[string][]string{
 					"memcached-operator:0.0.1": {"alpha", "beta"},
 				}
 
-				ch := getChannelsByCSV(&bundle, channels)
+				ch := getChannelsByCSV(&bundle, channels, defaultChannel)
 				Expect(ch).To(BeEquivalentTo("alpha,beta"))
 			})
 
 			It("if no channel is provided, default to preview", func() {
 				channels := map[string][]string{}
-				ch := getChannelsByCSV(&bundle, channels)
-				Expect(ch).To(BeEquivalentTo("preview"))
+				ch := getChannelsByCSV(&bundle, channels, defaultChannel)
+				Expect(ch).To(BeEquivalentTo(defaultChannel))
 			})
 		})
 	})
@@ -213,11 +215,11 @@ var _ = Describe("Running pkgmanToBundle command", func() {
 			Expect(err.Error()).To(ContainSubstring("cannot find packagename from the manifest directory"))
 		})
 
-		It("should assign default channel name of not provided", func() {
+		It("should error when defaultChannel name is empty", func() {
 			pkg.DefaultChannelName = ""
-			_, defaultChannel, _, err := getPackageMetadata(&pkg)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(defaultChannel).To(BeEquivalentTo("preview"))
+			_, _, _, err := getPackageMetadata(&pkg)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot find the default channel for package"))
 		})
 	})
 })


### PR DESCRIPTION
This is a cherry-pick of #5062 

Previously, the versions of manifests other than the latest version,
used to have channel specified as `candidate`. This caused errors
while running the bundle. With this commit, the channels for those
manifests would be the `defaultchannel` specified in package.yaml.

Signed-off-by: varshaprasad96 <varshaprasad96@gmail.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
