### PR TITLE
Make it so tests share one kind cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ e2e_targets := test-e2e $(e2e_tests)
 .PHONY: $(e2e_targets)
 
 .PHONY: test-e2e-setup
-export KIND_CLUSTER := operator-sdk-e2e
+export KIND_CLUSTER := osdk-test
 
 KUBEBUILDER_ASSETS = $(PWD)/$(shell go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest && $(shell go env GOPATH)/bin/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir tools/bin/ -p path)
 test-e2e-setup: build

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -61,5 +61,5 @@ fi
 
 DEST_IMAGE="quay.io/example/advanced-molecule-operator:v0.0.1"
 docker build -t "$DEST_IMAGE" --no-cache .
-load_image_if_kind "$DEST_IMAGE"
+# load_image_if_kind "$DEST_IMAGE"
 KUSTOMIZE_PATH=$KUSTOMIZE OPERATOR_PULL_POLICY=Never OPERATOR_IMAGE=${DEST_IMAGE} TEST_OPERATOR_NAMESPACE=osdk-test molecule test

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -48,8 +48,11 @@ else
   KUSTOMIZE="$(which kustomize)"
 fi
 KUSTOMIZE_PATH=${KUSTOMIZE} TEST_OPERATOR_NAMESPACE=default molecule test -s kind
+popd
 
 header_text "Running Default test with advanced-molecule-operator"
+
+make test-e2e-setup
 pushd $TMPDIR/advanced-molecule-operator
 
 make kustomize
@@ -61,5 +64,6 @@ fi
 
 DEST_IMAGE="quay.io/example/advanced-molecule-operator:v0.0.1"
 docker build -t "$DEST_IMAGE" --no-cache .
-# load_image_if_kind "$DEST_IMAGE"
+load_image_if_kind "$DEST_IMAGE"
 KUSTOMIZE_PATH=$KUSTOMIZE OPERATOR_PULL_POLICY=Never OPERATOR_IMAGE=${DEST_IMAGE} TEST_OPERATOR_NAMESPACE=osdk-test molecule test
+popd


### PR DESCRIPTION
This updates the `Makefile` so only one kind cluster is used for running
tests instead of two.

Signed-off-by: Ryan King <ryking@redhat.com>
