### PR TITLE
Removed Repetitive word

### DIFF
--- a/website/content/en/docs/building-operators/golang/quickstart.md
+++ b/website/content/en/docs/building-operators/golang/quickstart.md
@@ -12,7 +12,7 @@ This guide walks through an example of building a simple memcached-operator usin
 - Go through the [installation guide][install-guide].
 - User authorized with `cluster-admin` permissions.
 - An accessible image registry for various operator images (ex. [hub.docker.com](https://hub.docker.com/signup),
-[quay.io](https://quay.io/)) and be logged in in your command line environment.
+[quay.io](https://quay.io/)) and be logged in your command line environment.
   - `example.com` is used as the registry Docker Hub namespace in these examples.
   Replace it with another value if using a different registry or namespace.
   - [Authentication and certificates][image-reg-config] if the registry is private or uses a custom CA.


### PR DESCRIPTION
Removed a repetitive word `in`.

**Description of the change:**
Removed a repetitive word `in` in the quickstart documentation.

**Motivation for the change:**
To correct the quickstart guide for improving the interpretation.