### PR TITLE
Bz/2082793 bump hybrid plugin

### DIFF
--- a/changelog/fragments/bump-helm-operator-plugins.yaml
+++ b/changelog/fragments/bump-helm-operator-plugins.yaml
@@ -1,0 +1,33 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For Hybrid Helm (hybrid.helm/v1-alpha) language based operators: Bump Dockerfile Go version to 1.18
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: For Hybrid Helm (hybrid.helm/v1-alpha) language based operators - Bump Dockerfile Go version to 1.18
+      body: |
+        In the `Dockerfile`, replace the line `FROM golang:1.17 as builder` with `FROM golang:1.18 as builder`

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
 	github.com/operator-framework/api v0.15.0
-	github.com/operator-framework/helm-operator-plugins v0.0.12-0.20220613184440-7329cace347f
+	github.com/operator-framework/helm-operator-plugins v0.0.12-0.20220616200420-1a695cb9f6a1
 	github.com/operator-framework/java-operator-plugins v0.5.1
 	github.com/operator-framework/operator-lib v0.11.0
 	github.com/operator-framework/operator-manifest-tools v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -869,6 +869,8 @@ github.com/operator-framework/api v0.15.0 h1:4f9i0drtqHj7ykLoHxv92GR43S7MmQHhmFQ
 github.com/operator-framework/api v0.15.0/go.mod h1:scnY9xqSeCsOdtJtNoHIXd7OtHZ14gj1hkDA4+DlgLY=
 github.com/operator-framework/helm-operator-plugins v0.0.12-0.20220613184440-7329cace347f h1:lS/IvqlvEQGIwXE0VlW+mOCmFEXBKywNbGQDrK++r/g=
 github.com/operator-framework/helm-operator-plugins v0.0.12-0.20220613184440-7329cace347f/go.mod h1:D7zPPwmIFBqHtWigU2iJiLuZ0v7hOJOb1/VC+/UuBAQ=
+github.com/operator-framework/helm-operator-plugins v0.0.12-0.20220616200420-1a695cb9f6a1 h1:ulX/0zkiQIg2JkVuAtC329ygfXHg9Sb578vQ7kdNVkY=
+github.com/operator-framework/helm-operator-plugins v0.0.12-0.20220616200420-1a695cb9f6a1/go.mod h1:D7zPPwmIFBqHtWigU2iJiLuZ0v7hOJOb1/VC+/UuBAQ=
 github.com/operator-framework/java-operator-plugins v0.5.1 h1:HmiTocc61d/uqVPY/7EUR6ZTHDVeZ5/fgy7uo1QIBFc=
 github.com/operator-framework/java-operator-plugins v0.5.1/go.mod h1:UnUHAWY203Xw1j6Xpiirp/psJJaSRYcjenc0NH2+aVw=
 github.com/operator-framework/operator-lib v0.11.0 h1:eYzqpiOfq9WBI4Trddisiq/X9BwCisZd3rIzmHRC9Z8=


### PR DESCRIPTION
**Description of the change:**
Bumps helm-operator-plugins to commit `1a695cb9f6a1`

**Motivation for the change:**
The Dockerfile scaffolded with the Hybrid operator was not bumped to support Go 1.18 in the currently used commit. This bump makes it so that the Dockerfile now uses Go 1.18.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
