### PR TITLE
Add support for custom annotations to metadata annotations and bundle.Dockerfile

### DIFF
--- a/internal/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/internal/cmd/operator-sdk/generate/bundle/bundle.go
@@ -276,12 +276,26 @@ func (c bundleCmd) runMetadata() error {
 		}
 	}
 
+	cLabels := bundleutil.CustomMetaDataLabels{}
+	customAnno := filepath.Join(c.customAnno, "annotations.yaml")
+	if genutil.IsExist(customAnno) {
+		file, err := ioutil.ReadFile(customAnno)
+		if err != nil {
+			return err
+		}
+
+		if err := yaml.Unmarshal(file, &cLabels); err != nil {
+			return err
+		}
+	}
+
 	bundleMetadata := bundleutil.BundleMetaData{
 		BundleDir:            c.outputDir,
 		PackageName:          c.packageName,
 		Channels:             c.channels,
 		DefaultChannel:       c.defaultChannel,
 		OtherLabels:          metricsannotations.MakeBundleMetadataLabels(c.layout),
+		CustomLabels:         cLabels.Annotations,
 		IsScoreConfigPresent: true,
 	}
 

--- a/internal/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/generate/bundle/cmd.go
@@ -36,6 +36,7 @@ type bundleCmd struct {
 	kustomizeDir string
 	deployDir    string
 	crdsDir      string
+	customAnno   string
 	stdout       bool
 	quiet        bool
 	// ServiceAccount names to consider outside of the operator's service account.
@@ -129,6 +130,8 @@ func (c *bundleCmd) addFlagsTo(fs *pflag.FlagSet) {
 		"This option can only be used if --deploy-dir is set")
 	fs.StringVar(&c.kustomizeDir, "kustomize-dir", filepath.Join("config", "manifests"),
 		"Directory containing kustomize bases in a \"bases\" dir and a kustomization.yaml for operator-framework manifests")
+	fs.StringVar(&c.customAnno, "custom-annotations", filepath.Join("config", "metadata"),
+		"Directory containing custom annotations for operator bundle metadata")
 	fs.StringVar(&c.channels, "channels", "alpha", "A comma-separated list of channels the bundle belongs to")
 	fs.StringVar(&c.defaultChannel, "default-channel", "", "The default channel for the bundle")
 	fs.StringSliceVar(&c.extraServiceAccounts, "extra-service-accounts", nil,

--- a/internal/util/bundleutil/bundleutil.go
+++ b/internal/util/bundleutil/bundleutil.go
@@ -65,6 +65,9 @@ type BundleMetaData struct {
 
 	// Other labels to be added in CSV.
 	OtherLabels map[string]string
+
+	// Custom labels to be added in CSV.
+	CustomLabels map[string]string
 }
 
 // values to populate bundle metadata/Dockerfile.
@@ -74,7 +77,13 @@ type annotationsValues struct {
 	Channels                 string
 	DefaultChannel           string
 	OtherLabels              []string
+	CustomLabels             []string
 	IsScorecardConfigPresent bool
+}
+
+// CustomMetaDataLabels contains custom metadata for bundles.
+type CustomMetaDataLabels struct {
+	Annotations map[string]string
 }
 
 // GenerateMetadata scaffolds annotations.yaml and bundle.Dockerfile with the provided
@@ -99,6 +108,11 @@ func (meta *BundleMetaData) GenerateMetadata() error {
 		values.OtherLabels = append(values.OtherLabels, fmt.Sprintf("%s=%s", k, v))
 	}
 	sort.Strings(values.OtherLabels)
+
+	for k, v := range meta.CustomLabels {
+		values.CustomLabels = append(values.CustomLabels, fmt.Sprintf("%s=%s", k, v))
+	}
+	sort.Strings(values.CustomLabels)
 
 	// Write each file
 	metadataDir := filepath.Join(meta.BundleDir, defaultMetadataDir)

--- a/internal/util/bundleutil/template.go
+++ b/internal/util/bundleutil/template.go
@@ -52,6 +52,15 @@ COPY {{ .BundleDir }}/manifests /manifests/
 COPY {{ .BundleDir }}/metadata /metadata/
 {{- if .IsScorecardConfigPresent }}
 COPY {{ .BundleDir }}/tests/scorecard /tests/scorecard/
+
+{{- if .CustomLabels }}
+
+# Custom project labels.
+{{- range $i, $l := .CustomLabels }}
+LABEL {{ $l }}
+{{- end }}
+{{- end }}
+
 {{- end }}
 `))
 
@@ -75,5 +84,14 @@ var annotationsTemplate = template.Must(template.New("").Funcs(funcs).Parse(`ann
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+
+  {{- if .CustomLabels }}
+
+  # Custom project annotations.
+  {{- range $i, $l := .CustomLabels }}
+  {{ toYAML $l }}
+  {{- end }}
+  {{- end }}
+
   {{- end }}
 `))


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

- Add capability for a project to add custom labels to bundle.Dockerfile and metadata annotations.yaml.
  This can be done by creating `config/metadata/annotations.yaml` which will allow changes to happen
  to annotations.yaml and bundle.Dockerfile in the operator-sdk code independently of a project's desired
  custom annotations.

**Motivation for the change:**

`operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)` consistently overwrites any custom annotations applied to `bundle/metadata/annotations.yaml` and `bundle.Dockerfile`. To add any custom annotations, you have to remove `--overwrite` and manually maintain these files which also means that `make bundle` will no longer make any changes that a project may want to happen to `bundle/metadata/annotations.yaml` and `bundle.Dockerfile`. This PR allows the best of both worlds where a project can inject custom labels simply by creating 
`config/metadata/annotations.yaml`, and the operator-sdk can continue if necessary to update/change the base settings as needed.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
