### PR TITLE
docs: fix link that moved permanently

### DIFF
--- a/website/content/en/docs/contribution-guidelines/reporting-issues.md
+++ b/website/content/en/docs/contribution-guidelines/reporting-issues.md
@@ -23,4 +23,4 @@ It may be worthwhile to read [Elika Etemad’s article on filing good bug report
 We might ask for further information to locate a bug. A duplicated bug report will be closed.
 
 [operator-sdk-issue]: https://github.com/operator-framework/operator-sdk/issues/new
-[filing-good-bugs]: http://fantasai.inkedblade.net/style/talks/filing-good-bugs/
+[filing-good-bugs]: https://fantasai.inkedblade.net/style/talks/filing-good-bugs/


### PR DESCRIPTION
**Description of the change:**
Update the link to use https.

**Motivation for the change:**
Documentation has a link to a url that has moved permanently (301).  This 301 error causes the link checker to fail. Investigated and found the new link, using that in our docs instead.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
