### PR TITLE
Updated release doc for MAC users

### DIFF
--- a/website/content/en/docs/contribution-guidelines/releasing.md
+++ b/website/content/en/docs/contribution-guidelines/releasing.md
@@ -77,6 +77,10 @@ correctly prior to the release commit.
   ```sh
   sed -i -E 's/(IMAGE_VERSION = ).+/\1v1\.3\.0/g' Makefile
   ```
+  For MAC users command will be little different.
+  ```sh
+  gsed -i -E 's/(IMAGE_VERSION = ).+/\1v1\.3\.0/g' Makefile
+  ```
 1. Lock down the `master` branch to prevent further commits before the release completes:
   1. Go to `Settings -> Branches` in the SDK repo.
   1. Under `Branch protection rules`, click `Edit` on the `master` branch rule.


### PR DESCRIPTION
`sed` command in MAC is used as `gsed`. Updated release doc.



**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
