### PR TITLE
Fix wrong bundle name and add clarification

### DIFF
--- a/website/content/en/docs/building-operators/helm/quickstart.md
+++ b/website/content/en/docs/building-operators/helm/quickstart.md
@@ -49,10 +49,15 @@ This guide walks through an example of building a simple nginx-operator powered 
   operator-sdk olm install
   ```
 
-1. Bundle your operator, then build and push the bundle image (defaults to `example.com/nginx-operator-bundle:v0.0.1`):
+1. Bundle your operator:
 
   ```sh
   make bundle IMG="example.com/nginx-operator:v0.0.1"
+  ```
+
+1. Push the bundle image. Defaults to `example.com/nginx-operator-bundle:v0.0.1`. You can set IMAGE_TAG_BASE to override the image tag (e.g. 1IMAGE_TAG_BASE=quay.io/example/nginx-operator1:
+
+  ```sh
   make bundle-build bundle-push
   ```
 
@@ -60,7 +65,7 @@ This guide walks through an example of building a simple nginx-operator powered 
 has a custom CA, these [configuration steps][image-reg-config] must be complete.
 
   ```sh
-  operator-sdk run bundle example.com/memcached-operator-bundle:v0.0.1
+  operator-sdk run bundle example.com/nginx-operator-bundle:v0.0.1
   ```
 
 1. Create a sample Nginx custom resource:

--- a/website/content/en/docs/building-operators/helm/quickstart.md
+++ b/website/content/en/docs/building-operators/helm/quickstart.md
@@ -55,7 +55,7 @@ This guide walks through an example of building a simple nginx-operator powered 
   make bundle IMG="example.com/nginx-operator:v0.0.1"
   ```
 
-1. Push the bundle image. Defaults to `example.com/nginx-operator-bundle:v0.0.1`. You can set IMAGE_TAG_BASE to override the image tag (e.g. 1IMAGE_TAG_BASE=quay.io/example/nginx-operator1:
+1. Push the bundle image. Defaults to `example.com/nginx-operator-bundle:v0.0.1`. You can set IMAGE_TAG_BASE to override the image tag (e.g. IMAGE_TAG_BASE=quay.io/example/nginx-operator1:)
 
   ```sh
   make bundle-build bundle-push


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Fixes a wrong bundle name (memcached, should be nginx) and adds more clarification about how to override image tag name so that the user knows how to complete the tutorial.

**Motivation for the change:**
While following the tutorial I found the wrong bundle name, then I wasn't able to do the bundle-push step since I had a different image tag. I had to dig in the Makefile to find out how to override that. The docs showed how to override IMG, so it's inconsistent not to state how to override `IMAGE_TAG_BASE`, which a user will need to do if they overrode IMG.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
