### PR TITLE
Fix marker for kubebuilder

### DIFF
--- a/website/content/en/docs/building-operators/golang/crds-scope.md
+++ b/website/content/en/docs/building-operators/golang/crds-scope.md
@@ -47,7 +47,7 @@ type Memcached struct {
 	Status MemcachedStatus `json:"status,omitempty"`
 }
 ```
-To set the scope to namespaced, the marker would be set to `//+kubebuilder:resource:scope=Namespace` instead.
+To set the scope to namespaced, the marker would be set to `//+kubebuilder:resource:scope=Namespaced` instead.
 
 
 ## Set scope in CRD YAML file


### PR DESCRIPTION
**Description of the change:**
CRD scope either `Namespaced` or `Cluster`, right marker should be 
`//+kubebuilder:resource:scope=Namespaced` , Not 
`//+kubebuilder:resource:scope=Namespace` .
