### PR TITLE
Drop the BLM banner.

### DIFF
--- a/website/layouts/index.html
+++ b/website/layouts/index.html
@@ -9,11 +9,6 @@
     </header>
     
       <main role="main" class="td-main">
-        <section class="of-section-page-message">
-          <h1 class="of-heading of-heading--lg of-section-page-message__title"> Black lives matter.</h1>
-        <p>We stand in solidarity with the Black community.<br>Racism is unacceptable.<br> It conflicts with the <a href="https://git.k8s.io/community/values.md">core values of the Kubernetes community</a> and we do not tolerate it.</p>
-  
-        </section>
         <section class="of-masthead of-masthead--home">
           <h1 class="of-heading of-masthead--home__title"><span>Operator</span><span>SDK</span></h1>
           <h2 class="of-heading of-heading--md of-masthead--home__content">The Operator SDK makes it easier to build Kubernetes native applications, a process that can require deep, application-specific operational knowledge.</h2>


### PR DESCRIPTION
**Description of the change:**
Drop the BLM banner.

**Motivation for the change:**
The banner was originally put in place as a response to current events at the time. Those events have past and I believe keeping the banner up will dilute the message. This change does not mean we are changing our policy, just simply cleaning up the documentation site.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
