### PR TITLE
docs: fix scorecard-test-kuttl version in "Writing Kuttl Scorecard Tests"

### DIFF
--- a/website/content/en/docs/testing-operators/scorecard/kuttl-tests.md
+++ b/website/content/en/docs/testing-operators/scorecard/kuttl-tests.md
@@ -50,7 +50,7 @@ definition of what the selector `suite=kuttlsuite` will translate to:
 ```yaml
 stages:
 - tests:
-  - image: quay.io/operator-framework/scorecard-test-kuttl:dev
+  - image: quay.io/operator-framework/scorecard-test-kuttl:v2.0.0
     labels:
       suite: kuttlsuite
       test: kuttltest1
@@ -111,7 +111,7 @@ The important fields to note here are:
  * `list-pods, list-other` - The names given by you for these test cases.
  * `00-assert.yaml` - The assert file is executed to test whether or
 not the test was successful, this assertion determines whether or not
-the test passed or failed.  
+the test passed or failed.
  * `00-pod.yaml` - The pod file is used to define what the test will
 create, in this case a pod will be created based on the manifest within
 00-pod.yaml.


### PR DESCRIPTION
Signed-off-by: Masato Naka <masatonaka1989@gmail.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

Change `quay.io/operator-framework/scorecard-test-kuttl:dev` -> `quay.io/operator-framework/scorecard-test-kuttl:v2.0.0` in https://sdk.operatorframework.io/docs/testing-operators/scorecard/kuttl-tests/#configuring-kuttl-tests-in-the-scorecard-configuration

**Motivation for the change:**

To save readers' time to investigate where is the failure coming from.

`quay.io/operator-framework/scorecard-test-kuttl:dev` doesn't work with the recent version.

The version I tested:
- operator-sdk version: `operator-sdk version: "v1.11.0", commit: "28dcd12a776d8a8ff597e1d8527b08792e7312fd", kubernetes version: "v1.20.2", go version: "go1.16.6", GOOS: "darwin", GOARCH: "amd64"`
- kubectl-kuttl version: `kubectl-kuttl version 0.11.1`

How I tested:

1. Prepare kuttl files following the docs:

	```
	tree bundle/tests/scorecard/kuttl/                     
	bundle/tests/scorecard/kuttl/
	├── kuttl-test.yaml
	└── list-pods
	    ├── 00-assert.yaml
	    └── 00-pod.yaml
	
	1 directory, 3 files
	```

	- `00-pod.yaml`
	  ```yaml
	  apiVersion: v1
	  kind: Pod
	  metadata:
	    creationTimestamp: null
	    labels:
	      run: nginx
	    name: nginx
	  spec:
	    containers:
	    - image: nginx
	      name: nginx
	      resources: {}
	    dnsPolicy: ClusterFirst
	    restartPolicy: Always
	  status: {}
	  ```
	- `00-assert.yaml`
	  ```yaml
	  apiVersion: v1
	  kind: Pod
	  metadata:
	    name: nginx
	  status:
	    phase: Running
      ```
1. Run with `dev` [FAIL]

	  ```
	  operator-sdk scorecard ./bundle --selector=suite=kuttlsuite --wait-time 60s
	  --------------------------------------------------------------------------------
	  Image:      quay.io/operator-framework/scorecard-test-kuttl:dev
	  Labels:
	          "test":"kuttltest1"
	          "suite":"kuttlsuite"
	  Results:
	          State: fail
	  
	          Errors:
	                  invalid character 'j' looking for beginning of value
	          Log:
	                  jeff kuttl bytes {
	                     "name": "",
	                     "tests": 1,
	                     "failures": 0,
	                     "time": "7.2031747s",
	                     "testsuite": [
	                       {
	                         "tests": 1,
	                         "failures": 0,
	                         "time": "5.7921032s",
	                         "name": "/bundle/tests/scorecard/kuttl",
	                         "testcase": [
	                           {
	                             "classname": "kuttl",
	                             "name": "list-pods",
	                             "time": "5.7916809s",
	                             "assertions": 1
	                           }
	                         ]
	                       }
	                     ]
	                   }
	                  {
	                      "results": [
	                          {
	                              "name": "list-pods",
	                              "state": "pass"
	                          }
	                      ]
	                  }
	  ```
1. Run with `v2.0.0`

	  ```
	  operator-sdk scorecard ./bundle --selector=suite=kuttlsuite --wait-time 60s
	  --------------------------------------------------------------------------------
	  Image:      quay.io/operator-framework/scorecard-test-kuttl:v2.0.0
	  Labels:
	          "suite":"kuttlsuite"
	          "test":"kuttltest1"
	  Results:
	          Name: list-pods
	          State: pass
	  ```

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
