### PR TITLE
Configure test pod to comply with Pod Security Standard

### DIFF
--- a/internal/cmd/operator-sdk/scorecard/cmd.go
+++ b/internal/cmd/operator-sdk/scorecard/cmd.go
@@ -92,7 +92,7 @@ If the argument holds an image tag, it must be present remotely.`,
 		"docker.io/library/busybox@sha256:c71cb4f7e8ececaffb34037c2637dc86820e4185100e18b4d02d613a9bd772af",
 		"Storage image to be used by the Scorecard pod")
 	scorecardCmd.Flags().StringVarP(&c.untarImage, "untar-image", "u",
-		"registry.access.redhat.com/ubi8@sha256:910f6bc0b5ae9b555eb91b88d28d568099b060088616eba2867b07ab6ea457c7",
+		"registry.access.redhat.com/ubi8@sha256:83c0e63f5efb64cba26be647e93bf036b8d88b774f0726936c1b956424b1abf6",
 		"Untar image to be used by the Scorecard pod")
 	scorecardCmd.Flags().StringVarP(&c.testOutput, "test-output", "t", "test-output",
 		"Test output directory.")

--- a/internal/cmd/operator-sdk/scorecard/cmd_test.go
+++ b/internal/cmd/operator-sdk/scorecard/cmd_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Running the scorecard command", func() {
 			flag = cmd.Flags().Lookup("untar-image")
 			Expect(flag).NotTo(BeNil())
 			Expect(flag.Shorthand).To(Equal("u"))
-			Expect(flag.DefValue).To(Equal("registry.access.redhat.com/ubi8@sha256:910f6bc0b5ae9b555eb91b88d28d568099b060088616eba2867b07ab6ea457c7"))
+			Expect(flag.DefValue).To(Equal("registry.access.redhat.com/ubi8@sha256:83c0e63f5efb64cba26be647e93bf036b8d88b774f0726936c1b956424b1abf6"))
 		})
 	})
 

--- a/internal/scorecard/testpod.go
+++ b/internal/scorecard/testpod.go
@@ -35,7 +35,6 @@ const (
 // getPodDefinition fills out a Pod definition based on
 // information from the test
 func getPodDefinition(configMapName string, test v1alpha3.TestConfiguration, r PodTestRunner) *v1.Pod {
-
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("scorecard-test-%s", rand.String(4)),
@@ -71,6 +70,15 @@ func getPodDefinition(configMapName string, test v1alpha3.TestConfiguration, r P
 							},
 						},
 					},
+					SecurityContext: &v1.SecurityContext{
+						RunAsNonRoot:             &[]bool{true}[0],
+						AllowPrivilegeEscalation: &[]bool{false}[0],
+						Capabilities: &v1.Capabilities{
+							Drop: []v1.Capability{
+								"ALL",
+							},
+						},
+					},
 				},
 			},
 			InitContainers: []v1.Container{
@@ -97,6 +105,15 @@ func getPodDefinition(configMapName string, test v1alpha3.TestConfiguration, r P
 							ReadOnly:  false,
 						},
 					},
+					SecurityContext: &v1.SecurityContext{
+						RunAsNonRoot:             &[]bool{true}[0],
+						AllowPrivilegeEscalation: &[]bool{false}[0],
+						Capabilities: &v1.Capabilities{
+							Drop: []v1.Capability{
+								"ALL",
+							},
+						},
+					},
 				},
 			},
 			Volumes: []v1.Volume{
@@ -115,6 +132,14 @@ func getPodDefinition(configMapName string, test v1alpha3.TestConfiguration, r P
 					VolumeSource: v1.VolumeSource{
 						EmptyDir: &v1.EmptyDirVolumeSource{},
 					},
+				},
+			},
+			SecurityContext: &v1.PodSecurityContext{
+				RunAsUser:    &[]int64{1000}[0],
+				RunAsGroup:   &[]int64{1000}[0],
+				RunAsNonRoot: &[]bool{true}[0],
+				SeccompProfile: &v1.SeccompProfile{
+					Type: v1.SeccompProfileTypeRuntimeDefault,
 				},
 			},
 		},

--- a/website/content/en/docs/cli/operator-sdk_scorecard.md
+++ b/website/content/en/docs/cli/operator-sdk_scorecard.md
@@ -29,7 +29,7 @@ operator-sdk scorecard [flags]
   -x, --skip-cleanup             Disable resource cleanup after tests are run
   -b, --storage-image string     Storage image to be used by the Scorecard pod (default "docker.io/library/busybox@sha256:c71cb4f7e8ececaffb34037c2637dc86820e4185100e18b4d02d613a9bd772af")
   -t, --test-output string       Test output directory. (default "test-output")
-  -u, --untar-image string       Untar image to be used by the Scorecard pod (default "registry.access.redhat.com/ubi8@sha256:910f6bc0b5ae9b555eb91b88d28d568099b060088616eba2867b07ab6ea457c7")
+  -u, --untar-image string       Untar image to be used by the Scorecard pod (default "registry.access.redhat.com/ubi8@sha256:83c0e63f5efb64cba26be647e93bf036b8d88b774f0726936c1b956424b1abf6")
   -w, --wait-time duration       seconds to wait for tests to complete. Example: 35s (default 30s)
 ```
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
The test pod is not yet created in accordance with the Pod Security Standard enforced in k8s 1.24. For compliance, the main pod security context needs:

RunAsNonRoot: true
SeccompProfile:
  Type: RuntimeDefault

And each container needs:

SecurityContext:
  AllowPrivilegeEscalation: false
  Capabilities:
    Drop:
      'ALL'

Fixes #5939

Signed-off-by: Brad P. Crochet <brad@redhat.com>



**Motivation for the change:**
Scorecard tests would not run under k8s 1.24 or OpenShift 4.12. This re-enables that functionality.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [X] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [X] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
