### PR TITLE
Proposal for change of logo position in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-<img src="website/static/operator_logo_sdk_color.svg" height="125px"></img>
+<p align=center>
+    <img src="website/static/operator_logo_sdk_color.svg" height="125px"></img>
+</p>
 
-
-[![Build Status](https://github.com/operator-framework/operator-sdk/workflows/deploy/badge.svg)](https://github.com/operator-framework/operator-sdk/actions)
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+<p align=center>
+    <a href="https://github.com/operator-framework/operator-sdk/actions">
+        <img class="center" src="https://github.com/operator-framework/operator-sdk/workflows/deploy/badge.svg">
+    </a>
+    <a href="http://www.apache.org/licenses/LICENSE-2.0.html">
+        <img src="http://img.shields.io/:license-apache-blue.svg">
+    </a>
+</p>
 
 ## Documentation
 


### PR DESCRIPTION
Hey operator-sdk team! 🙂 

I have a proposal of shifting the logo to the middle. Here is the changes made in the readme file for your kind reference. 
Let me know your thoughts on this.

Signed-off-by: Ankit Kurmi akurmi@redhat.com