### PR TITLE
change rerun github action to point at the operator-framework repo

### DIFF
--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -8,7 +8,7 @@ jobs:
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-20.04
     steps:
-    - uses: estroz/rerun-actions@v0.3.0
+    - uses: operator-framework/rerun-actions@v0.4.0
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         comment_id: ${{ github.event.comment.id }}


### PR DESCRIPTION
Fixes #5239

Hopefully the github release has gone through pipes so this works.