### PR TITLE
Merge feature/run-bundle into master: Add FBC support to `run bundle` and `run bundle-upgrade` commands

### DIFF
--- a/changelog/fragments/sdk-fbc-run-bundle(-upgrade).yaml
+++ b/changelog/fragments/sdk-fbc-run-bundle(-upgrade).yaml
@@ -1,0 +1,19 @@
+entries:
+  - description: >
+      Add File-Based Catalog support for both `run bundle` and `run bundle-upgrade` subcommands. 
+      Infer the image type and handle FBC scenarios accordingly for both commands. For FBC images,
+      Operator Registry APIs are called for rendering the bundle and/or the index image and serving these images
+      through the registry pod using a gRPC port. For images that are SQLite based, 
+      `opm registry add` and `opm serve` commands will be called during the registry pod creation. 
+      Support for these old opm commands will be deprecated and completely removed in the future. 
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: addition
+
+    # Is this a breaking change?
+    breaking: false

--- a/changelog/fragments/sdk-fbc-run-bundle(-upgrade).yaml
+++ b/changelog/fragments/sdk-fbc-run-bundle(-upgrade).yaml
@@ -1,11 +1,9 @@
 entries:
   - description: >
-      Add File-Based Catalog support for both `run bundle` and `run bundle-upgrade` subcommands. 
-      Infer the image type and handle FBC scenarios accordingly for both commands. For FBC images,
-      Operator Registry APIs are called for rendering the bundle and/or the index image and serving these images
-      through the registry pod using a gRPC port. For images that are SQLite based, 
-      `opm registry add` and `opm serve` commands will be called during the registry pod creation. 
-      Support for these old opm commands will be deprecated and completely removed in the future. 
+      Add support for File-Based Catalog to the subcommands [operator-sdk run bundle](https://sdk.operatorframework.io/docs/cli/operator-sdk_run_bundle/#m-docsclioperator-sdk_run_bundle) 
+      and [run bundle-upgrade](https://sdk.operatorframework.io/docs/cli/operator-sdk_run_bundle-upgrade/) so that 
+      new indexes created by these subcommands are using the new format. 
+      Users are able to pass in an index catalog with FBC format via the flag option `--index-image`.
 
     # kind is one of:
     # - addition
@@ -13,7 +11,7 @@ entries:
     # - deprecation
     # - removal
     # - bugfix
-    kind: addition
+    kind: change
 
     # Is this a breaking change?
     breaking: false

--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,9 @@ require (
 	github.com/garyburd/redigo v1.6.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.1.0 // indirect
+	github.com/go-git/go-git/v5 v5.3.0 // indirect
 	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
@@ -112,6 +115,7 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gofrs/uuid v3.3.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-migrate/migrate/v4 v4.6.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/btree v1.0.1 // indirect
@@ -134,7 +138,9 @@ require (
 	github.com/huandu/xstrings v1.3.1 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmoiron/sqlx v1.3.1 // indirect
+	github.com/joelanford/ignore v0.0.0-20210607151042-0d25dc18b62d // indirect
 	github.com/joho/godotenv v1.3.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -149,10 +155,12 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.7 // indirect
+	github.com/mattn/go-sqlite3 v1.14.10 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/copystructure v1.1.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
@@ -228,6 +236,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiserver v0.23.5 // indirect

--- a/internal/cmd/operator-sdk/run/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/run/bundle/cmd.go
@@ -36,7 +36,9 @@ The main purpose of this command is to streamline running the bundle without hav
 
 The ` + "`--index-image`" + ` flag specifies an index image in which to inject the given bundle. It can be specified to resolve dependencies for a bundle. 
 This is an optional flag which will default to ` + "`quay.io/operator-framework/opm:latest`." + `
-The index image provided should **NOT** already have the bundle.
+The index image provided should **NOT** already have the bundle. A limitation of the index image flag is that it does not check the upgrade graph
+as the annotations for channels are ignored but it is still a useful flag to have to validate the dependencies. 
+For example: It does not fail fast when the bundle version provided is <= ChannelHead.
 `,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: func(*cobra.Command, []string) error { return cfg.Load() },

--- a/internal/olm/fbcutil/util.go
+++ b/internal/olm/fbcutil/util.go
@@ -1,0 +1,151 @@
+// Copyright 2022 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fbcutil
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	declarativeconfig "github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/pkg/containertools"
+	registryutil "github.com/operator-framework/operator-sdk/internal/registry"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	SchemaChannel  = "olm.channel"
+	SchemaPackage  = "olm.package"
+	DefaultChannel = "operator-sdk-run"
+)
+
+const (
+	// defaultIndexImageBase is the base for defaultIndexImage. It is necessary to separate
+	// them for string comparison when defaulting bundle add mode.
+	DefaultIndexImageBase = "quay.io/operator-framework/opm:"
+	// DefaultIndexImage is the index base image used if none is specified. It contains no bundles.
+	// TODO(v2.0.0): pin this image tag to a specific version.
+	DefaultIndexImage = DefaultIndexImageBase + "latest"
+)
+
+// BundleDeclcfg represents a minimal File-Based Catalog.
+// This struct only consists of one Package, Bundle, and Channel blob. It is used to
+// represent the bundle image in the File-Based Catalog format.
+type BundleDeclcfg struct {
+	Package declcfg.Package
+	Channel declcfg.Channel
+	Bundle  declcfg.Bundle
+}
+
+// FBCContext is a struct that stores all the required information while constructing
+// a new File-Based Catalog on the fly. The fields from this struct are passed as
+// parameters to Operator Registry API calls to generate declarative config objects.
+type FBCContext struct {
+	Package      string
+	ChannelName  string
+	Refs         []string
+	ChannelEntry declarativeconfig.ChannelEntry
+}
+
+// CreateFBC generates an FBC by creating bundle, package and channel blobs.
+func (f *FBCContext) CreateFBC(ctx context.Context) (BundleDeclcfg, error) {
+	var bundleDC BundleDeclcfg
+	// Rendering the bundle image into a declarative config format.
+	declcfg, err := RenderRefs(ctx, f.Refs)
+	if err != nil {
+		return BundleDeclcfg{}, err
+	}
+
+	// Ensuring a valid bundle size.
+	if len(declcfg.Bundles) != 1 {
+		return BundleDeclcfg{}, fmt.Errorf("bundle image should contain exactly one bundle blob")
+	}
+
+	bundleDC.Bundle = declcfg.Bundles[0]
+
+	// generate package.
+	bundleDC.Package = declarativeconfig.Package{
+		Schema:         SchemaPackage,
+		Name:           f.Package,
+		DefaultChannel: f.ChannelName,
+	}
+
+	// generate channel.
+	bundleDC.Channel = declarativeconfig.Channel{
+		Schema:  SchemaChannel,
+		Name:    f.ChannelName,
+		Package: f.Package,
+		Entries: []declarativeconfig.ChannelEntry{f.ChannelEntry},
+	}
+
+	return bundleDC, nil
+}
+
+// ValidateAndStringify first converts the generated declarative config to a model and validates it.
+// If the declarative config model is valid, it will convert the declarative config to a YAML string and return it.
+func ValidateAndStringify(declcfg *declarativeconfig.DeclarativeConfig) (string, error) {
+	// validates and converts declarative config to model
+	_, err := declarativeconfig.ConvertToModel(*declcfg)
+	if err != nil {
+		return "", fmt.Errorf("error converting the declarative config to model: %v", err)
+	}
+
+	var buf bytes.Buffer
+	err = declarativeconfig.WriteYAML(*declcfg, &buf)
+	if err != nil {
+		return "", fmt.Errorf("error writing generated declarative config to JSON encoder: %v", err)
+	}
+
+	if buf.String() == "" {
+		return "", errors.New("file-based catalog contents cannot be empty")
+	}
+
+	return buf.String(), nil
+}
+
+// RenderRefs will invoke Operator Registry APIs and return a declarative config object representation
+// of the references that are passed in as a string array.
+func RenderRefs(ctx context.Context, refs []string) (*declarativeconfig.DeclarativeConfig, error) {
+	render := action.Render{
+		Refs: refs,
+	}
+
+	log.SetOutput(ioutil.Discard)
+	declcfg, err := render.Run(ctx)
+	log.SetOutput(os.Stdout)
+	if err != nil {
+		return nil, fmt.Errorf("error in rendering the bundle and index image: %v", err)
+	}
+
+	return declcfg, nil
+}
+
+// IsFBC will determine if an index image uses the File-Based Catalog or SQLite index image format.
+// The default index image will adopt the File-Based Catalog format.
+func IsFBC(ctx context.Context, indexImage string) (bool, error) {
+	// adding updates to the IndexImageCatalogCreator if it is an FBC image
+	catalogLabels, err := registryutil.GetImageLabels(ctx, nil, indexImage, false)
+	if err != nil {
+		return false, fmt.Errorf("get index image labels: %v", err)
+	}
+	_, hasFBCLabel := catalogLabels[containertools.ConfigsLocationLabel]
+
+	return hasFBCLabel || indexImage == DefaultIndexImage, nil
+}

--- a/internal/olm/operator/bundleupgrade/upgrade.go
+++ b/internal/olm/operator/bundleupgrade/upgrade.go
@@ -20,10 +20,9 @@ import (
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	registrybundle "github.com/operator-framework/operator-registry/pkg/lib/bundle"
-	"github.com/spf13/pflag"
-
 	"github.com/operator-framework/operator-sdk/internal/olm/operator"
 	"github.com/operator-framework/operator-sdk/internal/olm/operator/registry"
+	"github.com/spf13/pflag"
 )
 
 type Upgrade struct {
@@ -86,6 +85,12 @@ func (u *Upgrade) setup(ctx context.Context) error {
 	u.IndexImageCatalogCreator.PackageName = u.OperatorInstaller.PackageName
 	u.IndexImageCatalogCreator.BundleImage = u.BundleImage
 	u.IndexImageCatalogCreator.IndexImage = registry.DefaultIndexImage
+
+	if _, hasChannelMetadata := labels[registrybundle.ChannelsLabel]; hasChannelMetadata {
+		u.IndexImageCatalogCreator.ChannelName = strings.Split(labels[registrybundle.ChannelsLabel], ",")[0]
+	} else {
+		u.IndexImageCatalogCreator.ChannelName = registry.DefaultChannel
+	}
 
 	return nil
 }

--- a/internal/olm/operator/bundleupgrade/upgrade.go
+++ b/internal/olm/operator/bundleupgrade/upgrade.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	registrybundle "github.com/operator-framework/operator-registry/pkg/lib/bundle"
+	fbcutil "github.com/operator-framework/operator-sdk/internal/olm/fbcutil"
 	"github.com/operator-framework/operator-sdk/internal/olm/operator"
 	"github.com/operator-framework/operator-sdk/internal/olm/operator/registry"
 	"github.com/spf13/pflag"
@@ -84,12 +85,12 @@ func (u *Upgrade) setup(ctx context.Context) error {
 	// defer defaulting the bundle add mode to after the existing CatalogSource is retrieved.
 	u.IndexImageCatalogCreator.PackageName = u.OperatorInstaller.PackageName
 	u.IndexImageCatalogCreator.BundleImage = u.BundleImage
-	u.IndexImageCatalogCreator.IndexImage = registry.DefaultIndexImage
+	u.IndexImageCatalogCreator.IndexImage = fbcutil.DefaultIndexImage
 
 	if _, hasChannelMetadata := labels[registrybundle.ChannelsLabel]; hasChannelMetadata {
 		u.IndexImageCatalogCreator.ChannelName = strings.Split(labels[registrybundle.ChannelsLabel], ",")[0]
 	} else {
-		u.IndexImageCatalogCreator.ChannelName = registry.DefaultChannel
+		u.IndexImageCatalogCreator.ChannelName = fbcutil.DefaultChannel
 	}
 
 	return nil

--- a/internal/olm/operator/registry/catalog.go
+++ b/internal/olm/operator/registry/catalog.go
@@ -25,5 +25,5 @@ type CatalogCreator interface {
 }
 
 type CatalogUpdater interface {
-	UpdateCatalog(ctx context.Context, cs *v1alpha1.CatalogSource) error
+	UpdateCatalog(ctx context.Context, cs *v1alpha1.CatalogSource, subscription *v1alpha1.Subscription) error
 }

--- a/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
+++ b/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
@@ -1,0 +1,250 @@
+// Copyright 2022 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fbcindex
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/operator-framework/operator-sdk/internal/olm/operator"
+	"github.com/operator-framework/operator-sdk/internal/olm/operator/registry/index"
+	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
+)
+
+const (
+	// defaultGRPCPort is the default grpc container port that the registry pod exposes
+	defaultGRPCPort = 50051
+
+	defaultContainerName     = "registry-grpc"
+	defaultContainerPortName = "grpc"
+)
+
+// FBCRegistryPod holds resources necessary for creation of a registry pod in FBC scenarios.
+type FBCRegistryPod struct { //nolint:maligned
+	// BundleItems contains all bundles to be added to a registry pod.
+	BundleItems []index.BundleItem
+
+	// Index image contains a database of pointers to operator manifest content that is queriable via an API.
+	// new version of an operator bundle when published can be added to an index image
+	IndexImage string
+
+	// GRPCPort is the container grpc port
+	GRPCPort int32
+
+	// pod represents a kubernetes *corev1.pod that will be created on a cluster using an index image
+	pod *corev1.Pod
+
+	// FBCContent represents the contents of the FBC file (string YAML).
+	FBCContent string
+
+	// FBCDir is the name of the FBC directory name where the FBC resides in.
+	FBCDir string
+
+	// FBCFile represents the FBC filename that has all the contents to be served through the registry pod.
+	FBCFile string
+
+	cfg *operator.Configuration
+}
+
+// init initializes the FBCRegistryPod struct.
+func (f *FBCRegistryPod) init(cfg *operator.Configuration) error {
+	if f.GRPCPort == 0 {
+		f.GRPCPort = defaultGRPCPort
+	}
+
+	f.cfg = cfg
+
+	// validate the FBCRegistryPod struct and ensure required fields are set
+	if err := f.validate(); err != nil {
+		return fmt.Errorf("invalid FBC registry pod: %v", err)
+	}
+
+	bundleImage := f.BundleItems[len(f.BundleItems)-1].ImageTag
+	trimmedbundleImage := strings.Split(bundleImage, ":")[0]
+	f.FBCDir = fmt.Sprintf("%s-index", filepath.Join("/tmp", strings.Split(trimmedbundleImage, "/")[2]))
+	f.FBCFile = filepath.Join(f.FBCDir, strings.Split(bundleImage, ":")[1])
+
+	// podForBundleRegistry() to make the pod definition
+	pod, err := f.podForBundleRegistry()
+	if err != nil {
+		return fmt.Errorf("error building registry pod definition: %v", err)
+	}
+	f.pod = pod
+
+	return nil
+}
+
+// Create creates a bundle registry pod built from an fbc index image,
+// sets the catalog source as the owner for the pod and verifies that
+// the pod is running
+func (f *FBCRegistryPod) Create(ctx context.Context, cfg *operator.Configuration, cs *v1alpha1.CatalogSource) (*corev1.Pod, error) {
+	if err := f.init(cfg); err != nil {
+		return nil, err
+	}
+
+	// make catalog source the owner of registry pod object
+	if err := controllerutil.SetOwnerReference(cs, f.pod, f.cfg.Scheme); err != nil {
+		return nil, fmt.Errorf("error setting owner reference: %w", err)
+	}
+
+	if err := f.cfg.Client.Create(ctx, f.pod); err != nil {
+		return nil, fmt.Errorf("error creating pod: %w", err)
+	}
+
+	// get registry pod key
+	podKey := types.NamespacedName{
+		Namespace: f.cfg.Namespace,
+		Name:      f.pod.GetName(),
+	}
+
+	// poll and verify that pod is running
+	podCheck := wait.ConditionFunc(func() (done bool, err error) {
+		err = f.cfg.Client.Get(ctx, podKey, f.pod)
+		if err != nil {
+			return false, fmt.Errorf("error getting pod %s: %w", f.pod.Name, err)
+		}
+		return f.pod.Status.Phase == corev1.PodRunning, nil
+	})
+
+	// check pod status to be `Running`
+	if err := f.checkPodStatus(ctx, podCheck); err != nil {
+		return nil, fmt.Errorf("registry pod did not become ready: %w", err)
+	}
+	log.Infof("Created registry pod: %s", f.pod.Name)
+	return f.pod, nil
+}
+
+// checkPodStatus polls and verifies that the pod status is running
+func (f *FBCRegistryPod) checkPodStatus(ctx context.Context, podCheck wait.ConditionFunc) error {
+	// poll every 200 ms until podCheck is true or context is done
+	err := wait.PollImmediateUntil(200*time.Millisecond, podCheck, ctx.Done())
+	if err != nil {
+		return fmt.Errorf("error waiting for registry pod %s to run: %v", f.pod.Name, err)
+	}
+
+	return err
+}
+
+// validate will ensure that RegistryPod required fields are set
+// and throws error if not set
+func (f *FBCRegistryPod) validate() error {
+	if len(f.BundleItems) == 0 {
+		return errors.New("bundle image set cannot be empty")
+	}
+	for _, item := range f.BundleItems {
+		if item.ImageTag == "" {
+			return errors.New("bundle image cannot be empty")
+		}
+	}
+
+	if f.IndexImage == "" {
+		return errors.New("index image cannot be empty")
+	}
+
+	return nil
+}
+
+func GetRegistryPodHost(ipStr string) string {
+	return fmt.Sprintf("%s:%d", ipStr, defaultGRPCPort)
+}
+
+// getPodName will return a string constructed from the bundle Image name
+func getPodName(bundleImage string) string {
+	// todo(rashmigottipati): need to come up with human-readable references
+	// to be able to handle SHA references in the bundle images
+	return k8sutil.TrimDNS1123Label(k8sutil.FormatOperatorNameDNS1123(bundleImage))
+}
+
+// podForBundleRegistry constructs and returns the registry pod definition
+// and throws error when unable to build the pod definition successfully
+func (f *FBCRegistryPod) podForBundleRegistry() (*corev1.Pod, error) {
+	// rp was already validated so len(f.BundleItems) must be greater than 0.
+	bundleImage := f.BundleItems[len(f.BundleItems)-1].ImageTag
+
+	// construct the container command for pod spec
+	containerCmd, err := f.getContainerCmd()
+	if err != nil {
+		return nil, err
+	}
+
+	// make the pod definition
+	f.pod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getPodName(bundleImage),
+			Namespace: f.cfg.Namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  defaultContainerName,
+					Image: f.IndexImage,
+					Command: []string{
+						"sh",
+						"-c",
+						containerCmd,
+					},
+					Ports: []corev1.ContainerPort{
+						{Name: defaultContainerPortName, ContainerPort: f.GRPCPort},
+					},
+				},
+			},
+		},
+	}
+
+	return f.pod, nil
+}
+
+const fbcCmdTemplate = `mkdir -p {{ .FBCDir }} && \
+echo '{{ .FBCContent }}' >> {{ .FBCFile  }} && \
+opm serve {{ .FBCDir }} -p {{ .GRPCPort }}
+`
+
+// getContainerCmd uses templating to construct the container command
+// and throws error if unable to parse and execute the container command
+func (f *FBCRegistryPod) getContainerCmd() (string, error) {
+	var t *template.Template
+	// create a custom dirname template function
+	funcMap := template.FuncMap{
+		"dirname": path.Dir,
+	}
+
+	// add the custom dirname template function to the
+	// template's FuncMap and parse the cmdTemplate
+	t = template.Must(template.New("cmd").Funcs(funcMap).Parse(fbcCmdTemplate))
+
+	// execute the command by applying the parsed template to command
+	// and write command output to out
+	out := &bytes.Buffer{}
+	if err := t.Execute(out, f); err != nil {
+		return "", fmt.Errorf("parse container command: %w", err)
+	}
+
+	return out.String(), nil
+}

--- a/internal/olm/operator/registry/index/registry_pod_test.go
+++ b/internal/olm/operator/registry/index/registry_pod_test.go
@@ -43,7 +43,7 @@ func TestCreateRegistryPod(t *testing.T) {
 	RunSpecs(t, "Test Registry Pod Suite")
 }
 
-var _ = Describe("RegistryPod", func() {
+var _ = Describe("SQLiteRegistryPod", func() {
 
 	var defaultBundleItems = []BundleItem{{
 		ImageTag: "quay.io/example/example-operator-bundle:0.2.0",
@@ -55,7 +55,7 @@ var _ = Describe("RegistryPod", func() {
 		Context("with valid registry pod values", func() {
 
 			var (
-				rp  *RegistryPod
+				rp  *SQLiteRegistryPod
 				cfg *operator.Configuration
 				pod *corev1.Pod
 				err error
@@ -66,15 +66,15 @@ var _ = Describe("RegistryPod", func() {
 					Client:    newFakeClient(),
 					Namespace: "test-default",
 				}
-				rp = &RegistryPod{
+				rp = &SQLiteRegistryPod{
 					BundleItems: defaultBundleItems,
 					IndexImage:  testIndexImageTag,
 				}
-				By("initializing the RegistryPod")
+				By("initializing the SQLiteRegistryPod")
 				Expect(rp.init(cfg)).To(Succeed())
 			})
 
-			It("should create the RegistryPod successfully", func() {
+			It("should create the SQLiteRegistryPod successfully", func() {
 				expectedPodName := "quay-io-example-example-operator-bundle-0-2-0"
 				Expect(rp).NotTo(BeNil())
 				Expect(rp.pod.Name).To(Equal(expectedPodName))
@@ -130,7 +130,7 @@ var _ = Describe("RegistryPod", func() {
 						AddMode:  SemverBundleAddMode,
 					},
 				)
-				rp2 := RegistryPod{
+				rp2 := SQLiteRegistryPod{
 					DBPath:        defaultDBPath,
 					GRPCPort:      defaultGRPCPort,
 					BundleItems:   bundleItems,
@@ -180,7 +180,7 @@ var _ = Describe("RegistryPod", func() {
 						AddMode:  SemverBundleAddMode,
 					},
 				)
-				rp2 := RegistryPod{
+				rp2 := SQLiteRegistryPod{
 					DBPath:      defaultDBPath,
 					GRPCPort:    defaultGRPCPort,
 					BundleItems: bundleItems,
@@ -242,7 +242,7 @@ var _ = Describe("RegistryPod", func() {
 
 			It("should error when bundle image is not provided", func() {
 				expectedErr := "bundle image set cannot be empty"
-				rp := &RegistryPod{}
+				rp := &SQLiteRegistryPod{}
 				err := rp.init(cfg)
 				Expect(err).NotTo(BeNil())
 				Expect(err.Error()).Should(ContainSubstring(expectedErr))
@@ -250,7 +250,7 @@ var _ = Describe("RegistryPod", func() {
 
 			It("should not accept any other bundle add mode other than semver or replaces", func() {
 				expectedErr := `bundle add mode "invalid" does not exist`
-				rp := &RegistryPod{
+				rp := &SQLiteRegistryPod{
 					BundleItems: []BundleItem{{ImageTag: "quay.io/example/example-operator-bundle:0.2.0", AddMode: "invalid"}},
 				}
 				err := rp.init(cfg)
@@ -259,7 +259,7 @@ var _ = Describe("RegistryPod", func() {
 			})
 
 			It("checkPodStatus should return error when pod check is false and context is done", func() {
-				rp := &RegistryPod{
+				rp := &SQLiteRegistryPod{
 					BundleItems: defaultBundleItems,
 					IndexImage:  testIndexImageTag,
 				}

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -15,19 +15,14 @@
 package registry
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/operator-framework/operator-registry/alpha/action"
-	"github.com/operator-framework/operator-registry/pkg/containertools"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	gofunk "github.com/thoas/go-funk"
@@ -37,21 +32,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 
-	"github.com/operator-framework/operator-registry/alpha/declcfg"
 	declarativeconfig "github.com/operator-framework/operator-registry/alpha/declcfg"
+	fbcutil "github.com/operator-framework/operator-sdk/internal/olm/fbcutil"
 	"github.com/operator-framework/operator-sdk/internal/olm/operator"
 	"github.com/operator-framework/operator-sdk/internal/olm/operator/registry/fbcindex"
 	"github.com/operator-framework/operator-sdk/internal/olm/operator/registry/index"
 	registryutil "github.com/operator-framework/operator-sdk/internal/registry"
-)
-
-const (
-	// defaultIndexImageBase is the base for defaultIndexImage. It is necessary to separate
-	// them for string comparison when defaulting bundle add mode.
-	defaultIndexImageBase = "quay.io/operator-framework/opm:"
-	// DefaultIndexImage is the index base image used if none is specified. It contains no bundles.
-	// TODO(v2.0.0): pin this image tag to a specific version.
-	DefaultIndexImage = defaultIndexImageBase + "latest"
 )
 
 // Internal CatalogSource annotations.
@@ -65,31 +51,6 @@ const (
 	// Holds the name of the existing registry pod associated with a catalog.
 	registryPodNameAnnotation = operatorFrameworkGroup + "/registry-pod-name"
 )
-
-const (
-	schemaChannel  = "olm.channel"
-	schemaPackage  = "olm.package"
-	DefaultChannel = "operator-sdk-run"
-)
-
-// BundleDeclcfg represents a minimal File-Based Catalog.
-// This struct only consists of one Package, Bundle, and Channel blob. It is used to
-// represent the bundle image in the File-Based Catalog format.
-type BundleDeclcfg struct {
-	Package declcfg.Package
-	Channel declcfg.Channel
-	Bundle  declcfg.Bundle
-}
-
-// FBCContext is a struct that stores all the required information while constructing
-// a new File-Based Catalog on the fly. The fields from this struct are passed as
-// parameters to Operator Registry API calls to generate declarative config objects.
-type FBCContext struct {
-	Package      string
-	ChannelName  string
-	Refs         []string
-	ChannelEntry declarativeconfig.ChannelEntry
-}
 
 type IndexImageCatalogCreator struct {
 	SkipTLS         bool
@@ -185,13 +146,13 @@ func getChannelHead(entries []declarativeconfig.ChannelEntry) (string, error) {
 // handleTraditionalUpgrade upgrades an operator that was installed using OLM. Subsequent upgrades will go through the runFBCUpgrade function
 func handleTraditionalUpgrade(ctx context.Context, indexImage string, bundleImage string, channelName string) (string, error) {
 	// render the index image
-	originalDeclCfg, err := renderRefs(ctx, []string{indexImage})
+	originalDeclCfg, err := fbcutil.RenderRefs(ctx, []string{indexImage})
 	if err != nil {
 		return "", fmt.Errorf("error in rendering index %q", indexImage)
 	}
 
 	// render the bundle image
-	bundleDeclConfig, err := renderRefs(ctx, []string{bundleImage})
+	bundleDeclConfig, err := fbcutil.RenderRefs(ctx, []string{bundleImage})
 	if err != nil {
 		return "", fmt.Errorf("error in rendering index %q", bundleImage)
 	}
@@ -222,7 +183,7 @@ func handleTraditionalUpgrade(ctx context.Context, indexImage string, bundleImag
 
 	// validate the declarative config and convert it to a string
 	var content string
-	if content, err = ValidateAndStringify(originalDeclCfg); err != nil {
+	if content, err = fbcutil.ValidateAndStringify(originalDeclCfg); err != nil {
 		return "", fmt.Errorf("error validating and converting the declarative config object to a string format: %v", err)
 	}
 
@@ -236,18 +197,18 @@ func handleTraditionalUpgrade(ctx context.Context, indexImage string, bundleImag
 func (c *IndexImageCatalogCreator) runFBCUpgrade(ctx context.Context) error {
 	// render the index image if it is not the default index image
 	var refs []string
-	if c.IndexImage != DefaultIndexImage {
+	if c.IndexImage != fbcutil.DefaultIndexImage {
 		refs = append(refs, c.IndexImage)
 	}
 
-	originalDeclcfg, err := renderRefs(ctx, refs)
+	originalDeclcfg, err := fbcutil.RenderRefs(ctx, refs)
 	if err != nil {
 		return err
 	}
 
 	// add the upgraded bundle to the list of previous bundles so that they can be rendered with a single API call
 	c.PreviousBundles = append(c.PreviousBundles, c.BundleImage)
-	f := &FBCContext{
+	f := &fbcutil.FBCContext{
 		Package:     c.PackageName,
 		Refs:        c.PreviousBundles,
 		ChannelName: c.ChannelName,
@@ -261,7 +222,7 @@ func (c *IndexImageCatalogCreator) runFBCUpgrade(ctx context.Context) error {
 
 	// validate the declarative config and convert it to a string
 	var content string
-	if content, err = ValidateAndStringify(declcfg); err != nil {
+	if content, err = fbcutil.ValidateAndStringify(declcfg); err != nil {
 		return fmt.Errorf("error validating/stringifying the declarative config object: %v", err)
 	}
 
@@ -272,25 +233,10 @@ func (c *IndexImageCatalogCreator) runFBCUpgrade(ctx context.Context) error {
 	return nil
 }
 
-func renderRefs(ctx context.Context, refs []string) (*declarativeconfig.DeclarativeConfig, error) {
-	render := action.Render{
-		Refs: refs,
-	}
-
-	log.SetOutput(ioutil.Discard)
-	declcfg, err := render.Run(ctx)
-	log.SetOutput(os.Stdout)
-	if err != nil {
-		return nil, fmt.Errorf("error in rendering the bundle and index image: %v", err)
-	}
-
-	return declcfg, nil
-}
-
 // upgradeFBC constructs a new File-Based Catalog from both the FBCContext object and the declarative config object. This function will check to see
 // if the FBCContext object "f" is already present in the original declarative config.
-func upgradeFBC(ctx context.Context, f *FBCContext, originalDeclCfg *declarativeconfig.DeclarativeConfig) (*declarativeconfig.DeclarativeConfig, error) {
-	declcfg, err := renderRefs(ctx, f.Refs)
+func upgradeFBC(ctx context.Context, f *fbcutil.FBCContext, originalDeclCfg *declarativeconfig.DeclarativeConfig) (*declarativeconfig.DeclarativeConfig, error) {
+	declcfg, err := fbcutil.RenderRefs(ctx, f.Refs)
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +309,7 @@ func upgradeFBC(ctx context.Context, f *FBCContext, originalDeclCfg *declarative
 	// create a new channel if it does not exist
 	if !channelExists {
 		originalDeclCfg.Channels = append(originalDeclCfg.Channels, declarativeconfig.Channel{
-			Schema:  schemaChannel,
+			Schema:  fbcutil.SchemaChannel,
 			Name:    f.ChannelName,
 			Package: f.Package,
 			Entries: entries,
@@ -382,26 +328,13 @@ func upgradeFBC(ctx context.Context, f *FBCContext, originalDeclCfg *declarative
 	// only add the new package if it does not already exist
 	if !packagePresent {
 		originalDeclCfg.Packages = append(originalDeclCfg.Packages, declarativeconfig.Package{
-			Schema:         schemaPackage,
+			Schema:         fbcutil.SchemaPackage,
 			Name:           f.Package,
 			DefaultChannel: f.ChannelName,
 		})
 	}
 
 	return originalDeclCfg, nil
-}
-
-// isFBC will determine if an index image uses the File-Based Catalog or SQLite index image format.
-// The default index image will adopt the File-Based Catalog format.
-func isFBC(ctx context.Context, indexImage string) (bool, error) {
-	// adding updates to the IndexImageCatalogCreator if it is an FBC image
-	catalogLabels, err := registryutil.GetImageLabels(ctx, nil, indexImage, false)
-	if err != nil {
-		return false, fmt.Errorf("get index image labels: %v", err)
-	}
-	_, hasFBCLabel := catalogLabels[containertools.ConfigsLocationLabel]
-
-	return hasFBCLabel || indexImage == DefaultIndexImage, nil
 }
 
 // UpdateCatalog links a new registry pod in catalog source by updating the address and annotations,
@@ -442,7 +375,7 @@ func (c IndexImageCatalogCreator) UpdateCatalog(ctx context.Context, cs *v1alpha
 		c.IndexImage = cs.Spec.Image
 
 		// check if index image adopts File-Based Catalog or SQLite index image format
-		isFBCImage, err := isFBC(ctx, c.IndexImage)
+		isFBCImage, err := fbcutil.IsFBC(ctx, c.IndexImage)
 		if err != nil {
 			return fmt.Errorf("unable to determine if index image adopts File-Based Catalog or SQLite format: %v", err)
 		}
@@ -464,7 +397,7 @@ func (c IndexImageCatalogCreator) UpdateCatalog(ctx context.Context, cs *v1alpha
 		}
 	} else {
 		// check if index image adopts File-Based Catalog or SQLite index image format
-		isFBCImage, err := isFBC(ctx, c.IndexImage)
+		isFBCImage, err := fbcutil.IsFBC(ctx, c.IndexImage)
 		if err != nil {
 			return fmt.Errorf("error in upgrading the bundle %q that was installed traditionally", c.BundleImage)
 		}
@@ -518,7 +451,7 @@ func (c IndexImageCatalogCreator) UpdateCatalog(ctx context.Context, cs *v1alpha
 // TODO(v2.0.0): this should default to semver mode.
 func (c *IndexImageCatalogCreator) setAddMode() {
 	if c.BundleAddMode == "" {
-		if strings.HasPrefix(c.IndexImage, defaultIndexImageBase) {
+		if strings.HasPrefix(c.IndexImage, fbcutil.DefaultIndexImageBase) {
 			c.BundleAddMode = index.SemverBundleAddMode
 		} else {
 			c.BundleAddMode = index.ReplacesBundleAddMode
@@ -532,7 +465,7 @@ func (c IndexImageCatalogCreator) createAnnotatedRegistry(ctx context.Context, c
 	items []index.BundleItem, updates ...func(*v1alpha1.CatalogSource)) (err error) {
 	var pod *corev1.Pod
 	if c.IndexImage == "" {
-		c.IndexImage = DefaultIndexImage
+		c.IndexImage = fbcutil.DefaultIndexImage
 	}
 
 	if c.HasFBCLabel {
@@ -682,60 +615,4 @@ func (c IndexImageCatalogCreator) deleteRegistryPod(ctx context.Context, podName
 	}
 
 	return nil
-}
-
-// CreateFBC generates an FBC by creating bundle, package and channel blobs.
-func (f *FBCContext) CreateFBC(ctx context.Context) (BundleDeclcfg, error) {
-	var bundleDC BundleDeclcfg
-	// Rendering the bundle image into a declarative config format.
-	declcfg, err := renderRefs(ctx, f.Refs)
-	if err != nil {
-		return BundleDeclcfg{}, err
-	}
-
-	// Ensuring a valid bundle size.
-	if len(declcfg.Bundles) != 1 {
-		return BundleDeclcfg{}, fmt.Errorf("bundle image should contain exactly one bundle blob")
-	}
-
-	bundleDC.Bundle = declcfg.Bundles[0]
-
-	// generate package.
-	bundleDC.Package = declarativeconfig.Package{
-		Schema:         schemaPackage,
-		Name:           f.Package,
-		DefaultChannel: f.ChannelName,
-	}
-
-	// generate channel.
-	bundleDC.Channel = declarativeconfig.Channel{
-		Schema:  schemaChannel,
-		Name:    f.ChannelName,
-		Package: f.Package,
-		Entries: []declarativeconfig.ChannelEntry{f.ChannelEntry},
-	}
-
-	return bundleDC, nil
-}
-
-// ValidateAndStringify first converts the generated declarative config to a model and validates it.
-// If the declarative config model is valid, it will convert the declarative config to a YAML string and return it.
-func ValidateAndStringify(declcfg *declarativeconfig.DeclarativeConfig) (string, error) {
-	// validates and converts declarative config to model
-	_, err := declarativeconfig.ConvertToModel(*declcfg)
-	if err != nil {
-		return "", fmt.Errorf("error converting the declarative config to model: %v", err)
-	}
-
-	var buf bytes.Buffer
-	err = declarativeconfig.WriteYAML(*declcfg, &buf)
-	if err != nil {
-		return "", fmt.Errorf("error writing generated declarative config to JSON encoder: %v", err)
-	}
-
-	if buf.String() == "" {
-		return "", errors.New("file-based catalog contents cannot be empty")
-	}
-
-	return buf.String(), nil
 }

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -15,14 +15,19 @@
 package registry
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/pkg/containertools"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	gofunk "github.com/thoas/go-funk"
@@ -32,6 +37,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	declarativeconfig "github.com/operator-framework/operator-registry/alpha/declcfg"
 	"github.com/operator-framework/operator-sdk/internal/olm/operator"
 	"github.com/operator-framework/operator-sdk/internal/olm/operator/registry/fbcindex"
 	"github.com/operator-framework/operator-sdk/internal/olm/operator/registry/index"
@@ -59,20 +66,46 @@ const (
 	registryPodNameAnnotation = operatorFrameworkGroup + "/registry-pod-name"
 )
 
-type IndexImageCatalogCreator struct {
-	SkipTLS       bool
-	SkipTLSVerify bool
-	UseHTTP       bool
-	HasFBCLabel   bool
-	FBCContent    string
-	PackageName   string
-	IndexImage    string
-	BundleImage   string
-	SecretName    string
-	CASecretName  string
-	BundleAddMode index.BundleAddMode
+const (
+	schemaChannel  = "olm.channel"
+	schemaPackage  = "olm.package"
+	DefaultChannel = "operator-sdk-run"
+)
 
-	cfg *operator.Configuration
+// BundleDeclcfg represents a minimal File-Based Catalog.
+// This struct only consists of one Package, Bundle, and Channel blob. It is used to
+// represent the bundle image in the File-Based Catalog format.
+type BundleDeclcfg struct {
+	Package declcfg.Package
+	Channel declcfg.Channel
+	Bundle  declcfg.Bundle
+}
+
+// FBCContext is a struct that stores all the required information while constructing
+// a new File-Based Catalog on the fly. The fields from this struct are passed as
+// parameters to Operator Registry API calls to generate declarative config objects.
+type FBCContext struct {
+	Package      string
+	ChannelName  string
+	Refs         []string
+	ChannelEntry declarativeconfig.ChannelEntry
+}
+
+type IndexImageCatalogCreator struct {
+	SkipTLS         bool
+	SkipTLSVerify   bool
+	UseHTTP         bool
+	HasFBCLabel     bool
+	FBCContent      string
+	PackageName     string
+	IndexImage      string
+	BundleImage     string
+	SecretName      string
+	CASecretName    string
+	BundleAddMode   index.BundleAddMode
+	PreviousBundles []string
+	cfg             *operator.Configuration
+	ChannelName     string
 }
 
 var _ CatalogCreator = &IndexImageCatalogCreator{}
@@ -126,13 +159,269 @@ func (c IndexImageCatalogCreator) CreateCatalog(ctx context.Context, name string
 	return cs, nil
 }
 
+// getChannelHead retrieves the channel head from an array of entries
+func getChannelHead(entries []declarativeconfig.ChannelEntry) (string, error) {
+	nameMap := make(map[string]bool)
+	replacesMap := make(map[string]bool)
+
+	for i := range entries {
+		nameMap[entries[i].Name] = true
+		if entries[i].Replaces != "" {
+			replacesMap[entries[i].Replaces] = true
+		}
+	}
+
+	// gets the CSV name that does not appear in any replaces field in the entries array
+	for key := range nameMap {
+		if _, present := replacesMap[key]; !present {
+			return key, nil
+		}
+	}
+
+	// this should not be reached since there must be an edge to upgrade from
+	return "", errors.New("no channel head found")
+}
+
+// handleTraditionalUpgrade upgrades an operator that was installed using OLM. Subsequent upgrades will go through the runFBCUpgrade function
+func handleTraditionalUpgrade(ctx context.Context, indexImage string, bundleImage string, channelName string) (string, error) {
+	// render the index image
+	originalDeclCfg, err := renderRefs(ctx, []string{indexImage})
+	if err != nil {
+		return "", fmt.Errorf("error in rendering index %q", indexImage)
+	}
+
+	// render the bundle image
+	bundleDeclConfig, err := renderRefs(ctx, []string{bundleImage})
+	if err != nil {
+		return "", fmt.Errorf("error in rendering index %q", bundleImage)
+	}
+
+	if len(bundleDeclConfig.Bundles) != 1 {
+		return "", errors.New("bundle image must have exactly one bundle")
+	}
+
+	// search for the specific channel in which the upgrade needs to take place, and upgrade from the channel head
+	for i := range originalDeclCfg.Channels {
+		if originalDeclCfg.Channels[i].Name == channelName && originalDeclCfg.Channels[i].Package == bundleDeclConfig.Bundles[0].Package {
+			// found specific channel
+			channelHead, err := getChannelHead(originalDeclCfg.Channels[i].Entries)
+			if err != nil {
+				return "", err
+			}
+			entry := declarativeconfig.ChannelEntry{
+				Name:     bundleDeclConfig.Bundles[0].Name,
+				Replaces: channelHead,
+			}
+			originalDeclCfg.Channels[i].Entries = append(originalDeclCfg.Channels[i].Entries, entry)
+			break
+		}
+	}
+
+	// add the upgraded bundle to resulting declarative config
+	originalDeclCfg.Bundles = append(originalDeclCfg.Bundles, bundleDeclConfig.Bundles[0])
+
+	// validate the declarative config and convert it to a string
+	var content string
+	if content, err = ValidateAndStringify(originalDeclCfg); err != nil {
+		return "", fmt.Errorf("error validating and converting the declarative config object to a string format: %v", err)
+	}
+
+	log.Infof("Generated a valid Upgraded File-Based Catalog")
+
+	return content, nil
+}
+
+// runFBCUpgrade starts the process of upgrading a bundle in an FBC. This function will recreate the FBC that was generated
+// during run bundle and upgrade a specific bundle in the specified channel.
+func (c *IndexImageCatalogCreator) runFBCUpgrade(ctx context.Context) error {
+	// render the index image if it is not the default index image
+	var refs []string
+	if c.IndexImage != DefaultIndexImage {
+		refs = append(refs, c.IndexImage)
+	}
+
+	originalDeclcfg, err := renderRefs(ctx, refs)
+	if err != nil {
+		return err
+	}
+
+	// add the upgraded bundle to the list of previous bundles so that they can be rendered with a single API call
+	c.PreviousBundles = append(c.PreviousBundles, c.BundleImage)
+	f := &FBCContext{
+		Package:     c.PackageName,
+		Refs:        c.PreviousBundles,
+		ChannelName: c.ChannelName,
+	}
+
+	// Adding the FBC "f" to the originalDeclcfg to generate a new FBC
+	declcfg, err := upgradeFBC(ctx, f, originalDeclcfg)
+	if err != nil {
+		return fmt.Errorf("error creating the upgraded FBC: %v", err)
+	}
+
+	// validate the declarative config and convert it to a string
+	var content string
+	if content, err = ValidateAndStringify(declcfg); err != nil {
+		return fmt.Errorf("error validating/stringifying the declarative config object: %v", err)
+	}
+
+	log.Infof("Generated a valid Upgraded File-Based Catalog")
+
+	c.FBCContent = content
+
+	return nil
+}
+
+func renderRefs(ctx context.Context, refs []string) (*declarativeconfig.DeclarativeConfig, error) {
+	render := action.Render{
+		Refs: refs,
+	}
+
+	log.SetOutput(ioutil.Discard)
+	declcfg, err := render.Run(ctx)
+	log.SetOutput(os.Stdout)
+	if err != nil {
+		return nil, fmt.Errorf("error in rendering the bundle and index image: %v", err)
+	}
+
+	return declcfg, nil
+}
+
+// upgradeFBC constructs a new File-Based Catalog from both the FBCContext object and the declarative config object. This function will check to see
+// if the FBCContext object "f" is already present in the original declarative config.
+func upgradeFBC(ctx context.Context, f *FBCContext, originalDeclCfg *declarativeconfig.DeclarativeConfig) (*declarativeconfig.DeclarativeConfig, error) {
+	declcfg, err := renderRefs(ctx, f.Refs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensuring a valid bundle size
+	if len(declcfg.Bundles) < 1 {
+		return nil, fmt.Errorf("bundle image should contain at least one bundle blob")
+	}
+
+	// Checking if the existing file-based catalog (before upgrade) contains the bundle and channel that we intend to insert.
+	// If the bundle already exists, we error out. If the channel already exists, we store the index of the channel. This
+	// index will be used to access the channel from the declarative config object
+	channelExists := false
+	channelIndex := -1
+	channelHead := ""
+	for i, channel := range originalDeclCfg.Channels {
+		// Find the specific channel that the bundle needs to be inserted into
+		if channel.Name == f.ChannelName && channel.Package == f.Package {
+			channelExists = true
+			channelIndex = i
+			// Check if the CSV name is already present in the channel's entries
+			for _, entry := range channel.Entries {
+				// Our upgraded bundle image is the last element of the refs we passed in
+				if entry.Name == declcfg.Bundles[len(declcfg.Bundles)-1].Name {
+					return nil, fmt.Errorf("bundle %q already exists in the Index Image %q", declcfg.Bundles[len(declcfg.Bundles)-1].Name, entry.Name)
+				}
+			}
+			channelHead, err = getChannelHead(channel.Entries)
+
+			if err != nil {
+				return nil, err
+			}
+
+			break // We only want to search through the specific channel
+		}
+	}
+
+	// Storing a list of the existing bundles and their packages for easier querying via maps
+	existingBundles := make(map[string]string)
+	for _, bundle := range originalDeclCfg.Bundles {
+		existingBundles[bundle.Name] = bundle.Package
+	}
+
+	// declcfg contains all the bundles we need to insert to form the new FBC
+	entries := []declarativeconfig.ChannelEntry{} // Used when generating a new channel
+	for i, bundle := range declcfg.Bundles {
+		// if it is not present in the bundles array or belongs to a different package, we can add it
+		if _, present := existingBundles[bundle.Name]; !present || existingBundles[bundle.Name] != bundle.Package {
+			originalDeclCfg.Bundles = append(originalDeclCfg.Bundles, bundle)
+		}
+
+		// constructing a new entry to add
+		entry := declarativeconfig.ChannelEntry{
+			Name: declcfg.Bundles[i].Name,
+		}
+		if i > 0 {
+			entry.Replaces = declcfg.Bundles[i-1].Name
+		} else if channelExists {
+			entry.Replaces = channelHead
+		}
+
+		// either add it to a new channel or an existing channel
+		if channelExists {
+			originalDeclCfg.Channels[channelIndex].Entries = append(originalDeclCfg.Channels[channelIndex].Entries, entry)
+		} else {
+			entries = append(entries, entry)
+		}
+	}
+
+	// create a new channel if it does not exist
+	if !channelExists {
+		originalDeclCfg.Channels = append(originalDeclCfg.Channels, declarativeconfig.Channel{
+			Schema:  schemaChannel,
+			Name:    f.ChannelName,
+			Package: f.Package,
+			Entries: entries,
+		})
+	}
+
+	// check if package already exists
+	packagePresent := false
+	for _, packageName := range originalDeclCfg.Packages {
+		if packageName.Name == f.Package {
+			packagePresent = true
+			break
+		}
+	}
+
+	// only add the new package if it does not already exist
+	if !packagePresent {
+		originalDeclCfg.Packages = append(originalDeclCfg.Packages, declarativeconfig.Package{
+			Schema:         schemaPackage,
+			Name:           f.Package,
+			DefaultChannel: f.ChannelName,
+		})
+	}
+
+	return originalDeclCfg, nil
+}
+
+// isFBC will determine if an index image uses the File-Based Catalog or SQLite index image format.
+// The default index image will adopt the File-Based Catalog format.
+func isFBC(ctx context.Context, indexImage string) (bool, error) {
+	// adding updates to the IndexImageCatalogCreator if it is an FBC image
+	catalogLabels, err := registryutil.GetImageLabels(ctx, nil, indexImage, false)
+	if err != nil {
+		return false, fmt.Errorf("get index image labels: %v", err)
+	}
+	_, hasFBCLabel := catalogLabels[containertools.ConfigsLocationLabel]
+
+	return hasFBCLabel || indexImage == DefaultIndexImage, nil
+}
+
 // UpdateCatalog links a new registry pod in catalog source by updating the address and annotations,
 // then deletes existing registry pod based on annotation name found in catalog source object
-func (c IndexImageCatalogCreator) UpdateCatalog(ctx context.Context, cs *v1alpha1.CatalogSource) error {
+func (c IndexImageCatalogCreator) UpdateCatalog(ctx context.Context, cs *v1alpha1.CatalogSource, subscription *v1alpha1.Subscription) error {
 	var prevRegistryPodName string
 	if annotations := cs.GetAnnotations(); len(annotations) != 0 {
 		if value, hasAnnotation := annotations[indexImageAnnotation]; hasAnnotation && value != "" {
 			c.IndexImage = value
+		}
+
+		// search for the list of the previous injected bundles using the catalog source's annotations
+		if value, hasAnnotation := annotations[injectedBundlesAnnotation]; hasAnnotation && value != "" {
+			var injectedBundles []map[string]interface{}
+			if err := json.Unmarshal([]byte(annotations[injectedBundlesAnnotation]), &injectedBundles); err != nil {
+				return fmt.Errorf("unable to unmarshal injected bundles json: %v", err)
+			}
+			for i := range injectedBundles {
+				c.PreviousBundles = append(c.PreviousBundles, injectedBundles[i]["imageTag"].(string))
+			}
 		}
 		prevRegistryPodName = annotations[registryPodNameAnnotation]
 	}
@@ -148,8 +437,51 @@ func (c IndexImageCatalogCreator) UpdateCatalog(ctx context.Context, cs *v1alpha
 			// if no annotations exist and image reference is empty, error out
 			return errors.New("cannot upgrade: no catalog image reference exists in catalog source spec or annotations")
 		}
+
 		// if no annotations exist and image reference exists, set it to index image
 		c.IndexImage = cs.Spec.Image
+
+		// check if index image adopts File-Based Catalog or SQLite index image format
+		isFBCImage, err := isFBC(ctx, c.IndexImage)
+		if err != nil {
+			return fmt.Errorf("unable to determine if index image adopts File-Based Catalog or SQLite format: %v", err)
+		}
+		c.HasFBCLabel = isFBCImage
+
+		// Upgrade a bundle that was installed using OLM
+		if c.HasFBCLabel {
+			// bundle add modes are not supported for FBC
+			if c.BundleAddMode != "" {
+				return fmt.Errorf("specifying the bundle add mode is not supported for File-Based Catalog bundles and index images")
+			}
+
+			// Upgrading when installed traditionally by OLM
+			upgradedFBC, err := handleTraditionalUpgrade(ctx, c.IndexImage, c.BundleImage, subscription.Spec.Channel)
+			if err != nil {
+				return fmt.Errorf("unable to upgrade bundle: %v", err)
+			}
+			c.FBCContent = upgradedFBC
+		}
+	} else {
+		// check if index image adopts File-Based Catalog or SQLite index image format
+		isFBCImage, err := isFBC(ctx, c.IndexImage)
+		if err != nil {
+			return fmt.Errorf("error in upgrading the bundle %q that was installed traditionally", c.BundleImage)
+		}
+		c.HasFBCLabel = isFBCImage
+
+		// Upgrade an installed bundle from catalog source annotations
+		if c.HasFBCLabel {
+			// bundle add modes are not supported for FBC
+			if c.BundleAddMode != "" {
+				return fmt.Errorf("specifying the bundle add mode is not supported for File-Based Catalog bundles and index images")
+			}
+
+			err = c.runFBCUpgrade(ctx)
+			if err != nil {
+				return fmt.Errorf("unable to determine if index image adopts File-Based Catalog or SQLite format: %v", err)
+			}
+		}
 	}
 
 	c.setAddMode()
@@ -350,4 +682,60 @@ func (c IndexImageCatalogCreator) deleteRegistryPod(ctx context.Context, podName
 	}
 
 	return nil
+}
+
+// CreateFBC generates an FBC by creating bundle, package and channel blobs.
+func (f *FBCContext) CreateFBC(ctx context.Context) (BundleDeclcfg, error) {
+	var bundleDC BundleDeclcfg
+	// Rendering the bundle image into a declarative config format.
+	declcfg, err := renderRefs(ctx, f.Refs)
+	if err != nil {
+		return BundleDeclcfg{}, err
+	}
+
+	// Ensuring a valid bundle size.
+	if len(declcfg.Bundles) != 1 {
+		return BundleDeclcfg{}, fmt.Errorf("bundle image should contain exactly one bundle blob")
+	}
+
+	bundleDC.Bundle = declcfg.Bundles[0]
+
+	// generate package.
+	bundleDC.Package = declarativeconfig.Package{
+		Schema:         schemaPackage,
+		Name:           f.Package,
+		DefaultChannel: f.ChannelName,
+	}
+
+	// generate channel.
+	bundleDC.Channel = declarativeconfig.Channel{
+		Schema:  schemaChannel,
+		Name:    f.ChannelName,
+		Package: f.Package,
+		Entries: []declarativeconfig.ChannelEntry{f.ChannelEntry},
+	}
+
+	return bundleDC, nil
+}
+
+// ValidateAndStringify first converts the generated declarative config to a model and validates it.
+// If the declarative config model is valid, it will convert the declarative config to a YAML string and return it.
+func ValidateAndStringify(declcfg *declarativeconfig.DeclarativeConfig) (string, error) {
+	// validates and converts declarative config to model
+	_, err := declarativeconfig.ConvertToModel(*declcfg)
+	if err != nil {
+		return "", fmt.Errorf("error converting the declarative config to model: %v", err)
+	}
+
+	var buf bytes.Buffer
+	err = declarativeconfig.WriteYAML(*declcfg, &buf)
+	if err != nil {
+		return "", fmt.Errorf("error writing generated declarative config to JSON encoder: %v", err)
+	}
+
+	if buf.String() == "" {
+		return "", errors.New("file-based catalog contents cannot be empty")
+	}
+
+	return buf.String(), nil
 }

--- a/internal/olm/operator/registry/operator_installer.go
+++ b/internal/olm/operator/registry/operator_installer.go
@@ -142,7 +142,7 @@ func (o OperatorInstaller) UpgradeOperator(ctx context.Context) (*v1alpha1.Clust
 	log.Infof("Found existing catalog source with name %s and namespace %s", cs.Name, cs.Namespace)
 
 	// Update catalog source
-	err := o.CatalogUpdater.UpdateCatalog(ctx, cs)
+	err := o.CatalogUpdater.UpdateCatalog(ctx, cs, subscription)
 	if err != nil {
 		return nil, fmt.Errorf("update catalog error: %v", err)
 	}

--- a/website/content/en/docs/cli/operator-sdk_run_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle.md
@@ -14,7 +14,9 @@ The main purpose of this command is to streamline running the bundle without hav
 
 The `--index-image` flag specifies an index image in which to inject the given bundle. It can be specified to resolve dependencies for a bundle. 
 This is an optional flag which will default to `quay.io/operator-framework/opm:latest`.
-The index image provided should **NOT** already have the bundle.
+The index image provided should **NOT** already have the bundle. A limitation of the index image flag is that it does not check the upgrade graph
+as the annotations for channels are ignored but it is still a useful flag to have to validate the dependencies. 
+For example: It does not fail fast when the bundle version provided is &lt;= ChannelHead.
 
 
 ```


### PR DESCRIPTION
Closes #5593

**Description of the change:**

- Add FBC support to `run bundle` and `run bundle-upgrade` commands by create a file-based catalog (FBC) on the fly by generating the bundle, package and channel blobs, if an index image is not provided by the user (i.e. for a default index image `quay.io/operator-framework/opm:latest`) and serve it over a gRPC port.
- For run bundle: If an index image is provided through the flag, then bundle image will be inserted to the index by appending the bundle contents (rendered bundle image) to the index that's converted to a declarative config and this index containing the bundle will be served over a gRPC port.
- If bundle already exists in the index, then we error out and not serve the index image (which is consistent with the existing SQLite behavior).
- Generated FBC will be validated and converted to a string format. 
- Infer the label type on the index image and indicate there's an FBC label through registry pod for container creation. 
- Added a new container creation command for images that have FBC label on them. For images without the label, old commands (`opm registry add` and `opm registry serve`) that use SQLite under the hood will be called. So support for both (FBC/SQLite) exist at the moment. For more details, please refer to [run bundle design proposal](https://github.com/operator-framework/enhancements/blob/master/enhancements/sdk-fbc-run-bundle.md).

**For run bundle-upgrade:** Handle upgrade for both scenarios when an operator bundle is installed using `run bundle` command and also installed traditionally via OLM. For more details, please refer to [run bundle upgrade design proposal](https://github.com/operator-framework/enhancements/blob/master/enhancements/sdk-fbc-bundle-upgrade.md).


**Motivation for the change:**
https://github.com/operator-framework/operator-sdk/issues/5593 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Signed-off-by: rashmigottipati <chowdary.grashmi@gmail.com>