### PR TITLE
log error for url verification failure

### DIFF
--- a/changelog/fragments/log-error-url-verification.yaml
+++ b/changelog/fragments/log-error-url-verification.yaml
@@ -1,0 +1,9 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Added log so that URL verification errors when starting the ansible-operator are not silently swallowed.
+
+    kind: "addition"
+
+    breaking: false

--- a/internal/cmd/ansible-operator/run/cmd.go
+++ b/internal/cmd/ansible-operator/run/cmd.go
@@ -112,6 +112,7 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 	}
 
 	if err := verifyCfgURL(cfg.Host); err != nil {
+		log.Error(err, "URL verification failed.")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
**Description of the change:**
Simply logs the already generated error prior to exiting

**Motivation for the change:**
Prevent silent exit of ansible-operator when URL fails verification.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Apologies if I haven't followed the process correctly.