### PR TITLE
(bugfix): approve `InstallPlan` only if it is a new `InstallPlan`

### DIFF
--- a/changelog/fragments/rbu-ip-approval-bugfix.yaml
+++ b/changelog/fragments/rbu-ip-approval-bugfix.yaml
@@ -1,0 +1,17 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For `operator-sdk run bundle-upgrade`: fix a bug that caused `InstallPlan`s occasionally not being approved when attempting to upgrade a bundle.  
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false
+

--- a/internal/olm/operator/registry/operator_installer.go
+++ b/internal/olm/operator/registry/operator_installer.go
@@ -348,16 +348,16 @@ func (o OperatorInstaller) waitForInstallPlan(ctx context.Context, sub *v1alpha1
 	}
 
 	// Get the previous InstallPlanRef
-	prevIpRef := corev1.ObjectReference{}
+	prevIPRef := corev1.ObjectReference{}
 	if sub.Status.InstallPlanRef != nil {
-		prevIpRef = *sub.Status.InstallPlanRef
+		prevIPRef = *sub.Status.InstallPlanRef
 	}
 
 	ipCheck := wait.ConditionFunc(func() (done bool, err error) {
 		if err := o.cfg.Client.Get(ctx, subKey, sub); err != nil {
 			return false, err
 		}
-		if sub.Status.InstallPlanRef != nil && sub.Status.InstallPlanRef.Name != prevIpRef.Name {
+		if sub.Status.InstallPlanRef != nil && sub.Status.InstallPlanRef.Name != prevIPRef.Name {
 			return true, nil
 		}
 		return false, nil

--- a/internal/olm/operator/registry/operator_installer_test.go
+++ b/internal/olm/operator/registry/operator_installer_test.go
@@ -32,6 +32,9 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/olm/operator"
 )
 
+const name = "fakeName"
+const namespace = "fakeNS"
+
 var _ = Describe("OperatorInstaller", func() {
 	Describe("NewOperatorInstaller", func() {
 		It("should create an OperatorInstaller", func() {
@@ -161,29 +164,29 @@ var _ = Describe("OperatorInstaller", func() {
 			oi.cfg.Client = fake.NewClientBuilder().WithScheme(sch).WithObjects(
 				&v1alpha1.InstallPlan{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "fakeName",
-						Namespace: "fakeNS",
+						Name:      name,
+						Namespace: namespace,
 					},
 				},
 			).Build()
 
 			ip := &v1alpha1.InstallPlan{}
 			ipKey := types.NamespacedName{
-				Namespace: "fakeNS",
-				Name:      "fakeName",
+				Namespace: namespace,
+				Name:      name,
 			}
 
 			err := oi.cfg.Client.Get(context.TODO(), ipKey, ip)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ip.Name).To(Equal("fakeName"))
-			Expect(ip.Namespace).To(Equal("fakeNS"))
+			Expect(ip.Name).To(Equal(name))
+			Expect(ip.Namespace).To(Equal(namespace))
 
 			// Test
 			sub := &v1alpha1.Subscription{
 				Status: v1alpha1.SubscriptionStatus{
 					InstallPlanRef: &corev1.ObjectReference{
-						Name:      "fakeName",
-						Namespace: "fakeNS",
+						Name:      name,
+						Namespace: namespace,
 					},
 				},
 			}
@@ -191,8 +194,8 @@ var _ = Describe("OperatorInstaller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = oi.cfg.Client.Get(context.TODO(), ipKey, ip)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ip.Name).To(Equal("fakeName"))
-			Expect(ip.Namespace).To(Equal("fakeNS"))
+			Expect(ip.Name).To(Equal(name))
+			Expect(ip.Namespace).To(Equal(namespace))
 			Expect(ip.Spec.Approved).To(Equal(true))
 		})
 		It("should return an error if the install plan does not exist.", func() {
@@ -200,8 +203,8 @@ var _ = Describe("OperatorInstaller", func() {
 			sub := &v1alpha1.Subscription{
 				Status: v1alpha1.SubscriptionStatus{
 					InstallPlanRef: &corev1.ObjectReference{
-						Name:      "fakeName",
-						Namespace: "fakeNS",
+						Name:      name,
+						Namespace: namespace,
 					},
 				},
 			}
@@ -224,8 +227,8 @@ var _ = Describe("OperatorInstaller", func() {
 			cfg.Client = fake.NewClientBuilder().WithScheme(sch).Build()
 
 			oi = NewOperatorInstaller(cfg)
-			oi.StartingCSV = "fakeName"
-			oi.cfg.Namespace = "fakeNS"
+			oi.StartingCSV = name
+			oi.cfg.Namespace = namespace
 		})
 		It("should return an error if the subscription does not exist.", func() {
 			sub := newSubscription(oi.StartingCSV, oi.cfg.Namespace, withCatalogSource("duplicate", oi.cfg.Namespace))
@@ -236,8 +239,8 @@ var _ = Describe("OperatorInstaller", func() {
 
 		})
 		It("should return if subscription has an install plan and previous install plan is nil", func() {
-			name := "fakeName"
-			namespace := "fakeNS"
+			name := name
+			namespace := namespace
 			prevSub := &v1alpha1.Subscription{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
@@ -264,8 +267,8 @@ var _ = Describe("OperatorInstaller", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("should return if subscription has an install plan and is different than previous install plan", func() {
-			name := "fakeName"
-			namespace := "fakeNS"
+			name := name
+			namespace := namespace
 			prevSub := &v1alpha1.Subscription{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
@@ -593,7 +596,7 @@ var _ = Describe("OperatorInstaller", func() {
 			Expect(err).To(HaveOccurred())
 		})
 		It("should return nothing if namespace does not match", func() {
-			oi.cfg.Namespace = "fakens"
+			oi.cfg.Namespace = namespace
 			_ = createOperatorGroupHelper(context.TODO(), client, "og1", "atestns")
 			grp, found, err := oi.getOperatorGroup(context.TODO())
 			Expect(grp).To(BeNil())

--- a/internal/olm/operator/registry/operator_installer_test.go
+++ b/internal/olm/operator/registry/operator_installer_test.go
@@ -235,23 +235,66 @@ var _ = Describe("OperatorInstaller", func() {
 			Expect(err.Error()).Should(ContainSubstring("install plan is not available for the subscription"))
 
 		})
-		It("should return if subscription has an install plan.", func() {
+		It("should return if subscription has an install plan and previous install plan is nil", func() {
+			name := "fakeName"
+			namespace := "fakeNS"
+			prevSub := &v1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+			}
+
 			sub := &v1alpha1.Subscription{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "fakeName",
-					Namespace: "fakeNS",
+					Name:      name,
+					Namespace: namespace,
 				},
 				Status: v1alpha1.SubscriptionStatus{
 					InstallPlanRef: &corev1.ObjectReference{
-						Name:      "fakeName",
-						Namespace: "fakeNS",
+						Name:      name,
+						Namespace: namespace,
 					},
 				},
 			}
 			err := oi.cfg.Client.Create(context.TODO(), sub)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = oi.waitForInstallPlan(context.TODO(), sub)
+			err = oi.waitForInstallPlan(context.TODO(), prevSub)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should return if subscription has an install plan and is different than previous install plan", func() {
+			name := "fakeName"
+			namespace := "fakeNS"
+			prevSub := &v1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Status: v1alpha1.SubscriptionStatus{
+					InstallPlanRef: &corev1.ObjectReference{
+						Name:      name + "diff",
+						Namespace: namespace + "diff",
+					},
+				},
+			}
+
+			sub := &v1alpha1.Subscription{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Status: v1alpha1.SubscriptionStatus{
+					InstallPlanRef: &corev1.ObjectReference{
+						Name:      name,
+						Namespace: namespace,
+					},
+				},
+			}
+			err := oi.cfg.Client.Create(context.TODO(), sub)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = oi.waitForInstallPlan(context.TODO(), prevSub)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Modify the `internal/olm/operator/registry/operator_installer.go` `waitForInstallPlan` function to now wait for the `InstallPlan` to be different than the previous `InstallPlan` before attempting to approve it.

Update the tests as well.

**Motivation for the change:**
resolves #5897 

The previous logic would approve the `InstallPlan` based on the `InstallPlanRef` in a `Subcription`s status not being empty. This caused an issue when running `operator-sdk run bundle-upgrade` as it would occasionally approve the previous CSV's `InstallPlan` because the `Subscription`'s `InstallPlanRef` had not yet been updated to reflect new changes. This lead to having to manually approve the new `InstallPlan`s so that the rest of the `operator-sdk run bundle-upgrade` command could run and finish the upgrade process. 

The new logic prevents this by ensuring that we wait until the `InstallPlanRef` refers to a new `InstallPlan` and not a previous one.

Testing this change with multiple different combinations of `run bundle` and `run bundle-upgrade` I never had to manually approve an `InstallPlan` where as before it was occurring quite often that I would have to manually approve the `InstallPlan`.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
