### PR TITLE
:bug: fix operator-sdk generate kustomize manifests to respect changes made by users in the config/manifests

### DIFF
--- a/changelog/fragments/fix.yaml
+++ b/changelog/fragments/fix.yaml
@@ -1,0 +1,8 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Fix operator-sdk generate kustomize manifests to respect changes made by users in the config/manifests
+    kind: "bugfix"
+    breaking: false
+

--- a/internal/plugins/manifests/v2/templates/config/manifests/kustomization.go
+++ b/internal/plugins/manifests/v2/templates/config/manifests/kustomization.go
@@ -36,6 +36,12 @@ func (f *Kustomization) SetTemplateDefaults() error {
 		f.Path = filepath.Join("config", "manifests", "kustomization.yaml")
 	}
 
+	// We cannot overwiting the file after it be created because
+	// it might contain user changes (i.e to work with Kustomize 4.x
+	// the target /spec/template/spec/containers/1/volumeMounts/0
+	// needs to be replaced with /spec/template/spec/containers/0/volumeMounts/0
+	f.IfExistsAction = machinery.SkipFile
+
 	f.TemplateBody = kustomizationTemplate
 
 	return nil

--- a/website/content/en/docs/faqs/_index.md
+++ b/website/content/en/docs/faqs/_index.md
@@ -337,7 +337,7 @@ If neither of those solutions work for you, please [open an issue][open-issue]
 
 > `Error: remove operation does not apply:doc is missing path: "/spec/template/spec/containers/1/volumeMounts/0": missing value` 
 
-The error occurs because with the upper Kustomize version the containers used in the Deployment spec of your CSV
+The error occurs due to a change in the Kustomize 4.x versions where the containers used in the Deployment spec of your CSV
 are no longer added at the same order. To sort it out you can update replace the target `/spec/template/spec/containers/1/volumeMounts/0`
 with `/spec/template/spec/containers/0/volumeMounts/0` in `config/manifest/kustomization.yaml`.
 

--- a/website/content/en/docs/faqs/_index.md
+++ b/website/content/en/docs/faqs/_index.md
@@ -331,5 +331,19 @@ Here are a couple workarounds to try to resolve the issue:
 
 If neither of those solutions work for you, please [open an issue][open-issue]
 
+## After update my project to use a Kustomize 4.x version the make bundle does not properly work
+
+**Valid only for Golang/Hybrid projects using webhooks**
+
+> `Error: remove operation does not apply:doc is missing path: "/spec/template/spec/containers/1/volumeMounts/0": missing value` 
+
+The error occurs because with the upper Kustomize version the containers used in the Deployment spec of your CSV
+are no longer added at the same order. To sort it out you can update replace the target `/spec/template/spec/containers/1/volumeMounts/0`
+with `/spec/template/spec/containers/0/volumeMounts/0` in `config/manifest/kustomization.yaml`.
+
+**NOTE** You MUST use SDK CLI versions > 1.22. Previous versions have a bug 
+where the command `operator-sdk generate kustomize manifests` is not respecting the changes
+made on this manifest. 
+
 [cgo-docs]: https://pkg.go.dev/cmd/cgo
 [open-issue]: https://github.com/operator-framework/operator-sdk/issues/new/choose

--- a/website/content/en/docs/faqs/_index.md
+++ b/website/content/en/docs/faqs/_index.md
@@ -331,7 +331,7 @@ Here are a couple workarounds to try to resolve the issue:
 
 If neither of those solutions work for you, please [open an issue][open-issue]
 
-## After update my project to use a Kustomize 4.x version the make bundle does not properly work
+## After updating my project to use a Kustomize 4.x version, 'make bundle' does not work
 
 **Valid only for Golang/Hybrid projects using webhooks**
 


### PR DESCRIPTION
Signed-off-by: Camila Macedo <cmacedo@redhat.com>

**Description of the change:**

 fix operator-sdk generate kustomize manifests to respect changes made by users in the config/manifests

**Motivation for the change:**

If we change the target value on the command to solve the breaking change faced with Kustomize v4 it still not working
because the SDK subcommand call the Helper plugin to generate the CSV and it was not configured to Skip the file when it is scaffolded already.  

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Motivation: https://github.com/operator-framework/operator-sdk/issues/5898