### PR TITLE
ci: add check for up-to-date olm versions

### DIFF
--- a/.github/workflows/olm-check.yml
+++ b/.github/workflows/olm-check.yml
@@ -1,0 +1,19 @@
+name: olm-check
+
+on:
+ pull_request:
+   branches:
+    - 'release-*'
+ workflow_dispatch:
+   
+
+jobs:
+  check-olm-minor-releases:
+    name: check-olm-minor-releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - id: run-check-olm
+        run: ./hack/check-olm.sh
+    
+    

--- a/hack/check-olm.sh
+++ b/hack/check-olm.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+FAILED="false"
+
+# clone OLM
+mkdir olm-test
+cd olm-test
+git clone https://github.com/operator-framework/operator-lifecycle-manager.git
+cd operator-lifecycle-manager
+
+# Get list of unique minor versions sorted highest to lowest
+MINOR_ARRAY=($(git tag --list --sort=-version:refname "v0.*" | awk -F. '{ print $1 "." $2 "." }' | sort -ur))
+
+# Get highest patch version for each unique minor version
+# Loop through the latest 3 minor versions
+VERSIONS_STRING=""
+for i in {2..0}
+do
+    MINOR_VERSION=$(echo "${MINOR_ARRAY[i]}")
+    PATCH_ARRAY=($(git tag --list --sort=-version:refname "$MINOR_VERSION*" | awk -F. '{ print $1 "." $2 "." $3 }' | sort -ur))
+    VERSIONS_STRING+=$(echo " ${PATCH_ARRAY[0]}" | tr -d 'v')
+done
+
+VERSIONS_ARRAY=($(echo "$VERSIONS_STRING" | tr ' ' '\n'))
+
+# check Makefile OLM_VERSIONS
+EXPECTED="OLM_VERSIONS =$VERSIONS_STRING"
+ACTUAL=$(cat ../../Makefile | grep "OLM_VERSIONS =")
+
+if [[ $ACTUAL != $EXPECTED ]]
+then
+    echo -e "\nMakefile does not have the most up to date OLM release versions.\nEXPECTED: $EXPECTED | ACTUAL: $ACTUAL"
+    FAILED="true"
+fi
+
+# check internal/bindata/olm/versions.go
+AVAILABLE_VERSIONS=($(cat ../../internal/bindata/olm/versions.go | awk '/var availableVersions/,/},\n}/' | tr -d '\t' | tr -d ' ":{},'))
+
+ACTUAL=""
+for i in {1..3}
+do 
+    ACTUAL+=" ${AVAILABLE_VERSIONS[i]}"
+done
+
+if [[ $ACTUAL != $VERSIONS_STRING ]]
+then
+    echo -e "\ninternal/bindata/olm/versions.go does not have the most up to date OLM release versions as availableVersions.\nEXPECTED: $VERSIONS_STRING | ACTUAL: $ACTUAL"
+    FAILED="true"
+fi
+
+# check internal/testutils/olm.go
+EXPECTED="OlmVersionForTestSuite = \"${VERSIONS_ARRAY[2]}\""
+ACTUAL=$(cat ../../internal/testutils/olm.go | grep "OlmVersionForTestSuite =" | tr -d '\t')
+
+if [[ $ACTUAL != $EXPECTED ]]
+then
+    echo -e "\ninternal/testutils/olm.go does not have the most up to date OLM release versions.\nEXPECTED: $EXPECTED | ACTUAL: $ACTUAL"
+    FAILED="true"
+fi
+
+# check docs - website/content/en/docs/overview/_index.md
+EXPECTED="Currently, the officially supported OLM Versions are: ${VERSIONS_ARRAY[0]}, ${VERSIONS_ARRAY[1]}, and ${VERSIONS_ARRAY[2]}"
+ACTUAL=$(cat ../../website/content/en/docs/overview/_index.md | grep "Currently, the officially supported OLM Versions are:")
+
+if [[ $ACTUAL != $EXPECTED ]]
+then
+    echo -e "\nDocs (website/content/en/docs/overview/_index.md) does not have the most up to date OLM release versions.\nEXPECTED: $EXPECTED | ACTUAL: $ACTUAL"
+    FAILED="true"
+fi
+
+
+# clean up 
+cd ../../
+rm -rf olm-test
+
+# State pass or fail result
+if [[ $FAILED != "false" ]]
+then
+    echo -e "\nOLM Version Check - \033[0;31mFAILED\033[0m"
+    exit 1
+else
+    echo -e "\nOLM Version Check - \033[0;32mPASSED\033[0m"
+fi
+

--- a/hack/check-olm.sh
+++ b/hack/check-olm.sh
@@ -23,9 +23,13 @@ done
 
 VERSIONS_ARRAY=($(echo "$VERSIONS_STRING" | tr ' ' '\n'))
 
+# clean up OLM because we are done with it now
+cd ../../
+rm -rf olm-test
+
 # check Makefile OLM_VERSIONS
 EXPECTED="OLM_VERSIONS =$VERSIONS_STRING"
-ACTUAL=$(cat ../../Makefile | grep "OLM_VERSIONS =")
+ACTUAL=$(cat Makefile | grep "OLM_VERSIONS =")
 
 if [[ $ACTUAL != $EXPECTED ]]
 then
@@ -34,7 +38,7 @@ then
 fi
 
 # check internal/bindata/olm/versions.go
-AVAILABLE_VERSIONS=($(cat ../../internal/bindata/olm/versions.go | awk '/var availableVersions/,/},\n}/' | tr -d '\t' | tr -d ' ":{},'))
+AVAILABLE_VERSIONS=($(cat internal/bindata/olm/versions.go | awk '/var availableVersions/,/},\n}/' | tr -d '\t' | tr -d ' ":{},'))
 
 ACTUAL=""
 for i in {1..3}
@@ -50,7 +54,7 @@ fi
 
 # check internal/testutils/olm.go
 EXPECTED="OlmVersionForTestSuite = \"${VERSIONS_ARRAY[2]}\""
-ACTUAL=$(cat ../../internal/testutils/olm.go | grep "OlmVersionForTestSuite =" | tr -d '\t')
+ACTUAL=$(cat internal/testutils/olm.go | grep "OlmVersionForTestSuite =" | tr -d '\t')
 
 if [[ $ACTUAL != $EXPECTED ]]
 then
@@ -60,18 +64,13 @@ fi
 
 # check docs - website/content/en/docs/overview/_index.md
 EXPECTED="Currently, the officially supported OLM Versions are: ${VERSIONS_ARRAY[0]}, ${VERSIONS_ARRAY[1]}, and ${VERSIONS_ARRAY[2]}"
-ACTUAL=$(cat ../../website/content/en/docs/overview/_index.md | grep "Currently, the officially supported OLM Versions are:")
+ACTUAL=$(cat website/content/en/docs/overview/_index.md | grep "Currently, the officially supported OLM Versions are:")
 
 if [[ $ACTUAL != $EXPECTED ]]
 then
     echo -e "\nDocs (website/content/en/docs/overview/_index.md) does not have the most up to date OLM release versions.\nEXPECTED: $EXPECTED | ACTUAL: $ACTUAL"
     FAILED="true"
 fi
-
-
-# clean up 
-cd ../../
-rm -rf olm-test
 
 # State pass or fail result
 if [[ $FAILED != "false" ]]


### PR DESCRIPTION
**Description of the change:**
Add a check to CI that will check for the OLM versions to be up to date with the 3 latest minor releases.

The check is implemented as a shell script so that the check can also be run locally outside of CI. 

The script will check the following files for the most up to date OLM versions:
- Makefile
- internal/bindata/olm/versions.go
- internal/testutils/olm.go
- website/content/en/docs/overview/_index.md

The check assumes that if you change the `OLM_VERSIONS` variable in the Makefile that you also have run `make bindata` to update the OLM bindata and therefore does not directly check the bindata.

The CI check will also only run on PRs from a branch prefixed with `release-` as to prevent the check from running on every PR. 

**Motivation for the change:**
resolves #5682 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
