### PR TITLE
feat: add the deprecated APIs optional checker to the suite operator

### DIFF
--- a/changelog/fragments/suite.yaml
+++ b/changelog/fragments/suite.yaml
@@ -2,7 +2,7 @@
 # release notes and/or the migration guide
 entries:
   - description: >
-      Add the deprecated APIs optional checker, `alpha-deprecated-apis`, to the suite operatorframework.
+      Add the deprecated APIs optional checker, `alpha-deprecated-apis`, to the `operatorframework` suite.
 
     # kind is one of:
     # - addition

--- a/changelog/fragments/suite.yaml
+++ b/changelog/fragments/suite.yaml
@@ -1,0 +1,16 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Add the deprecated APIs optional checker, `alpha-deprecated-apis`, to the suite operatorframework.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/cmd/operator-sdk/bundle/validate/optional.go
+++ b/internal/cmd/operator-sdk/bundle/validate/optional.go
@@ -56,9 +56,10 @@ var optionalValidators = validators{
 		Validator: apivalidation.AlphaDeprecatedAPIsValidator,
 		name:      "alpha-deprecated-apis",
 		labels: map[string]string{
-			nameKey: "alpha-deprecated-apis",
+			nameKey:  "alpha-deprecated-apis",
+			suiteKey: "operatorframework",
 		},
-		desc: "(stage: alpha) Deprecated APIs bundle validation. This valiator can help you out verify if your bundle contains manifests which uses deprecated APIs. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/",
+		desc: "(stage: alpha) Deprecated APIs bundle validation. This validator can help you out verify if your bundle contains manifests which uses deprecated APIs. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/",
 	},
 }
 


### PR DESCRIPTION
**Description**
Add the deprecated APIs optional checker to the suite operator

**Motivation**
We can have many validators shipped and implemented.
The suite was designed to ensure that we can aggregate all checks to validate the bundle against the upstream/operator framework criteria