### PR TITLE
load_restrictor to load-restrictor

### DIFF
--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/molecule/mdefault/kustomize.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/molecule/mdefault/kustomize.go
@@ -38,8 +38,9 @@ func (f *Kustomize) SetTemplateDefaults() error {
 
 const kustomizeTemplate = `---
 - name: Build kustomize testing overlay
-  # load_restrictor must be set to none so we can load patch files from the default overlay
-  command: '{{ "{{ kustomize }}" }} build  --load_restrictor none .'
+  # load-restrictor must be set to none so we can load patch files from the default overlay
+  # use "--load-restrictor LoadRestrictionsNone" for kustomize 4+
+  command: '{{ "{{ kustomize }}" }} build  --load-restrictor none .'
   args:
     chdir: '{{ "{{ config_dir }}" }}/testing'
   register: resources


### PR DESCRIPTION
Signed-off-by: Leonardo Rossetti <lrossett@redhat.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

The ansible molecule template[1]  is using ` --load_restrictor` parameter in kustomize which is breaking molecule tests but replacing it with ` --load-restrictor` works fine.

[1] - https://github.com/operator-framework/operator-sdk/blob/master/internal/plugins/ansible/v1/scaffolds/internal/templates/molecule/mdefault/kustomize.go#L42

**Motivation for the change:**

The template generating `kustomize.yml` for ansible molecule tests is not using the correct CLI argument.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
