### PR TITLE
bump supported OLM versions in docs

### DIFF
--- a/website/content/en/docs/overview/_index.md
+++ b/website/content/en/docs/overview/_index.md
@@ -92,7 +92,7 @@ By project type (replace `${IMAGE_VERSION}` with base image version in your proj
 
 Operator SDK officially supports the latest 3 minor versions of OLM present at the time of a given Operator SDK release. These versions of OLM manifests are packaged with the SDK binary in the form of `bindata` to support low-latency installations of OLM with [`operator-sdk olm install`][olm-install-cmd]. Any other version installed with this command may work but is not tested nor officially supported.
 
-Currently, the officially supported OLM Versions are: 0.19.1, 0.20.0, and 0.21.2
+Currently, the officially supported OLM Versions are: 0.20.0, 0.21.2, and 0.22.0
 
 ## Platform support
 


### PR DESCRIPTION
someone forgot to do this when they bumped the olm bindata versions.

hmmmm @jmrodri 