### PR TITLE
Include lightweight tags in version annotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL = /bin/bash
 # version is moved to a separate repo and release process.
 export IMAGE_VERSION = v1.20.0
 # Build-time variables to inject into binaries
-export SIMPLE_VERSION = $(shell (test "$(shell git describe)" = "$(shell git describe --abbrev=0)" && echo $(shell git describe)) || echo $(shell git describe --abbrev=0)+git)
+export SIMPLE_VERSION = $(shell (test "$(shell git describe --tags)" = "$(shell git describe --tags --abbrev=0)" && echo $(shell git describe --tags)) || echo $(shell git describe --tags --abbrev=0)+git)
 export GIT_VERSION = $(shell git describe --dirty --tags --always)
 export GIT_COMMIT = $(shell git rev-parse HEAD)
 export K8S_VERSION = 1.23


### PR DESCRIPTION
**Description of the change:**
Changed Makefile command to include lightweight tags so that the correct SDK version is used in annotations. 

**Motivation for the change:**
Close #5612 

