### PR TITLE
Fixup: action syntax id must start with a letter

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -6,7 +6,7 @@ on:
       ansible_operator_base_tag:
         description: ansible-operator-base image tag, ex. "6e1b47e6ca7c507b8ecf197a8edcd412dd64d85d"
         required: false
-      ansible_operator_211_base_tag:
+      ansible_operator_base_tag_211:
         description: ansible-operator-2.11-preview-base image tag, ex. "6e1b47e6ca7c507b8ecf197a8edcd412dd64d85d"
         required: false
 
@@ -37,7 +37,7 @@ jobs:
 
     # Copied this for 2.11 rather than use a matrix because eventually 2.11 will be default and this will be removed.
     - name: create 2.9-base tag
-      id: 29_base_tag
+      id: base_tag_29
       run: |
         set -e
         IMG=quay.io/${{ github.repository_owner }}/ansible-operator-base
@@ -50,11 +50,11 @@ jobs:
         echo ::set-output name=git_commit::${GIT_COMMIT}
 
     - name: create 2.11-base tag
-      id: 211_base_tag
+      id: base_tag_211
       run: |
         set -e
         IMG=quay.io/${{ github.repository_owner }}/ansible-operator-2.11-preview-base
-        TAG="${{ github.event.inputs.ansible_operator_211_base_tag }}"
+        TAG="${{ github.event.inputs.ansible_operator_base_tag_211 }}"
         if [[ "$TAG" == "" ]]; then
           TAG="$(git branch --show-current)-${GIT_COMMIT}"
         fi
@@ -68,9 +68,9 @@ jobs:
         context: ./images/ansible-operator
         platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
         push: true
-        tags: ${{ steps.29_base_tag.outputs.tag }}
+        tags: ${{ steps.base_tag_29.outputs.tag }}
         build-args: |
-          GIT_COMMIT=${{ steps.29_base_tag.outputs.git_commit }}
+          GIT_COMMIT=${{ steps.base_tag_29.outputs.git_commit }}
 
     - name: build and push ansible 2.11 dep image
       uses: docker/build-push-action@v2
@@ -79,9 +79,9 @@ jobs:
         context: ./images/ansible-operator
         platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
         push: true
-        tags: ${{ steps.211_base_tag.outputs.tag }}
+        tags: ${{ steps.base_tag_211.outputs.tag }}
         build-args: |
-          GIT_COMMIT=${{ steps.211_base_tag.outputs.git_commit }}
+          GIT_COMMIT=${{ steps.base_tag_211.outputs.git_commit }}
 
     # This change will be staged and committed in the PR pushed below.
     # The script below will fail if no change was made.
@@ -89,7 +89,7 @@ jobs:
       id: 29_update
       run: |
         set -ex
-        sed -i -E 's|FROM quay\.io/operator-framework/ansible-operator-base:.+|FROM ${{ steps.29_base_tag.outputs.tag }}|g' images/ansible-operator/Dockerfile
+        sed -i -E 's|FROM quay\.io/operator-framework/ansible-operator-base:.+|FROM ${{ steps.base_tag_29.outputs.tag }}|g' images/ansible-operator/Dockerfile
         git diff --exit-code --quiet && echo "Failed to update images/ansible-operator/Dockerfile" && exit 1
         REF="${{ github.event.ref }}"
         echo ::set-output name=branch_name::"${REF##*/}"
@@ -97,9 +97,9 @@ jobs:
     - name: create PR for ansible-operator 2.9 Dockerfile
       uses: peter-evans/create-pull-request@v3
       with:
-        title: "[${{ steps.29_update.outputs.branch_name }}] image(ansible-operator): bump base to ${{ steps.29_base_tag.outputs.tag }}"
+        title: "[${{ steps.29_update.outputs.branch_name }}] image(ansible-operator): bump base to ${{ steps.base_tag_29.outputs.tag }}"
         commit-message: |
-          [${{ steps.29_update.outputs.branch_name }}] image(ansible-operator): bump base to ${{ steps.29_base_tag.outputs.tag }}
+          [${{ steps.29_update.outputs.branch_name }}] image(ansible-operator): bump base to ${{ steps.base_tag_29.outputs.tag }}
 
           Signed-off-by: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
         body: "New ansible-operator-base image built by https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -112,7 +112,7 @@ jobs:
       id: 211_update
       run: |
         set -ex
-        sed -i -E 's|FROM quay\.io/operator-framework/ansible-operator-2.11-preview-base:.+|FROM ${{ steps.211_base_tag.outputs.tag }}|g' images/ansible-operator/Dockerfile
+        sed -i -E 's|FROM quay\.io/operator-framework/ansible-operator-2.11-preview-base:.+|FROM ${{ steps.base_tag_211.outputs.tag }}|g' images/ansible-operator/Dockerfile
         git diff --exit-code --quiet && echo "Failed to update images/ansible-operator-11-preview-base/Dockerfile" && exit 1
         REF="${{ github.event.ref }}"
         echo ::set-output name=branch_name::"${REF##*/}"
@@ -120,9 +120,9 @@ jobs:
     - name: create PR for ansible-operator-2.11-preview Dockerfile
       uses: peter-evans/create-pull-request@v3
       with:
-        title: "[${{ steps.211_update.outputs.branch_name }}] image(ansible-operator-2.11-preview): bump base to ${{ steps.211_base_tag.outputs.tag }}"
+        title: "[${{ steps.211_update.outputs.branch_name }}] image(ansible-operator-2.11-preview): bump base to ${{ steps.base_tag_211.outputs.tag }}"
         commit-message: |
-          [${{ steps.211_update.outputs.branch_name }}] image(ansible-operator-2.11-preview): bump base to ${{ steps.211_base_tag.outputs.tag }}
+          [${{ steps.211_update.outputs.branch_name }}] image(ansible-operator-2.11-preview): bump base to ${{ steps.base_tag_211.outputs.tag }}
 
           Signed-off-by: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
         body: "New ansible-operator-2.11-preview-base image built by https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
Signed-off-by: austin <austin@redhat.com>

https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions?query=%22id%22#outputsoutput_id
