### PR TITLE
[WIP] Add schema to options in ansible and helm operator commands

### DIFF
--- a/internal/cmd/ansible-operator/run/cmd.go
+++ b/internal/cmd/ansible-operator/run/cmd.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"net/url"
 	"os"
 	"runtime"
@@ -50,6 +51,7 @@ import (
 	sdkVersion "github.com/operator-framework/operator-sdk/internal/version"
 )
 
+var scheme = k8sruntime.NewScheme()
 var log = logf.Log.WithName("cmd")
 
 func printVersion() {
@@ -92,7 +94,7 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 	// Load config options from the config at f.ManagerConfigPath.
 	// These options will not override those set by flags.
 	var (
-		options manager.Options
+		options = ctrl.Options{Scheme: scheme}
 		err     error
 	)
 	if f.ManagerConfigPath != "" {

--- a/internal/cmd/helm-operator/run/cmd.go
+++ b/internal/cmd/helm-operator/run/cmd.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -45,6 +46,7 @@ import (
 	sdkVersion "github.com/operator-framework/operator-sdk/internal/version"
 )
 
+var scheme = k8sruntime.NewScheme()
 var log = logf.Log.WithName("cmd")
 
 func printVersion() {
@@ -87,9 +89,10 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 	// Load config options from the config at f.ManagerConfigPath.
 	// These options will not override those set by flags.
 	var (
-		options manager.Options
+		options = ctrl.Options{Scheme: scheme}
 		err     error
 	)
+
 	if f.ManagerConfigPath != "" {
 		cfgLoader := ctrl.ConfigFile().AtPath(f.ManagerConfigPath)
 		if options, err = options.AndFrom(cfgLoader); err != nil {


### PR DESCRIPTION
**Description of the change:**
This PR updates the creation of the Options object in the ansible and helm commands to include a scheme.

This PR is still work in progress because I'd like to validate the approach. This PR will also need extra work. There is another issue with the `manager_config_patch.yaml` generated for the ansible project:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: controller-manager
  namespace: system
spec:
  template:
    spec:
      containers:
      - name: manager
        args:
        - "--config=controller_manager_config.yaml"  # <-- here is the problem 
        volumeMounts:
        - name: manager-config
          mountPath: /controller_manager_config.yaml
          subPath: controller_manager_config.yaml
      volumes:
      - name: manager-config
        configMap:
          name: manager-config
```

The ansible-operator image sets the `home` directory as its workdir. However, the controller_manager_config.yaml gets mounted to the root (`/`) and the --config arg specifies a file in the same directory. This results in a file not found.

To get around this you can just set it to: --config=/controller_manager_config.yaml

But, I think the code for this patch resides upstream. So, I don't know if this is something that affects _all_ types of operators (go inc.), if it should be fixed upstream, or if the way the ansible image is put together should be fixed. Here I need some help from a more seasoned contributer.

**Motivation for the change:**
This change is intended to fix: https://github.com/operator-framework/operator-sdk/issues/5224

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
