### PR TITLE
Bug 2087032: update `run bundle(-upgrade)` cli documentation

### DIFF
--- a/internal/cmd/operator-sdk/run/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/run/bundle/cmd.go
@@ -31,6 +31,8 @@ func NewCmd(cfg *operator.Configuration) *cobra.Command {
 		Short: "Deploy an Operator in the bundle format with OLM",
 		Long: `The single argument to this command is a bundle image, with the full registry path specified.
 If using a docker.io image, you must specify docker.io(/<namespace>)?/<bundle-image-name>:<tag>.
+If the bundle image provided is a SQLite index, it must be pullable by the cluster as SQLite images are pulled from the cluster.
+If the bundle image provided is a File-Based Catalog (FBC) index, it will be pulled on the local machine.
 
 The main purpose of this command is to streamline running the bundle without having to provide an index image with the bundle already included.
 

--- a/internal/cmd/operator-sdk/run/bundleupgrade/cmd.go
+++ b/internal/cmd/operator-sdk/run/bundleupgrade/cmd.go
@@ -30,7 +30,9 @@ func NewCmd(cfg *operator.Configuration) *cobra.Command {
 		Use:   "bundle-upgrade <bundle-image>",
 		Short: "Upgrade an Operator previously installed in the bundle format with OLM",
 		Long: `The single argument to this command is a bundle image, with the full registry path specified.
-If using a docker.io image, you must specify docker.io(/<namespace>)?/<bundle-image-name>:<tag>.`,
+If using a docker.io image, you must specify docker.io(/<namespace>)?/<bundle-image-name>:<tag>.
+If the bundle image provided is a SQLite index, it must be pullable by the cluster as SQLite images are pulled from the cluster.
+If the bundle image provided is a File-Based Catalog (FBC) index, it will be pulled on the local machine.`,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: func(*cobra.Command, []string) error { return cfg.Load() },
 		Run: func(cmd *cobra.Command, args []string) {

--- a/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
@@ -9,6 +9,8 @@ Upgrade an Operator previously installed in the bundle format with OLM
 
 The single argument to this command is a bundle image, with the full registry path specified.
 If using a docker.io image, you must specify docker.io(/&lt;namespace&gt;)?/&lt;bundle-image-name&gt;:&lt;tag&gt;.
+If the bundle image provided is a SQLite index, it must be pullable by the cluster as SQLite images are pulled from the cluster.
+If the bundle image provided is a File-Based Catalog (FBC) index, it will be pulled on the local machine.
 
 ```
 operator-sdk run bundle-upgrade <bundle-image> [flags]

--- a/website/content/en/docs/cli/operator-sdk_run_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle.md
@@ -9,6 +9,8 @@ Deploy an Operator in the bundle format with OLM
 
 The single argument to this command is a bundle image, with the full registry path specified.
 If using a docker.io image, you must specify docker.io(/&lt;namespace&gt;)?/&lt;bundle-image-name&gt;:&lt;tag&gt;.
+If the bundle image provided is a SQLite index, it must be pullable by the cluster as SQLite images are pulled from the cluster.
+If the bundle image provided is a File-Based Catalog (FBC) index, it will be pulled on the local machine.
 
 The main purpose of this command is to streamline running the bundle without having to provide an index image with the bundle already included.
 


### PR DESCRIPTION
**Description of the change:**
Updates the `run bundle(-upgrade)` command cli documentation to explicitly state that a SQLite index bundle image must be pullable by the cluster.

**Motivation for the change:**
BugZilla: https://bugzilla.redhat.com/show_bug.cgi?id=2087032 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)