### PR TITLE
Now operator-sdk bundle validate also ensures that the  annotation has a valid JSON

### DIFF
--- a/changelog/fragments/add-check-to-ensure-examples.yaml
+++ b/changelog/fragments/add-check-to-ensure-examples.yaml
@@ -1,0 +1,18 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Now operator-sdk bundle validate also ensures that the `alm-examples` annotation has a valid JSON ([More info](https://github.com/operator-framework/api/pull/207))
+      Introduction done by upgrading operator-framework/api from the commit `54878ea280f7c7402549dae568916dfb330b9262` to the release `v0.11.1`
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false
+

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.15.0
-	github.com/operator-framework/api v0.11.1-0.20220110184307-ff6b5ebe3c25
+	github.com/operator-framework/api v0.11.1
 	github.com/operator-framework/java-operator-plugins v0.1.0
 	github.com/operator-framework/operator-lib v0.6.0
 	github.com/operator-framework/operator-registry v1.17.4

--- a/go.sum
+++ b/go.sum
@@ -906,8 +906,8 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/operator-framework/api v0.7.1/go.mod h1:L7IvLd/ckxJEJg/t4oTTlnHKAJIP/p51AvEslW3wYdY=
 github.com/operator-framework/api v0.10.0/go.mod h1:tV0BUNvly7szq28ZPBXhjp1Sqg5yHCOeX19ui9K4vjI=
-github.com/operator-framework/api v0.11.1-0.20220110184307-ff6b5ebe3c25 h1:MYC0rvZ5jrzS+2LdPpBhtz8sznyVL5jG7NTyIlSPy8s=
-github.com/operator-framework/api v0.11.1-0.20220110184307-ff6b5ebe3c25/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
+github.com/operator-framework/api v0.11.1 h1:5eNUMplyL/GZrnBgG4SS2csO3+Fl4F79OqXN6POHQyA=
+github.com/operator-framework/api v0.11.1/go.mod h1:FTiYGm11fZQ3cSX+EQHc/UWoGZAwkGfyeHU+wMJ8jmA=
 github.com/operator-framework/java-operator-plugins v0.1.0 h1:khkYsrkEG4m+wT+oPjZYmWXo8jd0QQ8E4agSrqrhPhU=
 github.com/operator-framework/java-operator-plugins v0.1.0/go.mod h1:sGKGELFkUeRqElcyvyPC89bC76YnCL7MPMa13P0AQcw=
 github.com/operator-framework/operator-lib v0.6.0 h1:srZoTL8P7OZUOovMkQkd4vwIbFzFNW413R/6V9N9rz4=


### PR DESCRIPTION
**Description**

Now operator-sdk bundle validate also ensures that the `alm-examples` annotation has a valid JSON ([More info](https://github.com/operator-framework/api/pull/207)), see:

<img width="737" alt="Screenshot 2022-01-13 at 10 43 49" src="https://user-images.githubusercontent.com/7708031/149315600-decb7061-d4cd-4e0a-8325-2d3886f826cf.png">

PS: Introduction done by upgrading operator-framework/api from the commit `54878ea280f7c7402549dae568916dfb330b9262` to the release `v0.11.1`