### PR TITLE
fix: scorecard: output the failed CR  from basic test

### DIFF
--- a/changelog/fragments/03-scorecard-error.yaml
+++ b/changelog/fragments/03-scorecard-error.yaml
@@ -1,0 +1,16 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      scorecard will now print out the failed CR when the basic test fails.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/scorecard/tests/basic.go
+++ b/internal/scorecard/tests/basic.go
@@ -15,6 +15,8 @@
 package tests
 
 import (
+	"fmt"
+
 	scapiv1alpha3 "github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
 	apimanifests "github.com/operator-framework/api/pkg/manifests"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -50,6 +52,7 @@ func checkSpec(crSet []unstructured.Unstructured,
 		if cr.Object["spec"] == nil {
 			res.Errors = append(res.Errors, "error spec does not exist")
 			res.State = scapiv1alpha3.FailState
+			res.Suggestions = append(res.Suggestions, fmt.Sprintf("spec missing from [%+v]", cr.GetName()))
 			return res
 		}
 	}


### PR DESCRIPTION
Signed-off-by: jesus m. rodriguez <jesusr@redhat.com>

**Description of the change:**
Print out the failed CRD in the Suggestions.

**Motivation for the change:**
When the basic test fails the error is just "spec is missing" but doesn't tell you where.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
