### PR TITLE
docs: add watch permission for pods resource

### DIFF
--- a/changelog/fragments/00-template.yaml
+++ b/changelog/fragments/00-template.yaml
@@ -1,45 +1,5 @@
-# entries is a list of entries to include in
-# release notes and/or the migration guide
 entries:
   - description: >
-      Description is the line that shows up in the CHANGELOG. This
-      should be formatted as markdown and be on a single line. Using
-      the YAML string '>' operator means you can write your entry
-      multiple lines and it will still be parsed as a single line.
-
-      If an operator type's plugin is being changed then prefix the description with
-      "(<operator language>/<plugin version>)", ex. "(go/v2)".
-      If an operator type's runtime is being changed, use then prefix the description
-      with "For <operator language>-based operators,", ex. "For Go-based operators".
-
-    # kind is one of:
-    # - addition
-    # - change
-    # - deprecation
-    # - removal
-    # - bugfix
-    kind: ""
-
-    # Is this a breaking change?
+      Added `watch` permission for `kubebuilder:rbac:groups=core,resources=pods` in Go Operator Tutorial.
+    kind: "bugfix"
     breaking: false
-
-    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
-    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
-    #
-    # The generator auto-detects the PR number from the commit
-    # message in which this file was originally added.
-    #
-    # What is the pull request number (without the "#")?
-    # pull_request_override: 0
-
-
-    # Migration can be defined to automatically add a section to
-    # the migration guide. This is required for breaking changes.
-    migration:
-      header: Header text for the migration section
-      body: |
-        Body of the migration section. This should be formatted as markdown and can
-        span multiple lines.
-
-        Using the YAML string '|' operator means that newlines in this string will
-        be honored and interpretted as newlines in the rendered markdown.

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -252,7 +252,7 @@ The controller needs certain [RBAC][rbac-k8s-doc] permissions to interact with t
 //+kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=update
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
 func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
   ...


### PR DESCRIPTION
**Description of the change:**
There is an RBAC permission error in the documentation for [Go Operator Tutorial](https://sdk.operatorframework.io/docs/building-operators/golang/tutorial/#specify-permissions-and-generate-rbac-manifests)
Added `watch` permission for pods when generating RBAC via `kubebuilder`

**Motivation for the change:**
Deploying a controller results in the following error
`[reflector.go:138] pkg/mod/k8s.io/client-go@v0.21.2/tools/cache/reflector.go:167: Failed to watch *v1.Pod: unknown (get pods)`

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Signed-off-by: Vladimir Belousov <vbelouso@redhat.com>