### PR TITLE
docs: update webhook link in go tutorial

### DIFF
--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -470,7 +470,7 @@ Next, check out the following:
 [builder_godocs]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/builder#example-Builder
 [activate_modules]: https://github.com/golang/go/wiki/Modules#how-to-install-and-activate-module-support
 [advanced-topics]: /docs/building-operators/golang/advanced-topics/
-[create_a_webhook]: https://book.kubebuilder.io/cronjob-tutorial/webhook-implementation.html
+[create_a_webhook]: /docs/building-operators/golang/webhook
 [status_marker]: https://book.kubebuilder.io/reference/generating-crd.html#status
 [status_subresource]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource
 [API-groups]:https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups


### PR DESCRIPTION
**Description of the change:**

Changes a link to Kubebuilder's webhook docs to point to the local docs instead.

**Motivation for the change:**

While reading I was slightly surprised that the link sent me straight to the Kubebuilder documentation because I was aware that a local webhook page existed.

The internal webhook page provides additional context on top of the Kubebuilder documentation, but links to the Kubebuilder documentation as well.

**Checklist**

- [x] Add or update relevant sections of the  website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
