### PR TITLE
fix: (scorecard: olm-status-descriptors) : warning if no status spec is defined for the CRD but not fail because it is missing a description since we cannot request a description for something that does not exist in the first place

### DIFF
--- a/internal/scorecard/tests/bundle_test.go
+++ b/internal/scorecard/tests/bundle_test.go
@@ -176,6 +176,24 @@ var _ = Describe("Basic and OLM tests", func() {
 				Expect(result.State).To(Equal(scapiv1alpha3.PassState))
 			})
 
+			It("should return warning when no spec status are defined for CRD", func() {
+				cr = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"spec": map[string]interface{}{
+							"spec": "val",
+						},
+					},
+				}
+				cr.SetGroupVersionKind(schema.GroupVersionKind{
+					Kind:  "TestKind",
+					Group: "test.example.com",
+				})
+
+				result = checkOwnedCSVStatusDescriptor(cr, &csv, result)
+				Expect(len(result.Suggestions)).To(Equal(1))
+				Expect(result.State).To(Equal(scapiv1alpha3.PassState))
+			})
+
 			It("should pass when CR Object Descriptor is nil", func() {
 				cr := unstructured.Unstructured{
 					Object: nil,
@@ -424,7 +442,6 @@ var _ = Describe("Basic and OLM tests", func() {
 			result = CheckResources(crd, result)
 			Expect(result.State).To(Equal(scapiv1alpha3.FailState))
 		})
-
 	})
 
 })

--- a/internal/scorecard/tests/olm.go
+++ b/internal/scorecard/tests/olm.go
@@ -234,24 +234,46 @@ func checkCSVDescriptors(bundle *apimanifests.Bundle, r scapiv1alpha3.TestResult
 func checkOwnedCSVStatusDescriptor(cr unstructured.Unstructured, csv *operatorsv1alpha1.ClusterServiceVersion,
 	r scapiv1alpha3.TestResult) scapiv1alpha3.TestResult {
 
-	var crd *operatorsv1alpha1.CRDDescription
+	var crdDescription *operatorsv1alpha1.CRDDescription
 
 	for _, owned := range csv.Spec.CustomResourceDefinitions.Owned {
 		if owned.Kind == cr.GetKind() {
-			crd = &owned
+			crdDescription = &owned
 			break
 		}
 	}
 
-	if crd == nil {
+	if crdDescription == nil {
 		msg := fmt.Sprintf("Failed to find an owned CRD for CR %s with GVK %s", cr.GetName(), cr.GroupVersionKind().String())
 		r.Errors = append(r.Errors, msg)
 		r.State = scapiv1alpha3.FailState
 		return r
 	}
 
-	if len(crd.StatusDescriptors) == 0 {
-		r.Errors = append(r.Errors, fmt.Sprintf("%s does not have a status descriptor", crd.Name))
+	hasStatusDefinition := false
+	if cr.Object["status"] != nil {
+		// Ensure that has no empty keys
+		status := cr.Object["status"].(map[string]interface{})
+		for key := range status {
+			if len(key) > 0 {
+				hasStatusDefinition = true
+				break
+			}
+		}
+	}
+
+	if !hasStatusDefinition {
+		r.Suggestions = append(r.Suggestions, fmt.Sprintf("%s does not have status spec. Note that"+
+			"All objects that represent a physical resource whose state may vary from the user's desired "+
+			"intent SHOULD have a spec and a status. "+
+			"More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status", crdDescription.Name))
+	}
+
+	if hasStatusDefinition && len(crdDescription.StatusDescriptors) == 0 {
+		r.Errors = append(r.Errors, fmt.Sprintf("%s does not have a status descriptor", crdDescription.Name))
+		r.Suggestions = append(r.Suggestions, fmt.Sprintf("add status descriptor for the crd %s. "+
+			"If your project is built using Golang you can use the csv markers. "+
+			"More info: https://sdk.operatorframework.io/docs/building-operators/golang/references/markers/", crdDescription.Name))
 		r.State = scapiv1alpha3.FailState
 	}
 

--- a/internal/scorecard/tests/olm.go
+++ b/internal/scorecard/tests/olm.go
@@ -253,13 +253,7 @@ func checkOwnedCSVStatusDescriptor(cr unstructured.Unstructured, csv *operatorsv
 	hasStatusDefinition := false
 	if cr.Object["status"] != nil {
 		// Ensure that has no empty keys
-		status := cr.Object["status"].(map[string]interface{})
-		for key := range status {
-			if len(key) > 0 {
-				hasStatusDefinition = true
-				break
-			}
-		}
+		hasStatusDefinition = len(cr.Object["status"].(map[string]interface{})) > 0
 	}
 
 	if !hasStatusDefinition {

--- a/test/common/scorecard.go
+++ b/test/common/scorecard.go
@@ -73,7 +73,9 @@ func ScorecardSpec(tc *testutils.TestContext, operatorType string) func() {
 				"olm-crds-have-validation": v1alpha3.FailState,
 				"olm-crds-have-resources":  v1alpha3.FailState,
 				"olm-spec-descriptors":     v1alpha3.FailState,
-				"olm-status-descriptors":   v1alpha3.FailState,
+				// For Ansible/Helm should PASS with a Suggestion
+				// For Golang should pass because we have status spec and descriptions
+				"olm-status-descriptors": v1alpha3.PassState,
 			}
 			if strings.ToLower(operatorType) == "go" {
 				// Go projects have generated CRD validation.


### PR DESCRIPTION
## Description

Warning if no status spec is NOT defined for the CRD and let the authors know what are the conditions that according to the k8s api convention they MUST set a status spec.

However, does not fail to say "You did not define a description for the status spec" since we cannot ask for a description for something that does not exist at all. 

PS.: we are also improving the scenario where we should fail because the status spec description is missing by providing the documentation and letting the authors know how to fix it. 

## Motivation

Closes: https://github.com/operator-framework/operator-sdk/issues/5548

