### PR TITLE
docs: fix typo in namespace labeling command

### DIFF
--- a/website/content/en/docs/best-practices/pod-security-standards.md
+++ b/website/content/en/docs/best-practices/pod-security-standards.md
@@ -157,7 +157,7 @@ kubectl create ns mytest
  kubectl label --overwrite ns mytest \
    pod-security.kubernetes.io/enforce=restricted \
    pod-security.kubernetes.io/enforce-version=v1.24 \
-   pod-security.kubernetes.io/audit: restricted
+   pod-security.kubernetes.io/audit=restricted
 ```
 
 3. Now, apply the following Pod which is **not** restricted on the namespace:
@@ -233,7 +233,7 @@ system: restricted
 ### Can I use the metrics to check if my Pod/Containers are violating the PodSecurity policies?
 
 Yes, you can. You need to label the namespaces with `pod-security.kubernetes.io/audit: restricted` 
-(i.e. `kubectl label --overwrite ns --all pod-security.kubernetes.io/enforce-version=v1.24 pod-security.kubernetes.io/audit: restricted`).
+(i.e. `kubectl label --overwrite ns --all pod-security.kubernetes.io/enforce-version=v1.24 pod-security.kubernetes.io/audit=restricted`).
  It is important to note that the results may include metrics that do not come from your Operator and Operand(s). 
 If you are looking to use the metrics to do the checks, ensure that you check the
 results before and after performing the tests, for example: 


### PR DESCRIPTION
Signed-off-by: Vladimir Belousov <vbelouso@redhat.com>

**Description of the change:**
Fixed typo in namespace labeling command. Сolon sign replaced with an equal sign.

```sh
kubectl label --overwrite ns mytest \
   pod-security.kubernetes.io/enforce=restricted \
   pod-security.kubernetes.io/enforce-version=v1.24 \
   pod-security.kubernetes.io/audit: restricted
```
**Motivation for the change:**
The current command does not execute correctly and ends with an error

```sh
error: all resources must be specified before label changes: pod-security.kubernetes.io/audit:restricted
```
**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
