### PR TITLE
bump goreleaser to 0.177.0 to address broken goreleaser install script

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -24,7 +24,7 @@ release: ## Publish an operator-sdk release, with option for a dry run with DRY_
 ifeq (,$(GIT_VERSION))
 	$(error "GIT_VERSION must be set to a git tag")
 endif
-	$(SCRIPTS_DIR)/fetch goreleaser 0.156.0
+	$(SCRIPTS_DIR)/fetch goreleaser 0.177.0
 	GORELEASER_CURRENT_TAG=$(GIT_VERSION) $(TOOLS_DIR)/goreleaser $(SNAPSHOT_FLAGS) --release-notes=$(CHANGELOG) --parallelism 5
 ifneq ($(DRY_RUN),)
 	rm $(CHANGELOG)


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Bump goreleaser to latest release.

**Motivation for the change:**
The goreleaser install script no longer works on older versions of goreleaser because it has been updated to handle the new location of the release checksum files.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
