### PR TITLE
Remove Helm diffs output for "info" zap log level

### DIFF
--- a/changelog/fragments/zap-verbosity.yaml
+++ b/changelog/fragments/zap-verbosity.yaml
@@ -1,0 +1,17 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Helm operator reconciliation diffs are now logged only at the zap
+      debug level.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "removal"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/helm/controller/reconcile.go
+++ b/internal/helm/controller/reconcile.go
@@ -130,7 +130,7 @@ func (r HelmOperatorReconciler) Reconcile(ctx context.Context, request reconcile
 			log.Info("Release not found")
 		} else {
 			log.Info("Uninstalled release")
-			if log.V(0).Enabled() && uninstalledRelease != nil {
+			if log.V(1).Enabled() && uninstalledRelease != nil {
 				fmt.Println(diff.Generate(uninstalledRelease.Manifest, ""))
 			}
 			if !wait {
@@ -252,7 +252,7 @@ func (r HelmOperatorReconciler) Reconcile(ctx context.Context, request reconcile
 		}
 
 		log.Info("Installed release")
-		if log.V(0).Enabled() {
+		if log.V(1).Enabled() {
 			fmt.Println(diff.Generate("", installedRelease.Manifest))
 		}
 		log.V(1).Info("Config values", "values", installedRelease.Config)
@@ -315,7 +315,7 @@ func (r HelmOperatorReconciler) Reconcile(ctx context.Context, request reconcile
 		}
 
 		log.Info("Upgraded release", "force", force)
-		if log.V(0).Enabled() {
+		if log.V(1).Enabled() {
 			fmt.Println(diff.Generate(previousRelease.Manifest, upgradedRelease.Manifest))
 		}
 		log.V(1).Info("Config values", "values", upgradedRelease.Config)


### PR DESCRIPTION
**Description of the change:**
Increased the verbosity threshold so that reconciliation diffs for Helm is not displayed when zap log level is set to "info."

**Motivation for the change:**
Close #5278 

**Notes**
1. The "debug" zap level has a verbosity 1. So if the operator is run with debug level, all logs, including diffs, will be outputted.
2. The "info" zap level has a verbosity of 0. So if the operator is run with the info level, helm diffs will not be outputted.