### PR TITLE
docs: fix broken reference links within the Golang section

### DIFF
--- a/website/content/en/docs/building-operators/golang/advanced-topics.md
+++ b/website/content/en/docs/building-operators/golang/advanced-topics.md
@@ -299,7 +299,7 @@ Authors may decide to distribute their bundles for various architectures: x86_64
 [garbage_collection]: https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/
 [finalizers]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers
 [cronjobs]: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
-[cronjobs_fields]: https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits
+[cronjob_fields]: https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits
 [cronjob_tutorial]: https://book.kubebuilder.io/cronjob-tutorial/controller-implementation.html#3-clean-up-old-jobs-according-to-the-history-limit
 [pv]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
 [reclaiming]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaiming

--- a/website/content/en/docs/building-operators/golang/crds-scope.md
+++ b/website/content/en/docs/building-operators/golang/crds-scope.md
@@ -30,7 +30,7 @@ $ operator-sdk create api --group cache --version v1alpha1 --kind Memcached --re
 
 You can also manually set the scope in the Go `types.go` file by adding or changing the [kubebuilder scope marker][kubebuilder_crd_markers]
 to your resource. This file is usually located in `api/<version>/<kind>_types.go` or `apis/<group>/<version>/<kind>_types.go` if
-you are using the [multigroup][multigroup-kubebuilder-doc] layout. Once this marker is set, the CRD files will be generated with the approriate scope.
+you are using the [multigroup][kubebuilder_multigroup] layout. Once this marker is set, the CRD files will be generated with the approriate scope.
 Here is an example API type with the marker set to cluster scope:
 
 ```golang

--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -34,7 +34,7 @@ Scaffolded projects now use:
 - Scaffolded tests that use the [`envtest`][envtest] test framework
 - Preliminary support for CLI plugins. For more info see the [plugins design document][plugins-phase1-design-doc]
 - A `PROJECT` configuration file to store information about GVKs, plugins, and help the CLI make decisions.
-- A new option to create projects using ComponentConfig. For more info, see [enhancement proposal][enhancement proposal] and the [Component config tutorial][component-config-tutorial]
+- A new option to create projects using ComponentConfig. For more info, see [enhancement proposal][component-proposal] and the [Component config tutorial][component-config-tutorial]
 - Go version `1.15` (previously it was `1.13`).
 
 Generated files with the default API versions:
@@ -444,6 +444,7 @@ For further steps regarding the deployment of the operator, creation of custom r
 [webhook-doc]: https://book.kubebuilder.io/reference/webhook-overview.html
 [healthz-ping]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/healthz#CheckHandler
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime/releases
+[component-proposal]: https://github.com/kubernetes-sigs/controller-runtime/blob/master/designs/component-config.md
 [component-config-tutorial]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/docs/book/src/component-config-tutorial/tutorial.md
 [plugins-phase1-design-doc]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/extensible-cli-and-scaffolding-plugins-phase-1.md
 [migration-doc]: /docs/upgrading-sdk-version/


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Motivation for the change:**
I noticed a few links within the Golang section had their references broken whilst browsing them.

**Description of the change:**
This corrects the reference name within the CRD and Advanced Topics pages. For the migration page I've made a best-guess as to the ComponentConfig proposal that should've been linked - I'm assuming it's that design Markdown doc?

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
