### PR TITLE
Close #5594: Ansible reconcile-period CLI flag

### DIFF
--- a/internal/ansible/watches/watches.go
+++ b/internal/ansible/watches/watches.go
@@ -46,7 +46,7 @@ type Watch struct {
 	Role                        string                    `yaml:"role"`
 	Vars                        map[string]interface{}    `yaml:"vars"`
 	MaxRunnerArtifacts          int                       `yaml:"maxRunnerArtifacts"`
-	ReconcilePeriod             time.Duration             `yaml:"reconcilePeriod"`
+	ReconcilePeriod             metav1.Duration           `yaml:"reconcilePeriod"`
 	Finalizer                   *Finalizer                `yaml:"finalizer"`
 	ManageStatus                bool                      `yaml:"manageStatus"`
 	WatchDependentResources     bool                      `yaml:"watchDependentResources"`
@@ -156,7 +156,7 @@ func (w *Watch) setValuesFromAlias(tmp alias) error {
 	w.Vars = tmp.Vars
 	w.MaxRunnerArtifacts = tmp.MaxRunnerArtifacts
 	w.MaxConcurrentReconciles = getMaxConcurrentReconciles(gvk, maxConcurrentReconcilesDefault)
-	w.ReconcilePeriod = tmp.ReconcilePeriod.Duration
+	w.ReconcilePeriod = *tmp.ReconcilePeriod
 	w.ManageStatus = *tmp.ManageStatus
 	w.WatchDependentResources = *tmp.WatchDependentResources
 	w.SnakeCaseParameters = *tmp.SnakeCaseParameters
@@ -289,7 +289,7 @@ func New(gvk schema.GroupVersionKind, role, playbook string, vars map[string]int
 		Vars:                        vars,
 		MaxRunnerArtifacts:          maxRunnerArtifactsDefault,
 		MaxConcurrentReconciles:     maxConcurrentReconcilesDefault,
-		ReconcilePeriod:             reconcilePeriodDefault.Duration,
+		ReconcilePeriod:             reconcilePeriodDefault,
 		ManageStatus:                manageStatusDefault,
 		WatchDependentResources:     watchDependentResourcesDefault,
 		WatchClusterScopedResources: watchClusterScopedResourcesDefault,

--- a/internal/ansible/watches/watches_test.go
+++ b/internal/ansible/watches/watches_test.go
@@ -67,7 +67,7 @@ func TestNew(t *testing.T) {
 				t.Fatalf("Unexpected maxConcurrentReconciles %v expected %v", watch.MaxConcurrentReconciles,
 					maxConcurrentReconcilesDefault)
 			}
-			if watch.ReconcilePeriod != expectedReconcilePeriod {
+			if watch.ReconcilePeriod.Duration != expectedReconcilePeriod {
 				t.Fatalf("Unexpected reconcilePeriod %v expected %v", watch.ReconcilePeriod,
 					expectedReconcilePeriod)
 			}
@@ -134,8 +134,8 @@ func TestLoad(t *testing.T) { //nolint:gocyclo
 		return
 	}
 
-	zeroSeconds := time.Duration(0)
-	twoSeconds := time.Second * 2
+	zeroSeconds := metav1.Duration{Duration: time.Duration(0)}
+	twoSeconds := metav1.Duration{Duration: time.Second * 2}
 
 	validWatches := []Watch{
 		Watch{

--- a/internal/cmd/ansible-operator/run/cmd.go
+++ b/internal/cmd/ansible-operator/run/cmd.go
@@ -23,6 +23,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -212,6 +213,13 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 		os.Exit(1)
 	}
 	for _, w := range watches {
+		reconcilePeriod := f.ReconcilePeriod
+		if w.ReconcilePeriod.Duration != time.Duration(0) {
+			// if a duration other than default was passed in through watches,
+			// it will take precedence over the command-line flag
+			reconcilePeriod = w.ReconcilePeriod.Duration
+		}
+
 		runner, err := runner.New(w, f.AnsibleArgs)
 		if err != nil {
 			log.Error(err, "Failed to create runner")
@@ -224,7 +232,7 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 			ManageStatus:            w.ManageStatus,
 			AnsibleDebugLogs:        getAnsibleDebugLog(),
 			MaxConcurrentReconciles: w.MaxConcurrentReconciles,
-			ReconcilePeriod:         w.ReconcilePeriod,
+			ReconcilePeriod:         reconcilePeriod,
 			Selector:                w.Selector,
 			LoggingLevel:            getAnsibleEventsToLog(f),
 		})


### PR DESCRIPTION
Signed-off-by: Venkat Ramaraju <vramaraj@redhat.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Added the usage of the reconcile-period CLI flag in Ansible

**Motivation for the change:**
Close #5594
