### PR TITLE
bump of/api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0
-	github.com/operator-framework/api v0.10.8-0.20211210181140-6897e9ad3883
+	github.com/operator-framework/api v0.11.1-0.20220110184307-ff6b5ebe3c25
 	github.com/operator-framework/java-operator-plugins v0.1.0
 	github.com/operator-framework/operator-lib v0.6.0
 	github.com/operator-framework/operator-registry v1.17.4

--- a/go.sum
+++ b/go.sum
@@ -906,8 +906,8 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/operator-framework/api v0.7.1/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
 github.com/operator-framework/api v0.10.0/go.mod h1:tV0BUNvly7szq28ZPBXhjp1Sqg5yHCOeX19ui9K4vjI=
-github.com/operator-framework/api v0.10.8-0.20211210181140-6897e9ad3883 h1:6AgeV76u7B7vuwDDMKneJg/jVFvqut35zBHfRMw0j8A=
-github.com/operator-framework/api v0.10.8-0.20211210181140-6897e9ad3883/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
+github.com/operator-framework/api v0.11.1-0.20220110184307-ff6b5ebe3c25 h1:MYC0rvZ5jrzS+2LdPpBhtz8sznyVL5jG7NTyIlSPy8s=
+github.com/operator-framework/api v0.11.1-0.20220110184307-ff6b5ebe3c25/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
 github.com/operator-framework/java-operator-plugins v0.1.0 h1:khkYsrkEG4m+wT+oPjZYmWXo8jd0QQ8E4agSrqrhPhU=
 github.com/operator-framework/java-operator-plugins v0.1.0/go.mod h1:sGKGELFkUeRqElcyvyPC89bC76YnCL7MPMa13P0AQcw=
 github.com/operator-framework/operator-lib v0.6.0 h1:srZoTL8P7OZUOovMkQkd4vwIbFzFNW413R/6V9N9rz4=


### PR DESCRIPTION
Just to get the update in the msg:

<img width="760" alt="Screenshot 2022-01-11 at 07 16 46" src="https://user-images.githubusercontent.com/7708031/148898947-8e66ae08-c850-4011-9cb7-49ec993fb7fa.png">

More about the diffs: https://github.com/operator-framework/api/compare/6897e9ad3883..ff6b5ebe3c25