### PR TITLE
Correct cloud.common version to match the requirements.yaml

### DIFF
--- a/website/content/en/docs/upgrading-sdk-version/v1.22.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.22.0.md
@@ -64,7 +64,7 @@ Replace:
 collections:
   ...
   - name: cloud.common
-    version: "2.2.0"
+    version: "2.1.0"
 ```
 
 With:
@@ -73,7 +73,7 @@ With:
 collections:
   ...
   - name: cloud.common
-    version: "2.2.1"
+    version: "2.1.1"
 ```
 
 _See [#5846](https://github.com/operator-framework/operator-sdk/pull/5846) for more details._


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**


**Motivation for the change:**
Correct the version in the docs to match the one in the [requirement.yaml](https://github.com/operator-framework/operator-sdk/blob/master/testdata/ansible/memcached-operator/requirements.yml#L10) for ansible operator. 

Reference PR https://github.com/operator-framework/operator-sdk/pull/5846 which delivered the incorrect version


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
