### PR TITLE
chore: bump java-operator-plugins to v0.2.0

### DIFF
--- a/changelog/fragments/01-bump-java-operator-plugins.yaml
+++ b/changelog/fragments/01-bump-java-operator-plugins.yaml
@@ -1,0 +1,53 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      (java/v1alpha) bumping the java-operator-plugins dependency to v0.2.0.
+      This release includes the following items.
+
+      ### Additions
+      - chore: bump go 1.17, k8s 1.23, and kubebuilder 3.3 (#69)
+      - chore(deps): update to Quarkus SDK extension 3.0.2 and Quarkus 2.6.3 (#70)
+      - chore(deps): update to use Quarkus JOSDK extension 3.0.1 (#67)
+      - Remove useless file (#65)
+      - chore: bump k8s 1.22.2 and kubebuilder 3.2 (#64)
+      - exposed endpoints for micrometer metrics (#45)
+      - modified the Quarkus operator SDK version and tutorial too (#40)
+      - chore: bump fabric8 5.8.0 & quarkus 2.4.0 (#42)
+      - modified the doc file and removed file after generation (#41)
+      - release: fix release script to understand release branches (#38)
+
+      ### Bug Fixes
+      - Fix for wrongly generated file name (#73)
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: Header text for the migration section
+      body: |
+        Body of the migration section. This should be formatted as markdown and can
+        span multiple lines.
+
+        Using the YAML string '|' operator means that newlines in this string will
+        be honored and interpretted as newlines in the rendered markdown.

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/onsi/gomega v1.17.0
 	github.com/operator-framework/api v0.11.2-0.20220118170607-6b187a1d0908
 	github.com/operator-framework/helm-operator-plugins v0.0.9
-	github.com/operator-framework/java-operator-plugins v0.1.0
+	github.com/operator-framework/java-operator-plugins v0.2.0
 	github.com/operator-framework/operator-lib v0.10.0
 	github.com/operator-framework/operator-registry v1.19.5
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -932,8 +932,8 @@ github.com/operator-framework/api v0.11.2-0.20220118170607-6b187a1d0908 h1:pD3v8
 github.com/operator-framework/api v0.11.2-0.20220118170607-6b187a1d0908/go.mod h1:OLKAZHSlVAjOHpeduyIQSQBTcI67asjV3w7E1W0FL8E=
 github.com/operator-framework/helm-operator-plugins v0.0.9 h1:G5aBY5sPrNXcRiKLpAaBMOYm7q0+qCmk9XWOAL/ZJuc=
 github.com/operator-framework/helm-operator-plugins v0.0.9/go.mod h1:LFi/PUYE+xA5ubF3ZrleYE1Ez7cphJzSYpjHAyLiNwQ=
-github.com/operator-framework/java-operator-plugins v0.1.0 h1:khkYsrkEG4m+wT+oPjZYmWXo8jd0QQ8E4agSrqrhPhU=
-github.com/operator-framework/java-operator-plugins v0.1.0/go.mod h1:sGKGELFkUeRqElcyvyPC89bC76YnCL7MPMa13P0AQcw=
+github.com/operator-framework/java-operator-plugins v0.2.0 h1:nIc3/pmH9j9lA6IzcnBBOl1D1V7XFculETUJrucOcrk=
+github.com/operator-framework/java-operator-plugins v0.2.0/go.mod h1:38ZUfA6J5JQjPZLQJZKyXE3v+t91mpJ2utAtVCDQTY0=
 github.com/operator-framework/operator-lib v0.3.0/go.mod h1:LTp5UQd8ivq4MXqm/W/XHulHQ0RRoZXsAj73sNMAQxc=
 github.com/operator-framework/operator-lib v0.10.0 h1:tTjrt8Udi0msABkMpgxKHp7sXKnC73jFPO5Col0tWso=
 github.com/operator-framework/operator-lib v0.10.0/go.mod h1:sdCls/olFjSHLXU0bHlaPtmyeIdentoxz/9miyw27kw=
@@ -1495,7 +1495,6 @@ golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1846,7 +1845,6 @@ k8s.io/apimachinery v0.19.4/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlm
 k8s.io/apimachinery v0.20.2/go.mod h1:WlLqWAHZGg07AeltaI0MV5uk1Omp8xaN0JGLY6gkRpU=
 k8s.io/apimachinery v0.21.0/go.mod h1:jbreFvJo3ov9rj7eWT7+sYiRx+qZuCYXwWT1bcDswPY=
 k8s.io/apimachinery v0.21.1/go.mod h1:jbreFvJo3ov9rj7eWT7+sYiRx+qZuCYXwWT1bcDswPY=
-k8s.io/apimachinery v0.21.2/go.mod h1:CdTY8fU/BlvAbJ2z/8kBwimGki5Zp8/fbVuLY8gJumM=
 k8s.io/apimachinery v0.22.0/go.mod h1:O3oNtNadZdeOMxHFVxOreoznohCpy0z6mocxbZr7oJ0=
 k8s.io/apimachinery v0.22.2/go.mod h1:O3oNtNadZdeOMxHFVxOreoznohCpy0z6mocxbZr7oJ0=
 k8s.io/apimachinery v0.23.0/go.mod h1:fFCTTBKvKcwTPFzjlcxp91uPFZr+JA0FubU4fLzzFYc=
@@ -1962,7 +1960,6 @@ sigs.k8s.io/controller-tools v0.8.0/go.mod h1:qE2DXhVOiEq5ijmINcFbqi9GZrrUjzB1Tu
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 h1:fD1pz4yfdADVNfFmcP2aBEtudwUQ1AlLnRBALr33v3s=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=
 sigs.k8s.io/kind v0.11.1/go.mod h1:fRpgVhtqAWrtLB9ED7zQahUimpUXuG/iHT88xYqEGIA=
-sigs.k8s.io/kubebuilder/v3 v3.0.0-alpha.0.0.20210702145813-742983631190/go.mod h1:pUhjQx9f/+cn1OtSa5zMohY1lgk9s/9Mbcvwj82lrNk=
 sigs.k8s.io/kubebuilder/v3 v3.3.0 h1:rl1d7qHajPDS83bM9IhR85jtEBTRZzQziWwAGYTsadE=
 sigs.k8s.io/kubebuilder/v3 v3.3.0/go.mod h1:573SPrO9ttCNPvXVuGQRCpjsEsFza/S+8Jo/b+a+wR0=
 sigs.k8s.io/kustomize/api v0.8.5/go.mod h1:M377apnKT5ZHJS++6H4rQoCHmWtt6qTpp3mbe7p6OLY=


### PR DESCRIPTION
**Description of the change:**
java-operator-plugins release: https://github.com/operator-framework/java-operator-plugins/releases/tag/v0.2.0

Additions:

- chore: bump go 1.17, k8s 1.23, and kubebuilder 3.3
- chore(deps): update to Quarkus SDK extension 3.0.2 and Quarkus 2.6.3
- chore(deps): update to use Quarkus JOSDK extension 3.0.1
- Remove useless file
- chore: bump k8s 1.22.2 and kubebuilder 3.2
- exposed exnpoints for micrometer metrics
- modified the Quarkus operator SDK version and tutorial too
- chore: bump fabric8 5.8.0 & quarkus 2.4.0
- modified the doc file and removed file after generation
- release: fix release script to understand release branches

Bug Fixes:

- Fix for wrongly generated file name

Signed-off-by: jesus m. rodriguez <jesusr@redhat.com>


**Motivation for the change:**
Update to latest java-operator-plugins

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
