### PR TITLE
update kubernetes compatibility matrix

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -42,6 +42,7 @@ endif
 prerelease: check_release_version changelog ## Create release commit changes to commit.
 	./website/scripts/update_branch_mappings.sh $(RELEASE_VERSION)
 	./website/scripts/update_download_url.sh $(RELEASE_VERSION)
+	./website/scripts/update_latest_release_compat.sh
 
 .PHONY: changelog
 changelog: check_release_version ## Generate the changelog.

--- a/website/config.toml
+++ b/website/config.toml
@@ -92,129 +92,194 @@ url_latest_version = "https://sdk.operatorframework.io"
 [[params.versions]]
   version = "master"
   url = "https://master.sdk.operatorframework.io"
+  ##LATEST_RELEASE_KUBE_VERSION##
+  kube_version = "1.25.0"
+  ##LATEST_RELEASE_CLIENT_GO_VERSION##
+  client_go_version = "v0.25.3"
 
 [[params.versions]]
   version = "Latest Release"
   url = "https://sdk.operatorframework.io"
+  ##LATEST_RELEASE_KUBE_VERSION##
+  kube_version = "1.25.0"
+  ##LATEST_RELEASE_CLIENT_GO_VERSION##
+  client_go_version = "v0.25.3"
 
 ##RELEASE_ADDME##
 
 [[params.versions]]
   version = "v1.25"
   url = "https://v1-25-x.sdk.operatorframework.io"
+  kube_version = "1.25.0"
+  client_go_version = "v0.25.3"
 
 [[params.versions]]
   version = "v1.24"
   url = "https://v1-24-x.sdk.operatorframework.io"
+  kube_version = "1.24.2"
+  client_go_version = "v0.24.2"
 
 [[params.versions]]
   version = "v1.23"
   url = "https://v1-23-x.sdk.operatorframework.io"
+  kube_version = "1.24.2"
+  client_go_version = "v0.24.2"
 
 [[params.versions]]
   version = "v1.22"
   url = "https://v1-22-x.sdk.operatorframework.io"
+  kube_version = "1.24.1"
+  client_go_version = "v0.24.0"
 
 [[params.versions]]
   version = "v1.21"
   url = "https://v1-21-x.sdk.operatorframework.io"
+  kube_version = "1.23"
+  client_go_version = "v0.23.5"
 
 [[params.versions]]
   version = "v1.20"
   url = "https://v1-20-x.sdk.operatorframework.io"
+  kube_version = "1.23"
+  client_go_version = "v0.23.1"
 
 [[params.versions]]
   version = "v1.19"
   url = "https://v1-19-x.sdk.operatorframework.io"
+  kube_version = "1.23"
+  client_go_version = "v0.23.1"
 
 [[params.versions]]
   version = "v1.18"
   url = "https://v1-18-x.sdk.operatorframework.io"
+  kube_version = "1.21"
+  client_go_version = "v0.23.1"
 
 [[params.versions]]
   version = "v1.17"
   url = "https://v1-17-x.sdk.operatorframework.io"
+  kube_version = "1.21"
+  client_go_version = "v0.23.1"
 
 [[params.versions]]
   version = "v1.16"
   url = "https://v1-16-x.sdk.operatorframework.io"
+  kube_version = "1.21"
+  client_go_version = "v0.22.2"
 
 [[params.versions]]
   version = "v1.15"
   url = "https://v1-15-x.sdk.operatorframework.io"
+  kube_version = "1.21"
+  client_go_version = "v0.22.2"
 
 [[params.versions]]
   version = "v1.14"
   url = "https://v1-14-x.sdk.operatorframework.io"
+  kube_version = "1.21"
+  client_go_version = "v0.22.2"
 
 [[params.versions]]
   version = "v1.13"
   url = "https://v1-13-x.sdk.operatorframework.io"
+  kube_version = "1.21"
+  client_go_version = "v0.22.1"
 
 [[params.versions]]
   version = "v1.12"
   url = "https://v1-12-x.sdk.operatorframework.io"
+  kube_version = "1.21"
+  client_go_version = "v0.21.2"
 
 [[params.versions]]
   version = "v1.11"
   url = "https://v1-11-x.sdk.operatorframework.io"
+  kube_version = "1.20.2"
+  client_go_version = "v0.21.2"
 
 [[params.versions]]
   version = "v1.10"
   url = "https://v1-10-x.sdk.operatorframework.io"
+  kube_version = "1.20.2"
+  client_go_version = "v0.21.2"
 
 [[params.versions]]
   version = "v1.9"
   url = "https://v1-9-x.sdk.operatorframework.io"
+  kube_version = "1.20.2"
+  client_go_version = "v0.20.2"
 
 [[params.versions]]
   version = "v1.8"
   url = "https://v1-8-x.sdk.operatorframework.io"
+  kube_version = "1.20.2"
+  client_go_version = "v0.20.2"
 
 [[params.versions]]
   version = "v1.7"
   url = "https://v1-7-x.sdk.operatorframework.io"
+  kube_version = "1.19.4"
+  client_go_version = "v0.20.2"
 
 [[params.versions]]
   version = "v1.6"
   url = "https://v1-6-x.sdk.operatorframework.io"
+  kube_version = "1.19.4"
+  client_go_version = "v0.20.2"
 
 [[params.versions]]
   version = "v1.5"
   url = "https://v1-5-x.sdk.operatorframework.io"
+  kube_version = "1.19.4"
+  client_go_version = "v0.20.2"
 
 [[params.versions]]
   version = "v1.4"
   url = "https://v1-4-x.sdk.operatorframework.io"
+  kube_version = "1.19.4"
+  client_go_version = "v0.20.1"
 
 [[params.versions]]
   version = "v1.3"
   url = "https://v1-3-x.sdk.operatorframework.io"
+  kube_version = "1.19.4"
+  client_go_version = "v0.19.4"
 
 [[params.versions]]
   version = "v1.2"
   url = "https://v1-2-x.sdk.operatorframework.io"
+  kube_version = "1.18.8"
+  client_go_version = "v0.18.8"
 
 [[params.versions]]
   version = "v1.1"
   url = "https://v1-1-x.sdk.operatorframework.io"
+  kube_version = "1.18.2"
+  client_go_version = "v0.18.8"
 
 [[params.versions]]
   version = "v1.0"
   url = "https://v1-0-x.sdk.operatorframework.io"
+  kube_version = "1.18.2"
+  client_go_version = "v0.18.6"
 
 [[params.versions]]
   version = "v0.19"
   url = "https://v0-19-x.sdk.operatorframework.io"
+  kube_version = "1.18.2"
+  client_go_version = "v12.0.0+incompatible"
 
 [[params.versions]]
   version = "v0.18"
   url = "https://v0-18-x.sdk.operatorframework.io"
+  kube_version = "1.18.2"
+  client_go_version = "v12.0.0+incompatible"
 
 [[params.versions]]
   version = "v0.17"
   url = "https://github.com/operator-framework/operator-sdk/tree/v0.17.x/doc"
-
+  kube_version = "1.17.2"
+  client_go_version = "v12.0.0+incompatible"
 
 # User interface configuration
 [params.ui]

--- a/website/content/en/docs/overview/_index.md
+++ b/website/content/en/docs/overview/_index.md
@@ -69,11 +69,11 @@ binary or project type to look up a Y-axis version to plug into the compatibilit
 
 By binary:
 
-| Binary                  | Lookup strategy               |
-|-------------------------|-------------------------------|
-| `operator-sdk`          | `$ operator-sdk version`      |
-| `ansible-operator`      | `$ ansible-operator version`  |
-| `helm-operator`         | `$ helm-operator version`     |
+| Binary                  | Lookup strategy               | Kubernetes version    | `client-go` version        |
+|-------------------------|-------------------------------|-----------------------|----------------------------|
+| `operator-sdk`          | `$ operator-sdk version`      | {{% kube-version %}}  | {{% client-go-version %}}  |
+| `ansible-operator`      | `$ ansible-operator version`  | {{% kube-version %}}  | {{% client-go-version %}}  |
+| `helm-operator`         | `$ helm-operator version`     | {{% kube-version %}}  | {{% client-go-version %}}  |
 
 By project type (replace `${IMAGE_VERSION}` with base image version in your project `Dockerfile`):
 

--- a/website/layouts/shortcodes/client-go-version.html
+++ b/website/layouts/shortcodes/client-go-version.html
@@ -1,0 +1,14 @@
+{{- $siteURL := .Page.Site.BaseURL -}}
+{{- $done := false -}}
+{{- range .Page.Site.Params.versions -}}
+    {{- $verUrl := printf "%s/" .url -}}
+    {{- if eq  $verUrl $siteURL -}}
+        {{- $done = true -}}
+        <code>{{- .client_go_version -}}</code>
+    {{- end -}}
+{{- end -}}
+{{- if eq $done false -}}
+    {{- range where .Page.Site.Params.versions "version" "Latest Release" -}}
+        <code>{{- .client_go_version -}}</code> 
+    {{- end -}}
+{{- end -}}

--- a/website/layouts/shortcodes/kube-version.html
+++ b/website/layouts/shortcodes/kube-version.html
@@ -1,0 +1,14 @@
+{{- $siteURL := .Page.Site.BaseURL -}}
+{{- $done := false -}}
+{{- range .Page.Site.Params.versions -}}
+    {{- $verUrl := printf "%s/" .url -}}
+    {{- if eq  $verUrl $siteURL -}}
+        {{- $done = true -}}
+        <code>{{- .kube_version -}}</code>
+    {{- end -}}
+{{- end -}}
+{{- if eq $done false -}}
+    {{- range where .Page.Site.Params.versions "version" "Latest Release" -}}
+        <code>{{- .kube_version -}}</code> 
+    {{- end -}}
+{{- end -}}

--- a/website/scripts/update_branch_mappings.sh
+++ b/website/scripts/update_branch_mappings.sh
@@ -15,8 +15,11 @@ if grep -C 1 "\[\[params\.versions\]\]" website/config.toml | grep -q "version =
   exit 0
 fi
 
+KUBE_VERSION="$(cat Makefile | grep "export K8S_VERSION" | awk -F= '{ gsub(/ /,""); print $2 }')"
+CLIENT_GO_VERSION="$(cat go.mod | grep "k8s.io/client-go" | awk -F" " '{ print $2 }')"
+
 MARKER="##RELEASE_ADDME##"
-PARAMS_VERSION="[[params.versions]]\\n  version = \"${VERSION_PATCHLESS}\"\\n  url = \"https://${VERSION_X_DOMAIN}.sdk.operatorframework.io\""
+PARAMS_VERSION="[[params.versions]]\\n  version = \"${VERSION_PATCHLESS}\"\\n  url = \"https://${VERSION_X_DOMAIN}.sdk.operatorframework.io\"\\n  kube_version = \"${KUBE_VERSION}\"\\n  client_go_version = \"${CLIENT_GO_VERSION}\""
 
 sed -i -E $'s@'${MARKER}'@'"${MARKER}\\n\\n${PARAMS_VERSION}"'@g' "$CONFIG_PATH"
 

--- a/website/scripts/update_latest_release_compat.sh
+++ b/website/scripts/update_latest_release_compat.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# This script updates the latest release version's `kube_version` and `client_go_version`
+# variable to be up to date. This change should be committed in the prerelease commit.
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+CONFIG_PATH="${DIR}/../config.toml"
+
+KUBE_VERSION="$(cat Makefile | grep "export K8S_VERSION" | awk -F= '{ gsub(/ /,""); print $2 }')"
+CLIENT_GO_VERSION="$(cat go.mod | grep "k8s.io/client-go" | awk -F" " '{ print $2 }')"
+
+KUBE_MARKER="##LATEST_RELEASE_KUBE_VERSION##"
+CLIENT_GO_MARKER="##LATEST_RELEASE_CLIENT_GO_VERSION##"
+
+perl -0777 -pi -e $'s@'"${KUBE_MARKER}\\n  kube_version = ".+'@'"${KUBE_MARKER}\\n  kube_version = \"${KUBE_VERSION}\""'@g' ${CONFIG_PATH}
+perl -0777 -pi -e $'s@'"${CLIENT_GO_MARKER}\\n  client_go_version = ".+'@'"${CLIENT_GO_MARKER}\\n  client_go_version = \"${CLIENT_GO_VERSION}\""'@g' ${CONFIG_PATH}


### PR DESCRIPTION
**Description of the change:**
- In the docs, update the Kubernetes compatibility matrix table to include the Kubernetes version that the binaries were tested against for a given version and the client-go version that the binary was built with.

**Motivation for the change:**
- Fixes #6072 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
