### PR TITLE
Handle GroupDiscoveryFailedError in proxy.go (#5596)

### DIFF
--- a/changelog/fragments/01-orphaned-apiserices.yaml
+++ b/changelog/fragments/01-orphaned-apiserices.yaml
@@ -1,0 +1,17 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For ansible-based operators, orphaned apiservices no longer cause a fatal
+      error when looking up api resources in the cluster
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false


### PR DESCRIPTION
**Description of the change:**

Similar to [the fix in helm](https://github.com/helm/helm/issues/6361), this fix allows GroupDiscoveryFailedError to not error out the process of managing apiserver resource types.

**Motivation for the change:**

The proposed fix in #5596 requires that the cluster's state be fixed (upgrading / cleaning up the metrics server `apiserver` resource). While this is correct, it's not a fix that can be made by the author of an `operator` as it requires the _user_ of the operator to fix their cluster. Fixing this on the client side (in the `operator` itself) will save headaches and support tickets in the future.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
