### PR TITLE
Respect deployment labels in the CSV

### DIFF
--- a/changelog/fragments/respect-deployment-labels.yaml
+++ b/changelog/fragments/respect-deployment-labels.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Add the labels defined in the Manager (Operator Deployment) to the ClusterServiceVersions [`DeploymentSpecs`](https://github.com/operator-framework/api/blob/master/pkg/operators/v1alpha1/clusterserviceversion_types.go#L78) to ensure that they will also be provided to the integration with OLM (CSV).
+    kind: bugfix
+    breaking: false

--- a/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
@@ -203,8 +203,9 @@ func applyDeployments(c *collector.Manifests, strategy *operatorsv1alpha1.Strate
 	depSpecs := []operatorsv1alpha1.StrategyDeploymentSpec{}
 	for _, dep := range c.Deployments {
 		depSpecs = append(depSpecs, operatorsv1alpha1.StrategyDeploymentSpec{
-			Name: dep.GetName(),
-			Spec: dep.Spec,
+			Name:  dep.GetName(),
+			Spec:  dep.Spec,
+			Label: dep.Labels,
 		})
 	}
 	strategy.DeploymentSpecs = depSpecs

--- a/internal/generate/testdata/clusterserviceversions/output/memcached-operator-multiVersion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/output/memcached-operator-multiVersion.yaml
@@ -102,6 +102,8 @@ spec:
         serviceAccountName: default
       deployments:
       - name: memcached-operator-controller-manager
+        label:
+          control-plane: controller-manager
         spec:
           replicas: 1
           selector:

--- a/internal/generate/testdata/clusterserviceversions/output/memcached-operator.clusterserviceversion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/output/memcached-operator.clusterserviceversion.yaml
@@ -64,6 +64,8 @@ spec:
         serviceAccountName: default
       deployments:
       - name: memcached-operator-controller-manager
+        label:
+          control-plane: controller-manager
         spec:
           replicas: 1
           selector:

--- a/internal/generate/testdata/clusterserviceversions/output/with-ui-metadata.clusterserviceversion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/output/with-ui-metadata.clusterserviceversion.yaml
@@ -108,6 +108,8 @@ spec:
         serviceAccountName: default
       deployments:
       - name: memcached-operator-controller-manager
+        label:
+          control-plane: controller-manager
         spec:
           replicas: 1
           selector:

--- a/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -92,7 +92,9 @@ spec:
           - create
         serviceAccountName: memcached-operator-controller-manager
       deployments:
-      - name: memcached-operator-controller-manager
+      - label:
+          control-plane: controller-manager
+        name: memcached-operator-controller-manager
         spec:
           replicas: 1
           selector:

--- a/testdata/go/v2/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v2/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -95,7 +95,9 @@ spec:
           - create
         serviceAccountName: default
       deployments:
-      - name: memcached-operator-controller-manager
+      - label:
+          control-plane: controller-manager
+        name: memcached-operator-controller-manager
         spec:
           replicas: 1
           selector:

--- a/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -96,7 +96,9 @@ spec:
           - create
         serviceAccountName: memcached-operator-controller-manager
       deployments:
-      - name: memcached-operator-controller-manager
+      - label:
+          control-plane: controller-manager
+        name: memcached-operator-controller-manager
         spec:
           replicas: 1
           selector:

--- a/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -180,7 +180,9 @@ spec:
           - create
         serviceAccountName: memcached-operator-controller-manager
       deployments:
-      - name: memcached-operator-controller-manager
+      - label:
+          control-plane: controller-manager
+        name: memcached-operator-controller-manager
         spec:
           replicas: 1
           selector:


### PR DESCRIPTION
**Description of the change:**
This change adds the labels of the deployment to the ClusterServiceVersions [`DeploymentSpecs`](https://github.com/operator-framework/api/blob/8e593f1c42b91ec75bf0787a28100a5f31690898/pkg/operators/v1alpha1/clusterserviceversion_types.go#L78). So the labels defined for the deployment (and defined in its manifest) will be applied too, if the operator gets bundled and  installed via OLM.

**Motivation for the change:**
Currently the CSV does not contain the labels of the deployment in the deployment spec, even there is a field for it ([clusterserviceversion_types.go#L71](https://github.com/operator-framework/api/blob/8e593f1c42b91ec75bf0787a28100a5f31690898/pkg/operators/v1alpha1/clusterserviceversion_types.go#L71)). 
This leads to missing labels of the deployment, when the operator is bundled and installed via OLM. This PR addresses it and adds the deployment labels to the CSV.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))  <- _not sure if this fix is seen as user-facing change_.
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
