### PR TITLE
doc-fix: update controller-gen command with required changes after k8s 1.22 bump

### DIFF
--- a/website/content/en/docs/olm-integration/tutorial-bundle.md
+++ b/website/content/en/docs/olm-integration/tutorial-bundle.md
@@ -86,7 +86,7 @@ We will now create bundle manifests by running `make bundle` in the root of the 
 
 ```console
 $ make bundle
-/home/user/go/bin/controller-gen "crd:trivialVersions=true" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+/home/user/go/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 operator-sdk generate kustomize manifests -q
 kustomize build config/manifests | operator-sdk generate bundle -q --overwrite --version 0.0.1
 INFO[0000] Building annotations.yaml

--- a/website/content/en/docs/olm-integration/tutorial-package-manifests.md
+++ b/website/content/en/docs/olm-integration/tutorial-package-manifests.md
@@ -21,7 +21,7 @@ We will now create a package manifests format by running `make packagemanifests`
 
 ```console
 $ make packagemanifests
-/home/user/go/bin/controller-gen "crd:trivialVersions=true" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+/home/user/go/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 operator-sdk generate kustomize manifests -q
 kustomize build config/manifests | operator-sdk generate packagemanifests -q --version 0.0.1
 ```


### PR DESCRIPTION
**Description**
The option `"crd:trivialVersions=true"` no longer exist in the latest version of controller-gen. This PR only update/fix the docs. 