### PR TITLE
bump operator-framework/api 

### DIFF
--- a/changelog/fragments/02-api-bump-k8s-125-validation.yaml
+++ b/changelog/fragments/02-api-bump-k8s-125-validation.yaml
@@ -1,0 +1,19 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For `operator-sdk bundle validate`: When checking for Kubernetes APIs deprecated
+      in Kubernetes v1.25.0 the ClusterServiceVersion's CustomResourceDefinitions, 
+      ClusterPermissions, and Permissions are now validated to ensure no references to 
+      deprecated APIs are being made.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2
 	github.com/onsi/ginkgo/v2 v2.2.0
 	github.com/onsi/gomega v1.20.2
-	github.com/operator-framework/api v0.17.2-0.20221006132308-b527a19c8e14
+	github.com/operator-framework/api v0.17.2-0.20221028193825-b611f6cef49c
 	github.com/operator-framework/helm-operator-plugins v0.0.12-0.20221014213227-6f6106714f0d
 	github.com/operator-framework/java-operator-plugins v0.7.1-0.20221007075838-2e24140314fb
 	github.com/operator-framework/operator-lib v0.11.1-0.20220921174810-791cc547e6c5

--- a/go.sum
+++ b/go.sum
@@ -818,8 +818,8 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
-github.com/operator-framework/api v0.17.2-0.20221006132308-b527a19c8e14 h1:HScLXXCRETEqJTB3KS16KD1bKWcMjvaC0Q8uiwb+wqI=
-github.com/operator-framework/api v0.17.2-0.20221006132308-b527a19c8e14/go.mod h1:34tb98EwTN5SZLkgoxwvRkhMJKLHUWHOrrcv1ZwvEeA=
+github.com/operator-framework/api v0.17.2-0.20221028193825-b611f6cef49c h1:aQPFE1Oc7qh02FniuUrAeUemv01wfisfUHGL1aQOxEc=
+github.com/operator-framework/api v0.17.2-0.20221028193825-b611f6cef49c/go.mod h1:34tb98EwTN5SZLkgoxwvRkhMJKLHUWHOrrcv1ZwvEeA=
 github.com/operator-framework/helm-operator-plugins v0.0.12-0.20221014213227-6f6106714f0d h1:xPqV1TH9ZCbo/fNIp1CVMYlKkD28wmIMrwuwibXaXo4=
 github.com/operator-framework/helm-operator-plugins v0.0.12-0.20221014213227-6f6106714f0d/go.mod h1:zaxx1ikQMg/sm/j5WDG2aJHK4phIti5TkeKH8EePt0M=
 github.com/operator-framework/java-operator-plugins v0.7.1-0.20221007075838-2e24140314fb h1:lHKsuPfcDwgFFvwwh4OdA9MUyZ+xY82Q/xztJkotUKI=


### PR DESCRIPTION
**Description of the change:**
- Bumps operator-framework/api to commit https://github.com/operator-framework/api/commit/b611f6cef49cb8c6d621145c4e31d8ddfd4c59f4

**Motivation for the change:**
- Add to `operator-sdk bundle validate` the updated k8s 1.25.x deprecated API validation logic

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
