### PR TITLE
Docs: update installation.md go version

### DIFF
--- a/website/content/en/docs/building-operators/golang/installation.md
+++ b/website/content/en/docs/building-operators/golang/installation.md
@@ -11,7 +11,7 @@ Follow the steps in the [installation guide][install-guide] to learn how to inst
 ## Additional Prerequisites
 
 - [git][git_tool]
-- [go][go_tool] version 1.16
+- [go][go_tool] version 1.17
 - [docker][docker_tool] version 17.03+.
 - [kubectl][kubectl_tool] and access to a Kubernetes cluster of a [compatible version][k8s-version-compat].
 


### PR DESCRIPTION
go1.16 not work for [go-quickstart](https://sdk.operatorframework.io/docs/building-operators/golang/quickstart/) anymore ,must update to go1.17

When i try to run ```operator-sdk init --domain example.com --repo github.com/example/memcached-operator``` ,failed at go1.16 and go1.18 ,only work at go1.17

Run error some as [https://github.com/kubernetes-sigs/controller-tools/issues/643](https://github.com/kubernetes-sigs/controller-tools/issues/643)

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
update installation.md go version




