### PR TITLE
Update .cncf-maintainers & OWNERS_ALIASES

### DIFF
--- a/.cncf-maintainers
+++ b/.cncf-maintainers
@@ -1,22 +1,19 @@
 approvers:
 - asmacdo
-- camilamacedo86
 - fabianvf
 - jberkhahn
 - jmrodri
 - joelanford
-- marc-obrien
 - rashmigottipati
 - theishshah
 - varshaprasad96
 reviewers:
 - asmacdo
-- camilamacedo86
+- everettraven
 - fabianvf
 - jberkhahn
 - jmrodri
 - joelanford
-- marc-obrien
 - rashmigottipati
 - theishshah
 - varshaprasad96

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,7 +8,6 @@ aliases:
   - asmacdo
   - jmrodri
   - joelanford
-  - marc-obrien
 
   # Contributors who can approve any PRs in the repo.
   sdk-approvers:
@@ -20,6 +19,7 @@ aliases:
 
   # Contributors who can review and LGTM any PRs in the repo.
   sdk-reviewers:
+  - everettraven
 
   # Contributors who were approvers that are no longer directly involved with the project.
   # This role is symbolic.
@@ -29,3 +29,4 @@ aliases:
   - shawn-hurley
   - estroz
   - camilamacedo86
+  - marc-obrien


### PR DESCRIPTION
**Description of the change:**
* removed camila and marc from cncf-maintainers
* removed marc from OWNERS_ALIASES
* added everettraven to OWNERS_ALIASES as reviewer

Signed-off-by: jesus m. rodriguez <jesusr@redhat.com>

**Motivation for the change:**
Failing `test-sanity` task.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
