### PR TITLE
Fix scorecard XUnit result schema

### DIFF
--- a/internal/cmd/operator-sdk/scorecard/xunit/xunit.go
+++ b/internal/cmd/operator-sdk/scorecard/xunit/xunit.go
@@ -72,7 +72,7 @@ func (ts *TestSuite) AddSuccess(name string, time time.Time, logs string) {
 func (ts *TestSuite) AddFailure(name string, time time.Time, logs, msg string) {
 	ts.Failures++
 	ts.addTest(name, time, logs, &Result{
-		Name:    xml.Name{Local: "failure"},
+		XMLName: xml.Name{Local: "failure"},
 		Type:    "failure",
 		Message: msg,
 	})
@@ -82,7 +82,7 @@ func (ts *TestSuite) AddFailure(name string, time time.Time, logs, msg string) {
 func (ts *TestSuite) AddError(name string, time time.Time, logs, msg string) {
 	ts.Errors++
 	ts.addTest(name, time, logs, &Result{
-		Name:    xml.Name{Local: "error"},
+		XMLName: xml.Name{Local: "error"},
 		Type:    "error",
 		Message: msg,
 	})
@@ -108,7 +108,7 @@ type TestCase struct {
 
 // Result represents the final state of the test case.
 type Result struct {
-	Name    xml.Name
-	Type    string
-	Message string
+	XMLName xml.Name
+	Type    string `xml:"type,attr"`
+	Message string `xml:",innerxml"`
 }


### PR DESCRIPTION
Error and failure cases are currently reported incorrectly. Tools that consume the XUnit schema expect the result element to be named with its type and also have an attribute with its type. This commit changes the output for the result from the incorrect format: `<result type="failure">..></result>` to the expected format: `<failure type="failure">...</failure>`.

Signed-off-by: Ryan King <ryking@redhat.com>
