### PR TITLE
Upgrade OPM version used

### DIFF
--- a/changelog/fragments/00-template.yaml
+++ b/changelog/fragments/00-template.yaml
@@ -2,15 +2,7 @@
 # release notes and/or the migration guide
 entries:
   - description: >
-      Description is the line that shows up in the CHANGELOG. This
-      should be formatted as markdown and be on a single line. Using
-      the YAML string '>' operator means you can write your entry
-      multiple lines and it will still be parsed as a single line.
-
-      If an operator type's plugin is being changed then prefix the description with
-      "(<operator language>/<plugin version>)", ex. "(go/v2)".
-      If an operator type's runtime is being changed, use then prefix the description
-      with "For <operator language>-based operators,", ex. "For Go-based operators".
+      Upgrade OPM version that is used by default in the generated Makefile so `make catalog-build` also works on OSX.
 
     # kind is one of:
     # - addition
@@ -18,7 +10,7 @@ entries:
     # - deprecation
     # - removal
     # - bugfix
-    kind: ""
+    kind: "change"
 
     # Is this a breaking change?
     breaking: false

--- a/changelog/fragments/00-template.yaml
+++ b/changelog/fragments/00-template.yaml
@@ -2,7 +2,15 @@
 # release notes and/or the migration guide
 entries:
   - description: >
-      Upgrade OPM version that is used by default in the generated Makefile so `make catalog-build` also works on OSX.
+      Description is the line that shows up in the CHANGELOG. This
+      should be formatted as markdown and be on a single line. Using
+      the YAML string '>' operator means you can write your entry
+      multiple lines and it will still be parsed as a single line.
+
+      If an operator type's plugin is being changed then prefix the description with
+      "(<operator language>/<plugin version>)", ex. "(go/v2)".
+      If an operator type's runtime is being changed, use then prefix the description
+      with "For <operator language>-based operators,", ex. "For Go-based operators".
 
     # kind is one of:
     # - addition
@@ -10,7 +18,7 @@ entries:
     # - deprecation
     # - removal
     # - bugfix
-    kind: "change"
+    kind: ""
 
     # Is this a breaking change?
     breaking: false

--- a/changelog/fragments/01-upgrade-opm-version.yaml
+++ b/changelog/fragments/01-upgrade-opm-version.yaml
@@ -1,6 +1,6 @@
 entries:
   - description: >
-      Upgrade OPM version that is used by default in the generated Makefile so `make catalog-build` also works on OSX.
+      Upgrade OPM version that is used by default to 1.19.1 in the generated Makefile so `make catalog-build` also works on OSX.
 
     kind: "change"
 

--- a/changelog/fragments/01-upgrade-opm-version.yaml
+++ b/changelog/fragments/01-upgrade-opm-version.yaml
@@ -1,0 +1,8 @@
+entries:
+  - description: >
+      Upgrade OPM version that is used by default in the generated Makefile so `make catalog-build` also works on OSX.
+
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/plugins/manifests/v2/init.go
+++ b/internal/plugins/manifests/v2/init.go
@@ -32,7 +32,7 @@ import (
 
 // Version of `opm` to download and use for building index images.
 // This version's release artifacts *must* contain a binary for multiple arches; certain releases do not.
-const opmVersion = "v1.17.5"
+const opmVersion = "v1.18"
 
 const filePath = "Makefile"
 

--- a/internal/plugins/manifests/v2/init.go
+++ b/internal/plugins/manifests/v2/init.go
@@ -32,7 +32,7 @@ import (
 
 // Version of `opm` to download and use for building index images.
 // This version's release artifacts *must* contain a binary for multiple arches; certain releases do not.
-const opmVersion = "v1.18.0"
+const opmVersion = "v1.19.1"
 
 const filePath = "Makefile"
 

--- a/internal/plugins/manifests/v2/init.go
+++ b/internal/plugins/manifests/v2/init.go
@@ -32,7 +32,7 @@ import (
 
 // Version of `opm` to download and use for building index images.
 // This version's release artifacts *must* contain a binary for multiple arches; certain releases do not.
-const opmVersion = "v1.18"
+const opmVersion = "v1.18.0"
 
 const filePath = "Makefile"
 

--- a/internal/plugins/manifests/v2/init.go
+++ b/internal/plugins/manifests/v2/init.go
@@ -32,7 +32,7 @@ import (
 
 // Version of `opm` to download and use for building index images.
 // This version's release artifacts *must* contain a binary for multiple arches; certain releases do not.
-const opmVersion = "v1.15.1"
+const opmVersion = "v1.17.5"
 
 const filePath = "Makefile"
 

--- a/testdata/ansible/memcached-operator/Makefile
+++ b/testdata/ansible/memcached-operator/Makefile
@@ -140,7 +140,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18.0/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.19.1/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/testdata/ansible/memcached-operator/Makefile
+++ b/testdata/ansible/memcached-operator/Makefile
@@ -140,7 +140,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18.0/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/testdata/ansible/memcached-operator/Makefile
+++ b/testdata/ansible/memcached-operator/Makefile
@@ -140,7 +140,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.17.5/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/testdata/ansible/memcached-operator/Makefile
+++ b/testdata/ansible/memcached-operator/Makefile
@@ -140,7 +140,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.17.5/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/testdata/go/v2/memcached-operator/Makefile
+++ b/testdata/go/v2/memcached-operator/Makefile
@@ -169,7 +169,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18.0/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.19.1/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/testdata/go/v2/memcached-operator/Makefile
+++ b/testdata/go/v2/memcached-operator/Makefile
@@ -169,7 +169,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.17.5/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/testdata/go/v2/memcached-operator/Makefile
+++ b/testdata/go/v2/memcached-operator/Makefile
@@ -169,7 +169,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18.0/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/testdata/go/v2/memcached-operator/Makefile
+++ b/testdata/go/v2/memcached-operator/Makefile
@@ -169,7 +169,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.17.5/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/testdata/go/v3/memcached-operator/Makefile
+++ b/testdata/go/v3/memcached-operator/Makefile
@@ -168,7 +168,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.17.5/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/testdata/go/v3/memcached-operator/Makefile
+++ b/testdata/go/v3/memcached-operator/Makefile
@@ -168,7 +168,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18.0/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.19.1/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/testdata/go/v3/memcached-operator/Makefile
+++ b/testdata/go/v3/memcached-operator/Makefile
@@ -168,7 +168,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18.0/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/testdata/go/v3/memcached-operator/Makefile
+++ b/testdata/go/v3/memcached-operator/Makefile
@@ -168,7 +168,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.17.5/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/testdata/helm/memcached-operator/Makefile
+++ b/testdata/helm/memcached-operator/Makefile
@@ -140,7 +140,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18.0/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.19.1/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/testdata/helm/memcached-operator/Makefile
+++ b/testdata/helm/memcached-operator/Makefile
@@ -140,7 +140,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18.0/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/testdata/helm/memcached-operator/Makefile
+++ b/testdata/helm/memcached-operator/Makefile
@@ -140,7 +140,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.17.5/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/testdata/helm/memcached-operator/Makefile
+++ b/testdata/helm/memcached-operator/Makefile
@@ -140,7 +140,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.17.5/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/website/content/en/docs/upgrading-sdk-version/v1.6.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.6.0.md
@@ -178,7 +178,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.17.5/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else 

--- a/website/content/en/docs/upgrading-sdk-version/v1.6.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.6.0.md
@@ -178,7 +178,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.17.5/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else 

--- a/website/content/en/docs/upgrading-sdk-version/v1.6.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.6.0.md
@@ -178,7 +178,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18.0/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else 

--- a/website/content/en/docs/upgrading-sdk-version/v1.6.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.6.0.md
@@ -178,7 +178,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18.0/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.19.1/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else 

--- a/website/content/en/docs/upgrading-sdk-version/v1.6.1.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.6.1.md
@@ -178,7 +178,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.15.1/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.17.5/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else 

--- a/website/content/en/docs/upgrading-sdk-version/v1.6.1.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.6.1.md
@@ -178,7 +178,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.17.5/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else 

--- a/website/content/en/docs/upgrading-sdk-version/v1.6.1.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.6.1.md
@@ -178,7 +178,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18.0/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else 

--- a/website/content/en/docs/upgrading-sdk-version/v1.6.1.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.6.1.md
@@ -178,7 +178,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.18.0/$(OS)-$(ARCH)-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.19.1/$(OS)-$(ARCH)-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
The generated `Makefile` uses a more recent version of `opm`

**Motivation for the change:**
On OSX, using the version `v1.15.1` of `opm` leads to the following error:
```
Error: Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work.
```
when doing a `make catalog-build`. Using the latest version of `opm` (`v1.19.1` at the time of this PR) solves the issue.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
