### PR TITLE
update Go operator quickstart docs

### DIFF
--- a/website/content/en/docs/building-operators/golang/quickstart.md
+++ b/website/content/en/docs/building-operators/golang/quickstart.md
@@ -97,6 +97,24 @@ has a custom CA, these [configuration steps][image-reg-config] must be complete.
   make undeploy
   ```
 
+### Run locally (outside the cluster)
+
+This is recommended ONLY for development purposes
+
+1. Run the operator:
+
+  ```sh
+  make install run
+  ```
+
+1. In a new terminal tab/window, create a sample Memcached custom resource:
+  
+  ```console
+  $ kubectl apply -f config/samples/cache_v1alpha1_memcached.yaml
+  memcached.cache.example.com/memcached-sample created
+  ```
+
+1. Stop the operator by pressing `ctrl+c` in the terminal tab or window the operator is running in
 
 ## Next Steps
 

--- a/website/content/en/docs/contribution-guidelines/documentation.md
+++ b/website/content/en/docs/contribution-guidelines/documentation.md
@@ -47,7 +47,7 @@ Any changes will be included in real time.
 Please consider running this locally before creating a PR to save CI resources.
 
 [hugo]:https://gohugo.io/
-[docsy-install]:https://www.docsy.dev/docs/theme-installation/docsy-as-module/installation-prerequisites/
+[docsy-install]:https://www.docsy.dev/docs/get-started/docsy-as-module/installation-prerequisites/
 [website-md]:https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs
 [changelog-template]:https://github.com/operator-framework/operator-sdk/blob/master/changelog/fragments/00-template.yaml
 [godocs]:https://blog.golang.org/godoc


### PR DESCRIPTION
Include steps for running the operator locally in the Go operator quickstart

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Add a section to the Go operator Quickstart guide that details how to run a Go operator locally (outside of the cluster)


**Motivation for the change:**
The steps for running a Go operator locally already exists in the detailed Go operator tutorial. Going through the docs it felt like it might be nice for someone who just wants to go through the Go operator Quickstart guide and not the in-depth tutorial to know that there is a way to run the operator locally.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
