### PR TITLE
Bump ubi 8.4 to 8.5 for ansible-operator images

### DIFF
--- a/images/ansible-operator-2.11-preview/base.Dockerfile
+++ b/images/ansible-operator-2.11-preview/base.Dockerfile
@@ -2,7 +2,7 @@
 # It is built with dependencies that take a while to download, thus speeding
 # up ansible deploy jobs.
 
-FROM registry.access.redhat.com/ubi8/ubi:8.4
+FROM registry.access.redhat.com/ubi8/ubi:8.5
 ARG TARGETARCH
 
 # Label this image with the repo and commit that built it, for freshmaking purposes.

--- a/images/ansible-operator/base.Dockerfile
+++ b/images/ansible-operator/base.Dockerfile
@@ -2,7 +2,7 @@
 # It is built with dependencies that take a while to download, thus speeding
 # up ansible deploy jobs.
 
-FROM registry.access.redhat.com/ubi8/ubi:8.4
+FROM registry.access.redhat.com/ubi8/ubi:8.5
 ARG TARGETARCH
 
 # Label this image with the repo and commit that built it, for freshmaking purposes.


### PR DESCRIPTION
Dockerfiles based on ubi8.4 recently started failing on `RUN yum update -y` step.

I was able to replicate this outside of SDK. Locally, I created a new Dockerfile:

```
FROM registry.access.redhat.com/ubi8/ubi:8.4

RUN yum update -y
```

Error: 
```
 Problem 1: cannot install the best update candidate for package python3-subscription-manager-rhsm-1.28.13-4.el8_4.x86_64
  - nothing provides python3-cloud-what = 1.28.21-3.el8 needed by python3-subscription-manager-rhsm-1.28.21-3.el8.x86_64
 Problem 2: cannot install the best update candidate for package subscription-manager-1.28.13-4.el8_4.x86_64
  - nothing provides python3-cloud-what = 1.28.21-3.el8 needed by subscription-manager-1.28.21-3.el8.x86_64
 Problem 3: package subscription-manager-1.28.13-4.el8_4.x86_64 requires dnf-plugin-subscription-manager = 1.28.13, but none of the providers can be installed
  - cannot install both dnf-plugin-subscription-manager-1.28.21-3.el8.x86_64 and dnf-plugin-subscription-manager-1.28.13-4.el8_4.x86_64
  - problem with installed package subscription-manager-1.28.13-4.el8_4.x86_64
  - cannot install the best update candidate for package dnf-plugin-subscription-manager-1.28.13-4.el8_4.x86_64
  - nothing provides python3-cloud-what = 1.28.21-3.el8 needed by subscription-manager-1.28.21-3.el8.x86_64
 Problem 4: package python3-subscription-manager-rhsm-1.28.13-4.el8_4.x86_64 requires subscription-manager-rhsm-certificates = 1.28.13-4.el8_4, but none of the providers can be installed
  - cannot install both subscription-manager-rhsm-certificates-1.28.21-3.el8.x86_64 and subscription-manager-rhsm-certificates-1.28.13-4.el8_4.x86_64
  - problem with installed package python3-subscription-manager-rhsm-1.28.13-4.el8_4.x86_64
  - cannot install the best update candidate for package subscription-manager-rhsm-certificates-1.28.13-4.el8_4.x86_64
  - nothing provides python3-cloud-what = 1.28.21-3.el8 needed by python3-subscription-manager-rhsm-1.28.21-3.el8.x86_64
```
Ubi 8.4 is outdated, we should just switch to 8.5

https://catalog.redhat.com/software/containers/ubi8/ubi/5c359854d70cc534b3a3784e?tag=8.4-213
