### PR TITLE
Actions/bump go e2e

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/changelog/fragments/actions-go-e2e-bump.yaml
+++ b/changelog/fragments/actions-go-e2e-bump.yaml
@@ -1,0 +1,18 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Bumps the Go version for the Go e2e tests from 1.17 --> 1.18.
+      Changed because as part of the Kubebuilder bump to support k8s 1.24,
+      Go 1.18 is now used when scaffolding a project with the go/v3 plugin.
+      
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false


### PR DESCRIPTION
**Description of the change:**
Make Go e2e tests run with Go version 1.18

**Motivation for the change:**
As part of the Kubebuilder  bump to support k8s 1.24, Go 1.18 is now used when scaffolding a project with the go/v3 plugin. We need to adjust our e2e tests/actions to accommodate this change in the scaffolding.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
