### PR TITLE
Bug 2090135: Propagate correct error message for an invalid index

### DIFF
--- a/internal/olm/operator/bundle/install.go
+++ b/internal/olm/operator/bundle/install.go
@@ -97,7 +97,7 @@ func (i *Install) setup(ctx context.Context) error {
 	// check if index image adopts File-Based Catalog or SQLite index image format
 	isFBCImage, err := fbcutil.IsFBC(ctx, i.IndexImageCatalogCreator.IndexImage)
 	if err != nil {
-		return fmt.Errorf("error in upgrading the bundle %q that was installed traditionally", i.IndexImageCatalogCreator.BundleImage)
+		return fmt.Errorf("error determining whether index %q is FBC or SQLite based: %v", i.IndexImageCatalogCreator.IndexImage, err)
 	}
 	i.IndexImageCatalogCreator.HasFBCLabel = isFBCImage
 

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -148,17 +148,17 @@ func handleTraditionalUpgrade(ctx context.Context, indexImage string, bundleImag
 	// render the index image
 	originalDeclCfg, err := fbcutil.RenderRefs(ctx, []string{indexImage})
 	if err != nil {
-		return "", fmt.Errorf("error in rendering index %q", indexImage)
+		return "", fmt.Errorf("error rendering index %q", indexImage)
 	}
 
 	// render the bundle image
 	bundleDeclConfig, err := fbcutil.RenderRefs(ctx, []string{bundleImage})
 	if err != nil {
-		return "", fmt.Errorf("error in rendering index %q", bundleImage)
+		return "", fmt.Errorf("error rendering bundle image %q", bundleImage)
 	}
 
 	if len(bundleDeclConfig.Bundles) != 1 {
-		return "", errors.New("bundle image must have exactly one bundle")
+		return "", errors.New("rendered bundle must have exactly one bundle")
 	}
 
 	// search for the specific channel in which the upgrade needs to take place, and upgrade from the channel head


### PR DESCRIPTION
**Description of the change:**
Propagate correct error message when an invalid index image is provider by the user that does not exist. 

**Motivation for the change:**
With this fix, the error below would be as below:

▶ ./build/operator-sdk run bundle quay.io/olmqe/k8sstatus-bundle:v4.10 --index-image quay.io/kakatest/kkkkk:test
FATA[0005] Failed to run bundle: error determining whether index "quay.io/kakatest/kkkkk:test" is FBC or SQLite based: get index image labels: error pulling image quay.io/kakatest/kkkkk:test: error resolving name : unexpected status code [manifests test]: 401 UNAUTHORIZED

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
