### PR TITLE
Move /database to /opm/database for sqlite pods

### DIFF
--- a/internal/olm/operator/registry/index/registry_pod.go
+++ b/internal/olm/operator/registry/index/registry_pod.go
@@ -38,7 +38,7 @@ import (
 const (
 	// defaultGRPCPort is the default grpc container port that the registry pod exposes
 	defaultGRPCPort = 50051
-	defaultDBPath   = "/database/index.db"
+	defaultDBPath   = "/opm/database/index.db"
 
 	defaultContainerName     = "registry-grpc"
 	defaultContainerPortName = "grpc"
@@ -62,7 +62,7 @@ type SQLiteRegistryPod struct { //nolint:maligned
 	IndexImage string
 
 	// DBPath refers to the registry DB;
-	// if an index image is provided, the existing registry DB is located at /database/index.db
+	// if an index image is provided, the existing registry DB is located at /opm/database/index.db
 	DBPath string
 
 	// GRPCPort is the container grpc port

--- a/internal/olm/operator/registry/index/registry_pod_test.go
+++ b/internal/olm/operator/registry/index/registry_pod_test.go
@@ -88,7 +88,7 @@ var _ = Describe("SQLiteRegistryPod", func() {
 			})
 
 			It("should create a registry pod when database path is not provided", func() {
-				Expect(rp.DBPath).To(Equal("/database/index.db"))
+				Expect(rp.DBPath).To(Equal("/opm/database/index.db"))
 			})
 
 			It("should return a valid container command for one image", func() {
@@ -292,5 +292,5 @@ func containerCommandFor(dbPath string, items []BundleItem, hasCA, skipTLSVerify
 	for _, item := range items {
 		additions.WriteString(fmt.Sprintf("opm registry add -d %s -b %s --mode=%s%s --skip-tls-verify=%v --use-http=%v && \\\n", dbPath, item.ImageTag, item.AddMode, caFlag, skipTLSVerify, useHTTP))
 	}
-	return fmt.Sprintf("mkdir -p /database && \\\n%sopm registry serve -d /database/index.db -p 50051\n", additions.String())
+	return fmt.Sprintf("mkdir -p /opm/database && \\\n%sopm registry serve -d /opm/database/index.db -p 50051\n", additions.String())
 }


### PR DESCRIPTION
Signed-off-by: perdasilva <perdasilva@redhat.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Moves the sqlite directory in the `run bundle` command pod spec to be `/opm/database`. 
Should only be merged after https://github.com/operator-framework/operator-registry/pull/985 is merged and a release is cut and the opm image is updated

**Motivation for the change:**
Closes https://github.com/operator-framework/operator-registry/issues/984

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
