### PR TITLE
Changed the default reconcile period for Ansible-based operators to 10 hours

### DIFF
--- a/internal/ansible/flags/flag.go
+++ b/internal/ansible/flags/flag.go
@@ -96,7 +96,7 @@ func (f *Flags) AddTo(flagSet *pflag.FlagSet) {
 	// Controller flags.
 	flagSet.DurationVar(&f.ReconcilePeriod,
 		"reconcile-period",
-		time.Minute,
+		10*time.Hour,
 		"Default reconcile period for controllers",
 	)
 	flagSet.IntVar(&f.MaxConcurrentReconciles,


### PR DESCRIPTION
**Description of the change:**
Changed default reconcile period (from the `--reconcile-period` command-line flag) to 10 hours.

**Motivation for the change:**
More reasonable reconcile interval. 