### PR TITLE
Update arch to build go memcached-operator images

### DIFF
--- a/changelog/fragments/update-memcahed-go-arch.yaml
+++ b/changelog/fragments/update-memcahed-go-arch.yaml
@@ -1,0 +1,17 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Use the correct architecture to build the manager binary within the go
+      memcached-operator images.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false

--- a/testdata/go/v2/memcached-operator/Dockerfile
+++ b/testdata/go/v2/memcached-operator/Dockerfile
@@ -1,6 +1,8 @@
 # Build the manager binary
 FROM golang:1.13 as builder
 
+ARG GOARCH=amd64
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -15,7 +17,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$GOARCH GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/go/v2/memcached-operator/Makefile
+++ b/testdata/go/v2/memcached-operator/Makefile
@@ -116,7 +116,8 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	GOARCH=$(shell go env GOARCH) && \
+	       docker build -t ${IMG} --build-arg GOARCH=${GOARCH} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/testdata/go/v3/memcached-operator/Dockerfile
+++ b/testdata/go/v3/memcached-operator/Dockerfile
@@ -1,6 +1,8 @@
 # Build the manager binary
 FROM golang:1.17 as builder
 
+ARG GOARCH=amd64
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -15,7 +17,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$GOARCH go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/go/v3/memcached-operator/Makefile
+++ b/testdata/go/v3/memcached-operator/Makefile
@@ -118,7 +118,8 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	GOARCH=$(shell go env GOARCH) && \
+	       docker build -t ${IMG} --build-arg GOARCH=${GOARCH} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
Use the correct architecture to build the manager binary  within the go memcached-operator images.

Signed-off-by: Gilles Quillard <gquillar@us.ibm.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
