### PR TITLE
update goreleaser install method

### DIFF
--- a/tools/scripts/fetch
+++ b/tools/scripts/fetch
@@ -32,7 +32,9 @@ fetch() {
       ;;
     "goreleaser")
       ver_cmd="${DEST}/goreleaser --version 2>/dev/null | grep version | cut -d' ' -f3"
-      fetch_cmd="curl -sSfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh -s -- -b \"${DEST}\" -d \"v${ver}\""
+      osCap="$(uname -s)"
+      archBase="$(uname -m)"
+      fetch_cmd="(curl -sSfLo '${DEST}/goreleaser.tar.gz' 'https://github.com/goreleaser/goreleaser/releases/download/v${ver}/goreleaser_${osCap}_${archBase}.tar.gz' && tar -xf $DEST/goreleaser.tar.gz -C $DEST)"
       ;;
     *)
       echo "unknown tool $tool"


### PR DESCRIPTION
**Description of the change:**
This change updates the goreleaser installation in the tools/scripts/fetch script to download the tar.gz file from the goreleaser github releases page (https://github.com/goreleaser/goreleaser/releases) based on the version tag given.

**Motivation for the change:**
When attempting to make a patch release for v1.20.1 the deploy action was failing due to curl not being able to resolve the hostname `install.goreleaser.com`. When attempting to reach that same hostname locally it fails to resolve it as well. 

We can see this in the following action results: https://github.com/operator-framework/operator-sdk/runs/6512280746?check_suite_focus=true

<details>
<summary>Error output from action</summary>

```
make -f release/Makefile release
make[1]: Entering directory '/home/runner/work/operator-sdk/operator-sdk'
tools/scripts/fetch goreleaser 0.177.0
goreleaser missing or not version '0.177.0', downloading...
curl: (6) Could not resolve host: install.goreleaser.com
GORELEASER_CURRENT_TAG=v1.20.1 tools/bin/goreleaser  --release-notes=changelog/generated/v1.20.1.md --parallelism 5
/bin/bash: tools/bin/goreleaser: No such file or directory
make[1]: *** [release] Error 127
make: *** [release] Error 2
release/Makefile:27: recipe for target 'release' failed
make[1]: Leaving directory '/home/runner/work/operator-sdk/operator-sdk'
Makefile:110: recipe for target 'release' failed
Error: Process completed with exit code 2.
```

</details>

I am assuming that the install.goreleaser.com domain has gone done in the past ~24 hours as a couple different deploy checks have failed recently due to the same failure.

The change made in this PR should hopefully resolve any of those issues due to it now downloading goreleaser straight from the github releases

**Additional Context:**
The only way I could think to test this was by testing the script locally. With the change, it successfully installed and attempted to run goreleaser in my local environment.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
