### PR TITLE
CHANGE capability level description to independent levels

### DIFF
--- a/website/content/en/docs/overview/operator-capabilities.md
+++ b/website/content/en/docs/overview/operator-capabilities.md
@@ -8,7 +8,7 @@ Operators come in different maturity levels in regards to their lifecycle manage
 
 ![operator-capability-level](/operator-capability-level.png)
 
-Each capability level is associated with a certain set of management features the Operator offers around the managed workload. Operator that do not manage a workload and/or are delegating to off-clusters orchestration services would remain at Level 1. Capability levels are accumulating, i.e. Level 3 capabilities require all capabilities desired from Level 1 and 2.
+Each capability level is associated with a certain set of management features the Operator offers around the managed workload. Operator that do not manage a workload and/or are delegating to off-clusters orchestration services would remain at Level 1. Capability levels are designated from level 1 to level 5. Each capability represents its own set of features and may be independent of each other.
 
 
 ## Terminology


### PR DESCRIPTION
- CHANGED accumulating for independent levels on cap description

Signed-off-by: acmenezes <adcmenezes@gmail.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

On this PR I propose to change the capability description found at https://sdk.operatorframework.io/docs/overview/operator-capabilities/ where the word accumulating leads to the understanding that capability levels are technically dependent on lower level ones. We know that we can include level 4 capabilities without having level 3 or 2 for example. We can have a broader discussion about how to grant badges for the operator hubs on this. This is not the intention here. It's just to eliminate the confusion for the users reading this doc.

**Motivation for the change:**

Multiple partners, operator-sdk users, have asked questions about this specifically showing that this particular wording causes confusion among them.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
