### PR TITLE
add rollback-force annotation for helm operators

### DIFF
--- a/changelog/fragments/helm-rollback-force-annotation.yaml
+++ b/changelog/fragments/helm-rollback-force-annotation.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      Helm-based Operators now support the `helm.sdk.operatorframework.io/rollback-force` annotation which, if
+      set to `false`, will run a possible rollback after a failed upgrade without the `--force` option.
+    kind: "addition"
+    breaking: false

--- a/internal/helm/controller/reconcile.go
+++ b/internal/helm/controller/reconcile.go
@@ -62,6 +62,7 @@ const (
 	uninstallFinalizerLegacy = "uninstall-helm-release"
 
 	helmUpgradeForceAnnotation  = "helm.sdk.operatorframework.io/upgrade-force"
+	helmRollbackForceAnnotation = "helm.sdk.operatorframework.io/rollback-force"
 	helmUninstallWaitAnnotation = "helm.sdk.operatorframework.io/uninstall-wait"
 )
 
@@ -125,7 +126,7 @@ func (r HelmOperatorReconciler) Reconcile(ctx context.Context, request reconcile
 		}
 		status.RemoveCondition(types.ConditionReleaseFailed)
 
-		wait := hasAnnotation(helmUninstallWaitAnnotation, o)
+		wait := hasAnnotation(helmUninstallWaitAnnotation, o, false)
 		if errors.Is(err, driver.ErrReleaseNotFound) {
 			log.Info("Release not found")
 		} else {
@@ -290,8 +291,9 @@ func (r HelmOperatorReconciler) Reconcile(ctx context.Context, request reconcile
 			r.EventRecorder.Eventf(o, "Warning", "OverrideValuesInUse",
 				"Chart value %q overridden to %q by operator's watches.yaml", k, v)
 		}
-		force := hasAnnotation(helmUpgradeForceAnnotation, o)
-		previousRelease, upgradedRelease, err := manager.UpgradeRelease(ctx, release.ForceUpgrade(force))
+		forceUpgrade := hasAnnotation(helmUpgradeForceAnnotation, o, false)
+		forceRollback := hasAnnotation(helmRollbackForceAnnotation, o, true)
+		previousRelease, upgradedRelease, err := manager.UpgradeRelease(ctx, []release.UpgradeOption{release.ForceUpgrade(forceUpgrade)}, []release.RollbackOption{release.ForceRollback(forceRollback)})
 		if err != nil {
 			log.Error(err, "Release failed")
 			status.SetCondition(types.HelmAppCondition{
@@ -314,7 +316,7 @@ func (r HelmOperatorReconciler) Reconcile(ctx context.Context, request reconcile
 			}
 		}
 
-		log.Info("Upgraded release", "force", force)
+		log.Info("Upgraded release", "forceUpgrade", forceUpgrade, "forceRollback", forceRollback)
 		if log.V(1).Enabled() {
 			fmt.Println(diff.Generate(previousRelease.Manifest, upgradedRelease.Manifest))
 		}
@@ -393,12 +395,12 @@ func (r HelmOperatorReconciler) Reconcile(ctx context.Context, request reconcile
 
 // returns the boolean representation of the annotation string
 // will return false if annotation is not set
-func hasAnnotation(anno string, o *unstructured.Unstructured) bool {
+func hasAnnotation(anno string, o *unstructured.Unstructured, fallback bool) bool {
+	value := fallback
 	boolStr := o.GetAnnotations()[anno]
 	if boolStr == "" {
-		return false
+		return value
 	}
-	value := false
 	if i, err := strconv.ParseBool(boolStr); err != nil {
 		log.Info("Could not parse annotation as a boolean",
 			"annotation", anno, "value informed", boolStr)

--- a/internal/helm/controller/reconcile_test.go
+++ b/internal/helm/controller/reconcile_test.go
@@ -22,9 +22,10 @@ import (
 )
 
 func TestHasAnnotation(t *testing.T) {
-	upgradeForceTests := []struct {
+	tests := []struct {
 		input       map[string]interface{}
 		expectedVal bool
+		fallback    bool
 		expectedOut string
 		name        string
 	}{
@@ -70,10 +71,34 @@ func TestHasAnnotation(t *testing.T) {
 			expectedVal: false,
 			name:        "upgrade force invalid value",
 		},
+		{
+			input: map[string]interface{}{
+				"helm.sdk.operatorframework.io/upgrade-force": "false",
+			},
+			fallback:    true,
+			expectedVal: false,
+			name:        "false annotation fallback true",
+		},
+		{
+			input: map[string]interface{}{
+				"helm.sdk.operatorframework.io/upgrade-force": "",
+			},
+			fallback:    true,
+			expectedVal: true,
+			name:        "empty annotation fallback true",
+		},
+		{
+			input: map[string]interface{}{
+				"helm.sdk.operatorframework.io/invalid": "",
+			},
+			fallback:    true,
+			expectedVal: true,
+			name:        "invalid annotation fallback true",
+		},
 	}
 
-	for _, test := range upgradeForceTests {
-		assert.Equal(t, test.expectedVal, hasAnnotation(helmUpgradeForceAnnotation, annotations(test.input)), test.name)
+	for _, test := range tests {
+		assert.Equal(t, test.expectedVal, hasAnnotation(helmUpgradeForceAnnotation, annotations(test.input), test.fallback), test.name)
 	}
 
 	uninstallWaitTests := []struct {
@@ -127,7 +152,7 @@ func TestHasAnnotation(t *testing.T) {
 	}
 
 	for _, test := range uninstallWaitTests {
-		assert.Equal(t, test.expectedVal, hasAnnotation(helmUninstallWaitAnnotation, annotations(test.input)), test.name)
+		assert.Equal(t, test.expectedVal, hasAnnotation(helmUninstallWaitAnnotation, annotations(test.input), false), test.name)
 	}
 }
 

--- a/website/content/en/docs/building-operators/helm/reference/advanced_features/annotations.md
+++ b/website/content/en/docs/building-operators/helm/reference/advanced_features/annotations.md
@@ -31,7 +31,36 @@ will cause the custom resource to be reconciled and upgraded with the `force` op
 log message when an upgrade succeeds:
 
 ```
-{"level":"info","ts":1591198931.1703992,"logger":"helm.controller","msg":"Upgraded release","namespace":"helm-nginx","name":"example-nginx","apiVersion":"cache.example.com/v1alpha1","kind":"Nginx","release":"example-nginx","force":true}
+{"level":"info","ts":1591198931.1703992,"logger":"helm.controller","msg":"Upgraded release","namespace":"helm-nginx","name":"example-nginx","apiVersion":"cache.example.com/v1alpha1","kind":"Nginx","release":"example-nginx","forceUpgrade":true}
+```
+
+## `helm.sdk.operatorframework.io/rollback-force`
+
+The operator will assume this annotation to be `"true"`, if it is not set or set to an invalid value.
+This annotation can be set to `"false"` to run a possible `helm rollback` after a failed release
+without the `--force` option. For more info see the [Helm Rollback documentation](https://helm.sh/docs/helm/helm_rollback/).
+
+Setting this can be required if a chart contains resources that have immutable fields after their first creation.
+See [helm/helm#6378](https://github.com/helm/helm/issues/6378#issuecomment-735812673) for a more detailed description
+of this issue.
+
+This for example applies to a `Service` of type `ClusterIP`. The `ClusterIP` can be empty on creation, but kubernetes will fill
+it with an actual IP, afterwards, the field is immutable. Helm (with `--force`) however will try to set it to `""`, which
+results in an error.
+
+**Example**
+
+```yaml
+apiVersion: example.com/v1alpha1
+kind: Nginx
+metadata:
+  name: nginx-sample
+  annotations:
+    helm.sdk.operatorframework.io/rollback-force: "false"
+spec:
+  replicaCount: 2
+  service:
+    port: 8080
 ```
 
 ## `helm.sdk.operatorframework.io/uninstall-wait`


### PR DESCRIPTION
I'm not sure if I'm allowed to reopen https://github.com/operator-framework/operator-sdk/pull/4279, so here is the same change as a new PR.

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Adds a `helm.sdk.operatorframework.io/rollback-force` annotation. This allows running a possible rollback after a failed upgrade without `rollback.Force` set to `true`.

In order to not break the current behavior, this annotation only overrides the current default of `true` if it is explicitly set to `"false"`.

**Motivation for the change:**
I ran into issues with failed upgrades on charts with a `Service` of type `ClusterIP`. After the upgrade had failed, the operator ran a rollback (currently with `rollback.Fore = true`) action. This would fail because the Service could not be rolled back to its previous state, which did not include the `ClusterIP` field. Without the `ClusterIP` field set, kubernetes assumes it to be empty on a force apply. And since this field is immutable after creation, it can't be force set to an empty string.

Without `rollback.Force = true` this works without errors. (I think?!) kubernetes will  use a `Three-Way-Merge` when the old Service gets applied.

See https://github.com/helm/helm/issues/6378#issuecomment-735812673 for more details.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
