### PR TITLE
Fix bug: 2.11 images should not use 2.9 pipfile

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -77,7 +77,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         file: ./images/ansible-operator-2.11-preview/base.Dockerfile
-        context: ./images/ansible-operator
+        context: ./images/ansible-operator-2.11-preview
         platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
         push: true
         tags: ${{ steps.base_tag_211.outputs.tag }}

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ image/%:
 
 image-base/%: export DOCKER_CLI_EXPERIMENTAL = enabled
 image-base/%:
-	docker buildx build $(DOCKER_PROGRESS) -t $(BUILD_IMAGE_REPO)/$*:dev -f ./images/$*/base.Dockerfile --load images/$*
+	docker buildx build $(DOCKER_PROGRESS) -t $(BUILD_IMAGE_REPO)/$*-base:dev -f ./images/$*/base.Dockerfile --load images/$*
 ##@ Release
 
 .PHONY: release


### PR DESCRIPTION
By incorrectly defining the context, the 2.11 images are using a 2.9 pipfile, resulting in only 2.9 images.