### PR TITLE
add import to go proxy docs

### DIFF
--- a/website/content/en/docs/building-operators/golang/references/proxy-vars.md
+++ b/website/content/en/docs/building-operators/golang/references/proxy-vars.md
@@ -17,6 +17,12 @@ Reconcile loop in `controllers/memcached_controller.go`:
 
 
 ```go
+import (
+  ...
+   "github.com/operator-framework/operator-lib/proxy"
+)
+
+
 for i, container := range dep.Spec.Template.Spec.Containers {
 		dep.Spec.Template.Spec.Containers[i].Env = append(container.Env, proxy.ReadProxyVarsFromEnv()...)
 }


### PR DESCRIPTION
Signed-off-by: austin <austin@redhat.com>

It was pointed out that the doc doesnt mention the import path :(