### PR TITLE
Remove metering from deep insights capability

### DIFF
--- a/website/content/en/docs/overview/operator-capabilities.md
+++ b/website/content/en/docs/overview/operator-capabilities.md
@@ -158,10 +158,6 @@ Native k8s objects emit events (“Events” objects) as their states change. Yo
 - Operand sends useful alerts
 - Custom Resources emit custom events
 
-### Metering
-
-- Operator leverages Operator Metering
-
 **Example:** A database Operator continues to parse the logging output of the database software and understands noteworthy log events, e.g. running out of space for database files and produces alerts. The operator also instruments the database and exposes application level, e.g. database queries per second
 
 **Guiding questions to determine Operator reaching Level 4**
@@ -180,7 +176,7 @@ Native k8s objects emit events (“Events” objects) as their states change. Yo
 
 8. Does your Operator expose Operand performance metrics?
 
-<sup>1</sup> The RED method  
+<sup>1</sup> The RED method
 The RED Method defines the three key metrics for every service in your architecture.
 * Rate (the number of requests per second)
 * Errors (the number of those requests that are failing)


### PR DESCRIPTION
Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Since metering is a deprecated feature, removed it from the Deep Insights capability level requirements.
Links to deprecation notice: 
 - https://github.com/kube-reporting/metering-operator
 - https://docs.openshift.com/container-platform/4.8/metering/metering-about-metering.html

**Motivation for the change:**
Incorrect requirements for Deep Insights capability level creates confusion.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
