### PR TITLE
Fix type-o in output.

### DIFF
--- a/internal/util/bundleutil/bundleutil.go
+++ b/internal/util/bundleutil/bundleutil.go
@@ -46,7 +46,7 @@ type BundleMetaData struct {
 	// The PackageName of the operator bundle.
 	PackageName string
 
-	// Channels and DefaultChannel the operator shoud be subscribed to.
+	// Channels and DefaultChannel the operator should be subscribed to.
 	Channels       string
 	DefaultChannel string
 
@@ -108,9 +108,9 @@ func (meta *BundleMetaData) GenerateMetadata() error {
 
 	dockerfilePath := defaultBundleDockerfilePath
 	// If migrating from packagemanifests to bundle, bundle.Dockerfile is present
-	// inside bundleDir, else its in the project directory. Hence dockerfile
+	// inside bundleDir, else it's in the project directory. Hence, dockerfile
 	// should have the path specified with respect to output directory of resulting bundles.
-	// Remmove this, when pkgman-to-bundle migrate command is removed.
+	// Remove this, when pkgman-to-bundle migrate command is removed.
 	if len(meta.PkgmanifestPath) != 0 {
 		dockerfilePath = filepath.Join(filepath.Dir(meta.BundleDir), "bundle.Dockerfile")
 		values.BundleDir = filepath.Base(meta.BundleDir)
@@ -137,7 +137,7 @@ func (meta *BundleMetaData) GenerateMetadata() error {
 			return err
 		}
 	}
-	log.Infof("Bundle metadata generated suceessfully")
+	log.Infof("Bundle metadata generated successfully")
 	return nil
 }
 
@@ -167,7 +167,7 @@ func copyOperatorManifests(src, dest string) error {
 
 		if f.IsDir() {
 			// TODO(verify): we may have to log an error here instead of recursively copying
-			// if there are no subfolders allowed under manifests dir of a packagemanifest.
+			// if there are no sub-folders allowed under manifests dir of a packagemanifest.
 			if err = copyOperatorManifests(srcPath, destPath); err != nil {
 				return err
 			}


### PR DESCRIPTION
**Description of the change:**
Fix a type-o in the output.

I've also fixed a few other type-o's and spelling mistakes.


**Motivation for the change:**
#6078


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
