### PR TITLE
(ansible/v1, helm/v1): deprecate the flag  since  APIs is not longer offered from k8s 1.22 and this flag is deprecated for Golang

### DIFF
--- a/changelog/fragments/deprecate-crdversionflag.yaml
+++ b/changelog/fragments/deprecate-crdversionflag.yaml
@@ -1,0 +1,8 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For Ansible/Helm based-operators (ansible/v1, helm/v1), deprecate the flag `crd-version` since
+      `v1beta1` APIs is not longer offered from k8s 1.22 and this flag is deprecated for Golang.
+    kind: "deprecation"
+    breaking: false

--- a/internal/plugins/util/message.go
+++ b/internal/plugins/util/message.go
@@ -14,7 +14,7 @@
 
 package util
 
-const WarnMessageRemovalV1beta1 = "The v1beta1 API version for CRDs and Webhooks are deprecated and are no longer offered since " +
-	"the Kubernetes release 1.22. This flag no longer required to exist in future releases. Also, we would like to " +
-	"recommend you no longer use these API versions." +
+const WarnMessageRemovalV1beta1 = "The v1beta1 API version for CRDs and Webhooks is deprecated and is no longer offered since " +
+	"Kubernetes 1.22. This flag will be removed in a future release. We " +
+	"recommend that you no longer use the v1beta1 API version" +
 	"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22"

--- a/internal/plugins/util/message.go
+++ b/internal/plugins/util/message.go
@@ -1,0 +1,20 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+const WarnMessageRemovalV1beta1 = "The v1beta1 API version for CRDs and Webhooks are deprecated and are no longer offered since " +
+	"the Kubernetes release 1.22. This flag no longer required to exist in future releases. Also, we would like to " +
+	"recommend you no longer use these API versions." +
+	"More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22"


### PR DESCRIPTION
**Description**

deprecate the flag  since  APIs is not longer offered from k8s 1.22 and this flag is deprecated for Golang

NOTE: Users should no longer be using this option since if they scaffold projects with v1beta1 it will no longer work on Kubernetes versions >= 1.22. By using v1 for CRDs they can create projects which can work since Kubernetes 1.16