### PR TITLE
Fix typo

### DIFF
--- a/website/content/en/docs/building-operators/golang/references/client.md
+++ b/website/content/en/docs/building-operators/golang/references/client.md
@@ -570,7 +570,7 @@ func (r *MemcachedReconciler) deploymentForMemcached(m *cachev1alpha1.Memcached)
     // Set Memcached instance as the owner and controller.memcac
     // NOTE: calling SetControllerReference, and setting owner references in
     // general, is important as it allows deleted objects to be garbage collected.
-    controllerutil.SetControllerReference(m, dep, r.scheme)
+    controllerutil.SetControllerReference(m, dep, r.Scheme)
     return dep
 }
 


### PR DESCRIPTION
The `scheme` field does not exist in the `PoolReconciler` struct definition, above. `Scheme`, with upper S, does.

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

Fix a typo.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- ~~Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))~~
- ~~Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)~~
