### PR TITLE
Add xunit sample to Scorecard Docs

### DIFF
--- a/website/content/en/docs/testing-operators/scorecard/_index.md
+++ b/website/content/en/docs/testing-operators/scorecard/_index.md
@@ -226,6 +226,26 @@ See an example of the JSON format produced by a scorecard test:
 }
 ```
 
+### XML format
+
+See below an example of XMl format produced by a scorecard test. Please note that the XMl is formatted to be compatible with the XUnit schema for post-processing the results.
+
+```xml
+<testsuites name="scorecard">
+  <testsuite name="olm-bundle-validation-test" tests="1" skipped="0" failures="0" errors="0">
+    <properties>
+      <property name="spec.image" value="quay.io/operator-framework/scorecard-test:v1.19.0"></property>
+      <property name="spec.entrypoint" value="scorecard-test olm-bundle-validation"></property>
+      <property name="labels.test" value="olm-bundle-validation-test"></property>
+    </properties>
+    <testcase name="olm-bundle-validation" time="0001-01-01T00:00:00Z">
+      <system-out>time=&#34;2022-04-12T19:21:52Z&#34; level=debug msg=&#34;Found manifests directory&#34; name=bundle-test&#xA;time=&#34;2022-04-12T19:21:52Z&#34; level=debug msg=&#34;Found metadata directory&#34; name=bundle-test&#xA;time=&#34;2022-04-12T19:21:52Z&#34; level=debug msg=&#34;Getting mediaType info from manifests directory&#34; name=bundle-test&#xA;time=&#34;2022-04-12T19:21:52Z&#34; level=debug msg=&#34;Found annotations file&#34; name=bundle-test&#xA;time=&#34;2022-04-12T19:21:52Z&#34; level=debug msg=&#34;Could not find optional dependencies file&#34; name=bundle-test&#xA;</system-out>
+    </testcase>
+  </testsuite>
+  <!-- Some suites omitted for readability -->
+</testsuites>
+```
+
 ### Text format
 
 See an example of the text format produced by a scorecard test:
@@ -246,26 +266,6 @@ Results:
 		time="2020-07-15T03:19:02Z" level=debug msg="Getting mediaType info from manifests directory" name=bundle-test
 		time="2020-07-15T03:19:02Z" level=info msg="Found annotations file" name=bundle-test
 		time="2020-07-15T03:19:02Z" level=info msg="Could not find optional dependencies file" name=bundle-test
-```
-
-### XML format
-
-See below an example of XMl format produced by a scorecard test. Please note that the XMl is formatted to be compatible with the XUnit schema for post-processing the results.
-
-```
-<testsuites name="scorecard">
-  <testsuite name="olm-bundle-validation-test" tests="1" skipped="0" failures="0" errors="0">
-    <properties>
-      <property name="spec.image" value="quay.io/operator-framework/scorecard-test:v1.19.0"></property>
-      <property name="spec.entrypoint" value="scorecard-test olm-bundle-validation"></property>
-      <property name="labels.test" value="olm-bundle-validation-test"></property>
-    </properties>
-    <testcase name="olm-bundle-validation" time="0001-01-01T00:00:00Z">
-      <system-out>time=&#34;2022-04-12T19:21:52Z&#34; level=debug msg=&#34;Found manifests directory&#34; name=bundle-test&#xA;time=&#34;2022-04-12T19:21:52Z&#34; level=debug msg=&#34;Found metadata directory&#34; name=bundle-test&#xA;time=&#34;2022-04-12T19:21:52Z&#34; level=debug msg=&#34;Getting mediaType info from manifests directory&#34; name=bundle-test&#xA;time=&#34;2022-04-12T19:21:52Z&#34; level=debug msg=&#34;Found annotations file&#34; name=bundle-test&#xA;time=&#34;2022-04-12T19:21:52Z&#34; level=debug msg=&#34;Could not find optional dependencies file&#34; name=bundle-test&#xA;</system-out>
-    </testcase>
-  </testsuite>
-  <!-- Some suites omitted for readability -->
-</testsuites>
 ```
 
 **NOTE** The output format spec for each test matches the [`Test`](https://pkg.go.dev/github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3#Test) type layout.

--- a/website/content/en/docs/testing-operators/scorecard/_index.md
+++ b/website/content/en/docs/testing-operators/scorecard/_index.md
@@ -248,6 +248,26 @@ Results:
 		time="2020-07-15T03:19:02Z" level=info msg="Could not find optional dependencies file" name=bundle-test
 ```
 
+### XML format
+
+See below an example of XMl format produced by a scorecard test. Please note that the XMl is formatted to be compatible with the XUnit schema for post-processing the results.
+
+```
+<testsuites name="scorecard">
+  <testsuite name="olm-bundle-validation-test" tests="1" skipped="0" failures="0" errors="0">
+    <properties>
+      <property name="spec.image" value="quay.io/operator-framework/scorecard-test:v1.19.0"></property>
+      <property name="spec.entrypoint" value="scorecard-test olm-bundle-validation"></property>
+      <property name="labels.test" value="olm-bundle-validation-test"></property>
+    </properties>
+    <testcase name="olm-bundle-validation" time="0001-01-01T00:00:00Z">
+      <system-out>time=&#34;2022-04-12T19:21:52Z&#34; level=debug msg=&#34;Found manifests directory&#34; name=bundle-test&#xA;time=&#34;2022-04-12T19:21:52Z&#34; level=debug msg=&#34;Found metadata directory&#34; name=bundle-test&#xA;time=&#34;2022-04-12T19:21:52Z&#34; level=debug msg=&#34;Getting mediaType info from manifests directory&#34; name=bundle-test&#xA;time=&#34;2022-04-12T19:21:52Z&#34; level=debug msg=&#34;Found annotations file&#34; name=bundle-test&#xA;time=&#34;2022-04-12T19:21:52Z&#34; level=debug msg=&#34;Could not find optional dependencies file&#34; name=bundle-test&#xA;</system-out>
+    </testcase>
+  </testsuite>
+  <!-- Some suites omitted for readability -->
+</testsuites>
+```
+
 **NOTE** The output format spec for each test matches the [`Test`](https://pkg.go.dev/github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3#Test) type layout.
 
 

--- a/website/content/en/docs/testing-operators/scorecard/_index.md
+++ b/website/content/en/docs/testing-operators/scorecard/_index.md
@@ -228,7 +228,7 @@ See an example of the JSON format produced by a scorecard test:
 
 ### XML format
 
-See the example below for the results of a scorecard test formatted in XML. Please note that the XML is formatted to be compatible with the XUnit schema for post-processing the results.
+See the example below for the results of a scorecard test formatted in XML. The scorecard tool formats the XML output for XUnit schema compatability. This format makes it easier for post-processing the test results.
 
 ```xml
 <testsuites name="scorecard">

--- a/website/content/en/docs/testing-operators/scorecard/_index.md
+++ b/website/content/en/docs/testing-operators/scorecard/_index.md
@@ -228,7 +228,7 @@ See an example of the JSON format produced by a scorecard test:
 
 ### XML format
 
-See below an example of XMl format produced by a scorecard test. Please note that the XMl is formatted to be compatible with the XUnit schema for post-processing the results.
+See the example below for the results of a scorecard test formatted in XML. Please note that the XML is formatted to be compatible with the XUnit schema for post-processing the results.
 
 ```xml
 <testsuites name="scorecard">


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Add xunit output example to docs website

**Motivation for the change:**
New functionality added to SDK, needs docs

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
