### PR TITLE
Add information to the errors raised by scorecard basic tests to allow easily identify the scenarios

### DIFF
--- a/changelog/fragments/msg_scorecard.yaml
+++ b/changelog/fragments/msg_scorecard.yaml
@@ -1,0 +1,13 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Add information to the errors raised by scorecard basic tests to allow easily identify the scenarios
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"

--- a/internal/scorecard/tests/basic.go
+++ b/internal/scorecard/tests/basic.go
@@ -15,6 +15,8 @@
 package tests
 
 import (
+	"fmt"
+
 	scapiv1alpha3 "github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
 	apimanifests "github.com/operator-framework/api/pkg/manifests"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -35,7 +37,7 @@ func CheckSpecTest(bundle *apimanifests.Bundle) scapiv1alpha3.TestStatus {
 
 	crSet, err := GetCRs(bundle)
 	if err != nil {
-		r.Errors = append(r.Errors, "error getting custom resources")
+		r.Errors = append(r.Errors, fmt.Sprintf("error getting custom resources: %s", err))
 		r.State = scapiv1alpha3.FailState
 	}
 
@@ -48,7 +50,7 @@ func checkSpec(crSet []unstructured.Unstructured,
 	res scapiv1alpha3.TestResult) scapiv1alpha3.TestResult {
 	for _, cr := range crSet {
 		if cr.Object["spec"] == nil {
-			res.Errors = append(res.Errors, "error spec does not exist")
+			res.Errors = append(res.Errors, fmt.Sprintf("error spec does not exist for the custom resource %s", cr.GetName()))
 			res.State = scapiv1alpha3.FailState
 			return res
 		}


### PR DESCRIPTION
**Description**
 Add information to the errors raised by scorecard basic tests to allow easily identify the scenarios

**Motivation**
I check these needs when I was troubleshooting the errors faced in the tests/ci of this repo or in the CVP pipeline trying to help Operator authors. Without the error message and the cr name is very hard to identify why the scenario is failing. 