### PR TITLE
deprecated skip-tls flag marked as hidden

### DIFF
--- a/changelog/fragments/hide-skip-tls.yaml
+++ b/changelog/fragments/hide-skip-tls.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Hide --skip-tls flag as it is deprecated.
+    kind: "change"
+    breaking: false

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -92,6 +92,8 @@ func (c *IndexImageCatalogCreator) BindFlags(fs *pflag.FlagSet) {
 			"and the file *must* be encoded under the key \"cert.pem\"")
 
 	_ = fs.MarkDeprecated("skip-tls", "use --skip-tls-verify or --use-http instead")
+	_ = fs.MarkHidden("skip-tls")
+
 	fs.BoolVar(&c.SkipTLS, "skip-tls", false, "skip authentication of image registry TLS "+
 		"certificate when pulling a bundle image in-cluster")
 


### PR DESCRIPTION
Hide `--skip-tls` flag as it is deprecated

**Description of the change:**
As per the discussion, we must keep this field hidden.

**Motivation for the change:**
The user will not see deprecated command.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
