### PR TITLE
docs: re-orders deploy steps and clarifies instructions

### DIFF
--- a/website/content/en/docs/building-operators/ansible/tutorial.md
+++ b/website/content/en/docs/building-operators/ansible/tutorial.md
@@ -178,14 +178,6 @@ make install run
 
 By default, a new namespace is created with name `<project-name>-system`, ex. `memcached-operator-system`, and will be used for the deployment.
 
-The scaffolded `Makefile` uses [`kustomize`][kustomize-docs] to apply
-custom configurations and generate manifests from the `config/`
-directory, which are piped to `kubectl`.
-
-```sh
-kustomize build config/default | kubectl apply -f -
-```
-
 Commonly, Operator authors may need to modify `config/rbac` in order to
 give their Operator the necessary permissions to reconcile.
 
@@ -193,6 +185,15 @@ Run the following to customize the manifests and deploy the operator.
 
 ```sh
 make deploy
+```
+
+The scaffolded `Makefile` uses [`kustomize`][kustomize-docs] to apply custom
+configurations and generate manifests from the `config/` directory, which are
+piped to `kubectl`. Run the following command to see the manifests that were
+applied to the cluster.
+
+```sh
+kustomize build config/default
 ```
 
 Verify that the memcached-operator is up and running:


### PR DESCRIPTION
**Description of the change:**

Previously, if you ran the suggested command `kustomize build config/default | kubectl apply -f -`, that would render an incorrect manifest. That is because when the user changed the value of `IMAGE_TAG_BASE` and `IMG` in the Makefile during a previous step, that change has not yet been applied to kustomize manifests at the time of running the suggested command. So the wrong image reference ends up being rendered, and the manifests get applies to the cluster. `make deploy` must be run first, which updates the kustomize manifest.

This change clarifies that running `kustomize build config/default` is part of explaining to the reader how things work, is not a required step that should apply anything to the cluster, AND importantly should not be run until after `make deploy`.

**Motivation for the change:**

Without it, the tutorial leads the user to a broken state.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
