### PR TITLE
Update createdAt when `make bundle` is run

### DIFF
--- a/hack/generate/samples/internal/ansible/memcached.go
+++ b/hack/generate/samples/internal/ansible/memcached.go
@@ -94,6 +94,11 @@ func (ma *Memcached) Run() {
 	log.Infof("striping bundle annotations")
 	err = ma.ctx.StripBundleAnnotations()
 	pkg.CheckError("striping bundle annotations", err)
+
+	log.Infof("setting createdAt annotation")
+	csv := filepath.Join(ma.ctx.Dir, "bundle", "manifests", ma.ctx.ProjectName+".clusterserviceversion.yaml")
+	err = kbutil.ReplaceRegexInFile(csv, "createdAt:.*", createdAt)
+	pkg.CheckError("setting createdAt annotation", err)
 }
 
 // addingMoleculeMockData will customize the molecule data
@@ -127,3 +132,5 @@ func (ma *Memcached) addingAnsibleTask() {
 		"# TODO(user): Add fields here", "size: 1")
 	pkg.CheckError("updating sample CR", err)
 }
+
+const createdAt = `createdAt: "2022-11-08T17:26:37Z"`

--- a/hack/generate/samples/internal/go/memcached-with-webhooks/memcached_with_webhooks.go
+++ b/hack/generate/samples/internal/go/memcached-with-webhooks/memcached_with_webhooks.go
@@ -156,6 +156,11 @@ func (mh *Memcached) Run() {
 	err = mh.ctx.GenerateBundle()
 	pkg.CheckError("creating the bundle", err)
 
+	log.Infof("setting createdAt annotation")
+	csv := filepath.Join(mh.ctx.Dir, "bundle", "manifests", mh.ctx.ProjectName+".clusterserviceversion.yaml")
+	err = kbutil.ReplaceRegexInFile(csv, "createdAt:.*", createdAt)
+	pkg.CheckError("setting createdAt annotation", err)
+
 	log.Infof("striping bundle annotations")
 	err = mh.ctx.StripBundleAnnotations()
 	pkg.CheckError("striping bundle annotations", err)
@@ -560,6 +565,8 @@ func (mh *Memcached) customizingDockerfile() {
 		"\nCOPY monitoring/ monitoring/")
 	pkg.CheckError("adding COPY monitoring/", err)
 }
+
+const createdAt = `createdAt: "2022-11-08T17:26:37Z"`
 
 const metricsFragment = `
 var (

--- a/hack/generate/samples/internal/helm/memcached.go
+++ b/hack/generate/samples/internal/helm/memcached.go
@@ -113,7 +113,14 @@ func (mh *Memcached) Run() {
 	log.Infof("striping bundle annotations")
 	err = mh.ctx.StripBundleAnnotations()
 	pkg.CheckError("striping bundle annotations", err)
+
+	log.Infof("setting createdAt annotation")
+	csv := filepath.Join(mh.ctx.Dir, "bundle", "manifests", mh.ctx.ProjectName+".clusterserviceversion.yaml")
+	err = kbutil.ReplaceRegexInFile(csv, "createdAt:.*", createdAt)
+	pkg.CheckError("setting createdAt annotation", err)
 }
+
+const createdAt = `createdAt: "2022-11-08T17:26:37Z"`
 
 const policyRolesFragment = `
 ##

--- a/internal/generate/clusterserviceversion/clusterserviceversion_test.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_test.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/blang/semver/v4"
 	. "github.com/onsi/ginkgo/v2"
@@ -193,6 +195,7 @@ var _ = Describe("Testing CRDs with single version", func() {
 						Version:      zeroZeroOne,
 						Collector:    col,
 					}
+					newCSV.Annotations["createdAt"] = time.Now().UTC().Format(time.RFC3339)
 					csv, err := g.generate()
 					Expect(err).ToNot(HaveOccurred())
 					Expect(csv).To(Equal(newCSV))
@@ -212,6 +215,7 @@ var _ = Describe("Testing CRDs with single version", func() {
 					csvExp := newCSVUIMeta.DeepCopy()
 					csvExp.SetName("memcached-operator.v0.0.3")
 					csvExp.GetAnnotations()["olm.skipRange"] = "<0.0.2"
+					csvExp.Annotations["createdAt"] = time.Now().UTC().Format(time.RFC3339)
 					csvExp.Spec.Replaces = "memcached-operator.v0.0.2"
 					csvExp.Spec.Version.Patch = 3
 					Expect(csv).To(Equal(csvExp))
@@ -223,6 +227,7 @@ var _ = Describe("Testing CRDs with single version", func() {
 						Version:      zeroZeroOne,
 						Collector:    col,
 					}
+					newCSVUIMeta.Annotations["createdAt"] = time.Now().UTC().Format(time.RFC3339)
 					csv, err := g.generate()
 					Expect(err).ToNot(HaveOccurred())
 					Expect(csv).To(Equal(newCSVUIMeta))
@@ -233,6 +238,7 @@ var _ = Describe("Testing CRDs with single version", func() {
 						OperatorName: operatorName,
 						Collector:    col,
 					}
+					newCSVUIMeta.Annotations["createdAt"] = time.Now().UTC().Format(time.RFC3339)
 					csv, err := g.generate()
 					Expect(err).ToNot(HaveOccurred())
 					Expect(csv).To(Equal(newCSVUIMeta))
@@ -246,6 +252,9 @@ var _ = Describe("Testing CRDs with single version", func() {
 						Version:      zeroZeroOne,
 						Collector: &collector.Manifests{
 							ClusterServiceVersions: []v1alpha1.ClusterServiceVersion{*newCSVUIMeta},
+						},
+						Annotations: map[string]string{
+							"createdAt": time.Now().UTC().Format(time.RFC3339),
 						},
 					}
 					// Update the input's and expected CSV's Deployment image.
@@ -390,6 +399,7 @@ func initTestCSVsHelper() {
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	path = filepath.Join(csvNewLayoutBundleDir, "with-ui-metadata.clusterserviceversion.yaml")
 	newCSVUIMeta, newCSVUIMetaStr, err = getCSVFromFile(path)
+	newCSVUIMetaStr = strings.ReplaceAll(newCSVUIMetaStr, "2022-11-08T16:44:38Z", time.Now().UTC().Format(time.RFC3339))
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 }
 
@@ -401,6 +411,7 @@ func initTestMultiVersionCSVHelper() {
 
 	path = filepath.Join(csvNewLayoutBundleDir, "memcached-operator-multiVersion.yaml")
 	_, multiVersionCSVStr, err = getCSVFromFile(path)
+	multiVersionCSVStr = strings.ReplaceAll(multiVersionCSVStr, "2022-11-08T16:44:38Z", time.Now().UTC().Format(time.RFC3339))
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 }
 
@@ -453,6 +464,7 @@ func updateCSV(csv *v1alpha1.ClusterServiceVersion,
 	opts ...func(*v1alpha1.ClusterServiceVersion)) *v1alpha1.ClusterServiceVersion {
 
 	updated := csv.DeepCopy()
+	updated.Annotations["createdAt"] = time.Now().UTC().Format(time.RFC3339)
 	for _, opt := range opts {
 		opt(updated)
 	}
@@ -465,6 +477,7 @@ func upgradeCSV(csv *v1alpha1.ClusterServiceVersion, name, version string) *v1al
 	// Update CSV name and upgrade version.
 	upgraded.SetName(genutil.MakeCSVName(name, version))
 	upgraded.Spec.Version = operatorversion.OperatorVersion{Version: semver.MustParse(version)}
+	upgraded.Annotations["createdAt"] = time.Now().UTC().Format(time.RFC3339)
 
 	return upgraded
 }

--- a/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_updaters.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/api/pkg/validation"
@@ -61,6 +62,9 @@ func apply(c *collector.Manifests, csv *operatorsv1alpha1.ClusterServiceVersion,
 		applyDeployments(c, &strategy.StrategySpec)
 	}
 	csv.Spec.InstallStrategy = strategy
+
+	// Update createdAt timestamp annotation since the CSV has been updated.
+	csv.ObjectMeta.Annotations["createdAt"] = time.Now().UTC().Format(time.RFC3339)
 
 	applyCustomResourceDefinitions(c, csv)
 	if err := applyCustomResources(c, csv); err != nil {

--- a/internal/generate/testdata/clusterserviceversions/bases/memcached-operator.clusterserviceversion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/bases/memcached-operator.clusterserviceversion.yaml
@@ -3,6 +3,20 @@ kind: ClusterServiceVersion
 metadata:
   name: memcached-operator.v0.0.0
   namespace: placeholder
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "cache.example.com/v1alpha1",
+          "kind": "Memcached",
+          "metadata": {
+            "name": "memcached-sample"
+          },
+          "spec": {
+            "foo": "bar"
+          }
+        }
+      ]
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions: {}

--- a/internal/generate/testdata/clusterserviceversions/output/memcached-operator-multiVersion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/output/memcached-operator-multiVersion.yaml
@@ -16,6 +16,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    createdAt: "2022-11-08T16:44:38Z"
   name: memcached-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/internal/generate/testdata/clusterserviceversions/output/with-ui-metadata.clusterserviceversion.yaml
+++ b/internal/generate/testdata/clusterserviceversions/output/with-ui-metadata.clusterserviceversion.yaml
@@ -16,6 +16,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    createdAt: "2022-11-08T16:44:38Z"
   name: memcached-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/ansible/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -23,6 +23,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    createdAt: "2022-11-08T17:26:37Z"
   name: memcached-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v3/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -17,6 +17,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    createdAt: "2022-11-08T17:26:37Z"
   name: memcached-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/testdata/go/v3/monitoring/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v3/monitoring/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -17,6 +17,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    createdAt: "2022-11-08T17:26:37Z"
   name: memcached-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/testdata/go/v4-alpha/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v4-alpha/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -17,6 +17,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    createdAt: "2022-11-08T17:26:37Z"
   name: memcached-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/testdata/go/v4-alpha/monitoring/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v4-alpha/monitoring/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -17,6 +17,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    createdAt: "2022-11-08T17:26:37Z"
   name: memcached-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/helm/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -56,6 +56,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    createdAt: "2022-11-08T17:26:37Z"
   name: memcached-operator.v0.0.1
   namespace: placeholder
 spec:


### PR DESCRIPTION
Signed-off-by: Gabe Alford <redhatrises@gmail.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
The createdAt field should be updated when `make bundle` is run.

**Motivation for the change:**
Per discussion with the operator-sdk team at KubeCon, having createdAt updated on a `make bundle` is one less thing that has to be manually updated.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
