### PR TITLE
(docs) Remove Red Hat links

### DIFF
--- a/website/layouts/partials/footer.html
+++ b/website/layouts/partials/footer.html
@@ -19,10 +19,6 @@
   </div>
   <div class="of-footer-main__copyright">
     <p>Copyright &copy; 2020</p>
-    <ul class="of-link-list">
-      <li class="of-link-list__li"><a href="https://www.redhat.com/en/about/privacy-policy">Privacy Statement</a></li>
-      <!-- <li class="of-link-list__li"><a href="/terms/">Terms of Use</a></li> -->
-    </ul>
     <a class="of-footer-main__badge" href="https://www.netlify.com">
       <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify" />
     </a>

--- a/website/layouts/partials/head.html
+++ b/website/layouts/partials/head.html
@@ -1,4 +1,3 @@
-<script id="dpal" src="//www.redhat.com/ma/dpal-staging.js" type="text/javascript"></script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{ hugo.Generator }}


### PR DESCRIPTION

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

This PR removes a RedHat specific script and the RedHat
Privacy statement link from the documentation site.


**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
