### PR TITLE
Point kubernetes collection to kubernetes/core instead of community.kubernetes

### DIFF
--- a/website/content/en/docs/building-operators/ansible/development-tips.md
+++ b/website/content/en/docs/building-operators/ansible/development-tips.md
@@ -511,7 +511,7 @@ operator. The `ansible_operator_meta` fields can be accessed via dot notation in
 [k8s_ansible_module]:https://docs.ansible.com/ansible/2.6/modules/k8s_module.html
 [openshift_restclient_python]:https://github.com/openshift/openshift-restclient-python
 [tutorial]:../tutorial
-[kubernetes_collection]: https://galaxy.ansible.com/community/kubernetes
+[kubernetes_collection]: https://galaxy.ansible.com/kubernetes/core
 [manage_status_proposal]:../../proposals/ansible-operator-status.md
 [openshift-restclient-python]: https://github.com/openshift/openshift-restclient-python
 [operator_sdk_util]: https://galaxy.ansible.com/operator_sdk/util


### PR DESCRIPTION
collection community.kubernetes is now deprecated in favor of kubernetes.core

**Description of the change:**
use collection kubernetes.core instead of community.kubernetes

**Motivation for the change:**
collection community.kubernetes is now deprecated in favor of kubernetes.core

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)