### PR TITLE
Fix typo from the Go operation building tutorial

### DIFF
--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -147,7 +147,7 @@ This makefile target will invoke [controller-gen][controller_tools] to generate 
 ### OpenAPI validation
 
 OpenAPI validation defined in a CRD ensures CRs are validated based on a set of declarative rules. All CRDs should have validation.
-See the [OpenAPI valiation][openapi-validation] doc for details.
+See the [OpenAPI validation][openapi-validation] doc for details.
 
 ## Implement the Controller
 


### PR DESCRIPTION
**Description of the change:**
Fix a typo

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- ~~Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))~~
- ~~Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)~~
