### PR TITLE
(bugfix): `run bundle` and `run bundle-upgrade` - update registry pod index directory

### DIFF
--- a/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
+++ b/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
@@ -81,7 +81,7 @@ func (f *FBCRegistryPod) init(cfg *operator.Configuration, cs *v1alpha1.CatalogS
 	}
 
 	if f.FBCIndexRootDir == "" {
-		f.FBCIndexRootDir = "/configs"
+		f.FBCIndexRootDir = fmt.Sprintf("/%s-configs", cs.Name)
 	}
 
 	f.cfg = cfg

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -329,6 +329,9 @@ func upgradeFBC(ctx context.Context, f *fbcutil.FBCContext, originalDeclCfg *dec
 	}
 	extraDeclConfig.Packages = []declarativeconfig.Package{packageBlob}
 
+	// copy over any other FBC metadata
+	extraDeclConfig.Others = originalDeclCfg.Others
+
 	return extraDeclConfig, nil
 }
 

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -246,6 +246,10 @@ func upgradeFBC(ctx context.Context, f *fbcutil.FBCContext, originalDeclCfg *dec
 		return nil, fmt.Errorf("bundle image should contain at least one bundle blob")
 	}
 
+	extraDeclConfig := &declarativeconfig.DeclarativeConfig{}
+	// declcfg contains all the bundles we need to insert to form the new FBC
+	entries := []declarativeconfig.ChannelEntry{} // Used when generating a new channel
+
 	// Checking if the existing file-based catalog (before upgrade) contains the bundle and channel that we intend to insert.
 	// If the bundle already exists, we error out. If the channel already exists, we store the index of the channel. This
 	// index will be used to access the channel from the declarative config object
@@ -270,6 +274,8 @@ func upgradeFBC(ctx context.Context, f *fbcutil.FBCContext, originalDeclCfg *dec
 				return nil, err
 			}
 
+			extraDeclConfig.Channels = append(extraDeclConfig.Channels, channel)
+
 			break // We only want to search through the specific channel
 		}
 	}
@@ -280,9 +286,6 @@ func upgradeFBC(ctx context.Context, f *fbcutil.FBCContext, originalDeclCfg *dec
 		existingBundles[bundle.Name] = bundle.Package
 	}
 
-	extraDeclConfig := &declarativeconfig.DeclarativeConfig{}
-	// declcfg contains all the bundles we need to insert to form the new FBC
-	entries := []declarativeconfig.ChannelEntry{} // Used when generating a new channel
 	for i, bundle := range declcfg.Bundles {
 		// if it is not present in the bundles array or belongs to a different package, we can add it
 		if _, present := existingBundles[bundle.Name]; !present || existingBundles[bundle.Name] != bundle.Package {
@@ -318,24 +321,13 @@ func upgradeFBC(ctx context.Context, f *fbcutil.FBCContext, originalDeclCfg *dec
 		extraDeclConfig.Channels = []declarativeconfig.Channel{channel}
 	}
 
-	// check if package already exists
-	packagePresent := false
-	for _, packageName := range originalDeclCfg.Packages {
-		if packageName.Name == f.Package {
-			packagePresent = true
-			break
-		}
+	// always add the package as we are starting with a new empty DeclarativeConfig
+	packageBlob := declarativeconfig.Package{
+		Schema:         fbcutil.SchemaPackage,
+		Name:           f.Package,
+		DefaultChannel: f.ChannelName,
 	}
-
-	// only add the new package if it does not already exist
-	if !packagePresent {
-		packageBlob := declarativeconfig.Package{
-			Schema:         fbcutil.SchemaPackage,
-			Name:           f.Package,
-			DefaultChannel: f.ChannelName,
-		}
-		extraDeclConfig.Packages = []declarativeconfig.Package{packageBlob}
-	}
+	extraDeclConfig.Packages = []declarativeconfig.Package{packageBlob}
 
 	return extraDeclConfig, nil
 }


### PR DESCRIPTION
The registry pod index directory now includes the CatalogSource name to prevent conflicts between indexes in the same directory

Signed-off-by: Bryce Palmer <bpalmer@redhat.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Update the registry pod index directory to include the `CatalogSource` name.

**Motivation for the change:**
Potential fix for #5870 

`run bundle-upgrade` was not working properly when upgrading a traditionally (OLM) installed  operator for FBC indexes. It seems this issue is due to multiple indexes being in the same directory that have repeating package definitions.

This change makes it so that the directory indexes are stored in correlate to the `CatalogSource` that is created/used for the upgrade. This seems to have resolved the issue.

(This change also affects `run bundle` as it will now use the same directory logic for storing indexes)

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
