### PR TITLE
add darwin-arm64 build to goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,7 @@ builds:
       - -X {{ .Env.REPO }}/internal/version.ImageVersion={{ .Env.IMAGE_VERSION }}
     targets: &build-targets
       - darwin_amd64
+      - darwin_arm64
       - linux_amd64
       - linux_arm64
       - linux_ppc64le

--- a/changelog/fragments/darwin-arm64.yaml
+++ b/changelog/fragments/darwin-arm64.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Add official binary builds for `darwin/arm64`
+    kind: addition
+    breaking: false

--- a/website/content/en/docs/overview/_index.md
+++ b/website/content/en/docs/overview/_index.md
@@ -100,9 +100,9 @@ Official build architectures for binaries:
 
 | Binary                    | `linux/amd64` | `linux/arm64` |`linux/ppc64le` | `linux/s390x` | `darwin/amd64` | `darwin/arm64` |
 |---------------------------|---------------|---------------|----------------|---------------|----------------|----------------|
-| `operator-sdk`            | ✓             | ✓             | ✓              | ✓             | ✓              | -              |
-| `ansible-operator`        | ✓             | ✓             | ✓              | ✓             | ✓              | -              |
-| `helm-operator`           | ✓             | ✓             | ✓              | ✓             | ✓              | -              |
+| `operator-sdk`            | ✓             | ✓             | ✓              | ✓             | ✓              | ✓              |
+| `ansible-operator`        | ✓             | ✓             | ✓              | ✓             | ✓              | ✓              |
+| `helm-operator`           | ✓             | ✓             | ✓              | ✓             | ✓              | ✓              |
 
 Official build architectures for images:
 


### PR DESCRIPTION
Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

**Description of the change:**
Add binary builds for `darwin/arm64`

**Motivation for the change:**
I have a Mac M1 machine :)

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
