### PR TITLE
Bump java-operator-plugins to v0.6.0

### DIFF
--- a/changelog/fragments/bump-java-operator-plugins.yaml
+++ b/changelog/fragments/bump-java-operator-plugins.yaml
@@ -1,0 +1,16 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Bumping java-operator-plugins to v0.6.0
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/onsi/gomega v1.18.1
 	github.com/operator-framework/api v0.15.1-0.20220624132056-decf74800a17
 	github.com/operator-framework/helm-operator-plugins v0.0.12-0.20220616200420-1a695cb9f6a1
-	github.com/operator-framework/java-operator-plugins v0.5.1
+	github.com/operator-framework/java-operator-plugins v0.6.0
 	github.com/operator-framework/operator-lib v0.11.0
 	github.com/operator-framework/operator-manifest-tools v0.2.1
 	github.com/operator-framework/operator-registry v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -869,8 +869,8 @@ github.com/operator-framework/api v0.15.1-0.20220624132056-decf74800a17 h1:05SuH
 github.com/operator-framework/api v0.15.1-0.20220624132056-decf74800a17/go.mod h1:scnY9xqSeCsOdtJtNoHIXd7OtHZ14gj1hkDA4+DlgLY=
 github.com/operator-framework/helm-operator-plugins v0.0.12-0.20220616200420-1a695cb9f6a1 h1:ulX/0zkiQIg2JkVuAtC329ygfXHg9Sb578vQ7kdNVkY=
 github.com/operator-framework/helm-operator-plugins v0.0.12-0.20220616200420-1a695cb9f6a1/go.mod h1:D7zPPwmIFBqHtWigU2iJiLuZ0v7hOJOb1/VC+/UuBAQ=
-github.com/operator-framework/java-operator-plugins v0.5.1 h1:HmiTocc61d/uqVPY/7EUR6ZTHDVeZ5/fgy7uo1QIBFc=
-github.com/operator-framework/java-operator-plugins v0.5.1/go.mod h1:UnUHAWY203Xw1j6Xpiirp/psJJaSRYcjenc0NH2+aVw=
+github.com/operator-framework/java-operator-plugins v0.6.0 h1:zVapay2Gm1PKigssVNagD4NdvkfyOLOKlVhRujGJ2aI=
+github.com/operator-framework/java-operator-plugins v0.6.0/go.mod h1:UnUHAWY203Xw1j6Xpiirp/psJJaSRYcjenc0NH2+aVw=
 github.com/operator-framework/operator-lib v0.11.0 h1:eYzqpiOfq9WBI4Trddisiq/X9BwCisZd3rIzmHRC9Z8=
 github.com/operator-framework/operator-lib v0.11.0/go.mod h1:RpyKhFAoG6DmKTDIwMuO6pI3LRc8IE9rxEYWy476o6g=
 github.com/operator-framework/operator-manifest-tools v0.2.1 h1:hD3iyOm2mBItzYhpFFWqU1StkolS4XGvXxRvFO4v3Oo=


### PR DESCRIPTION
**Description of the change:**
Bring in latest java-operator-plugins v0.6.0

**Motivation for the change:**
Released of java-operator-plugins.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
