### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -10,9 +10,15 @@ on:
         description: ansible-operator-2.11-preview-base image tag, ex. "6e1b47e6ca7c507b8ecf197a8edcd412dd64d85d"
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   # Build the ansible-operator-base image.
   ansible-operator-base:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     runs-on: ubuntu-18.04
     environment: deploy
     steps:

--- a/.github/workflows/freshen-images.yml
+++ b/.github/workflows/freshen-images.yml
@@ -11,6 +11,9 @@ on:
   # Run at 11 am UTC every day.
   - cron: '0 11 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   git_tags:
     runs-on: ubuntu-18.04

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,6 +2,9 @@ name: integration
 on:
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   check_docs_only:
     name: check_docs_only

--- a/.github/workflows/olm-check.yml
+++ b/.github/workflows/olm-check.yml
@@ -7,6 +7,9 @@ on:
  workflow_dispatch:
    
 
+permissions:
+  contents: read
+
 jobs:
   check-olm-minor-releases:
     name: check-olm-minor-releases

--- a/.github/workflows/test-ansible.yml
+++ b/.github/workflows/test-ansible.yml
@@ -2,6 +2,9 @@ name: ansible
 on:
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   check_docs_only:
     name: check_docs_only

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -2,6 +2,9 @@ name: go
 on:
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   check_docs_only:
     name: check_docs_only
@@ -36,6 +39,9 @@ jobs:
       - run: make test-e2e-go
 
   unit:
+    permissions:
+      checks: write  # for shogo82148/actions-goveralls to create a new check based on the results
+      contents: read  # for actions/checkout to fetch code
     name: unit
     runs-on: ubuntu-18.04
     needs: check_docs_only

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -2,6 +2,9 @@ name: helm
 on:
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   check_docs_only:
     name: check_docs_only


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
