### PR TITLE
Update k8s docs link to 1.21

### DIFF
--- a/website/content/en/docs/building-operators/ansible/reference/webhooks.md
+++ b/website/content/en/docs/building-operators/ansible/reference/webhooks.md
@@ -165,5 +165,5 @@ Ansible-based Operator, you must
 
 
 [admission-controllers]:https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
-[validating-webhook]:https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#validatingwebhookconfiguration-v1-admissionregistration-k8s-io
-[mutating-webhook]:https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#mutatingwebhookconfiguration-v1-admissionregistration-k8s-io
+[validating-webhook]:https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#validatingwebhookconfiguration-v1-admissionregistration-k8s-io
+[mutating-webhook]:https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#mutatingwebhookconfiguration-v1-admissionregistration-k8s-io


### PR DESCRIPTION
Old link hardcodes to k8s 1.17 docs, which is no longer available https://kubernetes.io/docs/home/supported-doc-versions/