### PR TITLE
upgrade pip before installing

### DIFF
--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -20,12 +20,14 @@ header_text "Running ansible molecule tests in a python3 virtual environment"
 # Set up a python3.8 virtual environment.
 ENVDIR="$(mktemp -d)"
 trap_add "set +u; deactivate; set -u; rm -rf $ENVDIR" EXIT
+python3 -m pip install --upgrade pip
 python3 -m venv "$ENVDIR"
 set +u; source "${ENVDIR}/bin/activate"; set -u
 
 # Install dependencies.
 TMPDIR="$(mktemp -d)"
 trap_add "rm -rf $TMPDIR" EXIT
+pip3 install pyasn1==0.4.7 pyasn1-modules==0.2.6 idna==2.8 ipaddress==1.0.23
 pip3 install pyasn1==0.4.7 pyasn1-modules==0.2.6 idna==2.8 ipaddress==1.0.23
 pip3 install cryptography==3.3.2 molecule==3.0.2
 pip3 install ansible-lint yamllint


### PR DESCRIPTION
Signed-off-by: austin <austin@redhat.com>

``` Complete output from command /tmp/tmp.l4ACFLkvMO/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-wel28p_y/tree-format/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmp1ylcxi3ipip-wheel- --python-tag cp36:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
  ```