### PR TITLE
manifests.go: Adds outputDir to Path config of kustomization

### DIFF
--- a/internal/cmd/operator-sdk/generate/kustomize/manifests.go
+++ b/internal/cmd/operator-sdk/generate/kustomize/manifests.go
@@ -226,6 +226,8 @@ func (c manifestsCmd) run(cfg config.Config) error {
 
 	// Write a kustomization.yaml to outputDir if one does not exist.
 	kustomization := manifests.Kustomization{SupportsWebhooks: operatorType == projutil.OperatorTypeGo}
+	// Ensure the path to the manifest directory is correctly carried through
+	kustomization.Path = c.outputDir
 	err = machinery.NewScaffold(machinery.Filesystem{FS: afero.NewOsFs()}, machinery.WithConfig(cfg)).Execute(
 		&kustomization,
 	)


### PR DESCRIPTION
If the outputDir is set then the kustomization manifest generation needs to
know otherwise the defaults set a new path of config/manifests and creates
a default kustomization.yaml, which can differ from custom yaml files that
may be in use.

#5143

Signed-off-by: phantomjinx <p.g.richardson@phantomjinx.co.uk>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
