### PR TITLE
Restrict secrets to watch with label selector

### DIFF
--- a/hack/generate/samples/internal/ansible/testdata/watches.yaml
+++ b/hack/generate/samples/internal/ansible/testdata/watches.yaml
@@ -26,6 +26,9 @@
   kind: Secret
   playbook: playbooks/secret.yml
   manageStatus: false
+  selector:
+    matchExpressions:
+     - {key: reconcile, operator: Exists, values: []}
   vars:
     meta: '{{ ansible_operator_meta }}'
 


### PR DESCRIPTION
This significantly lowers the load on the test-operator, which was
getting restarted due to resource limits.

Re #5547

