### PR TITLE
[Bugfix for #5285] Expose flags for storage and untar images

### DIFF
--- a/changelog/fragments/5285_bugfix.yaml
+++ b/changelog/fragments/5285_bugfix.yaml
@@ -1,0 +1,17 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Add new flag options `--storage-image` and `--untar-image` to the Scorecard command to allow overwrite its default values.
+      These options are useful for disconnect environments and to prevent an impact of the external registry's pull limits.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/cmd/operator-sdk/scorecard/cmd.go
+++ b/internal/cmd/operator-sdk/scorecard/cmd.go
@@ -49,6 +49,8 @@ type scorecardCmd struct {
 	list           bool
 	skipCleanup    bool
 	waitTime       time.Duration
+	storageImage   string
+	untarImage     string
 	testOutput     string
 }
 
@@ -86,6 +88,12 @@ If the argument holds an image tag, it must be present remotely.`,
 		"Disable resource cleanup after tests are run")
 	scorecardCmd.Flags().DurationVarP(&c.waitTime, "wait-time", "w", 30*time.Second,
 		"seconds to wait for tests to complete. Example: 35s")
+	scorecardCmd.Flags().StringVarP(&c.storageImage, "storage-image", "b",
+		"docker.io/library/busybox@sha256:c71cb4f7e8ececaffb34037c2637dc86820e4185100e18b4d02d613a9bd772af",
+		"Storage image to be used by the Scorecard pod")
+	scorecardCmd.Flags().StringVarP(&c.untarImage, "untar-image", "u",
+		"registry.access.redhat.com/ubi8@sha256:910f6bc0b5ae9b555eb91b88d28d568099b060088616eba2867b07ab6ea457c7",
+		"Untar image to be used by the Scorecard pod")
 	scorecardCmd.Flags().StringVarP(&c.testOutput, "test-output", "t", "test-output",
 		"Test output directory.")
 
@@ -208,6 +216,8 @@ func (c *scorecardCmd) run() (err error) {
 			BundlePath:     c.bundle,
 			TestOutput:     c.testOutput,
 			BundleMetadata: metadata,
+			StorageImage:   c.storageImage,
+			UntarImage:     c.untarImage,
 		}
 
 		// Only get the client if running tests.

--- a/internal/cmd/operator-sdk/scorecard/cmd_test.go
+++ b/internal/cmd/operator-sdk/scorecard/cmd_test.go
@@ -65,6 +65,16 @@ var _ = Describe("Running the scorecard command", func() {
 			Expect(flag).NotTo(BeNil())
 			Expect(flag.Shorthand).To(Equal("w"))
 			Expect(flag.DefValue).To(Equal("30s"))
+
+			flag = cmd.Flags().Lookup("storage-image")
+			Expect(flag).NotTo(BeNil())
+			Expect(flag.Shorthand).To(Equal("b"))
+			Expect(flag.DefValue).To(Equal("docker.io/library/busybox@sha256:c71cb4f7e8ececaffb34037c2637dc86820e4185100e18b4d02d613a9bd772af"))
+
+			flag = cmd.Flags().Lookup("untar-image")
+			Expect(flag).NotTo(BeNil())
+			Expect(flag.Shorthand).To(Equal("u"))
+			Expect(flag.DefValue).To(Equal("registry.access.redhat.com/ubi8@sha256:910f6bc0b5ae9b555eb91b88d28d568099b060088616eba2867b07ab6ea457c7"))
 		})
 	})
 

--- a/internal/scorecard/scorecard.go
+++ b/internal/scorecard/scorecard.go
@@ -52,6 +52,8 @@ type PodTestRunner struct {
 	BundleMetadata registryutil.Labels
 	Client         kubernetes.Interface
 	RESTConfig     *rest.Config
+	StorageImage   string
+	UntarImage     string
 
 	configMapName string
 }
@@ -221,7 +223,7 @@ func (r PodTestRunner) RunTest(ctx context.Context, test v1alpha3.TestConfigurat
 	podDef := getPodDefinition(r.configMapName, test, r)
 
 	if test.Storage.Spec.MountPath.Path != "" {
-		addStorageToPod(podDef, test.Storage.Spec.MountPath.Path)
+		addStorageToPod(podDef, test.Storage.Spec.MountPath.Path, r.StorageImage)
 	}
 
 	pod, err := r.Client.CoreV1().Pods(r.Namespace).Create(ctx, podDef, metav1.CreateOptions{})

--- a/internal/scorecard/storage.go
+++ b/internal/scorecard/storage.go
@@ -137,7 +137,7 @@ func untarAll(reader io.Reader, destDir, prefix string) error {
 	return nil
 }
 
-func addStorageToPod(podDef *v1.Pod, mountPath string) {
+func addStorageToPod(podDef *v1.Pod, mountPath string, storageImage string) {
 
 	// add the emptyDir volume for storage to the test Pod
 	newVolume := v1.Volume{}
@@ -149,7 +149,7 @@ func addStorageToPod(podDef *v1.Pod, mountPath string) {
 	// add the storage sidecar container
 	storageContainer := v1.Container{
 		Name:            StorageSidecarContainer,
-		Image:           "busybox",
+		Image:           storageImage,
 		ImagePullPolicy: v1.PullIfNotPresent,
 		Args: []string{
 			"/bin/sh",

--- a/internal/scorecard/testpod.go
+++ b/internal/scorecard/testpod.go
@@ -30,10 +30,6 @@ import (
 const (
 	// PodBundleRoot is the directory containing all bundle data within a test pod.
 	PodBundleRoot = "/bundle"
-
-	// The image used to untar bundles prior to running tests within a runner Pod.
-	// This image tag should always be pinned to a specific version.
-	scorecardUntarImage = "registry.access.redhat.com/ubi8/ubi:8.4"
 )
 
 // getPodDefinition fills out a Pod definition based on
@@ -80,7 +76,7 @@ func getPodDefinition(configMapName string, test v1alpha3.TestConfiguration, r P
 			InitContainers: []v1.Container{
 				{
 					Name:            "scorecard-untar",
-					Image:           scorecardUntarImage,
+					Image:           r.UntarImage,
 					ImagePullPolicy: v1.PullIfNotPresent,
 					Args: []string{
 						"tar",

--- a/website/content/en/docs/cli/operator-sdk_scorecard.md
+++ b/website/content/en/docs/cli/operator-sdk_scorecard.md
@@ -27,7 +27,9 @@ operator-sdk scorecard [flags]
   -l, --selector string          label selector to determine which tests are run
   -s, --service-account string   Service account to use for tests (default "default")
   -x, --skip-cleanup             Disable resource cleanup after tests are run
+  -b, --storage-image string     Storage image to be used by the Scorecard pod (default "docker.io/library/busybox@sha256:c71cb4f7e8ececaffb34037c2637dc86820e4185100e18b4d02d613a9bd772af")
   -t, --test-output string       Test output directory. (default "test-output")
+  -u, --untar-image string       Untar image to be used by the Scorecard pod (default "registry.access.redhat.com/ubi8@sha256:910f6bc0b5ae9b555eb91b88d28d568099b060088616eba2867b07ab6ea457c7")
   -w, --wait-time duration       seconds to wait for tests to complete. Example: 35s (default 30s)
 ```
 

--- a/website/content/en/docs/testing-operators/scorecard/custom-tests.md
+++ b/website/content/en/docs/testing-operators/scorecard/custom-tests.md
@@ -251,6 +251,13 @@ $ operator-sdk scorecard ./bundle --test-output=/mytestoutput
 
 **Note**: By default, the gathered test output will be stored in `$(pwd)/test-output`.
 
+### Overwrite storage and untar images to prevent downloading the images from external registries
+
+The following options are useful to prevent downloading the images from external registries during scorecard job execution.
+That could be a case of disconnected environments or to prevent an impact of the external registry's pull limits.
+- The `--storage-image` flag can be used when executing the `operator-sdk scorecard` command to overwrite the default `busybox` image used by the Scorecard pod.
+- The `--untar-image` flag can be used when executing the `operator-sdk scorecard` command to overwrite the default untar image used by the Scorecard pod.
+
 ### Scorecard initContainer
 
 The scorecard inserts an `initContainer` into the test pods it creates. The


### PR DESCRIPTION
**Description of the change:**

Exposes two tags to provide a possibility to overwrite hardcoded images:

```
--storage-image busybox 
--untar-image registry.access.redhat.com/ubi8/ubi:8.4
```

**Motivation for the change:**

Closes #5285 

Operator-sdk scorecard pulls two hardcoded images during the job execution:

https://github.com/operator-framework/operator-sdk/blob/82e8ebbcb8f460f9f8c3f4515142194249369919/internal/scorecard/storage.go#L152

https://github.com/operator-framework/operator-sdk/blob/50caa7420cef6b14590e205620330823e3013cb4/internal/scorecard/testpod.go#L36

In the disconnected environment that pull doesn't work because the images are pinned by tags and not by digests. 
As discussed in #5285 with @jmccormick2001 and @estroz , the solution could be to expose two tags to provide a possibility to overwrite these images with their local-registry copies.

**Tests in disconnected environment**

The changes from this PR were installed as operator-sdk-flag and tested by running in the disconnected environment

```
operator-sdk-flag scorecard \
    --output json \
    --selector=test=basic-check-spec-test \
    --kubeconfig "{{ kubeconfig_path }}" \
    --namespace scorecard-testing \
    --service-account default \
    --config {{ scorecard_config_path }} \
    --verbose \
    --wait-time 300s \
    --untar-image registry.access.redhat.com/ubi8@sha256:910f6bc0b5ae9b555eb91b88d28d568099b060088616eba2867b07ab6ea457c7 \
    --storage-image docker.io/library/busybox@sha256:c71cb4f7e8ececaffb34037c2637dc86820e4185100e18b4d02d613a9bd772af \
    "{{ scorecard_operator_dir }}"
```

and 

```
operator-sdk-flag scorecard \
    --output json \
    --selector=suite=olm \
    --kubeconfig "{{ kubeconfig_path }}" \
    --namespace scorecard-testing \
    --service-account default \
    --config {{ scorecard_config_path }} \
    --verbose \
    --wait-time 300s \
    "{{ scorecard_operator_dir }}"
```

[Here are scorecard logs of the above tests](https://www.distributed-ci.io/jobs/c342657f-c823-4e9e-ab4b-0a0cec8808a9/files)

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
