### PR TITLE
bump api to get fix in the bundle size check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
-	github.com/operator-framework/api v0.11.2-0.20220208215419-e8208e3dcf33
+	github.com/operator-framework/api v0.11.2-0.20220222220053-bbe9c3235aff
 	github.com/operator-framework/helm-operator-plugins v0.0.9
 	github.com/operator-framework/java-operator-plugins v0.2.0
 	github.com/operator-framework/operator-lib v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -928,8 +928,8 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/operator-framework/api v0.4.0/go.mod h1:xXYReW8+PpSBHMxsf0e7uhtfQTLqIM1iz4X6zUs20+c=
 github.com/operator-framework/api v0.10.0/go.mod h1:tV0BUNvly7szq28ZPBXhjp1Sqg5yHCOeX19ui9K4vjI=
 github.com/operator-framework/api v0.10.5/go.mod h1:tV0BUNvly7szq28ZPBXhjp1Sqg5yHCOeX19ui9K4vjI=
-github.com/operator-framework/api v0.11.2-0.20220208215419-e8208e3dcf33 h1:yOfR9ehPoeux2EUu+8wYzRwIeIPTC+v4lcrNcGGDl4k=
-github.com/operator-framework/api v0.11.2-0.20220208215419-e8208e3dcf33/go.mod h1:r/erkmp9Kc1Al4dnxmRkJYc0uCtD5FohN9VuJ5nTxz0=
+github.com/operator-framework/api v0.11.2-0.20220222220053-bbe9c3235aff h1:s0YTm8hQ363DhZiGo7QZgkiteauTIYb7oGUElW3PQnQ=
+github.com/operator-framework/api v0.11.2-0.20220222220053-bbe9c3235aff/go.mod h1:r/erkmp9Kc1Al4dnxmRkJYc0uCtD5FohN9VuJ5nTxz0=
 github.com/operator-framework/helm-operator-plugins v0.0.9 h1:G5aBY5sPrNXcRiKLpAaBMOYm7q0+qCmk9XWOAL/ZJuc=
 github.com/operator-framework/helm-operator-plugins v0.0.9/go.mod h1:LFi/PUYE+xA5ubF3ZrleYE1Ez7cphJzSYpjHAyLiNwQ=
 github.com/operator-framework/java-operator-plugins v0.2.0 h1:nIc3/pmH9j9lA6IzcnBBOl1D1V7XFculETUJrucOcrk=


### PR DESCRIPTION
**Description**

bump api to get the fix in the bundle size check
See: https://github.com/operator-framework/api/pull/227

PS.: Not added to changelog because this check was not shipped yet. It is part of the next release 1.18.0. See: https://github.com/operator-framework/operator-sdk/pull/5552


<img width="734" alt="Screenshot 2022-02-22 at 21 37 53" src="https://user-images.githubusercontent.com/7708031/155243643-887c4497-56d8-4d80-9ca2-3a412cfd0e64.png">
<img width="723" alt="Screenshot 2022-02-22 at 21 38 40" src="https://user-images.githubusercontent.com/7708031/155243708-f3eea402-e296-4e62-b1fa-56c7b4666ec4.png">

