### PR TITLE
Allow setting the namespace when installing OLM

### DIFF
--- a/changelog/fragments/olm_install.yaml
+++ b/changelog/fragments/olm_install.yaml
@@ -1,0 +1,16 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Add the new flag option `--namespace ` to the command  `operator-sdk olm install` to allow setting a namespace when installing OLM.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/cmd/operator-sdk/olm/install.go
+++ b/internal/cmd/operator-sdk/olm/install.go
@@ -34,6 +34,7 @@ func newInstallCmd() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVar(&mgr.OLMNamespace, "namespace", installer.DefaultOLMNamespace, "namespace to install the OLM. If not set, the OLM will be installed in the default OLM namespace which is `olm`. ")
 	cmd.Flags().StringVar(&mgr.Version, "version", installer.DefaultVersion, "version of OLM resources to install")
 	mgr.AddToFlagSet(cmd.Flags())
 	return cmd

--- a/internal/olm/installer/client.go
+++ b/internal/olm/installer/client.go
@@ -75,7 +75,12 @@ func (c Client) InstallVersion(ctx context.Context, namespace, version string) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resources: %v", err)
 	}
-	objs := toObjects(resources...)
+	np := newNamespacePatcher()
+	namespacedResources, err := np.setObjectsNamespace(resources, namespace)
+	if err != nil {
+		return nil, err
+	}
+	objs := toObjects(namespacedResources...)
 
 	status := c.GetObjectsStatus(ctx, objs...)
 	installed, err := status.HasInstalledResources()

--- a/internal/olm/installer/namespace_patcher.go
+++ b/internal/olm/installer/namespace_patcher.go
@@ -1,0 +1,106 @@
+package installer
+
+import (
+	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"strings"
+)
+
+type namespacePatcher struct {
+	uc runtime.UnstructuredConverter
+}
+
+func newNamespacePatcher() *namespacePatcher {
+	return &namespacePatcher{
+		uc: runtime.DefaultUnstructuredConverter,
+	}
+}
+
+func (np *namespacePatcher) setObjectsNamespace(objs []unstructured.Unstructured, namespace string) ([]unstructured.Unstructured, error) {
+	result := make([]unstructured.Unstructured, 0, len(objs))
+	for i := range objs {
+		obj := &objs[i]
+		if err := np.setNamespace(obj, namespace); err != nil {
+			return nil, err
+		}
+
+		result = append(result, *obj)
+	}
+
+	return result, nil
+}
+
+func (np *namespacePatcher) setNamespace(obj *unstructured.Unstructured, namespace string) error {
+	objKind := obj.GetObjectKind().GroupVersionKind().Kind
+	if obj.GetNamespace() == DefaultOLMNamespace {
+		obj.SetNamespace(namespace)
+	}
+
+	if objKind == "Namespace" && obj.GetName() == DefaultOLMNamespace {
+		obj.SetName(namespace)
+	}
+
+	if objKind == "ClusterRoleBinding" {
+		err := np.setClusterRoleBindingNamespace(obj, namespace)
+		if err != nil {
+			return err
+		}
+	}
+
+	if objKind == "Deployment" && obj.GetName() == catalogOperatorName {
+		err := np.setDeploymentArgNamespace(obj, namespace)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (np *namespacePatcher) setDeploymentArgNamespace(obj *unstructured.Unstructured, namespace string) error {
+	var deploy appsv1.Deployment
+	if err := np.uc.FromUnstructured(obj.Object, &deploy); err != nil {
+		return err
+	}
+	args := deploy.Spec.Template.Spec.Containers[0].Args
+	for i, arg := range args {
+		if arg == "-namespace" || arg == "--namespace" {
+			args[i+1] = namespace
+			continue
+		}
+
+		if strings.HasPrefix(arg, "-namespace=") {
+			parts := strings.SplitN(arg, "=", 2)
+			args[i] = fmt.Sprintf("%s=%s", parts[0], namespace)
+			continue
+		}
+	}
+
+	o, err := np.uc.ToUnstructured(&deploy)
+	if err != nil {
+		return err
+	}
+	obj.Object = o
+	return nil
+}
+
+func (np *namespacePatcher) setClusterRoleBindingNamespace(obj *unstructured.Unstructured, namespace string) error {
+	var crb rbacv1.ClusterRoleBinding
+	if err := np.uc.FromUnstructured(obj.Object, &crb); err != nil {
+		return err
+	}
+	for i := range crb.Subjects {
+		if crb.Subjects[i].Namespace == DefaultOLMNamespace {
+			crb.Subjects[i].Namespace = namespace
+		}
+	}
+	o, err := np.uc.ToUnstructured(&crb)
+	if err != nil {
+		return err
+	}
+	obj.Object = o
+	return nil
+}

--- a/internal/olm/installer/namespace_patcher_test.go
+++ b/internal/olm/installer/namespace_patcher_test.go
@@ -1,0 +1,231 @@
+package installer
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+var converter = runtime.DefaultUnstructuredConverter
+
+func TestNamespacePatcher(t *testing.T) {
+	ts := []struct {
+		name          string
+		object        client.Object
+		assertCorrect func(*testing.T, *unstructured.Unstructured)
+	}{
+		{
+			name:   "patch namespaced resource",
+			object: newService(DefaultOLMNamespace),
+			assertCorrect: func(t *testing.T, actual *unstructured.Unstructured) {
+				var service corev1.Service
+				if err := converter.FromUnstructured(actual.Object, &service); err != nil {
+					t.Fatal(err)
+				}
+
+				if service.Namespace != "new-namespace" {
+					t.Fatalf("invalid namespace, got %s, want new-namespace", service.Namespace)
+				}
+			},
+		},
+		{
+			name:   "patch cluster-scoped resource",
+			object: newCRD(),
+			assertCorrect: func(t *testing.T, actual *unstructured.Unstructured) {
+				var crd apiextensions.CustomResourceDefinition
+				if err := converter.FromUnstructured(actual.Object, &crd); err != nil {
+					t.Fatal(err)
+				}
+
+				if crd.Namespace != "" {
+					t.Fatalf("invalid namespace, got %s, want empty value", crd.Namespace)
+				}
+			},
+		},
+		{
+			name:   "patch cluster role binding",
+			object: newClusterRoleBinding(),
+			assertCorrect: func(t *testing.T, actual *unstructured.Unstructured) {
+				var crb rbacv1.ClusterRoleBinding
+				if err := converter.FromUnstructured(actual.Object, &crb); err != nil {
+					t.Fatal(err)
+				}
+
+				if crb.Namespace != "" {
+					t.Fatalf("invalid namespace, got %s, want empty value", crb.Namespace)
+				}
+
+				if crb.Subjects[0].Namespace != "new-namespace" {
+					t.Fatalf("invalid namespace, got %s, want new-namespace", crb.Subjects[0].Namespace)
+				}
+
+				if crb.Subjects[1].Namespace != "non-olm-namespace" {
+					t.Fatalf("invalid namespace, got %s, want non-olm-namespace", crb.Subjects[1].Namespace)
+				}
+			},
+		},
+		{
+			name:   "patch deployment for catalog operator",
+			object: newDeployment(catalogOperatorName, false),
+			assertCorrect: func(t *testing.T, actual *unstructured.Unstructured) {
+				var deployment appsv1.Deployment
+				if err := converter.FromUnstructured(actual.Object, &deployment); err != nil {
+					t.Fatal(err)
+				}
+
+				args := deployment.Spec.Template.Spec.Containers[0].Args
+				if args[0] != "-namespace" {
+					t.Fatalf("invalid arg 0, got %s, want -namespace", args[0])
+				}
+				if args[1] != "new-namespace" {
+					t.Fatalf("invalid arg 1, got %s, want new-namespace", args[1])
+				}
+			},
+		},
+		{
+			name:   "patch deployment for catalog operator with single line args",
+			object: newDeployment(catalogOperatorName, true),
+			assertCorrect: func(t *testing.T, actual *unstructured.Unstructured) {
+				var deployment appsv1.Deployment
+				if err := converter.FromUnstructured(actual.Object, &deployment); err != nil {
+					t.Fatal(err)
+				}
+
+				args := deployment.Spec.Template.Spec.Containers[0].Args
+				if args[0] != "-namespace=new-namespace" {
+					t.Fatalf("invalid arg 0, got %s, want -namespace=new-namespace", args[0])
+				}
+			},
+		},
+		{
+			name:   "patch deployment for regular deployment",
+			object: newDeployment("regular deployment", false),
+			assertCorrect: func(t *testing.T, actual *unstructured.Unstructured) {
+				var deployment appsv1.Deployment
+				if err := converter.FromUnstructured(actual.Object, &deployment); err != nil {
+					t.Fatal(err)
+				}
+
+				args := deployment.Spec.Template.Spec.Containers[0].Args
+				if args[0] != "-namespace" {
+					t.Fatalf("invalid arg 0, got %s, want -namespace", args[0])
+				}
+				if args[1] != "olm" {
+					t.Fatalf("invalid arg 1, got %s, want olm", args[1])
+				}
+			},
+		},
+	}
+
+	for _, tc := range ts {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := toUnstructured(tc.object)
+			if err != nil {
+				t.Fatal(err)
+			}
+			np := newNamespacePatcher()
+			actual, err := np.setObjectsNamespace([]unstructured.Unstructured{u}, "new-namespace")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(actual) != 1 {
+				t.Fatalf("invalid response length, got %d, want 1", len(actual))
+			}
+
+			tc.assertCorrect(t, &actual[0])
+		})
+	}
+}
+
+func newDeployment(name string, singleLineArgs bool) *appsv1.Deployment {
+	var args []string
+	if singleLineArgs {
+		args = []string{"-namespace=" + DefaultOLMNamespace}
+	} else {
+		args = []string{"-namespace", DefaultOLMNamespace}
+	}
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "old-namespace",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Args: args,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newService(namespace string) *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "regular-service",
+			Namespace: namespace,
+		},
+	}
+}
+
+func newCRD() *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "crd",
+		},
+	}
+}
+
+func newClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ClusterRoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster-role-binding",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Name:      "subject1",
+				Namespace: DefaultOLMNamespace,
+			},
+			{
+				Name:      "subject1",
+				Namespace: "non-olm-namespace",
+			},
+		},
+	}
+}
+
+func toUnstructured(object client.Object) (unstructured.Unstructured, error) {
+	var u unstructured.Unstructured
+	o, err := converter.ToUnstructured(object)
+	if err != nil {
+		return unstructured.Unstructured{}, err
+	}
+	u.Object = o
+
+	return u, nil
+}

--- a/website/content/en/docs/cli/operator-sdk_olm_install.md
+++ b/website/content/en/docs/cli/operator-sdk_olm_install.md
@@ -13,6 +13,7 @@ operator-sdk olm install [flags]
 
 ```
   -h, --help               help for install
+      --namespace string   the OLM namespace (default "olm")
       --timeout duration   time to wait for the command to complete before failing (default 2m0s)
       --version string     version of OLM resources to install (default "latest")
 ```


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Allow users to set the namespace in the `operator-sdk olm install` command.

**Motivation for the change:**
We want to test bundles built for various environments locally and in the CI before publishing. In OpenShift clusters, OLM community catalogs are available in the `openshift-marketplace` namespace, and locally they are installed in the `olm` namespace. Installing OLM in a custom namespace would allow us to bridge the gap and have better parity between the two environments.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
