### PR TITLE
(bugfix): fix SecurityContext in Go memcached sample

### DIFF
--- a/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
@@ -437,6 +437,7 @@ func (r *MemcachedReconciler) deploymentForMemcached(m *cachev1alpha1.Memcached)
 									"ALL",
 								},
 							},
+							RunAsUser: &[]int64{1000}[0],
 						},
 						Command: []string{"memcached", "-m=64", "-o", "modern", "-v"},
 						Ports: []corev1.ContainerPort{{

--- a/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/v3/memcached_with_webhooks.go
@@ -437,6 +437,9 @@ func (r *MemcachedReconciler) deploymentForMemcached(m *cachev1alpha1.Memcached)
 									"ALL",
 								},
 							},
+							// The memcached image does not use a non-zero numeric user as the default user.
+							// Due to RunAsNonRoot field being set to true, we need to force the user in the
+							// container to a non-zero numeric user. We do this using the RunAsUser field.
 							RunAsUser: &[]int64{1000}[0],
 						},
 						Command: []string{"memcached", "-m=64", "-o", "modern", "-v"},

--- a/testdata/go/v3/memcached-operator/controllers/memcached_controller.go
+++ b/testdata/go/v3/memcached-operator/controllers/memcached_controller.go
@@ -180,6 +180,7 @@ func (r *MemcachedReconciler) deploymentForMemcached(m *cachev1alpha1.Memcached)
 									"ALL",
 								},
 							},
+							RunAsUser: &[]int64{1000}[0],
 						},
 						Command: []string{"memcached", "-m=64", "-o", "modern", "-v"},
 						Ports: []corev1.ContainerPort{{

--- a/testdata/go/v3/memcached-operator/controllers/memcached_controller.go
+++ b/testdata/go/v3/memcached-operator/controllers/memcached_controller.go
@@ -180,6 +180,9 @@ func (r *MemcachedReconciler) deploymentForMemcached(m *cachev1alpha1.Memcached)
 									"ALL",
 								},
 							},
+							// The memcached image does not use a non-zero numeric user as the default user.
+							// Due to RunAsNonRoot field being set to true, we need to force the user in the
+							// container to a non-zero numeric user. We do this using the RunAsUser field.
 							RunAsUser: &[]int64{1000}[0],
 						},
 						Command: []string{"memcached", "-m=64", "-o", "modern", "-v"},

--- a/website/content/en/docs/best-practices/pod-security-standards.md
+++ b/website/content/en/docs/best-practices/pod-security-standards.md
@@ -54,6 +54,7 @@ Please, do **not** use this field if you are looking to build Operators that wor
 
 **On Reconciliations, such as code implementation in Go:**
 
+**Note:** *if you are setting the `RunAsNonRoot` value to `true` in the `SecurityContext` you will also need to specify the `RunAsUser` value to set the user to a numeric user. In this implementation it sets the user uid to `1000`.*
 ```go
 dep:= &appsv1.Deployment{
   ObjectMeta: metav1.ObjectMeta{
@@ -87,6 +88,7 @@ dep:= &appsv1.Deployment{
                        "ALL",
                     },
                  },
+                 RunAsUser: &[]int64{1000}[0],
               },
            }},
         },

--- a/website/content/en/docs/best-practices/pod-security-standards.md
+++ b/website/content/en/docs/best-practices/pod-security-standards.md
@@ -54,7 +54,7 @@ Please, do **not** use this field if you are looking to build Operators that wor
 
 **On Reconciliations, such as code implementation in Go:**
 
-**Note:** *if you are setting the `RunAsNonRoot` value to `true` in the `SecurityContext` you will also need to specify the `RunAsUser` value to set the user to a numeric user. In this implementation it sets the user uid to `1000`.*
+**Note:** *if you are setting the `RunAsNonRoot` value to `true` in the `SecurityContext` you will need to verify that the Pod or Container(s) are running with a numeric user that is not 0 (root). If the Pod or Container(s) do not use a non-zero numeric user, you can use the `RunAsUser` value to set the user to a numeric user. In this example, the memcached container does not use a non-zero numeric user and therefor the `RunAsUser` value is set to use a uid of `1000`.*
 ```go
 dep:= &appsv1.Deployment{
   ObjectMeta: metav1.ObjectMeta{

--- a/website/content/en/docs/best-practices/pod-security-standards.md
+++ b/website/content/en/docs/best-practices/pod-security-standards.md
@@ -54,7 +54,7 @@ Please, do **not** use this field if you are looking to build Operators that wor
 
 **On Reconciliations, such as code implementation in Go:**
 
-**Note:** *if you are setting the `RunAsNonRoot` value to `true` in the `SecurityContext` you will need to verify that the Pod or Container(s) are running with a numeric user that is not 0 (root). If the Pod or Container(s) do not use a non-zero numeric user, you can use the `RunAsUser` value to set the user to a numeric user. In this example, the memcached container does not use a non-zero numeric user and therefor the `RunAsUser` value is set to use a uid of `1000`.*
+**Note:** *if you are setting the `RunAsNonRoot` value to `true` in the `SecurityContext` you will need to verify that the Pod or Container(s) are running with a numeric user that is not 0 (root). If the Pod or Container(s) do not use a non-zero numeric user, you can use the `RunAsUser` value to set the user to a non-zero numeric user. In this example, the memcached container does not use a non-zero numeric user and therefore the `RunAsUser` value is set to use a uid of `1000`.*
 ```go
 dep:= &appsv1.Deployment{
   ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
- Update the `SecurityContext` to contain the `RunAsUser` field with the UID set to `1000`.
- Update Go e2e tests to make sure all pods that contain the substring `memcached` are in the "Running" state
- Update https://sdk.operatorframework.io/docs/best-practices/pod-security-standards/ to include information about this change.

**Motivation for the change:**
resolves #5902

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
