### PR TITLE
Support test selection in scorecard-kuttl integration

### DIFF
--- a/changelog/fragments/kuttl-selector.yaml
+++ b/changelog/fragments/kuttl-selector.yaml
@@ -1,0 +1,24 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Support test selectors in scorecard-kuttl. This only works if you
+      supply a test name in the config for the entrypoint in the scorecard test config.yaml
+
+      In the `stages.tests`section add an `entrypoint`, in this entrypoint you add the
+      name of the test you want to associate with the selector.
+
+      If you have a kuttl test directory called `smoke` your entrypoint should have `- smoke`
+      as an entry. That way scorecard can pass that into the image and kuttl will run the single
+      test.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false

--- a/images/scorecard-test-kuttl/Dockerfile
+++ b/images/scorecard-test-kuttl/Dockerfile
@@ -1,6 +1,7 @@
 # Build the scorecard-test-kuttl binary
 FROM --platform=$BUILDPLATFORM golang:1.18 as builder
 ARG TARGETARCH
+ARG BUILDPLATFORM
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/images/scorecard-test-kuttl/Dockerfile
+++ b/images/scorecard-test-kuttl/Dockerfile
@@ -19,7 +19,7 @@ RUN GOOS=linux GOARCH=$TARGETARCH make build/scorecard-test-kuttl
 
 # Final image.
 #FROM kudobuilder/kuttl@sha256:924a709a1d2c6bede8815415ea5d5be640b506ec5aeaddc68acb443ae8ee7926
-FROM kudobuilder/kuttl:v0.9.0
+FROM kudobuilder/kuttl:v0.12.1
 
 ENV HOME=/opt/scorecard-test-kuttl \
     USER_NAME=scorecard-test-kuttl \

--- a/images/scorecard-test-kuttl/entrypoint
+++ b/images/scorecard-test-kuttl/entrypoint
@@ -3,9 +3,25 @@
 KUTTL_PATH=${KUTTL_PATH:-"/bundle/tests/scorecard/kuttl"}
 KUTTL_CONFIG=${KUTTL_CONFIG:-"${KUTTL_PATH}/kuttl-test.yaml"}
 
-kubectl-kuttl test ${KUTTL_PATH} \
-  --config=${KUTTL_CONFIG} \
-  --namespace=${SCORECARD_NAMESPACE} \
-  --report=JSON --artifacts-dir=/tmp > /tmp/kuttl.stdout 2> /tmp/kuttl.stderr
+if [ $# -eq 0 ]
+  then
+    # if the arg list is 0, then just call kuttl with no test flag
+    # NOTE: this was the original call
+    kubectl-kuttl test ${KUTTL_PATH} \
+      --config=${KUTTL_CONFIG} \
+      --namespace=${SCORECARD_NAMESPACE} \
+      --report=JSON --artifacts-dir=/tmp > /tmp/kuttl.stdout 2> /tmp/kuttl.stderr
+  else
+    # if there is 1 or more then let's call kuttl multiple times
+    for i in $*; do
+      kubectl-kuttl test ${KUTTL_PATH} \
+      --test $i  \
+      --config=${KUTTL_CONFIG} \
+      --namespace=${SCORECARD_NAMESPACE} \
+      --report=JSON --artifacts-dir=/tmp > /tmp/kuttl.stdout 2> /tmp/kuttl.stderr
+    done
+fi
 
+# send the list of args to scorecard-test-kuttl
+# NOTE: I'm not sure it uses the args for anything at the moment
 exec scorecard-test-kuttl $@


### PR DESCRIPTION
**Description of the change:**
Update the `entrypoint` to use the test name passed in from the test config. 

**Motivation for the change:**
Fixes #5743 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
