### PR TITLE
Notify users of rbac marker parsing error

### DIFF
--- a/website/content/en/docs/faqs/_index.md
+++ b/website/content/en/docs/faqs/_index.md
@@ -175,6 +175,22 @@ For more information and examples, please see the type-specific docs:
 - [Golang][go-proxy-vars]
 - [Helm][helm-proxy-vars]
 
+
+## After running `make manifests`, `rbac` permissions are not updated in config
+
+[RBAC markers][rbac-markers] that are not followed by a newline will not be
+parsed correctly, resulting in missing `rbac` configuration.
+
+This is a known issue with `controller-tools`, see [issue #551][controller-tools-issue-551]
+The current workaround is to add a new line after the `rbac` marker.
+
+```go
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
+
+func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+```
+
 [ansible-proxy-vars]: /docs/building-operators/ansible/reference/proxy-vars/
 [client.Reader]:https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client#Reader
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime
@@ -192,6 +208,7 @@ For more information and examples, please see the type-specific docs:
 [rbac]:https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 [scorecard-doc]: https://sdk.operatorframework.io/docs/testing-operators/scorecard/
 [project-doc]: /docs/overview/project-layout
+[controller-tools-issue-551]: https://github.com/kubernetes-sigs/controller-tools/issues/551
 
 ## Preserve the `preserveUnknownFields` in your CRDs
 


### PR DESCRIPTION
There is a known controller-tools issue where rbac markers are not
parsed correctly if they are not followed by a newline.

Fixes: Bugzilla 2061611
Fixes: #5627 
Signed-off-by: jesus m. rodriguez <jesusr@redhat.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Add an FAQ to notify users about a known issue in `controller-tools`.

**Motivation for the change:**
There is a known controller-tools issue where rbac markers are not
parsed correctly if they are not followed by a newline.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
