### PR TITLE
fixes broken "make run" for ansible operators

### DIFF
--- a/changelog/fragments/01-ansible-fix-make-run.yaml
+++ b/changelog/fragments/01-ansible-fix-make-run.yaml
@@ -1,0 +1,40 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: 'ansible: fixed "make run" so it finds local roles'
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: update ansible operator Makefile's run target
+      body: |
+        For an ansible operator, update the Makefile's run target to the
+        following to fix a bug in its implementation.
+
+        ```
+        .PHONY: run
+        ANSIBLE_ROLES_PATH?="$(shell pwd)/roles"
+        run: ansible-operator ## Run against the configured Kubernetes cluster in ~/.kube/config
+            $(ANSIBLE_OPERATOR) run
+        ```

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/makefile.go
@@ -91,8 +91,9 @@ help: ## Display this help.
 ##@ Build
 
 .PHONY: run
+ANSIBLE_ROLES_PATH?="$(shell pwd)/roles"
 run: ansible-operator ## Run against the configured Kubernetes cluster in ~/.kube/config
-	ANSIBLE_ROLES_PATH="$(ANSIBLE_ROLES_PATH):$(shell pwd)/roles" $(ANSIBLE_OPERATOR) run
+	$(ANSIBLE_OPERATOR) run
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.

--- a/website/content/en/docs/building-operators/ansible/tutorial.md
+++ b/website/content/en/docs/building-operators/ansible/tutorial.md
@@ -178,14 +178,6 @@ make install run
 
 By default, a new namespace is created with name `<project-name>-system`, ex. `memcached-operator-system`, and will be used for the deployment.
 
-The scaffolded `Makefile` uses [`kustomize`][kustomize-docs] to apply
-custom configurations and generate manifests from the `config/`
-directory, which are piped to `kubectl`.
-
-```sh
-kustomize build config/default | kubectl apply -f -
-```
-
 Commonly, Operator authors may need to modify `config/rbac` in order to
 give their Operator the necessary permissions to reconcile.
 
@@ -193,6 +185,15 @@ Run the following to customize the manifests and deploy the operator.
 
 ```sh
 make deploy
+```
+
+The scaffolded `Makefile` uses [`kustomize`][kustomize-docs] to apply custom
+configurations and generate manifests from the `config/` directory, which are
+piped to `kubectl`. Run the following command to see the manifests that were
+applied to the cluster.
+
+```sh
+kustomize build config/default
 ```
 
 Verify that the memcached-operator is up and running:


### PR DESCRIPTION
**Description of the change:**

Previously, an ansible operator would be scaffolded with a Makefile whose "run" target had incorrect syntax. It would run this command:

`ANSIBLE_ROLES_PATH="$(ANSIBLE_ROLES_PATH):$(shell pwd)/roles" $(ANSIBLE_OPERATOR) run`

That command failed to set the `ANSIBLE_ROLES_PATH` variable correctly because it was using Makefile syntax in a target's recipe, which gets interpreted as shell script.

This commit moves the variable setting statement, which uses Makefile syntax, out of the recipe. It also uses the standard `?=` operator to only set the variable if it is unset.

Signed-off-by: Michael Hrivnak <mhrivnak@redhat.com>

**Motivation for the change:**

fix the bug

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
