### PR TITLE
(actions): update dependabot commit prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,28 +4,47 @@ updates:
     directory: "/images/ansible-operator"
     schedule:
       interval: daily
+    commit-message:
+      prefix: "[no ci]"
+
   - package-ecosystem: docker
     directory: "/images/custom-scorecard-tests"
     schedule:
       interval: daily
+    commit-message:
+      prefix: "[no ci]"
+
   - package-ecosystem: docker
     directory: "/images/helm-operator"
     schedule:
       interval: daily
+    commit-message:
+      prefix: "[no ci]"
+
   - package-ecosystem: docker
     directory: "/images/operator-sdk"
     schedule:
       interval: daily
+    commit-message:
+      prefix: "[no ci]"
+
   - package-ecosystem: docker
     directory: "/images/scorecard-test"
     schedule:
       interval: daily
+    commit-message:
+      prefix: "[no ci]"
+
   - package-ecosystem: docker
     directory: "/images/scorecard-test-kuttl"
     schedule:
       interval: daily
+    commit-message:
+      prefix: "[no ci]"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule: 
-     interval: daily
-  
+      interval: daily
+    commit-message:
+      prefix: "[no ci]"


### PR DESCRIPTION
**Description of the change:**
Make all dependabot commits begin with `[no ci]` to skip running CI checks on dependabot PRs. 

For more information see:
- Skipping CI with commit message: https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
- Dependabot commit message configuration settings: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message

**Motivation for the change:**
Dependabot PRs are hogging CI resources making contributor PRs take much longer to run tests. This change should make it so that Dependabot PRs will not run CI checks. When we are ready for them to run tests we can push a commit to the branch in the PR without the `[no ci]` in the commit message and that should start running CI for the PR.

This will conserve the CI resources as the 10 PRs dependabot makes at a time won't run CI checks :smile: 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
