### PR TITLE
Add bundle size built in Scorecard test

### DIFF
--- a/changelog/fragments/add-bundle-size-test.yaml
+++ b/changelog/fragments/add-bundle-size-test.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      Adds a built-in Scorecard test to check total bundle size. Bundles must be less than 1MB and until
+      this limit can be changed, we should test for it.
+    kind: "addition"
+    breaking: false

--- a/images/scorecard-test/main.go
+++ b/images/scorecard-test/main.go
@@ -67,6 +67,8 @@ func main() {
 		result = tests.SpecDescriptorsTest(bundle)
 	case tests.OLMStatusDescriptorsTest:
 		result = tests.StatusDescriptorsTest(bundle)
+	case tests.OLMBundleSizeTest:
+		result = tests.BundleSizeTest(bundle)
 	case tests.BasicCheckSpecTest:
 		result = tests.CheckSpecTest(bundle)
 	default:
@@ -88,12 +90,13 @@ func printValidTests() scapiv1alpha3.TestStatus {
 	result.Errors = make([]string, 0)
 	result.Suggestions = make([]string, 0)
 
-	str := fmt.Sprintf("Valid tests for this image include: %s, %s, %s, %s, %s, %s",
+	str := fmt.Sprintf("Valid tests for this image include: %s, %s, %s, %s, %s, %s, %s",
 		tests.OLMBundleValidationTest,
 		tests.OLMCRDsHaveValidationTest,
 		tests.OLMCRDsHaveResourcesTest,
 		tests.OLMSpecDescriptorsTest,
 		tests.OLMStatusDescriptorsTest,
+		tests.OLMBundleSizeTest,
 		tests.BasicCheckSpecTest)
 	result.Errors = append(result.Errors, str)
 	return scapiv1alpha3.TestStatus{

--- a/internal/scorecard/tests/olm_test.go
+++ b/internal/scorecard/tests/olm_test.go
@@ -1,0 +1,58 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	scapiv1alpha3 "github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
+)
+
+func Test_checkSize(t *testing.T) {
+	type args struct {
+		size int64
+		r    *scapiv1alpha3.TestResult
+	}
+	tests := []struct {
+		name string
+		args args
+		want scapiv1alpha3.State
+	}{
+		{
+			name: "fail on bundle size too large",
+			args: args{
+				size: 1048577,
+				r:    new(scapiv1alpha3.TestResult),
+			},
+			want: scapiv1alpha3.FailState,
+		},
+		{
+			name: "pass on bundle size small enough",
+			args: args{
+				size: 1048576,
+				r:    new(scapiv1alpha3.TestResult),
+			},
+			want: scapiv1alpha3.PassState,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkSize(tt.args.size, *tt.args.r)
+			if got.State != tt.want {
+				t.Errorf("BundleSizeTest CheckSize() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description of the change:**

Adds a new Scorecard OLM test suite test to check total size of the bundle.

**Motivation for the change:**
Bundles greater than 1MB still cannot be installed and until a fix lands (https://issues.redhat.com/browse/OLM-2236) it would be good if the basic Scorecard tests, that are run, for instance, in the pipeline, could catch the bundle size problem.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [X] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs) Done with this (draft) PR: https://github.com/operator-framework/operator-sdk/pull/5165