### PR TITLE
Don't override relatedImages in base CSV. #5763

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.extensionOutputFolder": "./.vscode"
+}

--- a/changelog/fragments/do-not-override-base-csv-relatedImages.yaml
+++ b/changelog/fragments/do-not-override-base-csv-relatedImages.yaml
@@ -1,0 +1,37 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      No longer overriding the base csv relatedImages.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: Header text for the migration section
+      body: |
+        Body of the migration section. This should be formatted as markdown and can
+        span multiple lines.
+
+        Using the YAML string '|' operator means that newlines in this string will
+        be honored and interpretted as newlines in the rendered markdown.

--- a/changelog/fragments/do-not-override-base-csv-relatedImages.yaml
+++ b/changelog/fragments/do-not-override-base-csv-relatedImages.yaml
@@ -14,24 +14,3 @@ entries:
 
     # Is this a breaking change?
     breaking: false
-
-    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
-    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
-    #
-    # The generator auto-detects the PR number from the commit
-    # message in which this file was originally added.
-    #
-    # What is the pull request number (without the "#")?
-    # pull_request_override: 0
-
-
-    # Migration can be defined to automatically add a section to
-    # the migration guide. This is required for breaking changes.
-    migration:
-      header: Header text for the migration section
-      body: |
-        Body of the migration section. This should be formatted as markdown and can
-        span multiple lines.
-
-        Using the YAML string '|' operator means that newlines in this string will
-        be honored and interpretted as newlines in the rendered markdown.

--- a/changelog/fragments/do-not-override-base-csv-relatedImages.yaml
+++ b/changelog/fragments/do-not-override-base-csv-relatedImages.yaml
@@ -2,7 +2,7 @@
 # release notes and/or the migration guide
 entries:
   - description: >
-      No longer overriding the base csv relatedImages.
+      Fixes an issue that caused hardcoded values in the base CSV's `spec.relatedImages` field to be overwritten during bundle generation.
 
     # kind is one of:
     # - addition

--- a/internal/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/internal/cmd/operator-sdk/generate/bundle/bundle.go
@@ -191,7 +191,7 @@ func (c bundleCmd) runManifests() (err error) {
 		c.println("Building a ClusterServiceVersion without an existing base")
 	}
 
-	relatedImages, err := genutil.FindRelatedImages(col)
+	relatedImages, err := genutil.FindRelatedImages(col, c.packageName)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/operator-sdk/generate/internal/relatedimages.go
+++ b/internal/cmd/operator-sdk/generate/internal/relatedimages.go
@@ -104,7 +104,7 @@ func (c *relatedImageCollector) collectFromBaseCSV(base *operatorsv1alpha1.Clust
 }
 
 func isStaticImage(image string) bool {
-	return strings.Contains(image, ":")
+	return !strings.Contains(image, "@sha256:")
 }
 
 func (c *relatedImageCollector) collect(name, imageRef, containerRef string) {

--- a/internal/generate/clusterserviceversion/clusterserviceversion.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion.go
@@ -167,7 +167,7 @@ func (g *Generator) generate() (base *operatorsv1alpha1.ClusterServiceVersion, e
 	if g.FromVersion != "" {
 		base.Spec.Replaces = genutil.MakeCSVName(g.OperatorName, g.FromVersion)
 	}
-	base.Spec.RelatedImages = g.RelatedImages
+	base.Spec.RelatedImages = append(base.Spec.RelatedImages, g.RelatedImages...)
 
 	if err := ApplyTo(g.Collector, base, g.ExtraServiceAccounts); err != nil {
 		return nil, err

--- a/internal/generate/collector/manifests.go
+++ b/internal/generate/collector/manifests.go
@@ -22,8 +22,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	scorecardv1alpha3 "github.com/operator-framework/api/pkg/apis/scorecard/v1alpha3"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	log "github.com/sirupsen/logrus"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
@@ -373,4 +375,15 @@ func isDirExist(dir string) bool {
 	}
 	info, err := os.Stat(dir)
 	return (err == nil && info.IsDir()) || os.IsExist(err)
+}
+
+// Get ClusterServiceVersion for operator with package name provided
+func (c *Manifests) GetClusterServiceVersion(name string) *v1alpha1.ClusterServiceVersion {
+	csvNamePrefix := name + "."
+	for _, csv := range c.ClusterServiceVersions {
+		if strings.HasPrefix(csv.GetName(), csvNamePrefix) {
+			return csv.DeepCopy()
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Closes #5763, #5000
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Regression: relatedImages in base CSV were being overridden.

**Motivation for the change:**
Do not want relatedImages overridden from baseCSV.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
