### PR TITLE
docs: specify go 1.16 must be used

### DIFF
--- a/website/content/en/docs/building-operators/golang/installation.md
+++ b/website/content/en/docs/building-operators/golang/installation.md
@@ -11,7 +11,7 @@ Follow the steps in the [installation guide][install-guide] to learn how to inst
 ## Additional Prerequisites
 
 - [git][git_tool]
-- [go][go_tool] version 1.15
+- [go][go_tool] version 1.16
 - [docker][docker_tool] version 17.03+.
 - [kubectl][kubectl_tool] and access to a Kubernetes cluster of a [compatible version][k8s-version-compat].
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->
**Description of the change:** specify go 1.16 must be used

**Motivation for the change:** `operator-sdk init --domain example.com --repo github.com/example/memcached-operator` fails with older or newer versions of go.

```bash
>> operator-sdk init --domain example.com --repo github.com/example/memcached-operator
Writing kustomize manifests for you to edit...
Writing scaffold for you to edit...
Get controller runtime:
$ go get sigs.k8s.io/controller-runtime@v0.9.2
Update dependencies:
$ go mod tidy
go mod tidy: go.mod file indicates go 1.16, but maximum supported version is 1.15
Error: failed to initialize project: unable to run post-scaffold tasks of "base.go.kubebuilder.io/v3": exit status 1
``` 
/kind documentation

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
