### PR TITLE
Scorecard optional Config.yaml Service Account selection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0
-	github.com/operator-framework/api v0.10.6-0.20210916204207-e2541569a535
+	github.com/operator-framework/api v0.10.6
 	github.com/operator-framework/java-operator-plugins v0.1.0
 	github.com/operator-framework/operator-lib v0.6.0
 	github.com/operator-framework/operator-registry v1.17.4

--- a/go.sum
+++ b/go.sum
@@ -902,6 +902,8 @@ github.com/operator-framework/api v0.7.1/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/
 github.com/operator-framework/api v0.10.0/go.mod h1:tV0BUNvly7szq28ZPBXhjp1Sqg5yHCOeX19ui9K4vjI=
 github.com/operator-framework/api v0.10.6-0.20210916204207-e2541569a535 h1:KaxHrTuHE6e23ajWqN/McxMetmtZhKbE+jYLfmpo500=
 github.com/operator-framework/api v0.10.6-0.20210916204207-e2541569a535/go.mod h1:PtQSNSuVrhSC6YE6JJJZv3nnZJc32osKX8FmFUZK05U=
+github.com/operator-framework/api v0.10.6 h1:Vi2l5xbdDFLa9ktpOPpfsepmT+mtHD9ztI8PDWMZ1Co=
+github.com/operator-framework/api v0.10.6/go.mod h1:PtQSNSuVrhSC6YE6JJJZv3nnZJc32osKX8FmFUZK05U=
 github.com/operator-framework/java-operator-plugins v0.1.0 h1:khkYsrkEG4m+wT+oPjZYmWXo8jd0QQ8E4agSrqrhPhU=
 github.com/operator-framework/java-operator-plugins v0.1.0/go.mod h1:sGKGELFkUeRqElcyvyPC89bC76YnCL7MPMa13P0AQcw=
 github.com/operator-framework/operator-lib v0.6.0 h1:srZoTL8P7OZUOovMkQkd4vwIbFzFNW413R/6V9N9rz4=

--- a/go.sum
+++ b/go.sum
@@ -900,8 +900,6 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/operator-framework/api v0.7.1/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
 github.com/operator-framework/api v0.10.0/go.mod h1:tV0BUNvly7szq28ZPBXhjp1Sqg5yHCOeX19ui9K4vjI=
-github.com/operator-framework/api v0.10.6-0.20210916204207-e2541569a535 h1:KaxHrTuHE6e23ajWqN/McxMetmtZhKbE+jYLfmpo500=
-github.com/operator-framework/api v0.10.6-0.20210916204207-e2541569a535/go.mod h1:PtQSNSuVrhSC6YE6JJJZv3nnZJc32osKX8FmFUZK05U=
 github.com/operator-framework/api v0.10.6 h1:Vi2l5xbdDFLa9ktpOPpfsepmT+mtHD9ztI8PDWMZ1Co=
 github.com/operator-framework/api v0.10.6/go.mod h1:PtQSNSuVrhSC6YE6JJJZv3nnZJc32osKX8FmFUZK05U=
 github.com/operator-framework/java-operator-plugins v0.1.0 h1:khkYsrkEG4m+wT+oPjZYmWXo8jd0QQ8E4agSrqrhPhU=

--- a/internal/cmd/operator-sdk/scorecard/cmd.go
+++ b/internal/cmd/operator-sdk/scorecard/cmd.go
@@ -198,11 +198,9 @@ func (c *scorecardCmd) run() (err error) {
 	if c.list {
 		scorecardTests = o.List()
 	} else {
-		runnerSA := ""
+		runnerSA := c.serviceAccount
 		if o.Config.ServiceAccount != "" {
 			runnerSA = o.Config.ServiceAccount
-		} else {
-			runnerSA = c.serviceAccount
 		}
 		runner := scorecard.PodTestRunner{
 			ServiceAccount: runnerSA,

--- a/internal/cmd/operator-sdk/scorecard/cmd.go
+++ b/internal/cmd/operator-sdk/scorecard/cmd.go
@@ -198,8 +198,14 @@ func (c *scorecardCmd) run() (err error) {
 	if c.list {
 		scorecardTests = o.List()
 	} else {
+		runnerSA := ""
+		if o.Config.ServiceAccount != "" {
+			runnerSA = o.Config.ServiceAccount
+		} else {
+			runnerSA = c.serviceAccount
+		}
 		runner := scorecard.PodTestRunner{
-			ServiceAccount: c.serviceAccount,
+			ServiceAccount: runnerSA,
 			Namespace:      scorecard.GetKubeNamespace(c.kubeconfig, c.namespace),
 			BundlePath:     c.bundle,
 			TestOutput:     c.testOutput,


### PR DESCRIPTION
This enables selecting the service account for the scorecard using the config.yaml in addition to the existing method of changing it at runtime in the CLI. 

This blocked on an API release which should occur shortly.