### PR TITLE
registry_pod: Avoid grace period delay

### DIFF
--- a/internal/olm/operator/registry/index/registry_pod.go
+++ b/internal/olm/operator/registry/index/registry_pod.go
@@ -310,7 +310,7 @@ const cmdTemplate = `mkdir -p {{ dirname .DBPath }} && \
 {{- range $i, $item := .BundleItems }}
 opm registry add -d {{ $.DBPath }} -b {{ $item.ImageTag }} --mode={{ $item.AddMode }}{{ if $.CASecretName }} --ca-file=/certs/cert.pem{{ end }} --skip-tls-verify={{ $.SkipTLSVerify }} --use-http={{ $.UseHTTP }} && \
 {{- end }}
-opm registry serve -d {{ .DBPath }} -p {{ .GRPCPort }}
+exec opm registry serve -d {{ .DBPath }} -p {{ .GRPCPort }}
 `
 
 // getContainerCmd uses templating to construct the container command

--- a/internal/olm/operator/registry/index/registry_pod_test.go
+++ b/internal/olm/operator/registry/index/registry_pod_test.go
@@ -292,5 +292,5 @@ func containerCommandFor(dbPath string, items []BundleItem, hasCA, skipTLSVerify
 	for _, item := range items {
 		additions.WriteString(fmt.Sprintf("opm registry add -d %s -b %s --mode=%s%s --skip-tls-verify=%v --use-http=%v && \\\n", dbPath, item.ImageTag, item.AddMode, caFlag, skipTLSVerify, useHTTP))
 	}
-	return fmt.Sprintf("mkdir -p /database && \\\n%sopm registry serve -d /database/index.db -p 50051\n", additions.String())
+	return fmt.Sprintf("mkdir -p /database && \\\n%sexec opm registry serve -d /database/index.db -p 50051\n", additions.String())
 }


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

Substitute shell by the last command that serve the registry pod.

**Motivation for the change:**

The shell script does not propagate the SIGTERM signal that is sent to
the pod when it is terminated; to avoid this, we run the last command to
substitute the shell process, so that the pod stop immediately instead of
waiting the 30 default seconds of the grace period when an user uninstall
the operator by using 'operator-sdk cleanup ...' command.


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

**issue**: https://github.com/operator-framework/operator-sdk/issues/5866