### PR TITLE
docs: fix comment for "what did you see instead"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -26,7 +26,7 @@ Note: Make sure to first check the prerequisites that can be found in the main R
 
 #### What did you see instead? Under which circumstances?
 
-<!-- A clear and concise description of what you expected to happen (or insert a code snippet). -->
+<!-- A clear and concise description of what ACTUALLY happened (or insert a code snippet). -->
 
 #### Environment
 


### PR DESCRIPTION
**Description of the change:**

docs: fix comment for "what did you see instead"

**Motivation for the change:**

The original seems to have been a blind copy-paste.

**Checklist**

GH metadata change only, no additional documentation changes needed.