### PR TITLE
OSDK-2303: Scorecard testOutput is tightly coupled with storage mountPath

### DIFF
--- a/changelog/fragments/fix-scorecard-mountpath.yaml
+++ b/changelog/fragments/fix-scorecard-mountpath.yaml
@@ -1,0 +1,7 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Fixed scorecard testOutput tightly coupling with scorecard storage mountPath
+    kind: "bugfix"
+    breaking: false

--- a/internal/scorecard/storage.go
+++ b/internal/scorecard/storage.go
@@ -188,7 +188,7 @@ func gatherTestOutput(r PodTestRunner, suiteName, testName, podName, mountPath s
 		return err
 	}
 
-	srcPath := r.TestOutput
+	srcPath := mountPath
 	prefix := getStoragePrefix(srcPath)
 	prefix = path.Clean(prefix)
 	destPath := getDestPath(r.TestOutput, suiteName, testName)


### PR DESCRIPTION
Signed-off-by: Andrej Podhradsky <apodhrad@redhat.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
