### PR TITLE
deprecation:Optional(stage: alpha) Community Operator bundle validator

### DIFF
--- a/changelog/fragments/deprecation.yaml
+++ b/changelog/fragments/deprecation.yaml
@@ -1,0 +1,16 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Deprecation of the Optional(stage: alpha) Community Operator bundle validation. Its checks were moved to the [external validator](https://github.com/redhat-openshift-ecosystem/ocp-olm-catalog-validator/).
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "deprecation"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/cmd/operator-sdk/bundle/validate/cmd.go
+++ b/internal/cmd/operator-sdk/bundle/validate/cmd.go
@@ -85,7 +85,7 @@ This validator allows check the bundle against an specific Kubernetes cluster ve
 
   $ operator-sdk bundle validate ./bundle --select-optional name=operatorhub --optional-values=k8s-version=1.22
 
-To validate a bundle against the (alpha) validator for Community Operators specifically, in addition to required bundle validators:
+[Deprecated] To validate a bundle against the (alpha) validator for Community Operators specifically, in addition to required bundle validators:
 
   $ operator-sdk bundle validate ./bundle --select-optional name=community --optional-values=index-path=bundle.Dockerfile
 	
@@ -123,6 +123,12 @@ func NewCmd() *cobra.Command {
 					logger.Fatal(err)
 				}
 				return nil
+			}
+
+			if c.selectorRaw == "name=community" {
+				logger.Warnf("The Optional(stage: alpha) Community Operator bundle validator is deprecated and" +
+					" will be removed in a future release. You can do these checks using the external validator: " +
+					"https://github.com/redhat-openshift-ecosystem/ocp-olm-catalog-validator/")
 			}
 
 			result, err := c.run(logger, args[0])

--- a/website/content/en/docs/cli/operator-sdk_bundle_validate.md
+++ b/website/content/en/docs/cli/operator-sdk_bundle_validate.md
@@ -71,7 +71,7 @@ This validator allows check the bundle against an specific Kubernetes cluster ve
 
   $ operator-sdk bundle validate ./bundle --select-optional name=operatorhub --optional-values=k8s-version=1.22
 
-To validate a bundle against the (alpha) validator for Community Operators specifically, in addition to required bundle validators:
+[Deprecated] To validate a bundle against the (alpha) validator for Community Operators specifically, in addition to required bundle validators:
 
   $ operator-sdk bundle validate ./bundle --select-optional name=community --optional-values=index-path=bundle.Dockerfile
 	


### PR DESCRIPTION
**Description of the change:**

Deprecation the Optional(stage: alpha) Community Operator bundle validation. Its checks were moved to the [external validator](https://github.com/redhat-openshift-ecosystem/ocp-olm-catalog-validator/).

<img width="724" alt="Screenshot 2021-11-26 at 09 29 33" src="https://user-images.githubusercontent.com/7708031/143558519-6ca10786-0787-4407-bf52-c433d17c1436.png">


**Motivation for the change:**

We reach the consensus that this check is more vendor-like and specific and should not be shipped with SDK.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
