### PR TITLE
Docs: olm status when installed via non-standard installations

### DIFF
--- a/website/content/en/docs/olm-integration/tutorial-bundle.md
+++ b/website/content/en/docs/olm-integration/tutorial-bundle.md
@@ -55,6 +55,15 @@ subscriptions.operators.coreos.com                           CustomResourceDefin
 
 All resources listed should have status `Installed`.
 
+
+**Note:** The `operator-sdk olm status` command is geared to detect the status of OLM that was installed by installation methods like `operator-sdk olm install` or by applying OLM [manifests][olm-manifests] directly on the cluster. This command retrieves the resources that were compiled into SDK at the time of installation from the OLM [manifests][olm-manifests]. However, if OLM was installed in a cluster in a custom fashion (such as in OpenShift clusters), it is possible that some resources will show a `Not Found` status when the `operator-sdk olm status` command is issued.
+
+To check the true status of such resources in OCP clusters, run:
+
+```
+oc get <resource-name> -n <resource-namespace>
+```
+
 If OLM is not already installed, go ahead and install the latest version:
 
 ```console
@@ -293,3 +302,4 @@ In-depth discussions of OLM concepts mentioned here:
 [catalogsource]:https://olm.operatorframework.io/docs/concepts/crds/catalogsource/
 [subscription]:https://olm.operatorframework.io/docs/concepts/crds/subscription/
 [olm-install]:https://olm.operatorframework.io/docs/tasks/install-operator-with-olm/
+[olm-manifests]:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/deploy/upstream/quickstart/olm.yaml


### PR DESCRIPTION
**Description of the change:**
Added the caveat that ``olm status`` does not work with non-standard olm installations to the enabling-olm docs.

**Motivation for the change:**
Short term solution for #4714, as mentioned in [this](https://github.com/operator-framework/operator-sdk/issues/4714#issuecomment-963493281) comment.

