### PR TITLE
update default opm index image for run bundle(-upgrade)

### DIFF
--- a/changelog/fragments/default-opm-image.yaml
+++ b/changelog/fragments/default-opm-image.yaml
@@ -1,0 +1,12 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Update default base image used in `run bundle` and `run bundle-upgrade` to
+      the multi-arch `quay.io/operator-framework/opm:latest` image to support non-amd64
+      clusters.
+
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/olm/operator/registry/index/registry_pod.go
+++ b/internal/olm/operator/registry/index/registry_pod.go
@@ -219,7 +219,7 @@ func (rp *RegistryPod) podForBundleRegistry() (*corev1.Pod, error) {
 					Name:  defaultContainerName,
 					Image: rp.IndexImage,
 					Command: []string{
-						"/bin/sh",
+						"sh",
 						"-c",
 						containerCmd,
 					},
@@ -303,11 +303,11 @@ func newBool(b bool) *bool {
 	return bp
 }
 
-const cmdTemplate = `/bin/mkdir -p {{ dirname .DBPath }} && \
+const cmdTemplate = `mkdir -p {{ dirname .DBPath }} && \
 {{- range $i, $item := .BundleItems }}
-/bin/opm registry add -d {{ $.DBPath }} -b {{ $item.ImageTag }} --mode={{ $item.AddMode }}{{ if $.CASecretName }} --ca-file=/certs/cert.pem{{ end }} --skip-tls={{ $.SkipTLS }} && \
+opm registry add -d {{ $.DBPath }} -b {{ $item.ImageTag }} --mode={{ $item.AddMode }}{{ if $.CASecretName }} --ca-file=/certs/cert.pem{{ end }} --skip-tls={{ $.SkipTLS }} && \
 {{- end }}
-/bin/opm registry serve -d {{ .DBPath }} -p {{ .GRPCPort }}
+opm registry serve -d {{ .DBPath }} -p {{ .GRPCPort }}
 `
 
 // getContainerCmd uses templating to construct the container command

--- a/internal/olm/operator/registry/index/registry_pod_test.go
+++ b/internal/olm/operator/registry/index/registry_pod_test.go
@@ -238,7 +238,7 @@ func containerCommandFor(dbPath string, items []BundleItem, hasCA, skipTLS bool)
 	}
 	additions := &strings.Builder{}
 	for _, item := range items {
-		additions.WriteString(fmt.Sprintf("/bin/opm registry add -d %s -b %s --mode=%s%s --skip-tls=%v && \\\n", dbPath, item.ImageTag, item.AddMode, caFlag, skipTLS))
+		additions.WriteString(fmt.Sprintf("opm registry add -d %s -b %s --mode=%s%s --skip-tls=%v && \\\n", dbPath, item.ImageTag, item.AddMode, caFlag, skipTLS))
 	}
-	return fmt.Sprintf("/bin/mkdir -p /database && \\\n%s/bin/opm registry serve -d /database/index.db -p 50051\n", additions.String())
+	return fmt.Sprintf("mkdir -p /database && \\\n%sopm registry serve -d /database/index.db -p 50051\n", additions.String())
 }

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -40,7 +40,7 @@ import (
 const (
 	// defaultIndexImageBase is the base for defaultIndexImage. It is necessary to separate
 	// them for string comparison when defaulting bundle add mode.
-	defaultIndexImageBase = "quay.io/operator-framework/upstream-opm-builder:"
+	defaultIndexImageBase = "quay.io/operator-framework/opm:"
 	// DefaultIndexImage is the index base image used if none is specified. It contains no bundles.
 	// TODO(v2.0.0): pin this image tag to a specific version.
 	DefaultIndexImage = defaultIndexImageBase + "latest"

--- a/website/content/en/docs/cli/operator-sdk_run_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle.md
@@ -19,7 +19,7 @@ operator-sdk run bundle <bundle-image> [flags]
 ```
       --ca-secret-name string           Name of a generic secret containing a PEM root certificate file required to pull bundle images. This secret *must* be in the namespace that this command is configured to run in, and the file *must* be encoded under the key "cert.pem"
   -h, --help                            help for bundle
-      --index-image string              index image in which to inject bundle (default "quay.io/operator-framework/upstream-opm-builder:latest")
+      --index-image string              index image in which to inject bundle (default "quay.io/operator-framework/opm:latest")
       --install-mode InstallModeValue   install mode
       --kubeconfig string               Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string                If present, namespace scope for this CLI request

--- a/website/content/en/docs/olm-integration/testing-deployment.md
+++ b/website/content/en/docs/olm-integration/testing-deployment.md
@@ -50,7 +50,7 @@ Let's look at the anatomy of the `run bundle` configuration model:
   required parameter. The bundle image must be pullable.
 - **index-image**: specifies an index image in which to inject the given bundle.
   This is an optional field which will default to
-  `quay.io/operator-framework/upstream-opm-builder:latest`
+  `quay.io/operator-framework/opm:latest`
 - **install-mode**: specifies which supported [`installMode`][csv-install-modes]
   should be used to create an `OperatorGroup` by configuring its
   `spec.targetNamespaces` field. The `InstallModeType` string passed must be


### PR DESCRIPTION
Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Update default base image used in `run bundle` and `run bundle-upgrade` to the multi-arch `quay.io/operator-framework/opm:latest` image.

**Motivation for the change:**
To support non-amd64 clusters and to avoid using the latest `master` build of `opm` (which is what `quay.io/operator-framework/upstream-opm-builder:latest` points to). The `quay.io/operator-framework/opm:latest` image is the latest tagged release of `opm`

See also: https://github.com/operator-framework/operator-registry/pull/762


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
