### PR TITLE
prepend local roles path to ANSIBLE_ROLES_PATH

### DIFF
--- a/changelog/fragments/ansible-set-local-rolespath.yaml
+++ b/changelog/fragments/ansible-set-local-rolespath.yaml
@@ -1,0 +1,18 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      (ansible/v1) Previously, when scaffolding an Ansible-based operator with
+      both Roles and Playbooks, the roles imported by the playbook could not be
+      found when running locally (`make run`). This change prepends the
+      `ANSIBLE_ROLES_PATH` environment variable with the path to the local
+      roles directory.
+    kind: "bugfix"
+    breaking: false
+    migration:
+      header: (optional) Add local Ansible Roles path to Env in `make run`
+      body: >
+        If you would like to run your operator locally using `make run`, modify
+        the `run` target in the `Makefile` to:
+        `ANSIBLE_ROLES_PATH="$(ANSIBLE_ROLES_PATH):$(shell pwd)/roles"
+        $(ANSIBLE_OPERATOR) run`

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
@@ -89,7 +89,7 @@ help: ## Display this help.
 ##@ Build
 
 run: ansible-operator ## Run against the configured Kubernetes cluster in ~/.kube/config
-	$(ANSIBLE_OPERATOR) run
+	ANSIBLE_ROLES_PATH="$(ANSIBLE_ROLES_PATH):$(shell pwd)/roles" $(ANSIBLE_OPERATOR) run
 
 docker-build: ## Build docker image with the manager.
 	docker build -t ${IMG} .

--- a/testdata/ansible/memcached-operator/Makefile
+++ b/testdata/ansible/memcached-operator/Makefile
@@ -59,7 +59,7 @@ help: ## Display this help.
 ##@ Build
 
 run: ansible-operator ## Run against the configured Kubernetes cluster in ~/.kube/config
-	$(ANSIBLE_OPERATOR) run
+	ANSIBLE_ROLES_PATH="$(ANSIBLE_ROLES_PATH):$(shell pwd)/roles" $(ANSIBLE_OPERATOR) run
 
 docker-build: ## Build docker image with the manager.
 	docker build -t ${IMG} .


### PR DESCRIPTION
closes: https://github.com/operator-framework/operator-sdk/issues/4071

When running locally, we set the ANSIBLE_ROLES_PATH to include the local
roles path, preventing users from needing to manually setting this
environment variable for normal development.

Signed-off-by: austin <austin@redhat.com>



**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [X] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [X] (Not Applicable) ~Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)~
