### PR TITLE
(bugfix): update run bundle(-upgrade) logic

### DIFF
--- a/changelog/fragments/04-rbu-large-fbc.yaml
+++ b/changelog/fragments/04-rbu-large-fbc.yaml
@@ -1,0 +1,19 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For `operator-sdk run bundle(-upgrade)`: fix a bug in the logic that would attempt to
+      create a `ConfigMap` that contained the entire contents of an FBC. Now if the FBC contents
+      are to large to fit into a single `ConfigMap`, the FBC contents will be partitioned and split
+      amongst multiple `ConfigMap` resources.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
+++ b/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
@@ -433,8 +433,8 @@ func (f *FBCRegistryPod) makeBaseConfigMap() *corev1.ConfigMap {
 // update it if it already exists.
 func (f *FBCRegistryPod) createOrUpdateConfigMap(cm *corev1.ConfigMap) error {
 	cmKey := types.NamespacedName{
-		Namespace: cm.Namespace,
-		Name:      cm.Name,
+		Namespace: cm.GetNamespace(),
+		Name:      cm.GetName(),
 	}
 
 	// create a ConfigMap if it does not exist;
@@ -446,6 +446,7 @@ func (f *FBCRegistryPod) createOrUpdateConfigMap(cm *corev1.ConfigMap) error {
 			if err := f.cfg.Client.Create(context.TODO(), cm); err != nil {
 				return fmt.Errorf("error creating ConfigMap: %w", err)
 			}
+			return nil
 		}
 		// update ConfigMap with new FBCContent
 		tempCm.Data = cm.Data

--- a/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
+++ b/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"strings"
 	"text/template"
 	"time"
 
@@ -46,8 +47,9 @@ const (
 	defaultContainerName     = "registry-grpc"
 	defaultContainerPortName = "grpc"
 
-	defaultConfigMapName = "operator-sdk-run-bundle-config"
-	defaultConfigMapKey  = "extraFBC"
+	defaultConfigMapKey = "extraFBC"
+
+	maxConfigMapSize = 1 * 1024 * 1024
 )
 
 // FBCRegistryPod holds resources necessary for creation of a registry pod in FBC scenarios.
@@ -76,6 +78,8 @@ type FBCRegistryPod struct { //nolint:maligned
 	// SecurityContext on the Pod
 	SecurityContext string
 
+	configMapName string
+
 	cfg *operator.Configuration
 }
 
@@ -87,6 +91,10 @@ func (f *FBCRegistryPod) init(cfg *operator.Configuration, cs *v1alpha1.CatalogS
 
 	if f.FBCIndexRootDir == "" {
 		f.FBCIndexRootDir = fmt.Sprintf("/%s-configs", cs.Name)
+	}
+
+	if f.configMapName == "" {
+		f.configMapName = fmt.Sprintf("%s-configmap", cs.Name)
 	}
 
 	f.cfg = cfg
@@ -210,9 +218,37 @@ func (f *FBCRegistryPod) podForBundleRegistry(cs *v1alpha1.CatalogSource) (*core
 
 	// create ConfigMap if it does not exist,
 	// if it exists, then update it with new content.
-	cm, err := f.createConfigMap(cs)
+	cms, err := f.createConfigMaps(cs)
 	if err != nil {
 		return nil, fmt.Errorf("configMap error: %w", err)
+	}
+
+	volumes := []corev1.Volume{}
+	volumeMounts := []corev1.VolumeMount{}
+
+	for _, cm := range cms {
+		volumes = append(volumes, corev1.Volume{
+			Name: k8sutil.TrimDNS1123Label(cm.Name + "-volume"),
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					Items: []corev1.KeyToPath{
+						{
+							Key:  defaultConfigMapKey,
+							Path: path.Join(cm.Name, fmt.Sprintf("%s.yaml", defaultConfigMapKey)),
+						},
+					},
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: cm.Name,
+					},
+				},
+			},
+		})
+
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      k8sutil.TrimDNS1123Label(cm.Name + "-volume"),
+			MountPath: path.Join(f.FBCIndexRootDir, cm.Name),
+			SubPath:   cm.Name,
+		})
 	}
 
 	// make the pod definition
@@ -256,24 +292,7 @@ func (f *FBCRegistryPod) podForBundleRegistry(cs *v1alpha1.CatalogSource) (*core
 			//         Type: corev1.SeccompProfileTypeRuntimeDefault,
 			//     },
 			// },
-			Volumes: []corev1.Volume{
-				{
-					Name: k8sutil.TrimDNS1123Label(cm.Name + "-volume"),
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							Items: []corev1.KeyToPath{
-								{
-									Key:  defaultConfigMapKey,
-									Path: path.Join(defaultConfigMapName, fmt.Sprintf("%s.yaml", defaultConfigMapKey)),
-								},
-							},
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: cm.Name,
-							},
-						},
-					},
-				},
-			},
+			Volumes: volumes,
 			Containers: []corev1.Container{
 				{
 					Name:  defaultContainerName,
@@ -286,13 +305,7 @@ func (f *FBCRegistryPod) podForBundleRegistry(cs *v1alpha1.CatalogSource) (*core
 					Ports: []corev1.ContainerPort{
 						{Name: defaultContainerPortName, ContainerPort: f.GRPCPort},
 					},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      k8sutil.TrimDNS1123Label(cm.Name + "-volume"),
-							MountPath: path.Join(f.FBCIndexRootDir, cm.Name),
-							SubPath:   cm.Name,
-						},
-					},
+					VolumeMounts: volumeMounts,
 					SecurityContext: &corev1.SecurityContext{
 						Privileged:               pointer.Bool(false),
 						ReadOnlyRootFilesystem:   pointer.Bool(false),
@@ -315,50 +328,133 @@ const fbcCmdTemplate = `opm serve {{ .FBCIndexRootDir}} -p {{ .GRPCPort }}`
 
 // createConfigMap creates a ConfigMap if it does not exist and if it does, then update it with new content.
 // Also, sets the owner reference by making CatalogSource the owner of ConfigMap object for cleanup purposes.
-func (f *FBCRegistryPod) createConfigMap(cs *v1alpha1.CatalogSource) (*corev1.ConfigMap, error) {
-	// new ConfigMap
-	cm := &corev1.ConfigMap{
+func (f *FBCRegistryPod) createConfigMaps(cs *v1alpha1.CatalogSource) ([]*corev1.ConfigMap, error) {
+	// By default just use the partitioning logic.
+	// If the entire FBC contents can fit in one ConfigMap it will.
+	cms, err := f.partitionedConfigMaps()
+	if err != nil {
+		return nil, err
+	}
+
+	// Loop through all the ConfigMaps and set the OwnerReference and try to create them
+	for _, cm := range cms {
+		// set owner reference by making catalog source the owner of ConfigMap object
+		if err := controllerutil.SetOwnerReference(cs, cm, f.cfg.Scheme); err != nil {
+			return nil, fmt.Errorf("set configmap %q owner reference: %v", cm.GetName(), err)
+		}
+
+		f.createOrUpdateConfigMap(cm)
+	}
+
+	return cms, nil
+}
+
+// partitionedConfigMaps will create and return a list of *corev1.ConfigMap
+// that represents all the ConfigMaps that will need to be created to
+// properly have all the FBC contents rendered in the registry pod.
+func (f *FBCRegistryPod) partitionedConfigMaps() ([]*corev1.ConfigMap, error) {
+	// Split on the YAML separator `---`
+	yamlDefs := strings.Split(f.FBCContent, "---")[1:]
+	configMaps := []*corev1.ConfigMap{}
+
+	// Keep the number of ConfigMaps that are created to a minimum by
+	// stuffing them as full as possible.
+	partitionCount := 1
+	cm := f.makeBaseConfigMap()
+	// for each chunk of yaml see if it can be added to the ConfigMap partition
+	for _, yamlDef := range yamlDefs {
+		// If the ConfigMap has data then lets attempt to add to it
+		if len(cm.Data) != 0 {
+			// Create a copy to use to verify that adding the data doesn't
+			// exceed the max ConfigMap size of 1 MiB.
+			tempCm := cm.DeepCopy()
+			tempCm.Data[defaultConfigMapKey] = tempCm.Data[defaultConfigMapKey] + "\n---\n" + yamlDef
+
+			// if it would be too large adding the data then partition it.
+			if tempCm.Size() >= maxConfigMapSize {
+				// Set the ConfigMap name based on the partition it is
+				cm.SetName(fmt.Sprintf("%s-partition-%d", f.configMapName, partitionCount))
+				// Increase the partition count
+				partitionCount++
+				// Add the ConfigMap to the list of ConfigMaps
+				configMaps = append(configMaps, cm.DeepCopy())
+
+				// Create a new ConfigMap
+				cm = f.makeBaseConfigMap()
+				// Since adding this data would have made the previous
+				// ConfigMap too large, add it to this new one.
+				// No chunk of YAML from the bundle should cause
+				// the ConfigMap size to exceed 1 MiB and if
+				// somehow it does then there is a problem with the
+				// YAML itself. We can't reasonably break it up smaller
+				// since it is a single object.
+				cm.Data[defaultConfigMapKey] = yamlDef
+			} else {
+				// if adding the data to the ConfigMap
+				// doesn't make the ConfigMap exceed the
+				// size limit then actually add it.
+				cm.Data = tempCm.Data
+			}
+		} else {
+			// If there is no data in the ConfigMap
+			// then this is the first pass. Since it is
+			// the first pass go ahead and add the data.
+			cm.Data[defaultConfigMapKey] = yamlDef
+		}
+	}
+
+	// if there aren't as many ConfigMaps as partitions AND the unadded ConfigMap has data
+	// then add it to the list of ConfigMaps. This is so we don't miss adding a ConfigMap
+	// after the above loop completes.
+	if len(configMaps) != partitionCount && len(cm.Data) != 0 {
+		cm.SetName(fmt.Sprintf("%s-partition-%d", f.configMapName, partitionCount))
+		configMaps = append(configMaps, cm.DeepCopy())
+	}
+
+	return configMaps, nil
+}
+
+// makeBaseConfigMap will return the base *corev1.ConfigMap
+// definition that is used by various functions when creating a ConfigMap.
+func (f *FBCRegistryPod) makeBaseConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: corev1.SchemeGroupVersion.String(),
 			Kind:       "ConfigMap",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      defaultConfigMapName,
 			Namespace: f.cfg.Namespace,
 		},
-		Data: map[string]string{
-			defaultConfigMapKey: f.FBCContent,
-		},
+		Data: map[string]string{},
 	}
+}
 
-	// set owner reference by making catalog source the owner of ConfigMap object
-	if err := controllerutil.SetOwnerReference(cs, cm, f.cfg.Scheme); err != nil {
-		return nil, fmt.Errorf("set configmap %q owner reference: %v", cm.GetName(), err)
-	}
-
+// createOrUpdateConfigMap will create a ConfigMap if it doesn't exist or
+// update it if it already exists.
+func (f *FBCRegistryPod) createOrUpdateConfigMap(cm *corev1.ConfigMap) error {
 	cmKey := types.NamespacedName{
-		Namespace: f.cfg.Namespace,
-		Name:      defaultConfigMapName,
+		Namespace: cm.Namespace,
+		Name:      cm.Name,
 	}
 
 	// create a ConfigMap if it does not exist;
 	// update it with new data if it already exists.
 	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		err := f.cfg.Client.Get(context.TODO(), cmKey, cm)
+		tempCm := &corev1.ConfigMap{}
+		err := f.cfg.Client.Get(context.TODO(), cmKey, tempCm)
 		if apierrors.IsNotFound(err) {
 			if err := f.cfg.Client.Create(context.TODO(), cm); err != nil {
 				return fmt.Errorf("error creating ConfigMap: %w", err)
 			}
 		}
 		// update ConfigMap with new FBCContent
-		cm.Data = map[string]string{defaultConfigMapKey: f.FBCContent}
-		return f.cfg.Client.Update(context.TODO(), cm)
+		tempCm.Data = cm.Data
+		return f.cfg.Client.Update(context.TODO(), tempCm)
 	}); err != nil {
-		return nil, fmt.Errorf("error updating ConfigMap: %w", err)
+		return fmt.Errorf("error updating ConfigMap: %w", err)
 	}
 
-	return cm, nil
-
+	return nil
 }
 
 // getContainerCmd uses templating to construct the container command

--- a/internal/olm/operator/registry/fbcindex/fbc_registry_pod_test.go
+++ b/internal/olm/operator/registry/fbcindex/fbc_registry_pod_test.go
@@ -1,0 +1,180 @@
+// Copyright 2020 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fbcindex
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/operator-sdk/internal/olm/operator"
+	"github.com/operator-framework/operator-sdk/internal/olm/operator/registry/index"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const testIndexImageTag = "some-image:v1.2.3"
+const caSecretName = "foo-secret"
+
+// newFakeClient() returns a fake controller runtime client
+func newFakeClient() client.Client {
+	return fakeclient.NewClientBuilder().Build()
+}
+
+func TestCreateRegistryPod(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Registry Pod Suite")
+}
+
+var _ = Describe("FBCRegistryPod", func() {
+
+	var defaultBundleItems = []index.BundleItem{{
+		ImageTag: "quay.io/example/example-operator-bundle:0.2.0",
+		AddMode:  index.SemverBundleAddMode,
+	}}
+
+	Describe("creating registry pod", func() {
+		Context("with valid registry pod values", func() {
+			var (
+				rp  *FBCRegistryPod
+				cfg *operator.Configuration
+				cs  *v1alpha1.CatalogSource
+			)
+
+			BeforeEach(func() {
+				cs = &v1alpha1.CatalogSource{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "test-catalogsource",
+					},
+				}
+				cfg = &operator.Configuration{
+					Client:    newFakeClient(),
+					Namespace: "test-default",
+				}
+				rp = &FBCRegistryPod{
+					BundleItems: defaultBundleItems,
+					IndexImage:  testIndexImageTag,
+				}
+				By("initializing the FBCRegistryPod")
+				Expect(rp.init(cfg, cs)).To(Succeed())
+			})
+
+			It("should create the FBCRegistryPod successfully", func() {
+				expectedPodName := "quay-io-example-example-operator-bundle-0-2-0"
+				Expect(rp).NotTo(BeNil())
+				Expect(rp.pod.Name).To(Equal(expectedPodName))
+				Expect(rp.pod.Namespace).To(Equal(rp.cfg.Namespace))
+				Expect(rp.pod.Spec.Containers[0].Name).To(Equal(defaultContainerName))
+				if len(rp.pod.Spec.Containers) > 0 {
+					if len(rp.pod.Spec.Containers[0].Ports) > 0 {
+						Expect(rp.pod.Spec.Containers[0].Ports[0].ContainerPort).To(Equal(rp.GRPCPort))
+					}
+				}
+			})
+
+			It("should create a registry pod when database path is not provided", func() {
+				Expect(rp.FBCIndexRootDir).To(Equal(fmt.Sprintf("/%s-configs", cs.Name)))
+			})
+
+			It("should return a valid container command for one image", func() {
+				output, err := rp.getContainerCmd()
+				Expect(err).To(BeNil())
+				Expect(output).Should(Equal(containerCommandFor(rp.FBCIndexRootDir, rp.GRPCPort)))
+			})
+
+			It("should return a valid container command for three images", func() {
+				bundleItems := append(defaultBundleItems,
+					index.BundleItem{
+						ImageTag: "quay.io/example/example-operator-bundle:0.3.0",
+						AddMode:  index.ReplacesBundleAddMode,
+					},
+					index.BundleItem{
+						ImageTag: "quay.io/example/example-operator-bundle:1.0.1",
+						AddMode:  index.SemverBundleAddMode,
+					},
+					index.BundleItem{
+						ImageTag: "localhost/example-operator-bundle:1.0.1",
+						AddMode:  index.SemverBundleAddMode,
+					},
+				)
+				rp2 := FBCRegistryPod{
+					GRPCPort:    defaultGRPCPort,
+					BundleItems: bundleItems,
+				}
+				output, err := rp2.getContainerCmd()
+				Expect(err).To(BeNil())
+				Expect(output).Should(Equal(containerCommandFor(rp2.FBCIndexRootDir, rp2.GRPCPort)))
+			})
+		})
+
+		Context("with invalid registry pod values", func() {
+			var (
+				cfg *operator.Configuration
+				cs  *v1alpha1.CatalogSource
+			)
+			BeforeEach(func() {
+				cs = &v1alpha1.CatalogSource{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "test-catalogsource",
+					},
+				}
+				cfg = &operator.Configuration{
+					Client:    newFakeClient(),
+					Namespace: "test-default",
+				}
+			})
+
+			It("should error when bundle image is not provided", func() {
+				expectedErr := "bundle image set cannot be empty"
+				rp := &FBCRegistryPod{}
+				err := rp.init(cfg, cs)
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).Should(ContainSubstring(expectedErr))
+			})
+
+			It("checkPodStatus should return error when pod check is false and context is done", func() {
+				rp := &FBCRegistryPod{
+					BundleItems: defaultBundleItems,
+					IndexImage:  testIndexImageTag,
+				}
+				Expect(rp.init(cfg, cs)).To(Succeed())
+
+				mockBadPodCheck := wait.ConditionFunc(func() (done bool, err error) {
+					return false, fmt.Errorf("error waiting for registry pod")
+				})
+
+				expectedErr := "error waiting for registry pod"
+				// create a new context with a deadline of 1 millisecond
+				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+				cancel()
+
+				err := rp.checkPodStatus(ctx, mockBadPodCheck)
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).Should(ContainSubstring(expectedErr))
+			})
+		})
+	})
+})
+
+// containerCommandFor returns the expected container command for a db path and set of bundle items.
+func containerCommandFor(indexRootDir string, grpcPort int32) string { //nolint:unparam
+	return fmt.Sprintf("opm serve %s -p %d", indexRootDir, grpcPort)
+}


### PR DESCRIPTION
**Description of the change:**
Updates the logic of `operator-sdk run bundle(-upgrade)` to:
- Partition FBCs into multiple ConfigMaps and mount them as Volumes to the registry pod as needed
    - It will only partition into multiple ConfigMaps if the FBC contents are too large to fit into a single ConfigMap
- Use the `CatalogSource` name as part of the `ConfigMap` name so that its contents aren't overwritten every time `operator-sdk run bundle(-upgrade)` is used in the same namespace.

**Motivation for the change:**
- Fixes #6144 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
