### PR TITLE
docs: Add version range for `ansible-runner` in installation.md

### DIFF
--- a/website/content/en/docs/building-operators/ansible/installation.md
+++ b/website/content/en/docs/building-operators/ansible/installation.md
@@ -13,7 +13,7 @@ Follow the steps in the [installation guide][install-guide] to learn how to inst
 - [docker][docker_tool] version 17.03+.
 - [python][python] version 3.8.6+
 - [ansible][ansible] version v2.9.0+
-- [ansible-runner][ansible-runner] version v1.1.0+
+- [ansible-runner][ansible-runner] version >=1.1.0,<2.0
 - [ansible-runner-http][ansible-runner-http-plugin] version v1.0.0+
 - [openshift][openshift-module] version v0.11.2+
 - [kubectl][kubectl_tool] and access to a Kubernetes cluster of a [compatible version][k8s-version-compat].


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
- Add version range for `ansible-runner` to the document

**Motivation for the change:**
To prevent other readers from spending time debugging the failure caused by an unsupported version of ansible-runner. also mentioned in https://github.com/operator-framework/operator-sdk/issues/5043

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
