### PR TITLE
Update URL for Docs

### DIFF
--- a/proposals/ansible-operator-status.md
+++ b/proposals/ansible-operator-status.md
@@ -2,7 +2,7 @@
 
 > Status: **implemented**
 > 
-> The operator can surface basic information from the Ansible code in a generic fashion - it can set the conditions and it can surface a failure message if the run failed. See documentation in the Developer Guide: [Custom Resource Status Management](https://sdk.operatorframework.io/docs/ansible/development-tips/#custom-resource-status-management)
+> The operator can surface basic information from the Ansible code in a generic fashion - it can set the conditions and it can surface a failure message if the run failed. See documentation in the Developer Guide: [Custom Resource Status Management](https://sdk.operatorframework.io/docs/building-operators/ansible/development-tips/#custom-resource-status-management)
 
 - [Problem](#problem)
 - [Proposal](#proposal)


### PR DESCRIPTION
The Previous URL is outdated and results in a 404 - Update the docs to point to the correct page

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Update the URL of doc for implemented status management proposal with the correct URL 

**Motivation for the change:**
Inability to find the correct doc for days :smiling_face_with_tear: 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
