### PR TITLE
Docs: Update the minimum version of go from 1.17 to 1.18

### DIFF
--- a/changelog/fragments/docs-bump-go-version.yaml
+++ b/changelog/fragments/docs-bump-go-version.yaml
@@ -1,0 +1,14 @@
+entries:
+  - description: >
+      (docs) Update the go version in the developer guide.  The documentation wasn't updated when the go version was bumped to v1.18.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false

--- a/website/content/en/docs/contribution-guidelines/developer-guide.md
+++ b/website/content/en/docs/contribution-guidelines/developer-guide.md
@@ -9,7 +9,7 @@ weight: 1
 ### Prerequisites
 
 - [git][git-tool]
-- [go][go-tool] version 1.17
+- [go][go-tool] version 1.18
 
 ### Download Operator SDK
 


### PR DESCRIPTION
**Description of the change:**
The version of go has been bumped, but the docs haven't been updated.  The commit updates the developer guide with the correct version.

**Motivation for the change:**
#6087 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [X] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [X] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Closes #6087
