### PR TITLE
add gcc to image dependencies, so it can be used to fully run operator-sdk cli

### DIFF
--- a/images/operator-sdk/Dockerfile
+++ b/images/operator-sdk/Dockerfile
@@ -22,7 +22,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 ENV GO_VERSION 1.19
 
 ARG TARGETARCH
-RUN microdnf install -y make which tar gzip
+RUN microdnf install -y make gcc which tar gzip
 RUN curl -sSLo /tmp/go.tar.gz https://golang.org/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz \
 	&& rm -rf /usr/local/go \
 	&& tar -C /usr/local -xzf /tmp/go.tar.gz \


### PR DESCRIPTION
Closes 6171

<!--
https://github.com/operator-framework/operator-sdk/issues/6171
Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

Added GCC to dependencies

**Motivation for the change:**

operator-sdk cli is not fully functional without it with default settings if run through docker image

For more details see #6171 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
