### PR TITLE
Update documentation for generating manifests

### DIFF
--- a/website/content/en/docs/olm-integration/generation.md
+++ b/website/content/en/docs/olm-integration/generation.md
@@ -47,9 +47,10 @@ These values will persist when generating a bundle, so make necessary metadata c
 **For Go Operators only:** the command parses [CSV markers][csv-markers] from Go API type definitions, located
 in `./api` for single group projects and `./apis` for multigroup projects, to populate certain CSV fields.
 You can set an alternative path to the API types root directory with `--apis-dir`. These markers are not available
-to Ansible or Helm project types. Also note that the command will attempt to process local types defined in your API.
-If you import a package and use a type with the same name as a local type as a field in the local type it will loop infinitely.
-For example, the following local type definition will cause an infinite loop:
+to Ansible or Helm project types. 
+
+The command attempts to process the local types defined in your API.
+If you import a package that uses the same name as a local type, running the command causes an infinite loop. For example:
 ```go
 type PodStatus struct {
   SomeField string
@@ -58,14 +59,13 @@ type PodStatus struct {
   Status v1.PodStatus 
 }
 ```
-To prevent this, name the local type something different than the imported type:
+To prevent an infinite loop, edit the local type definition to use a different name. For example:
 ```go
 type PodStatusWrapper struct {
   SomeField string
   Status v1.PodStatus 
 }
 ```
-Since the local type has a different name than the imported type the parser does not get stuck.
 
 ### ClusterServiceVersion manifests
 

--- a/website/content/en/docs/olm-integration/generation.md
+++ b/website/content/en/docs/olm-integration/generation.md
@@ -23,11 +23,11 @@ See this [CLI overview][cli-overview] for details on each command.
 ### Kustomize files
 
 `operator-sdk generate kustomize manifests` generates a CSV kustomize base
-`config/manifests/bases/<project-name>.clusterserviceversion.yaml` and a `config/manifests/bases/kustomization.yaml`
+`config/manifests/bases/<project-name>.clusterserviceversion.yaml` and a `config/manifests/kustomization.yaml`
 by default. These files are required as `kustomize build` input in downstream commands.
 
 By default, the command starts an interactive prompt if a CSV base in `config/manifests/bases` is not present
-to collect [UI metadata](#csv-fields). You can disable the interactive prompt by passing `--kustomize=false`.
+to collect [UI metadata](#csv-fields). You can disable the interactive prompt by passing `--interactive=false`.
 
 ```console
 $ operator-sdk generate kustomize manifests
@@ -47,7 +47,8 @@ These values will persist when generating a bundle, so make necessary metadata c
 **For Go Operators only:** the command parses [CSV markers][csv-markers] from Go API type definitions, located
 in `./api` for single group projects and `./apis` for multigroup projects, to populate certain CSV fields.
 You can set an alternative path to the API types root directory with `--apis-dir`. These markers are not available
-to Ansible or Helm project types.
+to Ansible or Helm project types. Also note that the command will attempt to process local types defined in your API.
+If you import a package and use a type with the same name as a local type the parser will loop infinitely.
 
 ### ClusterServiceVersion manifests
 

--- a/website/content/en/docs/olm-integration/generation.md
+++ b/website/content/en/docs/olm-integration/generation.md
@@ -75,7 +75,7 @@ themselves; this version is present in both their `metadata.name` and `spec.vers
 by `generate <bundle|packagemanifests>` requires certain input manifests to construct a CSV manifest; all inputs
 are read when either command is invoked, along with a CSV's [base](#kustomize-files), to idempotently regenerate a CSV.
 
-The following resource kinds are typically included in a CSV, which are addressed by `config/manifests/bases/kustomization.yaml`:
+The following resource kinds are typically included in a CSV, which are addressed by `config/manifests/kustomization.yaml`:
   - `Role`: define Operator permissions within a namespace.
   - `ClusterRole`: define cluster-wide Operator permissions.
   - `Deployment`: define how the Operator's operand is run in pods.

--- a/website/content/en/docs/olm-integration/generation.md
+++ b/website/content/en/docs/olm-integration/generation.md
@@ -48,7 +48,24 @@ These values will persist when generating a bundle, so make necessary metadata c
 in `./api` for single group projects and `./apis` for multigroup projects, to populate certain CSV fields.
 You can set an alternative path to the API types root directory with `--apis-dir`. These markers are not available
 to Ansible or Helm project types. Also note that the command will attempt to process local types defined in your API.
-If you import a package and use a type with the same name as a local type the parser will loop infinitely.
+If you import a package and use a type with the same name as a local type as a field in the local type it will loop infinitely.
+For example, the following local type definition will cause an infinite loop:
+```go
+type PodStatus struct {
+  SomeField string
+  // imported type with the same name will infinitely trigger
+  // the parser to process the local PodStatus type
+  Status v1.PodStatus 
+}
+```
+To prevent this, name the local type something different than the imported type:
+```go
+type PodStatusWrapper struct {
+  SomeField string
+  Status v1.PodStatus 
+}
+```
+Since the local type has a different name than the imported type the parser does not get stuck.
 
 ### ClusterServiceVersion manifests
 


### PR DESCRIPTION
**Description of the change:**
- Updates the documentation for generating manifests

**Motivation for the change:**
- fixes #6028

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
