### PR TITLE
testutils: fix method references in comments

### DIFF
--- a/internal/testutils/olm.go
+++ b/internal/testutils/olm.go
@@ -74,7 +74,7 @@ func (tc TestContext) AddPackagemanifestsTarget(operatorType projutil.OperatorTy
 	return nil
 }
 
-// DisableOLMBundleInterativeMode will update the Makefile to disable the interactive mode
+// DisableManifestsInteractiveMode will update the Makefile to disable the interactive mode
 func (tc TestContext) DisableManifestsInteractiveMode() error {
 	// Todo: check if we cannot improve it since the replace/content will exists in the
 	// pkgmanifest target if it be scaffolded before this call

--- a/internal/testutils/utils.go
+++ b/internal/testutils/utils.go
@@ -90,7 +90,7 @@ func makeBundleImageName(projectName string) string {
 	return fmt.Sprintf("quay.io/example/%s-bundle:v0.0.1", projectName)
 }
 
-// InstallOLM runs 'operator-sdk olm install' for specific version
+// InstallOLMVersion runs 'operator-sdk olm install' for specific version
 // and returns any errors emitted by that command.
 func (tc TestContext) InstallOLMVersion(version string) error {
 	cmd := exec.Command(tc.BinaryName, "olm", "install", "--version", version, "--timeout", "4m")
@@ -98,7 +98,7 @@ func (tc TestContext) InstallOLMVersion(version string) error {
 	return err
 }
 
-// InstallOLM runs 'operator-sdk olm uninstall' and logs any errors emitted by that command.
+// UninstallOLM runs 'operator-sdk olm uninstall' and logs any errors emitted by that command.
 func (tc TestContext) UninstallOLM() {
 	cmd := exec.Command(tc.BinaryName, "olm", "uninstall")
 	if _, err := tc.Run(cmd); err != nil {


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Fix methods references in testutils comments

**Motivation for the change:**
Prevent discrepancy between method naming and references in comments

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
