### PR TITLE
fix: K8S_VERSION in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export GIT_VERSION = $(shell git describe --dirty --tags --always)
 export GIT_COMMIT = $(shell git rev-parse HEAD)
 export K8S_VERSION = 1.23
 # TODO: bump this to 1.21, after kubectl `--generator` flag is removed from e2e tests.
-export ENVTEST_K8S_VERSION = 1.21.1
+export ENVTEST_K8S_VERSION = 1.23.1
 
 # Build settings
 export TOOLS_DIR = tools/bin

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export IMAGE_VERSION = v1.16.0
 export SIMPLE_VERSION = $(shell (test "$(shell git describe)" = "$(shell git describe --abbrev=0)" && echo $(shell git describe)) || echo $(shell git describe --abbrev=0)+git)
 export GIT_VERSION = $(shell git describe --dirty --tags --always)
 export GIT_COMMIT = $(shell git rev-parse HEAD)
-export K8S_VERSION = 1.21
+export K8S_VERSION = 1.23
 # TODO: bump this to 1.21, after kubectl `--generator` flag is removed from e2e tests.
 export ENVTEST_K8S_VERSION = 1.21.1
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Set the `K8S_VERSION` to 1.23.

**Motivation for the change:**
Allow `K8S_VERSION` to match the actual K8S version we're using. 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
