### PR TITLE
fix: trim quotes in interactive input

### DIFF
--- a/changelog/fragments/trim-quotes-input.yaml
+++ b/changelog/fragments/trim-quotes-input.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Fixed a bug in `generate kustomze manifest` that quotes from interactive input were not trimmed properly.
+    kind: bugfix
+    breaking: false

--- a/internal/util/projutil/interactive_promt_util.go
+++ b/internal/util/projutil/interactive_promt_util.go
@@ -90,7 +90,7 @@ func readLine(reader *bufio.Reader) string {
 	if err != nil {
 		log.Fatalf("Error when reading input: %v", err)
 	}
-	return strings.TrimSpace(text)
+	return strings.Trim(strings.TrimSpace(text), "`'\"")
 }
 
 func readInput(reader *bufio.Reader) string {

--- a/internal/util/projutil/interactive_promt_util_test.go
+++ b/internal/util/projutil/interactive_promt_util_test.go
@@ -47,6 +47,14 @@ func TestUserInput(t *testing.T) {
 			},
 			want: "Memcached Operator",
 		},
+		{
+			name: "test when user provides quoted input to the command",
+			args: args{
+				msg:     "Enter a word: ",
+				content: []byte("'Memcached Operator'\n"),
+			},
+			want: "Memcached Operator",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #5499 

Signed-off-by: Ryo Imai <iryo@jp.ibm.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

This PR changes the handling of interactive input string to trim quotes (double quotes, single quotes, back quotes) to fix #5499 . The functions depending on the changed function are only used for generating bundle CSV base manifests first time. So, I assume the impact by this change is limited. 

**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
