### PR TITLE
Closes #5565: Helm reconcile period from CR annotations or watches.yaml

### DIFF
--- a/changelog/fragments/helm-annotations-reconcile-period.yaml
+++ b/changelog/fragments/helm-annotations-reconcile-period.yaml
@@ -1,0 +1,11 @@
+entries:
+  - description: >
+      For the helm/v1 plugin, parsed the "helm.sdk.operatorframework.io/reconcile-period" 
+      value from the custom resource annotations for helm operators. This value is then 
+      set to the 'ReconcilePeriod' field of the reconciler to reconcile the cluster
+      in the specified intervals of time.
+
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/cmd/helm-operator/run/cmd.go
+++ b/internal/cmd/helm-operator/run/cmd.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -194,11 +195,16 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 	}
 	for _, w := range ws {
 		// Register the controller with the factory.
+		reconcilePeriod := f.ReconcilePeriod
+		if w.ReconcilePeriod.Duration != time.Duration(0) {
+			reconcilePeriod = w.ReconcilePeriod.Duration
+		}
+
 		err := controller.Add(mgr, controller.WatchOptions{
 			Namespace:               namespace,
 			GVK:                     w.GroupVersionKind,
 			ManagerFactory:          release.NewManagerFactory(mgr, w.ChartDir),
-			ReconcilePeriod:         f.ReconcilePeriod,
+			ReconcilePeriod:         reconcilePeriod,
 			WatchDependentResources: *w.WatchDependentResources,
 			OverrideValues:          w.OverrideValues,
 			MaxConcurrentReconciles: f.MaxConcurrentReconciles,

--- a/internal/helm/watches/watches.go
+++ b/internal/helm/watches/watches.go
@@ -40,6 +40,7 @@ type Watch struct {
 	WatchDependentResources *bool                `json:"watchDependentResources,omitempty"`
 	OverrideValues          map[string]string    `json:"overrideValues,omitempty"`
 	Selector                metav1.LabelSelector `json:"selector"`
+	ReconcilePeriod         metav1.Duration      `json:"reconcilePeriod,omitempty"`
 }
 
 // UnmarshalYAML unmarshals an individual watch from the Helm watches.yaml file

--- a/website/content/en/docs/building-operators/helm/reference/advanced_features/reconcile-period.md
+++ b/website/content/en/docs/building-operators/helm/reference/advanced_features/reconcile-period.md
@@ -1,0 +1,26 @@
+---
+title: Reconcile Period from Custom Resource Annotations
+linkTitle: Custom Resource Annotations Reconcile Period
+weight: 200
+description: Allow a user to set the desired reconcile period from the custom resource's annotations
+---
+
+While running a Helm-based operator, the reconcile-period can be specified through the custom resource's annotations under the `helm.sdk.operatorframework.io/reconcile-period` key. 
+This feature guarantees that an operator will get reconciled, at minimum, in the specified interval of time. In other words, it ensures that the cluster will not go longer
+than the specified reconcile-period without being reconciled. However, the cluster may be reconciled at any moment if there are changes detected in the desired state.
+
+The reconcile period can be specified in the custom resource's annotations in the following manner: 
+
+```sh
+...
+metadata:
+  name: nginx-sample
+  annotations:
+    helm.sdk.operatorframework.io/reconcile-period: 5s
+...
+```
+
+The value that is present under this key must be in the h/m/s format. For example, 1h2m4s, 3m0s, 4s are all valid values, but 1x3m9s is invalid. 
+
+**NOTE**: This is just one way of specifying the reconcile period for Helm-based operators. There are two other ways: using the `--reconcile-period` command-line flag and under the 'reconcilePeriod'
+key in the watches.yaml file. If these three methods are used simultaneously to specify reconcile period (which they should not be), the order of precedence is as follows. Custom Resource Annotations > watches.yaml > command-line flag.


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
1. Added the parsing of the `helm.sdk.operatorframework.io/reconcile-period` key in the custom resource's annotations. 
2. Added the option to specify the reconcile-period through the `watches.yaml` file.

The value obtained from either of these two is set to the `RequeueAfter` field of the reconciler for Helm. If both are specified, then the CR annotations takes precedence.

**Motivation for the change:**
Close #5565 

**Checklist**
- [x] Add a new changelog fragment in `changelog/fragments`
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)


**Note:**
As mentioned in my [comment](https://github.com/operator-framework/operator-sdk/issues/5565#issuecomment-1049421940) on the issue: this functionality already exists via a command line flag. This PR is to provide the user with the option of doing the same in the CR annotations or `watches.yaml`, which there seems to be a demand for. This feature already exists for the Ansible-based operator, so I thought it would be a good idea to do the same for the Helm-based operator. 

The current order of precedence is: flag < watches < CR annotations.