### PR TITLE
docs: fix custom scorecard test code sample

### DIFF
--- a/website/content/en/docs/testing-operators/scorecard/custom-tests.md
+++ b/website/content/en/docs/testing-operators/scorecard/custom-tests.md
@@ -69,7 +69,7 @@ The `tests.go` file is where the custom tests are implemented in the sample test
 package tests
 
 import (
-  "github.com/operator-framework/operator-registry/pkg/registry"
+  apimanifests "github.com/operator-framework/api/pkg/manifests"
   scapiv1alpha3 "github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
 )
 
@@ -78,10 +78,9 @@ const (
 )
 
 // CustomTest1
-func CustomTest1(bundle registry.Bundle) scapiv1alpha3.TestStatus {
+func CustomTest1(bundle *apimanifests.Bundle) scapiv1alpha3.TestStatus {
   r := scapiv1alpha3.TestResult{}
   r.Name = CustomTest1Name
-  r.Description = "Custom Test 1"
   r.State = scapiv1alpha3.PassState
   r.Errors = make([]string, 0)
   r.Suggestions = make([]string, 0)


### PR DESCRIPTION
**Description of the change:**

Updates the code sample in the custom scorecard test documentation replacing the `github.com/operator-framework/operator-registry/pkg/registry`  import for `apimanifests "github.com/operator-framework/api/pkg/manifests"` and  making the required fixes. Also changes the function signature to take a pointer to a bundle.

**Motivation for the change:**

Was going through the documentation and noticed that it wasn't working. Then checked against sample code from the repo, e.g. https://github.com/operator-framework/operator-sdk/blob/master/internal/scorecard/tests/basic.go#L19