### PR TITLE
fix: printout errors even if we have a timeout

### DIFF
--- a/changelog/fragments/scorecard-deadline.yaml
+++ b/changelog/fragments/scorecard-deadline.yaml
@@ -1,0 +1,17 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      scorecard will now printout test results, if any, even when there is a context timeout.
+      This will allow underlying errors from a test to be shown helping users address the issues.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/cmd/operator-sdk/scorecard/cmd.go
+++ b/internal/cmd/operator-sdk/scorecard/cmd.go
@@ -233,6 +233,12 @@ func (c *scorecardCmd) run() (err error) {
 
 		scorecardTests, err = o.Run(ctx)
 		if err != nil {
+			// if we got a timeout; printout the test results if there are any
+			if err == context.DeadlineExceeded {
+				if errpo := c.printOutput(scorecardTests); errpo != nil {
+					log.Fatal(errpo)
+				}
+			}
 			return fmt.Errorf("error running tests %w", err)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: jesus m. rodriguez <jesusr@redhat.com>

**Description of the change:**
Handle `DeadlineExceeded` errors by allowing test output to be printed even during context timeouts

**Motivation for the change:**
context timeouts hide all test results

Fixes: #5415 
**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
