### PR TITLE
bump envtest, golangci-lint, and kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export IMAGE_VERSION = v1.24.0
 export SIMPLE_VERSION = $(shell (test "$(shell git describe --tags)" = "$(shell git describe --tags --abbrev=0)" && echo $(shell git describe --tags)) || echo $(shell git describe --tags --abbrev=0)+git)
 export GIT_VERSION = $(shell git describe --dirty --tags --always)
 export GIT_COMMIT = $(shell git rev-parse HEAD)
-export K8S_VERSION = 1.24.2
+export K8S_VERSION = 1.25.0
 
 # Build settings
 export TOOLS_DIR = tools/bin
@@ -57,7 +57,7 @@ fix: ## Fixup files in the repo.
 
 .PHONY: setup-lint
 setup-lint: ## Setup the lint
-	$(SCRIPTS_DIR)/fetch golangci-lint 1.46.2
+	$(SCRIPTS_DIR)/fetch golangci-lint 1.50.0
 
 .PHONY: lint
 lint: setup-lint ## Run the lint check
@@ -175,12 +175,12 @@ cluster-create::
 
 .PHONY: dev-install
 dev-install::
-	$(SCRIPTS_DIR)/fetch kind 0.14.0
+	$(SCRIPTS_DIR)/fetch kind 0.16.0
 	$(SCRIPTS_DIR)/fetch kubectl $(K8S_VERSION) # Install kubectl AFTER envtest because envtest includes its own kubectl binary
 
 .PHONY: test-e2e-teardown
 test-e2e-teardown:
-	$(SCRIPTS_DIR)/fetch kind 0.14.0
+	$(SCRIPTS_DIR)/fetch kind 0.16.0
 	$(TOOLS_DIR)/kind delete cluster --name $(KIND_CLUSTER)
 	rm -f $(KUBECONFIG)
 

--- a/internal/ansible/apiserver/apiserver.go
+++ b/internal/ansible/apiserver/apiserver.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -38,8 +39,9 @@ func Run(options Options) error {
 	mux.HandleFunc("/metrics", metricsHandler)
 
 	server := http.Server{
-		Addr:    fmt.Sprintf("%s:%d", options.Address, options.Port),
-		Handler: mux,
+		Addr:              fmt.Sprintf("%s:%d", options.Address, options.Port),
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 	log.Info("Starting to serve metrics listener", "Address", server.Addr)
 	return server.ListenAndServe()

--- a/internal/ansible/proxy/kubectl.go
+++ b/internal/ansible/proxy/kubectl.go
@@ -254,7 +254,8 @@ func (s *server) ListenUnix(path string) (net.Listener, error) {
 // ServeOnListener starts the server using given listener, loops forever.
 func (s *server) ServeOnListener(l net.Listener) error {
 	server := http.Server{
-		Handler: s.Handler,
+		Handler:           s.Handler,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 	return server.Serve(l)
 }

--- a/internal/ansible/runner/eventapi/eventapi.go
+++ b/internal/ansible/runner/eventapi/eventapi.go
@@ -80,7 +80,7 @@ func New(ident string, errChan chan<- error) (*EventReceiver, error) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc(rec.URLPath, rec.handleEvents)
-	srv := http.Server{Handler: mux}
+	srv := http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
 	rec.server = &srv
 
 	go func() {


### PR DESCRIPTION
**Description of the change:**
- bumps Makefile var `K8S_VERSION` to be `1.25.0` which bumps k8s version used by envtest to be 1.25.0
- bumps `golangci-lint` to be `1.50.0` which is the latest and works with Go 1.19
- bumps `kind` to `0.16.0` which is the latest and defaults to using k8s 1.25.2 as the node image
- Adds `ReadHeaderTimeout` to `http.Server` creation logic for ansible.
    - Running `make lint` locally without this lead to linting errors stating that without the `ReadHeaderTimeout` there is the potential for a Slowloris attack.

**Motivation for the change:**
- bumping SDK to support k8s 1.25.x

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
