### PR TITLE
[Doc] Added git url release note v1.22.0.md 

### DIFF
--- a/changelog/generated/v1.22.0.md
+++ b/changelog/generated/v1.22.0.md
@@ -8,7 +8,7 @@
 - For Quarkus (quarkus/v1-alpha) language based operator: add bundle generation [More info](https://github.com/operator-framework/java-operator-plugins/pull/84). ([#5843](https://github.com/operator-framework/operator-sdk/pull/5843))
 - For operator-sdk run bundle and bundle-upgrade subcommands: improve message from common scenario faced to add a new bundle [More info](https://github.com/operator-framework/operator-registry/pull/954). ([#5843](https://github.com/operator-framework/operator-sdk/pull/5843))
 - For operator-sdk run bundle and bundle-upgrade subcommands: adds some extra text context to sql statement errors [More info](https://github.com/operator-framework/operator-registry/pull/953). ([#5843](https://github.com/operator-framework/operator-sdk/pull/5843))
-- For Golang/Ansible/Helm/HybridHelm language-based operators (go/v3, ansible/v1, helm/v1, hybrid.helm/v1-alpha, add a new comment with the option `leaderElectionReleaseOnCancel` ((More info)[https://github.com/kubernetes-sigs/kubebuilder/pull/2596]). ([#5814](https://github.com/operator-framework/operator-sdk/pull/5814))
+- For Golang/Ansible/Helm/HybridHelm language-based operators (go/v3, ansible/v1, helm/v1, hybrid.helm/v1-alpha, add a new comment with the option `leaderElectionReleaseOnCancel` [More info] (https://github.com/kubernetes-sigs/kubebuilder/pull/2596]). ([#5814](https://github.com/operator-framework/operator-sdk/pull/5814))
 
 ### Changes
 

--- a/website/content/en/docs/upgrading-sdk-version/v1.22.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.22.0.md
@@ -64,7 +64,7 @@ Replace:
 collections:
   ...
   - name: cloud.common
-    version: "2.2.0"
+    version: "2.1.0"
 ```
 
 With:
@@ -73,7 +73,7 @@ With:
 collections:
   ...
   - name: cloud.common
-    version: "2.2.1"
+    version: "2.1.1"
 ```
 
 _See [#5846](https://github.com/operator-framework/operator-sdk/pull/5846) for more details._


### PR DESCRIPTION
Signed-off-by: Mitulsharma123 <sharmamitul72@gmail.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Added missing url for https://github.com/kubernetes-sigs/kubebuilder/pull/2596 in v1.22.0.md 

**Motivation for the change:**
To make documentation readable and precise 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
