### PR TITLE
update docs for operator-sdk run bundle with SQLite

### DIFF
--- a/website/content/en/docs/faqs/_index.md
+++ b/website/content/en/docs/faqs/_index.md
@@ -347,3 +347,13 @@ made on this manifest.
 
 [cgo-docs]: https://pkg.go.dev/cmd/cgo
 [open-issue]: https://github.com/operator-framework/operator-sdk/issues/new/choose
+
+## 'operator-sdk run bundle' command fails and the registry pod has an error of 'mkdir: can't create directory '/database': Permission denied'
+
+This error occurs when using `operator-sdk` versions < `v1.22.0` as earlier versions use the deprecated SQLite bundle format by default. 
+By default `operator-sdk run bundle` will use `quay.io/operator-framework/opm:latest` as the index image for creating a registry pod.
+Due to recent pod security updates, using `quay.io/operator-framework/opm:latest` will not work as expected with the SQLite bundle format.
+
+To resolve this, there are two options:
+1. Upgrade to a version of `operator-sdk` >= `v1.22.0` which will use the new FBC bundle format by default
+2. When using `operator-sdk run bundle` specify the index image with `--index-image=quay.io/operator-framework/opm:v1.23.0`

--- a/website/content/en/docs/faqs/_index.md
+++ b/website/content/en/docs/faqs/_index.md
@@ -350,10 +350,10 @@ made on this manifest.
 
 ## 'operator-sdk run bundle' command fails and the registry pod has an error of 'mkdir: can't create directory '/database': Permission denied'
 
-This error occurs when using `operator-sdk` versions < `v1.22.0` as earlier versions use the deprecated SQLite bundle format by default. 
-By default `operator-sdk run bundle` will use `quay.io/operator-framework/opm:latest` as the index image for creating a registry pod.
-Due to recent pod security updates, using `quay.io/operator-framework/opm:latest` will not work as expected with the SQLite bundle format.
+In Operator SDK version `v1.22.0`, the `operator-sdk run bundle` command started using the new file-based catalog (FBC) bundle format by default. Earlier releases used the deprecated SQLite format. The command uses `quay.io/operator-framework/opm:latest` as the index image for creating a registry pod. Due to recent pod security updates, using the latest version of `opm` does not work as expected with the SQLite bundle format.
 
-To resolve this, there are two options:
-1. Upgrade to a version of `operator-sdk` >= `v1.22.0` which will use the new FBC bundle format by default
-2. When using `operator-sdk run bundle` specify the index image with `--index-image=quay.io/operator-framework/opm:v1.23.0`
+There are two workarounds available to resolve this issue:
+1. You can update the Operator SDK to version `v1.22.0` or later. Updating to a more recent version makes `operator-sdk run bundle` utilize the new FBC bundle format.
+2. If you are not ready to update your version of the Operator SDK, you can manually specify the index image by using the `--index-image=quay.io/operator-framework/opm:v1.23.0` flag.
+
+**Note:** The SQLite bundle format is deprecated and will be removed in a future release. If you can, it is recommended that you upgrade a newer version of the Operator SDK to resolve the issue.

--- a/website/content/en/docs/olm-integration/tutorial-bundle.md
+++ b/website/content/en/docs/olm-integration/tutorial-bundle.md
@@ -152,8 +152,9 @@ INFO[0040]   Found ClusterServiceVersion "default/memcached-operator.v0.0.1" pha
 INFO[0040] OLM has successfully installed "memcached-operator.v0.0.1"
 ```
 
-**Note:** If the bundle that is being installed has dependencies, the `--index-image` flag allows adding a bundle to a catalog that contains that bundle's dependencies.  
+**Note:** If the bundle that is being installed has dependencies, the `--index-image` flag allows adding a bundle to a catalog that contains that bundle's dependencies.
 
+**Note:** If the version of `operator-sdk` you are using is < `v1.22.0` then the SQLite bundle format will be used by default rather than the new FBC bundle format. Due to this, you will need to specify the index image when runnning `operator-sdk run bundle` by adding `--index-image=quay.io/operator-framework/opm:v1.23.0`. This prevents any issues that may occur from using the default index image of `quay.io/operator-framework/opm:latest`.
 <!-- TODO(jmccormick2001): add `scorecard` usage here -->
 
 ### Upgrading a bundle to a newer version

--- a/website/content/en/docs/olm-integration/tutorial-bundle.md
+++ b/website/content/en/docs/olm-integration/tutorial-bundle.md
@@ -154,7 +154,7 @@ INFO[0040] OLM has successfully installed "memcached-operator.v0.0.1"
 
 **Note:** If the bundle that is being installed has dependencies, the `--index-image` flag allows adding a bundle to a catalog that contains that bundle's dependencies.
 
-**Note:** If the version of `operator-sdk` you are using is < `v1.22.0` then the SQLite bundle format will be used by default rather than the new FBC bundle format. Due to this, you will need to specify the index image when runnning `operator-sdk run bundle` by adding `--index-image=quay.io/operator-framework/opm:v1.23.0`. This prevents any issues that may occur from using the default index image of `quay.io/operator-framework/opm:latest`.
+**Note:** Version `v1.22.0` and later of the `operator-sdk` use the new file-based catalog (FBC) bundle format by default. Earlier releases use the deprecated SQLite bundle format. If you use an earlier version of the Operator SDK, you must update to a newer version or specify the index image by adding the `--index-image=quay.io/operator-framework/opm:v1.23.0` flag. For more information about this known issue, see the [FAQ][run-bundle-fbc-sqlite-faq].
 <!-- TODO(jmccormick2001): add `scorecard` usage here -->
 
 ### Upgrading a bundle to a newer version
@@ -309,3 +309,4 @@ In-depth discussions of OLM concepts mentioned here:
 [olm-install]:https://olm.operatorframework.io/docs/tasks/install-operator-with-olm/
 [olm-manifests]:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/deploy/upstream/quickstart/olm.yaml
 [run-bundle]: https://sdk.operatorframework.io/docs/cli/operator-sdk_run_bundle/
+[run-bundle-fbc-sqlite-faq]: https://sdk.operatorframework.io/docs/faqs/#operator-sdk-run-bundle-command-fails-and-the-registry-pod-has-an-error-of-mkdir-cant-create-directory-database-permission-denied


### PR DESCRIPTION
**Description of the change:**
- Add a note in the bundle tutorial about specifying the index image used for handling SQLite bundles in versions of `operator-sdk` < `v1.22.0` as FBC support wasn't enabled until `v1.22.0`
- Add a FAQ section for the error that may be encountered when using `operator-sdk run bundle` with `operator-sdk` versions < `v1.22.0`

**Motivation for the change:**
- closes #6049 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
