### PR TITLE
Add Testing for Scorecard Storage Output Feature

### DIFF
--- a/test/common/scorecard.go
+++ b/test/common/scorecard.go
@@ -97,7 +97,7 @@ func ScorecardSpec(tc *testutils.TestContext, operatorType string) func() {
 				"--selector", "suite=basic",
 				"--output", "json",
 				"--test-output", "/testdata",
-				"--wait-time", "2m")
+				"--wait-time", "4m")
 			outputBytes, err = tc.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(json.Unmarshal(outputBytes, &output)).To(Succeed())

--- a/test/common/scorecard.go
+++ b/test/common/scorecard.go
@@ -98,7 +98,8 @@ func ScorecardSpec(tc *testutils.TestContext, operatorType string) func() {
 				"--selector", "suite=basic",
 				"--output", "json",
 				"--test-output", "/testdata",
-				"--wait-time", "2m")
+				"--wait-time", "2m",
+				"--skip-cleanup")
 			outputBytes, err = tc.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(json.Unmarshal(outputBytes, &output)).To(Succeed())

--- a/test/common/scorecard.go
+++ b/test/common/scorecard.go
@@ -97,18 +97,18 @@ func ScorecardSpec(tc *testutils.TestContext, operatorType string) func() {
 			cmd = exec.Command(tc.BinaryName, "scorecard", "bundle",
 				"--selector", "suite=basic",
 				"--output", "json",
-				"--test-output", "testdata/",
+				"--test-output", "/testdata",
 				"--wait-time", "2m")
 			outputBytes, err = tc.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(json.Unmarshal(outputBytes, &output)).To(Succeed())
 
-			if _, err := os.Stat("testdata/"); !os.IsNotExist(err) {
+			if _, err := os.Stat("/testdata"); !os.IsNotExist(err) {
 				// testdata/ does exist
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			if _, err := os.Stat("testdata/"); os.IsNotExist(err) {
+			if _, err := os.Stat("/testdata"); os.IsNotExist(err) {
 				// testdata/ does NOT exist
 				Fail("testdata storage folder failed to scaffold")
 			}

--- a/test/common/scorecard.go
+++ b/test/common/scorecard.go
@@ -97,8 +97,7 @@ func ScorecardSpec(tc *testutils.TestContext, operatorType string) func() {
 				"--selector", "suite=basic",
 				"--output", "json",
 				"--test-output", "/testdata",
-				"--wait-time", "2m",
-				"--skip-cleanup")
+				"--wait-time", "2m")
 			outputBytes, err = tc.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(json.Unmarshal(outputBytes, &output)).To(Succeed())

--- a/test/common/scorecard.go
+++ b/test/common/scorecard.go
@@ -17,7 +17,6 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 
@@ -103,16 +102,6 @@ func ScorecardSpec(tc *testutils.TestContext, operatorType string) func() {
 			outputBytes, err = tc.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(json.Unmarshal(outputBytes, &output)).To(Succeed())
-
-			if _, err := os.Stat("/testdata"); !os.IsNotExist(err) {
-				// testdata/ does exist
-				Expect(err).NotTo(HaveOccurred())
-			}
-
-			if _, err := os.Stat("/testdata"); os.IsNotExist(err) {
-				// testdata/ does NOT exist
-				Fail("testdata storage folder failed to scaffold")
-			}
 
 			Expect(output.Items).To(HaveLen(1))
 			results := output.Items[0].Status.Results


### PR DESCRIPTION
The scorecard storage feature has merged and now needs automated testing within our repo. Opening as a draft in order to test/sample various testing strategies.