### PR TITLE
fix: deploy-image for sdk to generate the bundle with the apis created by it

### DIFF
--- a/changelog/fragments/fix-plugin.yaml
+++ b/changelog/fragments/fix-plugin.yaml
@@ -1,0 +1,7 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      for deploy-image/v1alpha add support to generate SDK bundle manifests
+    kind: "addition"
+    breaking: false

--- a/changelog/fragments/fix-plugin.yaml
+++ b/changelog/fragments/fix-plugin.yaml
@@ -2,6 +2,6 @@
 # release notes and/or the migration guide
 entries:
   - description: >
-      for deploy-image/v1alpha add support to generate SDK bundle manifests
+      (deploy-image/v1alpha plugin) Add support to generate SDK bundle manifests
     kind: "addition"
     breaking: false

--- a/internal/cmd/operator-sdk/cli/cli.go
+++ b/internal/cmd/operator-sdk/cli/cli.go
@@ -114,6 +114,10 @@ func GetPluginsCLIAndRoot() (*cli.CLI, *cobra.Command) {
 		manifestsv2.Plugin{},
 		scorecardv2.Plugin{},
 	)
+	deployImageBundle, _ := plugin.NewBundle("deploy-image."+golang.DefaultNameQualifier, plugin.Version{Number: 1, Stage: stage.Alpha},
+		deployimagev1alpha.Plugin{},
+		manifestsv2.Plugin{},
+	)
 	c, err := cli.New(
 		cli.WithCommandName("operator-sdk"),
 		cli.WithVersion(makeVersionString()),
@@ -125,7 +129,7 @@ func GetPluginsCLIAndRoot() (*cli.CLI, *cobra.Command) {
 			helmBundle,
 			hybridBundle,
 			grafanav1alpha.Plugin{},
-			deployimagev1alpha.Plugin{},
+			deployImageBundle,
 			declarativev1.Plugin{},
 			&quarkusv1.Plugin{},
 		),


### PR DESCRIPTION
## Description
fix deploy-image for sdk to generate the bundle with the apis created by it

In SDK we need to update the manifests with the APIs created so that we can generate the bundle.  