### PR TITLE
Document setting logging with Kustomize

### DIFF
--- a/website/content/en/docs/building-operators/golang/references/logging.md
+++ b/website/content/en/docs/building-operators/golang/references/logging.md
@@ -181,6 +181,30 @@ spec:
         - "--zap-log-level=debug"
 ```
 
+### Setting flags when deploying with Kustomize
+
+It's very common to use [Kustomize](https://kustomize.io/) to deploy operators - typically by referencing the upstream manifests as a remote resource. You can't just edit the upstream `Deployment` to change log settings if you do this. Instead, use a Kustomize patch to add any argument you require.
+
+To set debug logging for the above example operator `controller-manager` in namespace `system`, for example, you might use:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://url-of-your-operator/
+patches:
+  - target:
+      kind: Deployment
+      name: controller-manager
+      namespace: system
+    patch: |-
+      - op: add
+        path: "/spec/template/spec/containers/1/args/-"
+        value: "--zap-log-level=debug"
+```
+
+Because of Kustomize's reliance on [jsonpatch](http://jsonpatch.com/) you must specify the container containing your operator as a 0-indexed offset within the `spec.template.spec.containers` array in the `Deployment` yaml, so check the index is correct for your Deployment.
+
 ## Creating a structured log statement
 
 There are two ways to create structured logs with `logr`. You can create new loggers using `log.WithValues(keyValues)` that include `keyValues`, a list of key-value pair `interface{}`'s, in each log record. Alternatively you can include `keyValues` directly in a log statement, as all `logr` log statements take some message and `keyValues`. The signature of `logr.Error()` has an `error`-type parameter, which can be `nil`.


### PR DESCRIPTION
**Description of the change:**

Add a short example showing how to configure the Zap log level for the operator with Kustomize.

Patches https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/

**Motivation for the change:**

The Zap logger framework does not appear to support using environment-variables for setting the log level etc, so users need to be able to modify the command line to set log levels.

Kustomize is very commonly used to deploy operators. Document how to set the log level with a Kustomize patch, without having to copy the whole Deployment and hack it by hand.

Ideally the controller would support log level configuration in the environment and document it, so a simple `ConfigMap` with `envFrom` could be used to control logging instead. But in the absence of this, documenting how to set up log levels somehow is desirable.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml)) **n/a**
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)  **n/a**
