### PR TITLE
Add UniqueID to XML Output

### DIFF
--- a/changelog/fragments/uid-output.yaml
+++ b/changelog/fragments/uid-output.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      If an optional UniqueID is provided by a user in the scorecard config and the user generates XML output the UID will be appended to the test result output.
+    kind: "addition"
+    breaking: false

--- a/internal/cmd/operator-sdk/scorecard/cmd.go
+++ b/internal/cmd/operator-sdk/scorecard/cmd.go
@@ -142,7 +142,11 @@ func (c *scorecardCmd) convertXunit(output v1alpha3.TestList) xunit.TestSuites {
 			}
 			tSuite.TestCases = append(tSuite.TestCases, tCase)
 			tSuite.URL = item.Spec.Image
-			tSuite.ID = item.Spec.UniqueID
+			if item.Spec.UniqueID != nil {
+				tSuite.ID = item.Spec.UniqueID
+			} else {
+				tSuite.ID = res.Name
+			}
 			resultSuite.TestSuite = append(resultSuite.TestSuite, tSuite)
 		}
 	}

--- a/internal/cmd/operator-sdk/scorecard/cmd.go
+++ b/internal/cmd/operator-sdk/scorecard/cmd.go
@@ -142,7 +142,7 @@ func (c *scorecardCmd) convertXunit(output v1alpha3.TestList) xunit.TestSuites {
 			}
 			tSuite.TestCases = append(tSuite.TestCases, tCase)
 			tSuite.URL = item.Spec.Image
-			if item.Spec.UniqueID != nil {
+			if item.Spec.UniqueID != "" {
 				tSuite.ID = item.Spec.UniqueID
 			} else {
 				tSuite.ID = res.Name

--- a/internal/cmd/operator-sdk/scorecard/cmd.go
+++ b/internal/cmd/operator-sdk/scorecard/cmd.go
@@ -142,8 +142,7 @@ func (c *scorecardCmd) convertXunit(output v1alpha3.TestList) xunit.TestSuites {
 			}
 			tSuite.TestCases = append(tSuite.TestCases, tCase)
 			tSuite.URL = item.Spec.Image
-			//TODO: Add TestStuite ID when API updates version
-			//tSuite.ID = item.Spec.UniqueID
+			tSuite.ID = item.Spec.UniqueID
 			resultSuite.TestSuite = append(resultSuite.TestSuite, tSuite)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Ish Shah <ishah@redhat.com>

Include optional Unique ID in XML output, change was withheld earlier as an API update was necessary 