### PR TITLE
Link to scorecard docs of version 1.8

### DIFF
--- a/website/content/en/docs/faqs/_index.md
+++ b/website/content/en/docs/faqs/_index.md
@@ -154,5 +154,5 @@ SHELL := /bin/bash
 [owner-references-permission-enforcement]: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
 [rbac-markers]: https://book.kubebuilder.io/reference/markers/rbac.html
 [rbac]:https://kubernetes.io/docs/reference/access-authn-authz/rbac/
-[scorecard-doc]: https://sdk.operatorframework.io/docs/testing-operators/scorecard/
+[scorecard-doc]:/docs/advanced-topics/scorecard/
 [project-doc]: /docs/overview/project-layout


### PR DESCRIPTION
In later versions of Operator SDK, the docs have been moved. Rather than
backporting the docs move as well, we can simply link to the full url
including version.