### PR TITLE
(docs): update Helm tutorial to remove status writer line from overview

### DIFF
--- a/website/content/en/docs/building-operators/helm/tutorial.md
+++ b/website/content/en/docs/building-operators/helm/tutorial.md
@@ -24,7 +24,6 @@ We will create a sample project to let you know how it works and this sample wil
 
 - Create a Nginx Deployment if it doesn't exist
 - Ensure that the Deployment size is the same as specified by the Nginx CR spec
-- Update the Nginx CR status using the status writer with the names of the CR's pods
 
 ## Create a new project
 


### PR DESCRIPTION
**Description of the change:**
Remove from the Overview section of theHelm tutorial the line that says: `Update the Nginx CR status using the status writer with the names of the CR’s pods`

**Motivation for the change:**
This seems to be something that is not operator author controlled, and when going through the tutorial I noticed that the CR is not populated with the names of the CR's pods.

resolves #5423 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
