### PR TITLE
helm: fix a memory leak resulting from too many k8s client instantiations

### DIFF
--- a/internal/helm/client/actionconfig.go
+++ b/internal/helm/client/actionconfig.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2020 The Operator-SDK Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/go-logr/logr"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/kube"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ActionConfigGetter interface {
+	ActionConfigFor(obj client.Object) (*action.Configuration, error)
+}
+
+func NewActionConfigGetter(cfg *rest.Config, rm meta.RESTMapper, log logr.Logger) (ActionConfigGetter, error) {
+	rcg := newRESTClientGetter(cfg, rm, "")
+	// Setup the debug log function that Helm will use
+	debugLog := func(format string, v ...interface{}) {
+		if log.Enabled() {
+			log.V(1).Info(fmt.Sprintf(format, v...))
+		}
+	}
+
+	kc := kube.New(rcg)
+	kc.Log = debugLog
+
+	kcs, err := kc.Factory.KubernetesClientSet()
+	if err != nil {
+		return nil, fmt.Errorf("creating kubernetes client set: %w", err)
+	}
+
+	return &actionConfigGetter{
+		kubeClient:       kc,
+		kubeClientSet:    kcs,
+		debugLog:         debugLog,
+		restClientGetter: rcg.restClientGetter,
+	}, nil
+}
+
+var _ ActionConfigGetter = &actionConfigGetter{}
+
+type actionConfigGetter struct {
+	kubeClient       *kube.Client
+	kubeClientSet    kubernetes.Interface
+	debugLog         func(string, ...interface{})
+	restClientGetter *restClientGetter
+}
+
+func (acg *actionConfigGetter) ActionConfigFor(obj client.Object) (*action.Configuration, error) {
+	ownerRef := metav1.NewControllerRef(obj, obj.GetObjectKind().GroupVersionKind())
+	d := driver.NewSecrets(&ownerRefSecretClient{
+		SecretInterface: acg.kubeClientSet.CoreV1().Secrets(obj.GetNamespace()),
+		refs:            []metav1.OwnerReference{*ownerRef},
+	})
+
+	// Also, use the debug log for the storage driver
+	d.Log = acg.debugLog
+
+	// Initialize the storage backend
+	s := storage.Init(d)
+
+	kubeClient := *acg.kubeClient
+	kubeClient.Namespace = obj.GetNamespace()
+
+	ownerRefClient, err := NewOwnerRefInjectingClient(&kubeClient, acg.restClientGetter.restMapper, obj)
+	if err != nil {
+		return nil, fmt.Errorf("could not create owner reference injecting client: %w", err)
+	}
+
+	return &action.Configuration{
+		RESTClientGetter: acg.restClientGetter.ForNamespace(obj.GetNamespace()),
+		Releases:         s,
+		KubeClient:       ownerRefClient,
+		Log:              acg.debugLog,
+	}, nil
+}
+
+var _ v1.SecretInterface = &ownerRefSecretClient{}
+
+type ownerRefSecretClient struct {
+	v1.SecretInterface
+	refs []metav1.OwnerReference
+}
+
+func (c *ownerRefSecretClient) Create(ctx context.Context, in *corev1.Secret, opts metav1.CreateOptions) (*corev1.Secret, error) {
+	in.OwnerReferences = append(in.OwnerReferences, c.refs...)
+	return c.SecretInterface.Create(ctx, in, opts)
+}
+
+func (c *ownerRefSecretClient) Update(ctx context.Context, in *corev1.Secret, opts metav1.UpdateOptions) (*corev1.Secret, error) {
+	in.OwnerReferences = append(in.OwnerReferences, c.refs...)
+	return c.SecretInterface.Update(ctx, in, opts)
+}

--- a/internal/helm/client/restclientgetter.go
+++ b/internal/helm/client/restclientgetter.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2020 The Operator-SDK Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	cached "k8s.io/client-go/discovery/cached"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func newRESTClientGetter(cfg *rest.Config, rm meta.RESTMapper, ns string) *namespacedRCG {
+	return &namespacedRCG{
+		restClientGetter: &restClientGetter{
+			restConfig: cfg,
+			restMapper: rm,
+		},
+		namespaceConfig: namespaceClientConfig{ns},
+	}
+}
+
+type restClientGetter struct {
+	restConfig *rest.Config
+	restMapper meta.RESTMapper
+
+	setupDiscoveryClient  sync.Once
+	cachedDiscoveryClient discovery.CachedDiscoveryInterface
+}
+
+func (c *restClientGetter) ToRESTConfig() (*rest.Config, error) {
+	return rest.CopyConfig(c.restConfig), nil
+}
+
+func (c *restClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	var (
+		dc  discovery.DiscoveryInterface
+		err error
+	)
+	c.setupDiscoveryClient.Do(func() {
+		dc, err = discovery.NewDiscoveryClientForConfig(c.restConfig)
+		if err != nil {
+			return
+		}
+		c.cachedDiscoveryClient = cached.NewMemCacheClient(dc)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return c.cachedDiscoveryClient, nil
+}
+
+func (c *restClientGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	return c.restMapper, nil
+}
+
+func (c *restClientGetter) ForNamespace(ns string) genericclioptions.RESTClientGetter {
+	return &namespacedRCG{
+		restClientGetter: c,
+		namespaceConfig:  namespaceClientConfig{namespace: ns},
+	}
+}
+
+var _ genericclioptions.RESTClientGetter = &namespacedRCG{}
+
+type namespacedRCG struct {
+	*restClientGetter
+	namespaceConfig namespaceClientConfig
+}
+
+func (c *namespacedRCG) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return c.namespaceConfig
+}
+
+var _ clientcmd.ClientConfig = &namespaceClientConfig{}
+
+type namespaceClientConfig struct {
+	namespace string
+}
+
+func (c namespaceClientConfig) RawConfig() (clientcmdapi.Config, error) {
+	return clientcmdapi.Config{}, nil
+}
+
+func (c namespaceClientConfig) ClientConfig() (*rest.Config, error) {
+	return nil, nil
+}
+
+func (c namespaceClientConfig) Namespace() (string, bool, error) {
+	return c.namespace, false, nil
+}
+
+func (c namespaceClientConfig) ConfigAccess() clientcmd.ConfigAccess {
+	return nil
+}


### PR DESCRIPTION
See https://github.com/operator-framework/helm-operator-plugins/pull/198 for a detailed description of the issue. This commit ports over the relevant changes.

I assume that eventually, the generic `helm-operator` code in this repo should depend on github.com/operator-framework/helm-operator-plugins. However, because the latter repo is still marked as experimental, and importing it would result in a large number of accidental dependency changes, I have decided to merely copy code over.

I've tried to minimize changes to both the copied code as well as the existing code in this repo. Because the bulk of the code is copied, I don't think replicating tests would be useful, but I can see if I can copy them over if it turns out to be not too much effort.

**Description of the change:** Fix a memory leak in the Helm operator code.

**Motivation for the change:** Excessive memory usage of Helm operators (2GB+)


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] ~Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))~
- [x] ~Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)~
