### PR TITLE
docs/upgrade-sdk-version/v1.3.0.md: correct link to migration guide

### DIFF
--- a/website/content/en/docs/upgrading-sdk-version/v1.3.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.3.0.md
@@ -23,7 +23,7 @@ _See [#4282](https://github.com/operator-framework/operator-sdk/pull/4282) for m
 
 The newly released go/v3 plugin has many new features and (breaking) changes incompatible with projects created by go/v2.
 You are not required to upgrade and your go/v2 project will continue to work with new operator-sdk versions.
-If you wish to upgrade, check out the upstream [migration guide](https://master.book.kubebuilder.io/migration/v2vsv3.html).
+If you wish to upgrade, check out the upstream [migration guide](https://master.book.kubebuilder.io/migration/legacy/v2vsv3.html).
 
 Additionally, if using project version "3-alpha", you must update your `plugins` config field:
 


### PR DESCRIPTION
Signed-off-by: Chirayu Kapoor <dev.csociety@gmail.com>

**Description of the change:**
External link https://master.book.kubebuilder.io/migration/v2vsv3.html in /target/docs/upgrading-sdk-version/v1.3.0/index.html is moved and gives a 404 error.

Updated the link to the new location https://master.book.kubebuilder.io/migration/legacy/v2vsv3.html

**Motivation for the change:**
Fixes https://github.com/operator-framework/operator-sdk/issues/6190

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
