### PR TITLE
chore(e2e-molecule): Watch own namespace only

### DIFF
--- a/hack/generate/samples/internal/ansible/constants.go
+++ b/hack/generate/samples/internal/ansible/constants.go
@@ -560,3 +560,21 @@ const customMetricsTest = `
       - "'histogram_test_sum 2' in metrics_output.stdout"
 
 `
+
+const watchNamespacePatch = `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+`


### PR DESCRIPTION
Fixes #5547

Signed-off-by: Ryo Imai <iryo@jp.ibm.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

`memcached-molecule-operator` used in e2e molecule test watches k8s core resources (`Secret`). Thus running the operator in cluster-scope causes watching all Secrets in the cluster, which causes high load of the operator and leads to resource creation timeout in the test case.

I locally verified that configuring the operator to watch own namespace workarounds the issue.

**Motivation for the change:**

Make running e2e test on local machine, where available computational resources could be limited compared to CI environment, more stable.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
