### PR TITLE
[webhook] Modify ordering of webhook based on name

### DIFF
--- a/changelog/fragments/fix-wh-ordering-csv.yaml
+++ b/changelog/fragments/fix-wh-ordering-csv.yaml
@@ -1,0 +1,17 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      The list of webhooks in `webhookdescription` was previously sorted based on `webhookType`. It is now being sorted
+      based on webhook names.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
@@ -338,7 +338,7 @@ func applyWebhooks(c *collector.Manifests, csv *operatorsv1alpha1.ClusterService
 	}
 	// Sorts the WebhookDescriptions based on natural order of webhookDescriptions Type
 	sort.Slice(webhookDescriptions, func(i, j int) bool {
-		return webhookDescriptions[i].Type < webhookDescriptions[j].Type
+		return webhookDescriptions[i].GenerateName < webhookDescriptions[j].GenerateName
 	})
 	csv.Spec.WebhookDefinitions = webhookDescriptions
 }


### PR DESCRIPTION

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
When there are multiple webhooks of the same type, the
ordering is not fixed. This PR modifies the ordering of webhooks
in a webhookdefinition based on the name, instead of the type.

Signed-off-by: varshaprasad96 <varshaprasad96@gmail.com>


**Motivation for the change:**
Closes: #5215 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
