### PR TITLE
website: Fix typo in reference link in quickstart-bundle.md

### DIFF
--- a/website/content/en/docs/olm-integration/quickstart-bundle.md
+++ b/website/content/en/docs/olm-integration/quickstart-bundle.md
@@ -32,7 +32,7 @@ $ export IMG=docker.io/$USERNAME/memcached-operator:v$VERSION // location where 
 $ export BUNDLE_IMG=docker.io/$USERNAME/memcached-operator-bundle:v$VERSION // location where your bundle will be hosted
 ```
 
-1. Create a bundle from the root directory of your project
+- Create a bundle from the root directory of your project
 
 ```sh
 $ make bundle
@@ -40,19 +40,19 @@ $ make bundle
 
 This will prompt you to enter basic information about your operator.
 
-1. Build and push the bundle image
+- Build and push the bundle image
 
 ```sh
 $ make bundle-build bundle-push
 ```
 
-1. Validate the bundle
+- Validate the bundle
 
 ```sh
 $ operator-sdk bundle validate $BUNDLE_IMG
 ```
 
-1. Install the bundle with OLM
+- Install the bundle with OLM
 
 ```sh
 $ operator-sdk run bundle $BUNDLE_IMG

--- a/website/content/en/docs/olm-integration/quickstart-bundle.md
+++ b/website/content/en/docs/olm-integration/quickstart-bundle.md
@@ -16,7 +16,8 @@ These features are unavailable to projects of version `2` or less; this informat
 your `PROJECT` file's `version` value.
 
 ## Prerequisites
-- Have a working operator that you have uploaded to a container registry. This guide assumes the simple Golang Memcached operator from [the building operators section][sdk-user-guid-go] at version `0.0.1`.
+
+- Have a working operator that you have uploaded to a container registry. This guide assumes the simple Golang Memcached operator from [the building operators section][sdk-user-guide-go] at version `0.0.1`.
 - User authorized with 'cluster-admin' permissions.
 - OLM installed on your cluster. The command `operator-sdk olm install` will attempt to install a basic OLM deployment on your cluster.
 


### PR DESCRIPTION
Update the reference link to the Go building-operators quickstart link.

Signed-off-by: timflannagan <timflannagan@gmail.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
