### PR TITLE
(bugfix): OCPBUGS-3072 - fix `operator-sdk run bundle(-upgrade)` PSA related issues

### DIFF
--- a/changelog/fragments/05-rbu-psa.yaml
+++ b/changelog/fragments/05-rbu-psa.yaml
@@ -1,0 +1,31 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      `operator-sdk run bundle(-upgrade)`: Fix a bug where SQLite bundle images were failing to be run properly due to
+      a change in the default channel that is used by `run bundle(-upgrade)` when creating a subscription.
+
+    kind: "bugfix"
+    breaking: false
+
+  - description: >
+      `operator-sdk run bundle(-upgrade)`: Update the logic used to set a Registry Pod's PSA configuration
+      to fix a bug where a Pod's containers still had a restrictive SecurityContext even when setting
+      `--security-context-config=legacy`.
+
+    kind: "bugfix"
+    breaking: false
+
+  - description: >
+      `operator-sdk run bundle(-upgrade)`: Change default of the `--security-context-config` flag to be `legacy`
+      instead of `restricted`.
+
+    kind: "change"
+    breaking: false
+
+  - description: >
+      `operator-sdk run bundle`: When creating the CatalogSource, we now set the `grpcPodConfig.SecurityContextConfig`
+      to the value of the  `--security-context-config` flag.
+
+    kind: "change"
+    breaking: false

--- a/internal/olm/operator/registry/index/registry_pod.go
+++ b/internal/olm/operator/registry/index/registry_pod.go
@@ -139,6 +139,16 @@ func (rp *SQLiteRegistryPod) Create(ctx context.Context, cfg *operator.Configura
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},
 		}
+
+		// Update the Registry Pod container security context to be restrictive
+		rp.pod.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+			Privileged:               pointer.Bool(false),
+			ReadOnlyRootFilesystem:   pointer.Bool(false),
+			AllowPrivilegeEscalation: pointer.Bool(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+		}
 	}
 
 	if err := rp.cfg.Client.Create(ctx, rp.pod); err != nil {
@@ -276,14 +286,6 @@ func (rp *SQLiteRegistryPod) podForBundleRegistry() (*corev1.Pod, error) {
 					},
 					Ports: []corev1.ContainerPort{
 						{Name: defaultContainerPortName, ContainerPort: rp.GRPCPort},
-					},
-					SecurityContext: &corev1.SecurityContext{
-						Privileged:               pointer.Bool(false),
-						ReadOnlyRootFilesystem:   pointer.Bool(false),
-						AllowPrivilegeEscalation: pointer.Bool(false),
-						Capabilities: &corev1.Capabilities{
-							Drop: []corev1.Capability{"ALL"},
-						},
 					},
 				},
 			},

--- a/internal/olm/operator/registry/index/registry_pod.go
+++ b/internal/olm/operator/registry/index/registry_pod.go
@@ -365,8 +365,7 @@ func newBool(b bool) *bool {
 	return bp
 }
 
-const cmdTemplate = `
-[[ -f {{ .DBPath }} ]] && cp {{ .DBPath }} /tmp/tmp.db; \
+const cmdTemplate = `[[ -f {{ .DBPath }} ]] && cp {{ .DBPath }} /tmp/tmp.db; \
 {{- range $i, $item := .BundleItems }}
 opm registry add -d /tmp/tmp.db -b {{ $item.ImageTag }} --mode={{ $item.AddMode }}{{ if $.CASecretName }} --ca-file=/certs/cert.pem{{ end }} --skip-tls-verify={{ $.SkipTLSVerify }} --use-http={{ $.UseHTTP }} && \
 {{- end }}

--- a/internal/olm/operator/registry/index/registry_pod_test.go
+++ b/internal/olm/operator/registry/index/registry_pod_test.go
@@ -290,7 +290,8 @@ func containerCommandFor(dbPath string, items []BundleItem, hasCA, skipTLSVerify
 	}
 	additions := &strings.Builder{}
 	for _, item := range items {
-		additions.WriteString(fmt.Sprintf("opm registry add -d %s -b %s --mode=%s%s --skip-tls-verify=%v --use-http=%v && \\\n", dbPath, item.ImageTag, item.AddMode, caFlag, skipTLSVerify, useHTTP))
+		additions.WriteString(fmt.Sprintf("opm registry add -d /tmp/tmp.db -b %s --mode=%s%s --skip-tls-verify=%v --use-http=%v && \\\n", item.ImageTag, item.AddMode, caFlag, skipTLSVerify, useHTTP))
 	}
-	return fmt.Sprintf("mkdir -p /database && \\\n%sopm registry serve -d /database/index.db -p 50051\n", additions.String())
+
+	return fmt.Sprintf("[[ -f %s ]] && cp %s /tmp/tmp.db; \\\n%sopm registry serve -d /tmp/tmp.db -p 50051\n", dbPath, dbPath, additions.String())
 }

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -139,7 +139,7 @@ func (c *IndexImageCatalogCreator) BindFlags(fs *pflag.FlagSet) {
 		"while pulling bundles")
 
 	// default to Restricted
-	c.SecurityContext = SecurityContext{ContextType: Restricted}
+	c.SecurityContext = SecurityContext{ContextType: Legacy}
 	fs.Var(&c.SecurityContext, "security-context-config", "specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy'.")
 }
 
@@ -148,6 +148,7 @@ func (c IndexImageCatalogCreator) CreateCatalog(ctx context.Context, name string
 	cs := newCatalogSource(name, c.cfg.Namespace,
 		withSDKPublisher(c.PackageName),
 		withSecrets(c.SecretName),
+		withGrpcPodConfig(c.SecurityContext.String()),
 	)
 	if err := c.cfg.Client.Create(ctx, cs); err != nil {
 		return nil, fmt.Errorf("error creating catalog source: %v", err)

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -138,7 +138,7 @@ func (c *IndexImageCatalogCreator) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.UseHTTP, "use-http", false, "use plain HTTP for container image registries "+
 		"while pulling bundles")
 
-	// default to Restricted
+	// default to Legacy
 	c.SecurityContext = SecurityContext{ContextType: Legacy}
 	fs.Var(&c.SecurityContext, "security-context-config", "specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy'.")
 }
@@ -148,7 +148,7 @@ func (c IndexImageCatalogCreator) CreateCatalog(ctx context.Context, name string
 	cs := newCatalogSource(name, c.cfg.Namespace,
 		withSDKPublisher(c.PackageName),
 		withSecrets(c.SecretName),
-		withGrpcPodConfig(c.SecurityContext.String()),
+		withGrpcPodSecurityContextConfig(c.SecurityContext.String()),
 	)
 	if err := c.cfg.Client.Create(ctx, cs); err != nil {
 		return nil, fmt.Errorf("error creating catalog source: %v", err)

--- a/internal/olm/operator/registry/olm_resources.go
+++ b/internal/olm/operator/registry/olm_resources.go
@@ -89,11 +89,12 @@ func withSecrets(secretNames ...string) func(*v1alpha1.CatalogSource) {
 	}
 }
 
-func withGrpcPodConfig(securityContextConfig string) func(*v1alpha1.CatalogSource) {
+func withGrpcPodSecurityContextConfig(securityContextConfig string) func(*v1alpha1.CatalogSource) {
 	return func(cs *v1alpha1.CatalogSource) {
-		cs.Spec.GrpcPodConfig = &v1alpha1.GrpcPodConfig{
-			SecurityContextConfig: v1alpha1.SecurityConfig(securityContextConfig),
+		if cs.Spec.GrpcPodConfig == nil {
+			cs.Spec.GrpcPodConfig = &v1alpha1.GrpcPodConfig{}
 		}
+		cs.Spec.GrpcPodConfig.SecurityContextConfig = v1alpha1.SecurityConfig(securityContextConfig)
 	}
 }
 

--- a/internal/olm/operator/registry/olm_resources.go
+++ b/internal/olm/operator/registry/olm_resources.go
@@ -89,6 +89,14 @@ func withSecrets(secretNames ...string) func(*v1alpha1.CatalogSource) {
 	}
 }
 
+func withGrpcPodConfig(securityContextConfig string) func(*v1alpha1.CatalogSource) {
+	return func(cs *v1alpha1.CatalogSource) {
+		cs.Spec.GrpcPodConfig = &v1alpha1.GrpcPodConfig{
+			SecurityContextConfig: v1alpha1.SecurityConfig(securityContextConfig),
+		}
+	}
+}
+
 // newCatalogSource creates a new CatalogSource with a name derived from
 // pkgName, the package manifest's packageName, in namespace. opts will
 // be applied to the CatalogSource object.

--- a/website/content/en/docs/advanced-topics/custom-bundle-validation.md
+++ b/website/content/en/docs/advanced-topics/custom-bundle-validation.md
@@ -309,7 +309,7 @@ $ operator-sdk bundle validate ./bundle --alpha-select-external ./myvalidator/ma
 WARN[0000] Warning: Value sandbox-op.v0.0.1: owned CRD "sandboxes.sandbox.example.come" has an empty description
 INFO[0000] All validation tests have completed successfully
 ```
-[errors-pkg]: https://github.com/operator-framework/api/pkg/tree/master/validation/errors
+[errors-pkg]: https://github.com/operator-framework/api/tree/master/pkg/validation/errors
 [manifest_result]: https://github.com/operator-framework/api/blob/master/pkg/validation/errors/error.go#L9-L16
 [of-api]: https://github.com/operator-framework/api
 [of-validation]: https://github.com/operator-framework/api/tree/master/pkg/validation

--- a/website/content/en/docs/advanced-topics/multi-arch.md
+++ b/website/content/en/docs/advanced-topics/multi-arch.md
@@ -50,7 +50,7 @@ For operators distributed through the [Operator Lifecycle Manager (OLM)][olm]:
 
 [manifest_list]: https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list
 [image_index]: https://github.com/opencontainers/image-spec/blob/main/image-index.md
-[buildah]: https://github.com/containers/buildah/blob/main/docs/buildah-bud.md#building-an-multi-architecture-image-using-a---manifest-option-requires-emulation-software
+[buildah]: https://github.com/containers/buildah/blob/main/docs/buildah-build.1.md#building-an-multi-architecture-image-using-the---manifest-option-requires-emulation-software
 [buildx]: https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images
 [buildx_multiarch]: https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images
 [olm]: https://olm.operatorframework.io/docs/

--- a/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
@@ -24,7 +24,7 @@ operator-sdk run bundle-upgrade <bundle-image> [flags]
       --kubeconfig string                         Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string                          If present, namespace scope for this CLI request
       --pull-secret-name string                   Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
-      --security-context-config SecurityContext   specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy'. (default restricted)
+      --security-context-config SecurityContext   specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy'. (default legacy)
       --service-account string                    Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
       --skip-tls                                  skip authentication of image registry TLS certificate when pulling a bundle image in-cluster
       --skip-tls-verify                           skip TLS certificate verification for container image registries while pulling bundles

--- a/website/content/en/docs/cli/operator-sdk_run_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle.md
@@ -35,7 +35,7 @@ operator-sdk run bundle <bundle-image> [flags]
       --kubeconfig string                         Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string                          If present, namespace scope for this CLI request
       --pull-secret-name string                   Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
-      --security-context-config SecurityContext   specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy'. (default restricted)
+      --security-context-config SecurityContext   specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy'. (default legacy)
       --service-account string                    Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
       --skip-tls                                  skip authentication of image registry TLS certificate when pulling a bundle image in-cluster
       --skip-tls-verify                           skip TLS certificate verification for container image registries while pulling bundles

--- a/website/content/en/docs/contribution-guidelines/releasing.md
+++ b/website/content/en/docs/contribution-guidelines/releasing.md
@@ -198,12 +198,10 @@ We will use the `v1.3.1` release version in this example.
 
 #### 0. Lock down release branches on GitHub
 
-Lock down the `v1.3.x` branch to prevent further merges/commits.
-
-To do this, edit the `Branch protection rules`: https://github.com/operator-framework/operator-sdk/settings/branches
-
-- click `Edit` on the `v.*` branch rule.
-- In section `Protect matching branches` of the `Rule settings` box, set "Required approving reviewers" to `6`.
+1. Lock down the `v1.3.x` branch to prevent further commits before the release completes:
+  1. Go to `Settings -> Branches` in the SDK repo.
+  1. Under `Branch protection rules`, click `Edit` on the `v*.` branch rule.
+  1. In section `Protect matching branches` of the `Rule settings` box, increase the number of required approving reviewers to `6`.
 
 #### 1. Branch
 

--- a/website/content/en/docs/overview/cheat-sheet.md
+++ b/website/content/en/docs/overview/cheat-sheet.md
@@ -70,7 +70,7 @@ make bundle CHANNELS=fast,preview DEFAULT_CHANNEL=stable VERSION=1.0.0 IMG=<some
 [bundle]:https://github.com/operator-framework/operator-registry/blob/v1.16.1/docs/design/operator-bundle.md
 [operatorhub-io]: https://operatorhub.io/
 [upgrade-project]: /docs/olm-integration/generation/#upgrade-your-operator
-[channel-namming-doc]: https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/channel-naming.md
+[channel-namming-doc]: https://olm.operatorframework.io/docs/best-practices/channel-naming/
 [controllers-k8s-doc]: https://kubernetes.io/docs/concepts/architecture/controller
 [gkvs]: https://book.kubebuilder.io/cronjob-tutorial/gvks.html
 [extend-k8s-api]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/

--- a/website/content/en/docs/upgrading-sdk-version/v1.5.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.5.0.md
@@ -11,7 +11,7 @@ _See [#4402](https://github.com/operator-framework/operator-sdk/pull/4402) for m
 
 ## PROJECT config version 3-alpha must be upgraded to 3.
 
-PROJECT config version 3-alpha has been stabilized as [version 3](https://github.com/kubernetes-sigs/kubebuilder/blob/master/docs/book/src/migration/manually_migration_guide_v2_v3.md) (the `version` key in your PROJECT file), and contains a set of config fields sufficient to fully describe a project. While this change is not technically breaking because the spec at that version was alpha, it was used by default in `operator-sdk` commands so should be marked as breaking and have a convenient migration path. The `alpha config-3alpha-to-3` command will convert most of your PROJECT file from version 3-alpha to 3, and leave comments with directions where automatic conversion is not possible:
+PROJECT config version 3-alpha has been stabilized as [version 3](https://github.com/kubernetes-sigs/kubebuilder/blob/master/docs/book/src/migration/legacy/manually_migration_guide_v2_v3.md) (the `version` key in your PROJECT file), and contains a set of config fields sufficient to fully describe a project. While this change is not technically breaking because the spec at that version was alpha, it was used by default in `operator-sdk` commands so should be marked as breaking and have a convenient migration path. The `alpha config-3alpha-to-3` command will convert most of your PROJECT file from version 3-alpha to 3, and leave comments with directions where automatic conversion is not possible:
 
 ```console
 $ cat PROJECT


### PR DESCRIPTION
**Description of the change:**
- Update default channel name selection to be different based on using FBC vs SQLite image.
- Update the `SecurityContext` from the registry pod containers created by `operator-sdk run bundle(-upgrade)` to only be added to the containers when `--security-context-config=restricted`
- Change default of `--security-context-config` flag to be `legacy` in anticipation of some OpenShift PSA changes.
- Set the `CatalogSource.grpcPodConfig.securityContextConfig` to the same value of the `--security-context-config` flag.

**Motivation for the change:**
- Fixes a bug where SQLite bundle images couldn't be properly run due to setting the default channel name to `operator-sdk-run-bundle`.
    - This became a problem because we can manipulate FBCs to utilize this default channel, but we can not as easily manipulate the SQLite bundle to do the same.
- Fixes a bug where even when specifying `--security-context-config=legacy` , the registry pod created still set the `SecurityContext` on the container as if it was in a restricted environment.


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
