### PR TITLE
OCPBUGS-1666: Expose flag to enable/disable PodSecurity

### DIFF
--- a/changelog/fragments/enable-seccompprofile-run-bundle.yaml
+++ b/changelog/fragments/enable-seccompprofile-run-bundle.yaml
@@ -2,8 +2,8 @@
 # release notes and/or the migration guide
 entries:
   - description: >
-      Added --security-context-config flag to enable seccompprofile.
-      It defaults to enabled to support k8s 1.25. You can disable it
+      For operator-sdk run bundle and bundle-upgrade subcommands: Added --security-context-config
+      flag to enable seccompprofile. It defaults to enabled to support k8s 1.25. You can disable it
       with --security-context-config=legacy
 
     # kind is one of:

--- a/changelog/fragments/enable-seccompprofile-run-bundle.yaml
+++ b/changelog/fragments/enable-seccompprofile-run-bundle.yaml
@@ -1,0 +1,18 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Added --security-context-config flag to enable seccompprofile.
+      It defaults to enabled to support k8s 1.25. You can disable it
+      with --security-context-config=legacy
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false

--- a/changelog/fragments/enable-seccompprofile-run-bundle.yaml
+++ b/changelog/fragments/enable-seccompprofile-run-bundle.yaml
@@ -3,7 +3,7 @@
 entries:
   - description: >
       For operator-sdk run bundle and bundle-upgrade subcommands: Added --security-context-config
-      flag to enable seccompprofile. It defaults to enabled to support k8s 1.25. You can disable it
+      flag to enable seccompprofile. It defaults to restricted to support k8s 1.25. You can disable it
       with --security-context-config=legacy
 
     # kind is one of:

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -138,7 +138,9 @@ func (c *IndexImageCatalogCreator) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.UseHTTP, "use-http", false, "use plain HTTP for container image registries "+
 		"while pulling bundles")
 
-	fs.Var(&c.SecurityContext, "security-context-config", "specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy'.")
+	// default to Restricted
+	c.SecurityContext = SecurityContext{ContextType: Restricted}
+	fs.Var(&c.SecurityContext, "security-context-config", "specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy', default: 'restricted'.")
 }
 
 func (c IndexImageCatalogCreator) CreateCatalog(ctx context.Context, name string) (*v1alpha1.CatalogSource, error) {

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -140,7 +140,7 @@ func (c *IndexImageCatalogCreator) BindFlags(fs *pflag.FlagSet) {
 
 	// default to Restricted
 	c.SecurityContext = SecurityContext{ContextType: Restricted}
-	fs.Var(&c.SecurityContext, "security-context-config", "specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy', default: 'restricted'.")
+	fs.Var(&c.SecurityContext, "security-context-config", "specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy'.")
 }
 
 func (c IndexImageCatalogCreator) CreateCatalog(ctx context.Context, name string) (*v1alpha1.CatalogSource, error) {

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -52,6 +52,44 @@ const (
 	registryPodNameAnnotation = operatorFrameworkGroup + "/registry-pod-name"
 )
 
+// TODO: Change this to use the values in operator-framework/api
+// once the release containing the enums is pulled into SDK
+type SecurityContextType string
+
+const (
+	Legacy     SecurityContextType = "legacy"
+	Restricted SecurityContextType = "restricted"
+)
+
+// SecurityContext represents the enum from the CatalogSource API
+// It is also being used by the binding flags to allow validation of the enum
+// values
+type SecurityContext struct {
+	ContextType SecurityContextType
+}
+
+func (sc *SecurityContext) String() string {
+	return string(sc.ContextType)
+}
+
+func (sc *SecurityContext) Set(value string) error {
+	switch value {
+	case "legacy", "restricted":
+		sc.ContextType = SecurityContextType(value)
+		return nil
+	default:
+		return fmt.Errorf("must be one of \"legacy\", or \"restricted\"")
+	}
+}
+
+func (sc *SecurityContext) IsEmpty() bool {
+	return sc.ContextType == ""
+}
+
+func (sc *SecurityContext) Type() string {
+	return "SecurityContext"
+}
+
 type IndexImageCatalogCreator struct {
 	SkipTLS         bool
 	SkipTLSVerify   bool
@@ -67,6 +105,7 @@ type IndexImageCatalogCreator struct {
 	PreviousBundles []string
 	cfg             *operator.Configuration
 	ChannelName     string
+	SecurityContext SecurityContext
 }
 
 var _ CatalogCreator = &IndexImageCatalogCreator{}
@@ -98,6 +137,9 @@ func (c *IndexImageCatalogCreator) BindFlags(fs *pflag.FlagSet) {
 		"while pulling bundles")
 	fs.BoolVar(&c.UseHTTP, "use-http", false, "use plain HTTP for container image registries "+
 		"while pulling bundles")
+
+	// fs.Var(&c.RestrictedMode, "security-context-config", true, "enables restricted mode TODO FILL ME IN")
+	fs.Var(&c.SecurityContext, "security-context-config", "specifies the security context to use for the catalog pod")
 }
 
 func (c IndexImageCatalogCreator) CreateCatalog(ctx context.Context, name string) (*v1alpha1.CatalogSource, error) {
@@ -478,9 +520,10 @@ func (c IndexImageCatalogCreator) createAnnotatedRegistry(ctx context.Context, c
 	if c.HasFBCLabel {
 		// Initialize and create the FBC registry pod.
 		fbcRegistryPod := fbcindex.FBCRegistryPod{
-			BundleItems: items,
-			IndexImage:  c.IndexImage,
-			FBCContent:  c.FBCContent,
+			BundleItems:     items,
+			IndexImage:      c.IndexImage,
+			FBCContent:      c.FBCContent,
+			SecurityContext: c.SecurityContext.String(),
 		}
 
 		pod, err = fbcRegistryPod.Create(ctx, c.cfg, cs)
@@ -491,12 +534,13 @@ func (c IndexImageCatalogCreator) createAnnotatedRegistry(ctx context.Context, c
 	} else {
 		// Initialize and create registry pod
 		registryPod := index.SQLiteRegistryPod{
-			BundleItems:   items,
-			IndexImage:    c.IndexImage,
-			SecretName:    c.SecretName,
-			CASecretName:  c.CASecretName,
-			SkipTLSVerify: c.SkipTLSVerify,
-			UseHTTP:       c.UseHTTP,
+			BundleItems:     items,
+			IndexImage:      c.IndexImage,
+			SecretName:      c.SecretName,
+			CASecretName:    c.CASecretName,
+			SkipTLSVerify:   c.SkipTLSVerify,
+			UseHTTP:         c.UseHTTP,
+			SecurityContext: c.SecurityContext.String(),
 		}
 
 		if registryPod.DBPath, err = c.getDBPath(ctx); err != nil {

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -138,8 +138,7 @@ func (c *IndexImageCatalogCreator) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.UseHTTP, "use-http", false, "use plain HTTP for container image registries "+
 		"while pulling bundles")
 
-	// fs.Var(&c.RestrictedMode, "security-context-config", true, "enables restricted mode TODO FILL ME IN")
-	fs.Var(&c.SecurityContext, "security-context-config", "specifies the security context to use for the catalog pod")
+	fs.Var(&c.SecurityContext, "security-context-config", "specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy'.")
 }
 
 func (c IndexImageCatalogCreator) CreateCatalog(ctx context.Context, name string) (*v1alpha1.CatalogSource, error) {

--- a/internal/olm/operator/registry/index_image_test.go
+++ b/internal/olm/operator/registry/index_image_test.go
@@ -1,0 +1,80 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IndexImage", func() {
+	Context("SecurityContext", func() {
+		Describe("String", func() {
+			It("should return a string value of the enum", func() {
+				sc := SecurityContext{}
+				Expect(sc.String()).To(Equal(""))
+				sc = SecurityContext{ContextType: Legacy}
+				Expect(sc.String()).To(Equal("legacy"))
+			})
+		})
+		Describe("Set", func() {
+			var sc SecurityContext
+			BeforeEach(func() {
+				sc = SecurityContext{}
+				Expect(sc.String()).To(Equal(""))
+			})
+			It("should not error with valid values", func() {
+				err := sc.Set("legacy")
+				Expect(sc.String()).To(Equal("legacy"))
+				Expect(err).ToNot(HaveOccurred())
+				err = sc.Set("restricted")
+				Expect(sc.String()).To(Equal("restricted"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("should return an error with unsupported values", func() {
+				err := sc.Set("fake")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("must be one of \"legacy\", or \"restricted\""))
+
+				err = sc.Set("")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("must be one of \"legacy\", or \"restricted\""))
+			})
+		})
+		Describe("IsEmpty", func() {
+			var sc SecurityContext
+			BeforeEach(func() {
+				sc = SecurityContext{}
+				Expect(sc.String()).To(Equal(""))
+			})
+			It("should return true default instantiation", func() {
+				Expect(sc.IsEmpty()).To(BeTrue())
+			})
+			It("should return false if set a value", func() {
+				sc.Set("legacy")
+				Expect(sc.IsEmpty()).To(BeFalse())
+
+				sc.Set("restricted")
+				Expect(sc.IsEmpty()).To(BeFalse())
+			})
+		})
+		Describe("Type", func() {
+			It("should return SecurityContext", func() {
+				sc := SecurityContext{}
+				Expect(sc.Type()).To(Equal("SecurityContext"))
+			})
+		})
+	})
+})

--- a/internal/olm/operator/registry/index_image_test.go
+++ b/internal/olm/operator/registry/index_image_test.go
@@ -63,10 +63,10 @@ var _ = Describe("IndexImage", func() {
 				Expect(sc.IsEmpty()).To(BeTrue())
 			})
 			It("should return false if set a value", func() {
-				sc.Set("legacy")
+				_ = sc.Set("legacy")
 				Expect(sc.IsEmpty()).To(BeFalse())
 
-				sc.Set("restricted")
+				_ = sc.Set("restricted")
 				Expect(sc.IsEmpty()).To(BeFalse())
 			})
 		})

--- a/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
@@ -24,7 +24,7 @@ operator-sdk run bundle-upgrade <bundle-image> [flags]
       --kubeconfig string                         Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string                          If present, namespace scope for this CLI request
       --pull-secret-name string                   Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
-      --security-context-config SecurityContext   specifies the security context to use for the catalog pod
+      --security-context-config SecurityContext   specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy', default: 'restricted'. (default restricted)
       --service-account string                    Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
       --skip-tls                                  skip authentication of image registry TLS certificate when pulling a bundle image in-cluster
       --skip-tls-verify                           skip TLS certificate verification for container image registries while pulling bundles

--- a/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
@@ -24,7 +24,7 @@ operator-sdk run bundle-upgrade <bundle-image> [flags]
       --kubeconfig string                         Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string                          If present, namespace scope for this CLI request
       --pull-secret-name string                   Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
-      --security-context-config SecurityContext   specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy', default: 'restricted'. (default restricted)
+      --security-context-config SecurityContext   specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy'. (default restricted)
       --service-account string                    Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
       --skip-tls                                  skip authentication of image registry TLS certificate when pulling a bundle image in-cluster
       --skip-tls-verify                           skip TLS certificate verification for container image registries while pulling bundles

--- a/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
@@ -19,16 +19,17 @@ operator-sdk run bundle-upgrade <bundle-image> [flags]
 ### Options
 
 ```
-      --ca-secret-name string     Name of a generic secret containing a PEM root certificate file required to pull bundle images. This secret *must* be in the namespace that this command is configured to run in, and the file *must* be encoded under the key "cert.pem"
-  -h, --help                      help for bundle-upgrade
-      --kubeconfig string         Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string          If present, namespace scope for this CLI request
-      --pull-secret-name string   Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
-      --service-account string    Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
-      --skip-tls                  skip authentication of image registry TLS certificate when pulling a bundle image in-cluster
-      --skip-tls-verify           skip TLS certificate verification for container image registries while pulling bundles
-      --timeout duration          Duration to wait for the command to complete before failing (default 2m0s)
-      --use-http                  use plain HTTP for container image registries while pulling bundles
+      --ca-secret-name string                     Name of a generic secret containing a PEM root certificate file required to pull bundle images. This secret *must* be in the namespace that this command is configured to run in, and the file *must* be encoded under the key "cert.pem"
+  -h, --help                                      help for bundle-upgrade
+      --kubeconfig string                         Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string                          If present, namespace scope for this CLI request
+      --pull-secret-name string                   Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
+      --security-context-config SecurityContext   specifies the security context to use for the catalog pod
+      --service-account string                    Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
+      --skip-tls                                  skip authentication of image registry TLS certificate when pulling a bundle image in-cluster
+      --skip-tls-verify                           skip TLS certificate verification for container image registries while pulling bundles
+      --timeout duration                          Duration to wait for the command to complete before failing (default 2m0s)
+      --use-http                                  use plain HTTP for container image registries while pulling bundles
 ```
 
 ### Options inherited from parent commands

--- a/website/content/en/docs/cli/operator-sdk_run_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle.md
@@ -35,7 +35,7 @@ operator-sdk run bundle <bundle-image> [flags]
       --kubeconfig string                         Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string                          If present, namespace scope for this CLI request
       --pull-secret-name string                   Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
-      --security-context-config SecurityContext   specifies the security context to use for the catalog pod
+      --security-context-config SecurityContext   specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy', default: 'restricted'. (default restricted)
       --service-account string                    Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
       --skip-tls                                  skip authentication of image registry TLS certificate when pulling a bundle image in-cluster
       --skip-tls-verify                           skip TLS certificate verification for container image registries while pulling bundles

--- a/website/content/en/docs/cli/operator-sdk_run_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle.md
@@ -35,7 +35,7 @@ operator-sdk run bundle <bundle-image> [flags]
       --kubeconfig string                         Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string                          If present, namespace scope for this CLI request
       --pull-secret-name string                   Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
-      --security-context-config SecurityContext   specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy', default: 'restricted'. (default restricted)
+      --security-context-config SecurityContext   specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy'. (default restricted)
       --service-account string                    Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
       --skip-tls                                  skip authentication of image registry TLS certificate when pulling a bundle image in-cluster
       --skip-tls-verify                           skip TLS certificate verification for container image registries while pulling bundles

--- a/website/content/en/docs/cli/operator-sdk_run_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle.md
@@ -28,18 +28,19 @@ operator-sdk run bundle <bundle-image> [flags]
 ### Options
 
 ```
-      --ca-secret-name string           Name of a generic secret containing a PEM root certificate file required to pull bundle images. This secret *must* be in the namespace that this command is configured to run in, and the file *must* be encoded under the key "cert.pem"
-  -h, --help                            help for bundle
-      --index-image string              index image in which to inject bundle (default "quay.io/operator-framework/opm:latest")
-      --install-mode InstallModeValue   install mode
-      --kubeconfig string               Path to the kubeconfig file to use for CLI requests.
-  -n, --namespace string                If present, namespace scope for this CLI request
-      --pull-secret-name string         Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
-      --service-account string          Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
-      --skip-tls                        skip authentication of image registry TLS certificate when pulling a bundle image in-cluster
-      --skip-tls-verify                 skip TLS certificate verification for container image registries while pulling bundles
-      --timeout duration                Duration to wait for the command to complete before failing (default 2m0s)
-      --use-http                        use plain HTTP for container image registries while pulling bundles
+      --ca-secret-name string                     Name of a generic secret containing a PEM root certificate file required to pull bundle images. This secret *must* be in the namespace that this command is configured to run in, and the file *must* be encoded under the key "cert.pem"
+  -h, --help                                      help for bundle
+      --index-image string                        index image in which to inject bundle (default "quay.io/operator-framework/opm:latest")
+      --install-mode InstallModeValue             install mode
+      --kubeconfig string                         Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string                          If present, namespace scope for this CLI request
+      --pull-secret-name string                   Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
+      --security-context-config SecurityContext   specifies the security context to use for the catalog pod
+      --service-account string                    Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
+      --skip-tls                                  skip authentication of image registry TLS certificate when pulling a bundle image in-cluster
+      --skip-tls-verify                           skip TLS certificate verification for container image registries while pulling bundles
+      --timeout duration                          Duration to wait for the command to complete before failing (default 2m0s)
+      --use-http                                  use plain HTTP for container image registries while pulling bundles
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
**Description of the change:**

Added --security-context-config flag to enable seccompprofile. It defaults to enabled to support k8s 1.25. You can disable it with --security-context-config=legacy

Signed-off-by: jesus m. rodriguez <jesusr@redhat.com>

**Motivation for the change:**
In k8s 1.25 PodSecurityAdmission is enabled. https://kubernetes.io/blog/2022/08/04/upcoming-changes-in-kubernetes-1-25/#podsecuritypolicy-removal

Fixes a few issues found downstream but affect upstream as well:
* https://issues.redhat.com/browse/OSDK-2481
* https://issues.redhat.com/browse/OCPBUGS-1666

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
