### PR TITLE
[do not merge before SDK 1.17 rolls out] - feat: Remove the Optional(stage: alpha) Community Operator bundle val…

### DIFF
--- a/changelog/fragments/remove-community.yaml
+++ b/changelog/fragments/remove-community.yaml
@@ -1,0 +1,7 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Remove the Optional(stage: alpha) Community Operator bundle validation. Its checks were moved to the [external validator](https://github.com/redhat-openshift-ecosystem/ocp-olm-catalog-validator/).
+    kind: "removal"
+    breaking: false

--- a/internal/cmd/operator-sdk/bundle/validate/cmd.go
+++ b/internal/cmd/operator-sdk/bundle/validate/cmd.go
@@ -85,10 +85,6 @@ This validator allows check the bundle against an specific Kubernetes cluster ve
 
   $ operator-sdk bundle validate ./bundle --select-optional name=operatorhub --optional-values=k8s-version=1.22
 
-To validate a bundle against the (alpha) validator for Community Operators specifically, in addition to required bundle validators:
-
-  $ operator-sdk bundle validate ./bundle --select-optional name=community --optional-values=index-path=bundle.Dockerfile
-	
 To validate a bundle against the (alpha) validator for Deprecated APIs specifically, in addition to required bundle validators:
 
   $ operator-sdk bundle validate ./bundle --select-optional name=alpha-deprecated-apis --optional-values=k8s-version=1.22	

--- a/internal/cmd/operator-sdk/bundle/validate/optional.go
+++ b/internal/cmd/operator-sdk/bundle/validate/optional.go
@@ -45,14 +45,6 @@ var optionalValidators = validators{
 		desc: "OperatorHub.io metadata validation. ",
 	},
 	{
-		Validator: apivalidation.CommunityOperatorValidator,
-		name:      "community",
-		labels: map[string]string{
-			nameKey: "community",
-		},
-		desc: "(stage: alpha) Community Operator bundle validation. See https://github.com/operator-framework/community-operators/blob/master/docs/packaging-required-fields.md",
-	},
-	{
 		Validator: apivalidation.AlphaDeprecatedAPIsValidator,
 		name:      "alpha-deprecated-apis",
 		labels: map[string]string{

--- a/website/content/en/docs/cli/operator-sdk_bundle_validate.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle_validate.md
@@ -71,10 +71,6 @@ This validator allows check the bundle against an specific Kubernetes cluster ve
 
   $ operator-sdk bundle validate ./bundle --select-optional name=operatorhub --optional-values=k8s-version=1.22
 
-To validate a bundle against the (alpha) validator for Community Operators specifically, in addition to required bundle validators:
-
-  $ operator-sdk bundle validate ./bundle --select-optional name=community --optional-values=index-path=bundle.Dockerfile
-	
 To validate a bundle against the (alpha) validator for Deprecated APIs specifically, in addition to required bundle validators:
 
   $ operator-sdk bundle validate ./bundle --select-optional name=alpha-deprecated-apis --optional-values=k8s-version=1.22	


### PR DESCRIPTION
**Description of the change:**

Remove the Optional(stage: alpha) Community Operator bundle validation. Its checks were moved to the [external validator](https://github.com/redhat-openshift-ecosystem/ocp-olm-catalog-validator/).

**Motivation for the change:**

We reach the consensus that this check is more vendor-like and specific and should not be shipped with SDK.
Besides, being alpha it shows that we could advise first: https://github.com/operator-framework/operator-sdk/pull/5414
Milestone: 1.17.0

IMPORTANT: Remove also the warning when https://github.com/operator-framework/operator-sdk/pull/5414 get merged. 
**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
