### PR TITLE
Implement file-based catalog (FBC) support for run bundle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,9 @@ require (
 	github.com/garyburd/redigo v1.6.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.1.0 // indirect
+	github.com/go-git/go-git/v5 v5.3.0 // indirect
 	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
@@ -112,6 +115,7 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gofrs/uuid v3.3.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-migrate/migrate/v4 v4.6.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/btree v1.0.1 // indirect
@@ -134,7 +138,9 @@ require (
 	github.com/huandu/xstrings v1.3.1 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmoiron/sqlx v1.3.1 // indirect
+	github.com/joelanford/ignore v0.0.0-20210607151042-0d25dc18b62d // indirect
 	github.com/joho/godotenv v1.3.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -149,10 +155,12 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.7 // indirect
+	github.com/mattn/go-sqlite3 v1.14.10 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/copystructure v1.1.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
@@ -228,6 +236,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiserver v0.23.1 // indirect

--- a/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
+++ b/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
@@ -1,0 +1,250 @@
+// Copyright 2022 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fbcindex
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/operator-framework/operator-sdk/internal/olm/operator"
+	"github.com/operator-framework/operator-sdk/internal/olm/operator/registry/index"
+	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
+)
+
+const (
+	// defaultGRPCPort is the default grpc container port that the registry pod exposes
+	defaultGRPCPort = 50051
+
+	defaultContainerName     = "registry-grpc"
+	defaultContainerPortName = "grpc"
+)
+
+// FBCRegistryPod holds resources necessary for creation of a registry pod in FBC scenarios.
+type FBCRegistryPod struct { //nolint:maligned
+	// BundleItems contains all bundles to be added to a registry pod.
+	BundleItems []index.BundleItem
+
+	// Index image contains a database of pointers to operator manifest content that is queriable via an API.
+	// new version of an operator bundle when published can be added to an index image
+	IndexImage string
+
+	// GRPCPort is the container grpc port
+	GRPCPort int32
+
+	// pod represents a kubernetes *corev1.pod that will be created on a cluster using an index image
+	pod *corev1.Pod
+
+	// FBCContent represents the contents of the FBC file (string YAML).
+	FBCContent string
+
+	// FBCDir is the name of the FBC directory name where the FBC resides in.
+	FBCDir string
+
+	// FBCFile represents the FBC filename that has all the contents to be served through the registry pod.
+	FBCFile string
+
+	cfg *operator.Configuration
+}
+
+// init initializes the FBCRegistryPod struct.
+func (f *FBCRegistryPod) init(cfg *operator.Configuration) error {
+	if f.GRPCPort == 0 {
+		f.GRPCPort = defaultGRPCPort
+	}
+
+	f.cfg = cfg
+
+	// validate the FBCRegistryPod struct and ensure required fields are set
+	if err := f.validate(); err != nil {
+		return fmt.Errorf("invalid FBC registry pod: %v", err)
+	}
+
+	bundleImage := f.BundleItems[len(f.BundleItems)-1].ImageTag
+	trimmedbundleImage := strings.Split(bundleImage, ":")[0]
+	f.FBCDir = fmt.Sprintf("%s-index", filepath.Join("/tmp", strings.Split(trimmedbundleImage, "/")[2]))
+	f.FBCFile = filepath.Join(f.FBCDir, strings.Split(bundleImage, ":")[1])
+
+	// podForBundleRegistry() to make the pod definition
+	pod, err := f.podForBundleRegistry()
+	if err != nil {
+		return fmt.Errorf("error building registry pod definition: %v", err)
+	}
+	f.pod = pod
+
+	return nil
+}
+
+// Create creates a bundle registry pod built from an fbc index image,
+// sets the catalog source as the owner for the pod and verifies that
+// the pod is running
+func (f *FBCRegistryPod) Create(ctx context.Context, cfg *operator.Configuration, cs *v1alpha1.CatalogSource) (*corev1.Pod, error) {
+	if err := f.init(cfg); err != nil {
+		return nil, err
+	}
+
+	// make catalog source the owner of registry pod object
+	if err := controllerutil.SetOwnerReference(cs, f.pod, f.cfg.Scheme); err != nil {
+		return nil, fmt.Errorf("error setting owner reference: %w", err)
+	}
+
+	if err := f.cfg.Client.Create(ctx, f.pod); err != nil {
+		return nil, fmt.Errorf("error creating pod: %w", err)
+	}
+
+	// get registry pod key
+	podKey := types.NamespacedName{
+		Namespace: f.cfg.Namespace,
+		Name:      f.pod.GetName(),
+	}
+
+	// poll and verify that pod is running
+	podCheck := wait.ConditionFunc(func() (done bool, err error) {
+		err = f.cfg.Client.Get(ctx, podKey, f.pod)
+		if err != nil {
+			return false, fmt.Errorf("error getting pod %s: %w", f.pod.Name, err)
+		}
+		return f.pod.Status.Phase == corev1.PodRunning, nil
+	})
+
+	// check pod status to be `Running`
+	if err := f.checkPodStatus(ctx, podCheck); err != nil {
+		return nil, fmt.Errorf("registry pod did not become ready: %w", err)
+	}
+	log.Infof("Created registry pod: %s", f.pod.Name)
+	return f.pod, nil
+}
+
+// checkPodStatus polls and verifies that the pod status is running
+func (f *FBCRegistryPod) checkPodStatus(ctx context.Context, podCheck wait.ConditionFunc) error {
+	// poll every 200 ms until podCheck is true or context is done
+	err := wait.PollImmediateUntil(200*time.Millisecond, podCheck, ctx.Done())
+	if err != nil {
+		return fmt.Errorf("error waiting for registry pod %s to run: %v", f.pod.Name, err)
+	}
+
+	return err
+}
+
+// validate will ensure that RegistryPod required fields are set
+// and throws error if not set
+func (f *FBCRegistryPod) validate() error {
+	if len(f.BundleItems) == 0 {
+		return errors.New("bundle image set cannot be empty")
+	}
+	for _, item := range f.BundleItems {
+		if item.ImageTag == "" {
+			return errors.New("bundle image cannot be empty")
+		}
+	}
+
+	if f.IndexImage == "" {
+		return errors.New("index image cannot be empty")
+	}
+
+	return nil
+}
+
+func GetRegistryPodHost(ipStr string) string {
+	return fmt.Sprintf("%s:%d", ipStr, defaultGRPCPort)
+}
+
+// getPodName will return a string constructed from the bundle Image name
+func getPodName(bundleImage string) string {
+	// todo(rashmigottipati): need to come up with human-readable references
+	// to be able to handle SHA references in the bundle images
+	return k8sutil.TrimDNS1123Label(k8sutil.FormatOperatorNameDNS1123(bundleImage))
+}
+
+// podForBundleRegistry constructs and returns the registry pod definition
+// and throws error when unable to build the pod definition successfully
+func (f *FBCRegistryPod) podForBundleRegistry() (*corev1.Pod, error) {
+	// rp was already validated so len(f.BundleItems) must be greater than 0.
+	bundleImage := f.BundleItems[len(f.BundleItems)-1].ImageTag
+
+	// construct the container command for pod spec
+	containerCmd, err := f.getContainerCmd()
+	if err != nil {
+		return nil, err
+	}
+
+	// make the pod definition
+	f.pod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getPodName(bundleImage),
+			Namespace: f.cfg.Namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  defaultContainerName,
+					Image: f.IndexImage,
+					Command: []string{
+						"sh",
+						"-c",
+						containerCmd,
+					},
+					Ports: []corev1.ContainerPort{
+						{Name: defaultContainerPortName, ContainerPort: f.GRPCPort},
+					},
+				},
+			},
+		},
+	}
+
+	return f.pod, nil
+}
+
+const fbcCmdTemplate = `mkdir -p {{ .FBCDir }} && \
+echo '{{ .FBCContent }}' >> {{ .FBCFile  }} && \
+opm serve {{ .FBCDir }} -p {{ .GRPCPort }}
+`
+
+// getContainerCmd uses templating to construct the container command
+// and throws error if unable to parse and execute the container command
+func (f *FBCRegistryPod) getContainerCmd() (string, error) {
+	var t *template.Template
+	// create a custom dirname template function
+	funcMap := template.FuncMap{
+		"dirname": path.Dir,
+	}
+
+	// add the custom dirname template function to the
+	// template's FuncMap and parse the cmdTemplate
+	t = template.Must(template.New("cmd").Funcs(funcMap).Parse(fbcCmdTemplate))
+
+	// execute the command by applying the parsed template to command
+	// and write command output to out
+	out := &bytes.Buffer{}
+	if err := t.Execute(out, f); err != nil {
+		return "", fmt.Errorf("parse container command: %w", err)
+	}
+
+	return out.String(), nil
+}

--- a/internal/olm/operator/registry/index/registry_pod_test.go
+++ b/internal/olm/operator/registry/index/registry_pod_test.go
@@ -43,7 +43,7 @@ func TestCreateRegistryPod(t *testing.T) {
 	RunSpecs(t, "Test Registry Pod Suite")
 }
 
-var _ = Describe("RegistryPod", func() {
+var _ = Describe("SQLiteRegistryPod", func() {
 
 	var defaultBundleItems = []BundleItem{{
 		ImageTag: "quay.io/example/example-operator-bundle:0.2.0",
@@ -55,7 +55,7 @@ var _ = Describe("RegistryPod", func() {
 		Context("with valid registry pod values", func() {
 
 			var (
-				rp  *RegistryPod
+				rp  *SQLiteRegistryPod
 				cfg *operator.Configuration
 				pod *corev1.Pod
 				err error
@@ -66,15 +66,15 @@ var _ = Describe("RegistryPod", func() {
 					Client:    newFakeClient(),
 					Namespace: "test-default",
 				}
-				rp = &RegistryPod{
+				rp = &SQLiteRegistryPod{
 					BundleItems: defaultBundleItems,
 					IndexImage:  testIndexImageTag,
 				}
-				By("initializing the RegistryPod")
+				By("initializing the SQLiteRegistryPod")
 				Expect(rp.init(cfg)).To(Succeed())
 			})
 
-			It("should create the RegistryPod successfully", func() {
+			It("should create the SQLiteRegistryPod successfully", func() {
 				expectedPodName := "quay-io-example-example-operator-bundle-0-2-0"
 				Expect(rp).NotTo(BeNil())
 				Expect(rp.pod.Name).To(Equal(expectedPodName))
@@ -130,7 +130,7 @@ var _ = Describe("RegistryPod", func() {
 						AddMode:  SemverBundleAddMode,
 					},
 				)
-				rp2 := RegistryPod{
+				rp2 := SQLiteRegistryPod{
 					DBPath:        defaultDBPath,
 					GRPCPort:      defaultGRPCPort,
 					BundleItems:   bundleItems,
@@ -180,7 +180,7 @@ var _ = Describe("RegistryPod", func() {
 						AddMode:  SemverBundleAddMode,
 					},
 				)
-				rp2 := RegistryPod{
+				rp2 := SQLiteRegistryPod{
 					DBPath:      defaultDBPath,
 					GRPCPort:    defaultGRPCPort,
 					BundleItems: bundleItems,
@@ -242,7 +242,7 @@ var _ = Describe("RegistryPod", func() {
 
 			It("should error when bundle image is not provided", func() {
 				expectedErr := "bundle image set cannot be empty"
-				rp := &RegistryPod{}
+				rp := &SQLiteRegistryPod{}
 				err := rp.init(cfg)
 				Expect(err).NotTo(BeNil())
 				Expect(err.Error()).Should(ContainSubstring(expectedErr))
@@ -250,7 +250,7 @@ var _ = Describe("RegistryPod", func() {
 
 			It("should not accept any other bundle add mode other than semver or replaces", func() {
 				expectedErr := `bundle add mode "invalid" does not exist`
-				rp := &RegistryPod{
+				rp := &SQLiteRegistryPod{
 					BundleItems: []BundleItem{{ImageTag: "quay.io/example/example-operator-bundle:0.2.0", AddMode: "invalid"}},
 				}
 				err := rp.init(cfg)
@@ -259,7 +259,7 @@ var _ = Describe("RegistryPod", func() {
 			})
 
 			It("checkPodStatus should return error when pod check is false and context is done", func() {
-				rp := &RegistryPod{
+				rp := &SQLiteRegistryPod{
 					BundleItems: defaultBundleItems,
 					IndexImage:  testIndexImageTag,
 				}

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	"github.com/operator-framework/operator-sdk/internal/olm/operator"
+	"github.com/operator-framework/operator-sdk/internal/olm/operator/registry/fbcindex"
 	"github.com/operator-framework/operator-sdk/internal/olm/operator/registry/index"
 	registryutil "github.com/operator-framework/operator-sdk/internal/registry"
 )
@@ -59,15 +60,17 @@ const (
 )
 
 type IndexImageCatalogCreator struct {
-	PackageName   string
-	IndexImage    string
-	BundleImage   string
 	SkipTLS       bool
 	SkipTLSVerify bool
 	UseHTTP       bool
-	BundleAddMode index.BundleAddMode
+	HasFBCLabel   bool
+	FBCContent    string
+	PackageName   string
+	IndexImage    string
+	BundleImage   string
 	SecretName    string
 	CASecretName  string
+	BundleAddMode index.BundleAddMode
 
 	cfg *operator.Configuration
 }
@@ -193,25 +196,43 @@ func (c *IndexImageCatalogCreator) setAddMode() {
 // from items and that pod, then applies updateFields.
 func (c IndexImageCatalogCreator) createAnnotatedRegistry(ctx context.Context, cs *v1alpha1.CatalogSource,
 	items []index.BundleItem, updates ...func(*v1alpha1.CatalogSource)) (err error) {
-
+	var pod *corev1.Pod
 	if c.IndexImage == "" {
 		c.IndexImage = DefaultIndexImage
 	}
-	// Initialize and create registry pod
-	registryPod := index.RegistryPod{
-		BundleItems:   items,
-		IndexImage:    c.IndexImage,
-		SecretName:    c.SecretName,
-		CASecretName:  c.CASecretName,
-		SkipTLSVerify: c.SkipTLSVerify,
-		UseHTTP:       c.UseHTTP,
-	}
-	if registryPod.DBPath, err = c.getDBPath(ctx); err != nil {
-		return fmt.Errorf("get database path: %v", err)
-	}
-	pod, err := registryPod.Create(ctx, c.cfg, cs)
-	if err != nil {
-		return err
+
+	if c.HasFBCLabel {
+		// Initialize and create the FBC registry pod.
+		fbcRegistryPod := fbcindex.FBCRegistryPod{
+			BundleItems: items,
+			IndexImage:  c.IndexImage,
+			FBCContent:  c.FBCContent,
+		}
+
+		pod, err = fbcRegistryPod.Create(ctx, c.cfg, cs)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		// Initialize and create registry pod
+		registryPod := index.SQLiteRegistryPod{
+			BundleItems:   items,
+			IndexImage:    c.IndexImage,
+			SecretName:    c.SecretName,
+			CASecretName:  c.CASecretName,
+			SkipTLSVerify: c.SkipTLSVerify,
+			UseHTTP:       c.UseHTTP,
+		}
+
+		if registryPod.DBPath, err = c.getDBPath(ctx); err != nil {
+			return fmt.Errorf("get database path: %v", err)
+		}
+
+		pod, err = registryPod.Create(ctx, c.cfg, cs)
+		if err != nil {
+			return err
+		}
 	}
 
 	// JSON marshal injected bundles


### PR DESCRIPTION
**Description of the change:**

- Create a file-based catalog (FBC) on the fly by generating the bundle, package and channel blobs, if an index image is not provided by the user (i.e. for a default index image `quay.io/operator-framework/opm:latest`) and serve it over a gRPC port.
- If an index image is provided through the flag, then bundle image will be inserted to the index by appending the bundle contents (rendered bundle image) to the index that's converted to a declarative config and this index containing the bundle will be served over a gRPC port.
- If bundle already exists in the index, then we will error out and not proceed with serving the index image.
- Generated FBC will be validated (equivalent to the `opm validate` command) and converted to a string format and sent down to registry pod creation to be served.
- Infer the label type on the index image and indicate there's an FBC label through registry pod for container creation. 
- Added a new container creation command for images that have FBC label on them. For images without the label, old commands (`opm registry add` and `opm registry serve`) that use SQLite under the hood will be called. So support for both (FBC/SQLite) exist at the moment. 

**Motivation for the change:**
https://github.com/operator-framework/operator-sdk/issues/5593 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Signed-off-by: rashmigottipati <chowdary.grashmi@gmail.com>