### PR TITLE
dx: add option to run only the lint checks as fix small issues automatically i.e. unused imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,17 @@ bindata: ## Update project bindata
 fix: ## Fixup files in the repo.
 	go mod tidy
 	go fmt ./...
+	make setup-lint
+	$(TOOLS_DIR)/golangci-lint run --fix
+
+.PHONY: setup-lint
+setup-lint: ## Setup the lint
+	$(SCRIPTS_DIR)/fetch golangci-lint 1.46.2
+
+.PHONY: lint
+lint: setup-lint ## Run the lint check
+	$(TOOLS_DIR)/golangci-lint run
+
 
 .PHONY: clean
 clean: ## Cleanup build artifacts and tool binaries.
@@ -132,7 +143,8 @@ test-sanity: generate fix ## Test repo formatting, linting, etc.
 	./hack/check-license.sh
 	./hack/check-error-log-msg-format.sh
 	go vet ./...
-	$(SCRIPTS_DIR)/fetch golangci-lint 1.46.2 && $(TOOLS_DIR)/golangci-lint run
+	setup-lint
+	lint
 	git diff --exit-code # diff again to ensure other checks don't change repo
 
 .PHONY: test-docs

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ test-sanity: generate fix ## Test repo formatting, linting, etc.
 	./hack/check-license.sh
 	./hack/check-error-log-msg-format.sh
 	go vet ./...
-	setup-lint
+	make setup-lint
 	lint
 	git diff --exit-code # diff again to ensure other checks don't change repo
 

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ test-sanity: generate fix ## Test repo formatting, linting, etc.
 	./hack/check-error-log-msg-format.sh
 	go vet ./...
 	make setup-lint
-	lint
+	make lint
 	git diff --exit-code # diff again to ensure other checks don't change repo
 
 .PHONY: test-docs


### PR DESCRIPTION
**Description**
- make lint -> to run only the lint checks ( many times we just want to check the lint and the sanity takes too long )
- make fix -> calling option used in Kubebuilder to fix small issues like when having unused imports which are very unproductive be required to be fixed manually. 

**Motivation**
Face scenarios like on the CI:
<img width="1042" alt="Screenshot 2022-06-26 at 23 45 41" src="https://user-images.githubusercontent.com/7708031/175836933-05e30c68-c34b-4e50-9d5e-9e6dc42939f8.png">

