### PR TITLE
update ansible operator images to use the base image that uses UBI 8.7

### DIFF
--- a/changelog/fragments/01-fix-ansible-image.yaml
+++ b/changelog/fragments/01-fix-ansible-image.yaml
@@ -1,0 +1,17 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For the ansible operator container images, update them to
+      properly pull in the base image that uses UBI 8.7
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false

--- a/images/ansible-operator-2.11-preview/Dockerfile
+++ b/images/ansible-operator-2.11-preview/Dockerfile
@@ -18,7 +18,7 @@ RUN GOOS=linux GOARCH=$TARGETARCH make build/ansible-operator
 
 # Final image.
 # TODO(asmacdo) update GH action to set this
-FROM quay.io/operator-framework/ansible-operator-2.11-preview-base:master-77dd4e2ff165c0317254d55ff01ec1f8d0f1c34a
+FROM quay.io/operator-framework/ansible-operator-2.11-preview-base:master-aa0243440429e60568c27df5c7c22976f2b23a16
 
 ENV HOME=/opt/ansible \
     USER_NAME=ansible \

--- a/images/ansible-operator/Dockerfile
+++ b/images/ansible-operator/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/ansible-operator
 
 # Final image.
-FROM quay.io/operator-framework/ansible-operator-base:master-77dd4e2ff165c0317254d55ff01ec1f8d0f1c34a
+FROM quay.io/operator-framework/ansible-operator-base:master-aa0243440429e60568c27df5c7c22976f2b23a16
 
 ENV HOME=/opt/ansible \
     USER_NAME=ansible \


### PR DESCRIPTION
**Description of the change:**
- Updates the `ansible-operator` and `ansible-operator-2.11-preview` Dockerfiles to now use the base image with tag `master-aa0243440429e60568c27df5c7c22976f2b23a16`. This tag was built with the UBI 8.7 image as a base.

**Motivation for the change:**
- patch the v1.25.x branch in preparation to create a v1.25.3 patch release that updates the ansible-operator images to use the proper ansible-operator base image that is built with UBI 8.7 instead of UBI 8.6. Creating this patch release would help in fixing #6183 
 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
