### PR TITLE
Fixup syntax for deploy-manual.

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -68,9 +68,9 @@ jobs:
         context: ./images/ansible-operator
         platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
         push: true
-        tags: ${{ steps.tag.outputs.29_base_tag }}
+        tags: ${{ steps.29_base_tag.outputs.tag }}
         build-args: |
-          GIT_COMMIT=${{ steps.tag.outputs.git_commit }}
+          GIT_COMMIT=${{ steps.29_base_tag.outputs.git_commit }}
 
     - name: build and push ansible 2.11 dep image
       uses: docker/build-push-action@v2
@@ -79,17 +79,17 @@ jobs:
         context: ./images/ansible-operator
         platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
         push: true
-        tags: ${{ steps.tag.outputs.211_base_tag }}
+        tags: ${{ steps.211_base_tag.outputs.tag }}
         build-args: |
-          GIT_COMMIT=${{ steps.tag.outputs.git_commit }}
+          GIT_COMMIT=${{ steps.211_base_tag.outputs.git_commit }}
 
     # This change will be staged and committed in the PR pushed below.
     # The script below will fail if no change was made.
     - name: update base of ansible-operator 2.9
-      id: update
+      id: 29_update
       run: |
         set -ex
-        sed -i -E 's|FROM quay\.io/operator-framework/ansible-operator-base:.+|FROM ${{ steps.tag.outputs.29_base_tag }}|g' images/ansible-operator/Dockerfile
+        sed -i -E 's|FROM quay\.io/operator-framework/ansible-operator-base:.+|FROM ${{ steps.29_base_tag.outputs.tag }}|g' images/ansible-operator/Dockerfile
         git diff --exit-code --quiet && echo "Failed to update images/ansible-operator/Dockerfile" && exit 1
         REF="${{ github.event.ref }}"
         echo ::set-output name=branch_name::"${REF##*/}"
@@ -97,9 +97,9 @@ jobs:
     - name: create PR for ansible-operator 2.9 Dockerfile
       uses: peter-evans/create-pull-request@v3
       with:
-        title: "[${{ steps.update.outputs.branch_name }}] image(ansible-operator): bump base to ${{ steps.tag.outputs.29_base_tag }}"
+        title: "[${{ steps.29_update.outputs.branch_name }}] image(ansible-operator): bump base to ${{ steps.29_base_tag.outputs.tag }}"
         commit-message: |
-          [${{ steps.update.outputs.branch_name }}] image(ansible-operator): bump base to ${{ steps.tag.outputs.29_base_tag }}
+          [${{ steps.29_update.outputs.branch_name }}] image(ansible-operator): bump base to ${{ steps.29_base_tag.outputs.tag }}
 
           Signed-off-by: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
         body: "New ansible-operator-base image built by https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -109,10 +109,10 @@ jobs:
     # This change will be staged and committed in the PR pushed below.
     # The script below will fail if no change was made.
     - name: update base of ansible-operator-2.11-preview
-      id: update
+      id: 211_update
       run: |
         set -ex
-        sed -i -E 's|FROM quay\.io/operator-framework/ansible-operator-2.11-preview-base:.+|FROM ${{ steps.tag.outputs.211_base_tag }}|g' images/ansible-operator/Dockerfile
+        sed -i -E 's|FROM quay\.io/operator-framework/ansible-operator-2.11-preview-base:.+|FROM ${{ steps.211_base_tag.outputs.tag }}|g' images/ansible-operator/Dockerfile
         git diff --exit-code --quiet && echo "Failed to update images/ansible-operator-11-preview-base/Dockerfile" && exit 1
         REF="${{ github.event.ref }}"
         echo ::set-output name=branch_name::"${REF##*/}"
@@ -120,9 +120,9 @@ jobs:
     - name: create PR for ansible-operator-2.11-preview Dockerfile
       uses: peter-evans/create-pull-request@v3
       with:
-        title: "[${{ steps.update.outputs.branch_name }}] image(ansible-operator-2.11-preview): bump base to ${{ steps.tag.outputs.211_base_tag }}"
+        title: "[${{ steps.211_update.outputs.branch_name }}] image(ansible-operator-2.11-preview): bump base to ${{ steps.211_base_tag.outputs.tag }}"
         commit-message: |
-          [${{ steps.update.outputs.branch_name }}] image(ansible-operator-2.11-preview): bump base to ${{ steps.tag.outputs.211_base_tag }}
+          [${{ steps.211_update.outputs.branch_name }}] image(ansible-operator-2.11-preview): bump base to ${{ steps.211_base_tag.outputs.tag }}
 
           Signed-off-by: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
         body: "New ansible-operator-2.11-preview-base image built by https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
This action (AFAICT) can't be tested locally or with PRs. A previous
commit mixed up 2 variable scopes.

Signed-off-by: austin <austin@redhat.com>