### PR TITLE
Add a metric to the sample memcached-operator

### DIFF
--- a/testdata/go/v3/memcached-operator/Dockerfile
+++ b/testdata/go/v3/memcached-operator/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY monitoring/ monitoring/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go

--- a/testdata/go/v3/memcached-operator/controllers/memcached_controller.go
+++ b/testdata/go/v3/memcached-operator/controllers/memcached_controller.go
@@ -33,6 +33,7 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	cachev1alpha1 "github.com/example/memcached-operator/api/v1alpha1"
+	"github.com/example/memcached-operator/monitoring"
 )
 
 // MemcachedReconciler reconciles a Memcached object
@@ -97,6 +98,8 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Ensure the deployment size is the same as the spec
 	size := memcached.Spec.Size
 	if *found.Spec.Replicas != size {
+		// Increment MemcachedDeploymentSizeUndesiredCountTotal metric by 1
+		monitoring.MemcachedDeploymentSizeUndesiredCountTotal.Inc()
 		found.Spec.Replicas = &size
 		err = r.Update(ctx, found)
 		if err != nil {

--- a/testdata/go/v3/memcached-operator/go.mod
+++ b/testdata/go/v3/memcached-operator/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
+	github.com/prometheus/client_golang v1.12.1
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
@@ -50,7 +51,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/testdata/go/v3/memcached-operator/main.go
+++ b/testdata/go/v3/memcached-operator/main.go
@@ -33,6 +33,7 @@ import (
 
 	cachev1alpha1 "github.com/example/memcached-operator/api/v1alpha1"
 	"github.com/example/memcached-operator/controllers"
+	"github.com/example/memcached-operator/monitoring"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -45,6 +46,8 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(cachev1alpha1.AddToScheme(scheme))
+
+	monitoring.RegisterMetrics()
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/testdata/go/v3/memcached-operator/monitoring/metrics.go
+++ b/testdata/go/v3/memcached-operator/monitoring/metrics.go
@@ -1,0 +1,23 @@
+package monitoring
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// MemcachedDeploymentSizeUndesiredCountTotal will count how many times was required
+	// to perform the operation to ensure that the number of replicas on the cluster
+	// is the same as the quantity desired and specified via the custom resource size spec.
+	MemcachedDeploymentSizeUndesiredCountTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "memcached_deployment_size_undesired_count_total",
+			Help: "Total number of times the deployment size was not as desired.",
+		},
+	)
+)
+
+// Register metrics with the global prometheus registry
+func RegisterMetrics() {
+	metrics.Registry.MustRegister(MemcachedDeploymentSizeUndesiredCountTotal)
+}

--- a/testdata/go/v4-alpha/memcached-operator/Dockerfile
+++ b/testdata/go/v4-alpha/memcached-operator/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY monitoring/ monitoring/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go

--- a/testdata/go/v4-alpha/memcached-operator/controllers/memcached_controller.go
+++ b/testdata/go/v4-alpha/memcached-operator/controllers/memcached_controller.go
@@ -33,6 +33,7 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	cachev1alpha1 "github.com/example/memcached-operator/api/v1alpha1"
+	"github.com/example/memcached-operator/monitoring"
 )
 
 // MemcachedReconciler reconciles a Memcached object
@@ -97,6 +98,8 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Ensure the deployment size is the same as the spec
 	size := memcached.Spec.Size
 	if *found.Spec.Replicas != size {
+		// Increment MemcachedDeploymentSizeUndesiredCountTotal metric by 1
+		monitoring.MemcachedDeploymentSizeUndesiredCountTotal.Inc()
 		found.Spec.Replicas = &size
 		err = r.Update(ctx, found)
 		if err != nil {

--- a/testdata/go/v4-alpha/memcached-operator/go.mod
+++ b/testdata/go/v4-alpha/memcached-operator/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
+	github.com/prometheus/client_golang v1.12.1
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
@@ -50,7 +51,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/testdata/go/v4-alpha/memcached-operator/main.go
+++ b/testdata/go/v4-alpha/memcached-operator/main.go
@@ -33,6 +33,7 @@ import (
 
 	cachev1alpha1 "github.com/example/memcached-operator/api/v1alpha1"
 	"github.com/example/memcached-operator/controllers"
+	"github.com/example/memcached-operator/monitoring"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -45,6 +46,8 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(cachev1alpha1.AddToScheme(scheme))
+
+	monitoring.RegisterMetrics()
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/testdata/go/v4-alpha/memcached-operator/monitoring/metrics.go
+++ b/testdata/go/v4-alpha/memcached-operator/monitoring/metrics.go
@@ -1,0 +1,23 @@
+package monitoring
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// MemcachedDeploymentSizeUndesiredCountTotal will count how many times was required
+	// to perform the operation to ensure that the number of replicas on the cluster
+	// is the same as the quantity desired and specified via the custom resource size spec.
+	MemcachedDeploymentSizeUndesiredCountTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "memcached_deployment_size_undesired_count_total",
+			Help: "Total number of times the deployment size was not as desired.",
+		},
+	)
+)
+
+// Register metrics with the global prometheus registry
+func RegisterMetrics() {
+	metrics.Registry.MustRegister(MemcachedDeploymentSizeUndesiredCountTotal)
+}


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
This PR adds to the sample `memcached-operator` (`testdata/go/v3/memcached-operator` & `testdata/go/v4-alpha/memcached-operator`) a metric named `memcached_deployment_size_undesired_count_total` as part of a new `monitoring` directory. 
This metric counts how many times it was required to perform the operation to ensure that the number of Memcached replicas on the cluster is the same as the quantity desired and specified via the custom resource size spec.
This PR includes scaffolding for this changes, within the existing sample `memcached-operator` scaffolding (i.e. `make generate` generates this functionally). 
  

**Motivation for the change:**
We would like to implement observability concepts for the `memcahced-operator`, in order to have the operator in [Deep Insights](https://sdk.operatorframework.io/docs/overview/operator-capabilities/#level-4---deep-insights) capability level. Then, we may use it as a reference in an observability best-practices tutorial in Operator-SDK. This metric would be the first step towards this goal.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Signed-off-by: assafad <aadmi@redhat.com>

