### PR TITLE
Comment monitoring imports in the sample memcached-operator

### DIFF
--- a/hack/generate/samples/internal/go/memcached-with-webhooks/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/memcached-with-webhooks/memcached_with_webhooks.go
@@ -412,7 +412,7 @@ func (mh *Memcached) implementingController() {
 		`	if *found.Spec.Replicas != size {`,
 		`
 		// Increment MemcachedDeploymentSizeUndesiredCountTotal metric by 1
-		monitoring.MemcachedDeploymentSizeUndesiredCountTotal.Inc()`)
+		//monitoring.MemcachedDeploymentSizeUndesiredCountTotal.Inc()`)
 	pkg.CheckError("adding monitoring import", err)
 
 	err = kbutil.InsertCode(controllerPath,
@@ -527,7 +527,7 @@ func (mh *Memcached) customizingMain() {
 	// Add metrics registry
 	err = kbutil.InsertCode(mainPath,
 		"utilruntime.Must(cachev1alpha1.AddToScheme(scheme))",
-		"\n\nmonitoring.RegisterMetrics()")
+		mainMonitoringRegisterMetricsFragment)
 	pkg.CheckError("adding metrics registry", err)
 }
 
@@ -569,8 +569,13 @@ import (
 `
 
 const mainMonitoringImportFragment = `
-	"github.com/example/memcached-operator/monitoring"
+	// To enable operator custom metrics, uncomment all sections with 'monitoring'
+	//"github.com/example/memcached-operator/monitoring"
 `
+
+const mainMonitoringRegisterMetricsFragment = `
+
+	//monitoring.RegisterMetrics()`
 
 const webhooksFragment = `
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
@@ -607,7 +612,10 @@ func validateOdd(n int32) error {
 `
 
 const controllerMonitoringImportFragment = `
-	"github.com/example/memcached-operator/monitoring"
+	// This sample has an example of how to create and work with custom metrics. The code is commented
+	// in order to not break the basic tutorial to show authors how to build an operator. 
+	// To enable operator custom metrics, uncomment all sections with 'monitoring'.
+	//"github.com/example/memcached-operator/monitoring"
 `
 
 const userIDWarningFragment = `

--- a/testdata/go/v3/memcached-operator/controllers/memcached_controller.go
+++ b/testdata/go/v3/memcached-operator/controllers/memcached_controller.go
@@ -37,7 +37,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	cachev1alpha1 "github.com/example/memcached-operator/api/v1alpha1"
-	"github.com/example/memcached-operator/monitoring"
+	// This sample has an example of how to create and work with custom metrics. The code is commented
+	// in order to not break the basic tutorial to show authors how to build an operator.
+	// To enable operator custom metrics, uncomment all sections with 'monitoring'.
+	//"github.com/example/memcached-operator/monitoring"
 )
 
 const memcachedFinalizer = "cache.example.com/finalizer"
@@ -239,7 +242,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	size := memcached.Spec.Size
 	if *found.Spec.Replicas != size {
 		// Increment MemcachedDeploymentSizeUndesiredCountTotal metric by 1
-		monitoring.MemcachedDeploymentSizeUndesiredCountTotal.Inc()
+		//monitoring.MemcachedDeploymentSizeUndesiredCountTotal.Inc()
 		found.Spec.Replicas = &size
 		if err = r.Update(ctx, found); err != nil {
 			log.Error(err, "Failed to update Deployment",

--- a/testdata/go/v3/memcached-operator/main.go
+++ b/testdata/go/v3/memcached-operator/main.go
@@ -33,7 +33,8 @@ import (
 
 	cachev1alpha1 "github.com/example/memcached-operator/api/v1alpha1"
 	"github.com/example/memcached-operator/controllers"
-	"github.com/example/memcached-operator/monitoring"
+	// To enable operator custom metrics, uncomment all sections with 'monitoring'
+	//"github.com/example/memcached-operator/monitoring"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -47,7 +48,7 @@ func init() {
 
 	utilruntime.Must(cachev1alpha1.AddToScheme(scheme))
 
-	monitoring.RegisterMetrics()
+	//monitoring.RegisterMetrics()
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/testdata/go/v4-alpha/memcached-operator/controllers/memcached_controller.go
+++ b/testdata/go/v4-alpha/memcached-operator/controllers/memcached_controller.go
@@ -37,7 +37,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	cachev1alpha1 "github.com/example/memcached-operator/api/v1alpha1"
-	"github.com/example/memcached-operator/monitoring"
+	// This sample has an example of how to create and work with custom metrics. The code is commented
+	// in order to not break the basic tutorial to show authors how to build an operator.
+	// To enable operator custom metrics, uncomment all sections with 'monitoring'.
+	//"github.com/example/memcached-operator/monitoring"
 )
 
 const memcachedFinalizer = "cache.example.com/finalizer"
@@ -239,7 +242,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	size := memcached.Spec.Size
 	if *found.Spec.Replicas != size {
 		// Increment MemcachedDeploymentSizeUndesiredCountTotal metric by 1
-		monitoring.MemcachedDeploymentSizeUndesiredCountTotal.Inc()
+		//monitoring.MemcachedDeploymentSizeUndesiredCountTotal.Inc()
 		found.Spec.Replicas = &size
 		if err = r.Update(ctx, found); err != nil {
 			log.Error(err, "Failed to update Deployment",

--- a/testdata/go/v4-alpha/memcached-operator/main.go
+++ b/testdata/go/v4-alpha/memcached-operator/main.go
@@ -33,7 +33,8 @@ import (
 
 	cachev1alpha1 "github.com/example/memcached-operator/api/v1alpha1"
 	"github.com/example/memcached-operator/controllers"
-	"github.com/example/memcached-operator/monitoring"
+	// To enable operator custom metrics, uncomment all sections with 'monitoring'
+	//"github.com/example/memcached-operator/monitoring"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -47,7 +48,7 @@ func init() {
 
 	utilruntime.Must(cachev1alpha1.AddToScheme(scheme))
 
-	monitoring.RegisterMetrics()
+	//monitoring.RegisterMetrics()
 	//+kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
Signed-off-by: assafad <aadmi@redhat.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
This PR changes the monitoring imports in the sample memcached-operator code to be comments by default. Users who want to use custom metrics for the operator, will uncomment these lines. Another separate PR will add a custom metric tutorial for the operator-SDK documentation, and there the users will be instructed to uncomment these lines. 

**Motivation for the change:**
https://github.com/operator-framework/operator-sdk/issues/6008

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
