### PR TITLE
fix run bundle(-upgrade) to no longer stall

### DIFF
--- a/changelog/fragments/rbu-stall-fix.yaml
+++ b/changelog/fragments/rbu-stall-fix.yaml
@@ -1,0 +1,8 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      `operator-sdk run bundle(-upgrade)`: fixed bug causing `operator-sdk run bundle-upgrade` and `operator-sdk run bundle ... --index-image=...` to stall indefinitely.
+    kind: "bugfix"
+    breaking: false
+

--- a/internal/olm/fbcutil/util.go
+++ b/internal/olm/fbcutil/util.go
@@ -147,7 +147,12 @@ func RenderRefs(ctx context.Context, refs []string, skipTLSVerify bool, useHTTP 
 		return nil, fmt.Errorf("error creating new image registry: %v", err)
 	}
 
-	defer reg.Destroy()
+	defer func() {
+		err = reg.Destroy()
+		if err != nil {
+			log.Warn(fmt.Sprintf("Unable to cleanup registry. You may have to manually cleanup by removing the %q directory", cacheDir))
+		}
+	}()
 
 	render := action.Render{
 		Refs:     refs,


### PR DESCRIPTION
**Description of the change:**
- Updates the process of creating a new containerdregistry during the `operator-sdk run bundle(-upgrade)` process to no longer stall due a file lock clash. Instead, we now create a temporary registry directory based on the image references being used in the `fbcutil.RenderRefs()` function

**Motivation for the change:**
- fixes #6039 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
