### PR TITLE
Add Attribute Tags to XML output

### DIFF
--- a/changelog/fragments/reformat-xml.yaml
+++ b/changelog/fragments/reformat-xml.yaml
@@ -1,0 +1,16 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Reformat xml output to support in-line attributes
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/cmd/operator-sdk/scorecard/xunit/xunit.go
+++ b/internal/cmd/operator-sdk/scorecard/xunit/xunit.go
@@ -17,60 +17,60 @@ package xunitapi
 // TestCase contain the core information from a test run, including its name and status
 type TestCase struct {
 	// Name is the name of the test
-	Name      string                `json:"name,omitempty"`
-	Time      string                `json:"time,omitempty"`
-	Classname string                `json:"classname,omitempty"`
-	Group     string                `json:"group,omitempty"`
-	Failures  []XUnitComplexFailure `json:"failure,omitempty"`
-	Errors    []XUnitComplexError   `json:"error,omitempty"`
-	Skipped   []XUnitComplexSkipped `json:"skipped,omitempty"`
+	Name      string                `xml:"name,attr,omitempty"`
+	Time      string                `xml:"time,attr,omitempty"`
+	Classname string                `xml:"classname,attr,omitempty"`
+	Group     string                `xml:"group,attr,omitempty"`
+	Failures  []XUnitComplexFailure `xml:"failure,omitempty"`
+	Errors    []XUnitComplexError   `xml:"error,omitempty"`
+	Skipped   []XUnitComplexSkipped `xml:"skipped,omitempty"`
 }
 
 // TestSuite contains for details about a test beyond the final status
 type TestSuite struct {
 	// Name is the name of the test
-	Name       string      `json:"name,omitempty"`
-	Tests      string      `json:"tests,omitempty"`
-	Failures   string      `json:"failures,omitempty"`
-	Errors     string      `json:"errors,omitempty"`
-	Group      string      `json:"group,omitempty"`
-	Skipped    string      `json:"skipped,omitempty"`
-	Timestamp  string      `json:"timestamp,omitempty"`
-	Hostname   string      `json:"hostnames,omitempty"`
-	ID         string      `json:"id,omitempty"`
-	Package    string      `json:"package,omitempty"`
-	File       string      `json:"file,omitempty"`
-	Log        string      `json:"log,omitempty"`
-	URL        string      `json:"url,omitempty"`
-	Version    string      `json:"version,omitempty"`
-	TestSuites []TestSuite `json:"testsuite,omitempty"`
-	TestCases  []TestCase  `json:"testcase,omitempty"`
+	Name       string      `xml:"name,attr,omitempty"`
+	Tests      string      `xml:"tests,attr,omitempty"`
+	Failures   string      `xml:"failures,attr,omitempty"`
+	Errors     string      `xml:"errors,attr,omitempty"`
+	Group      string      `xml:"group,attr,omitempty"`
+	Skipped    string      `xml:"skipped,attr,omitempty"`
+	Timestamp  string      `xml:"timestamp,attr,omitempty"`
+	Hostname   string      `xml:"hostnames,attr,omitempty"`
+	ID         string      `xml:"id,attr,omitempty"`
+	Package    string      `xml:"package,attr,omitempty"`
+	File       string      `xml:"file,attr,omitempty"`
+	Log        string      `xml:"log,attr,omitempty"`
+	URL        string      `xml:"url,attr,omitempty"`
+	Version    string      `xml:"version,attr,omitempty"`
+	TestSuites []TestSuite `xml:"testsuite,omitempty"`
+	TestCases  []TestCase  `xml:"testcase,omitempty"`
 }
 
 // TestSuites is the top level object for amassing Xunit test results
 type TestSuites struct {
 	// Name is the name of the test
-	Name      string      `json:"name,omitempty"`
-	Tests     string      `json:"tests,omitempty"`
-	Failures  string      `json:"failures,omitempty"`
-	Errors    string      `json:"errors,omitempty"`
-	TestSuite []TestSuite `json:"testsuite,omitempty"`
+	Name      string      `xml:"name,attr,omitempty"`
+	Tests     string      `xml:"tests,attr,omitempty"`
+	Failures  string      `xml:"failures,attr,omitempty"`
+	Errors    string      `xml:"errors,attr,omitempty"`
+	TestSuite []TestSuite `xml:"testsuite,omitempty"`
 }
 
 // XUnitComplexError contains a type header along with the error messages
 type XUnitComplexError struct {
-	Type    string `json:"type,omitempty"`
-	Message string `json:"message,omitempty"`
+	Type    string `xml:"type,attr,omitempty"`
+	Message string `xml:"message,attr,omitempty"`
 }
 
 // XUnitComplexFailure contains a type header along with the failure logs
 type XUnitComplexFailure struct {
-	Type    string `json:"type,omitempty"`
-	Message string `json:"message,omitempty"`
+	Type    string `xml:"type,attr,omitempty"`
+	Message string `xml:"message,attr,omitempty"`
 }
 
 // XUnitComplexSkipped contains a type header along with associated run logs
 type XUnitComplexSkipped struct {
-	Type    string `json:"type,omitempty"`
-	Message string `json:"message,omitempty"`
+	Type    string `xml:"type,attr,omitempty"`
+	Message string `xml:"message,attr,omitempty"`
 }


### PR DESCRIPTION
This is a PR to change the XML output to support attribute tags instead of nested attributes in the result. This will allow users of existing test parsing tools to use the scorecard xml results without post run pruning. 