### PR TITLE
OSDK-2345: Export scorecard storage as an env variable in a test pod

### DIFF
--- a/changelog/fragments/export-scorecard-storage.yaml
+++ b/changelog/fragments/export-scorecard-storage.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Test containers defined by `config.yaml` can now read the environment variable `SCORECARD_STORAGE` to get a storage path defined in the `config.yaml`.
+    kind: "addition"
+    breaking: false

--- a/internal/scorecard/storage.go
+++ b/internal/scorecard/storage.go
@@ -177,6 +177,13 @@ func addStorageToPod(podDef *v1.Pod, mountPath string, storageImage string) {
 	}
 	podDef.Spec.Containers[0].VolumeMounts = append(podDef.Spec.Containers[0].VolumeMounts, vMount)
 
+	// add mountPath to Env
+	mountPathEnv := v1.EnvVar{
+		Name:  "SCORECARD_STORAGE",
+		Value: mountPath,
+	}
+	podDef.Spec.Containers[0].Env = append(podDef.Spec.Containers[0].Env, mountPathEnv)
+
 }
 
 func gatherTestOutput(r PodTestRunner, suiteName, testName, podName, mountPath string) error {


### PR DESCRIPTION
Signed-off-by: Andrej Podhradsky <apodhrad@redhat.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
