### PR TITLE
Ansible-Vault password docs change

### DIFF
--- a/website/content/en/docs/building-operators/ansible/reference/advanced_options.md
+++ b/website/content/en/docs/building-operators/ansible/reference/advanced_options.md
@@ -242,7 +242,7 @@ Ansible-runner will perform the task relevant to the command specified by the us
         msg: The decrypted value is {{secret.the_secret}}
 ```
 
-Now, let's also assume that we have a password file, `pwd.yml`, that contains the password to decrypt the encrypted text. Then, by running the command `ansible-operator run --ansible-args='--vault-password-file pwd.yml'` the operator will read in the encrypted text from the file and perform decryption using the password stored in the `pwd.yml` file:
+Now, let's also assume that we have a password file, `pwd.yml`, that contains the password to decrypt the encrypted text. Then, by running the command `ansible-operator run --ansible-args='--vault-password-file absolute/path/to/pwd.yml'` the operator will read in the encrypted text from the file and perform decryption using the password stored in the `pwd.yml` file:
 
 ```
 --------------------------- Ansible Task StdOut -------------------------------

--- a/website/content/en/docs/building-operators/ansible/reference/advanced_options.md
+++ b/website/content/en/docs/building-operators/ansible/reference/advanced_options.md
@@ -242,7 +242,7 @@ Ansible-runner will perform the task relevant to the command specified by the us
         msg: The decrypted value is {{secret.the_secret}}
 ```
 
-Now, let's also assume that we have a password file, `pwd.yml`, that contains the password to decrypt the encrypted text. Then, by running the command `ansible-operator run --ansible-args='--vault-password-file absolute/path/to/pwd.yml'` the operator will read in the encrypted text from the file and perform decryption using the password stored in the `pwd.yml` file:
+Now, let's also assume that we have a password file, `pwd.yml`, that contains the password to decrypt the encrypted text. Then, by running the command `ansible-operator run --ansible-args='--vault-password-file /absolute/path/to/pwd.yml'` the operator will read in the encrypted text from the file and perform decryption using the password stored in the `pwd.yml` file:
 
 ```
 --------------------------- Ansible Task StdOut -------------------------------


### PR DESCRIPTION
Signed-off-by: Venkat Ramaraju <venky2063@gmail.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Password files for `ansible-args` need to be specified in their absolute path. Added this change to docs.

**Motivation for the change:**
More specific.
