### PR TITLE
Update Go samples (to show how the Pods/Containers should be configured as restrictive

### DIFF
--- a/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
@@ -409,9 +409,28 @@ func (r *MemcachedReconciler) deploymentForMemcached(m *cachev1alpha1.Memcached)
 					Labels: ls,
 				},
 				Spec: corev1.PodSpec{
+					// Ensure restrictive standard for the Pod.
+					// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: &[]bool{true}[0],
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []corev1.Container{{
 						Image:   "memcached:1.4.36-alpine",
 						Name:    "memcached",
+						// Ensure restrictive context for the container
+						// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
+						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot:  &[]bool{true}[0],
+							AllowPrivilegeEscalation:  &[]bool{false}[0],
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{
+									"ALL",
+								},
+							},
+						},
 						Command: []string{"memcached", "-m=64", "-o", "modern", "-v"},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 11211,

--- a/testdata/go/v3/memcached-operator/controllers/memcached_controller.go
+++ b/testdata/go/v3/memcached-operator/controllers/memcached_controller.go
@@ -155,9 +155,28 @@ func (r *MemcachedReconciler) deploymentForMemcached(m *cachev1alpha1.Memcached)
 					Labels: ls,
 				},
 				Spec: corev1.PodSpec{
+					// Ensure restrictive standard for the Pod.
+					// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: &[]bool{true}[0],
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []corev1.Container{{
-						Image:   "memcached:1.4.36-alpine",
-						Name:    "memcached",
+						Image: "memcached:1.4.36-alpine",
+						Name:  "memcached",
+						// Ensure restrictive context for the container
+						// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
+						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot:             &[]bool{true}[0],
+							AllowPrivilegeEscalation: &[]bool{false}[0],
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{
+									"ALL",
+								},
+							},
+						},
 						Command: []string{"memcached", "-m=64", "-o", "modern", "-v"},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 11211,


### PR DESCRIPTION
### Description
update samples (golang/ansible) to show how the Pods/Containers should be configured as restrictive

### Motivation
Ensure that authors have samples that follow the recommendations and good practices.

Kubernetes API has been changing, and the [PodSecurityPolicy](https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/#what-is-podsecuritypolicy) is deprecated and will no longer be served from k8s 1.25. This API is replaced by a new built-in admission controller ([KEP-2579: Pod Security Admission Control)](https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2579-psp-replacement) which allows cluster admins to enforce the [Pod Security Standards](https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/).

**So that means we should encourage authors to**

- (Recommend for common cases, when it does not require escalating privileges) ensure all containers are configured as [restrictive](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) ([ see an example](https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/240/files) )
OR 
- ensure the label for the privileged case scenarios ( [example](https://github.com/openshift/cluster-kube-apiserver-operator/pull/1234/files) ).
 
Note that you should ensure the above configuration is carried to your Operator bundle CSV. You can see an example, the CSV for the Memcached tutorial sample: [here](https://github.com/camilamacedo86/example-csv-scc/compare/v0.0.1...v0.0.2).


Blocked by : https://github.com/operator-framework/operator-sdk/pull/5846