### PR TITLE
Print kuttl logs if kuttl tests cannot be started

### DIFF
--- a/changelog/fragments/6225-print-kuttl-logs.yaml
+++ b/changelog/fragments/6225-print-kuttl-logs.yaml
@@ -1,0 +1,24 @@
+entries:
+  - description: >
+      The `scorecard-test-kuttl` image always prints the kuttl logs
+      in case there is an error processing the kuttl report.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: change
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/images/scorecard-test-kuttl/main.go
+++ b/images/scorecard-test-kuttl/main.go
@@ -57,7 +57,7 @@ func main() {
 
 	var suite *Testsuite
 	if len(jsonReport.Testsuite) == 0 {
-		printErrorStatus(errors.New("empty kuttl test suite was found"))
+		printErrorStatus(errors.New("no kuttl test suite was found. kuttl may not have run successfully"))
 		return
 	}
 
@@ -103,6 +103,7 @@ func printErrorStatus(err error) {
 	r := v1alpha3.TestResult{}
 	r.State = v1alpha3.FailState
 	r.Errors = []string{err.Error()}
+	r.Log = getKuttlLogs()
 	s.Results = append(s.Results, r)
 	jsonOutput, err := json.MarshalIndent(s, "", "    ")
 	if err != nil {
@@ -189,14 +190,12 @@ type Testsuites struct {
 func getKuttlLogs() string {
 	stderrFile, err := os.ReadFile("/tmp/kuttl.stderr")
 	if err != nil {
-		printErrorStatus(fmt.Errorf("could not open kuttl stderr file %v", err))
-		return err.Error()
+		return fmt.Sprintf("could not open kuttl stderr file: %v", err)
 	}
 
 	stdoutFile, err := os.ReadFile("/tmp/kuttl.stdout")
 	if err != nil {
-		printErrorStatus(fmt.Errorf("could not open kuttl stdout file %v", err))
-		return err.Error()
+		return fmt.Sprintf("could not open kuttl stdout file: %v", err)
 	}
 
 	return string(stderrFile) + string(stdoutFile)


### PR DESCRIPTION
**Description of the change:**
Print kuttl logs if kuttl tests cannot be started  (for example when specifying an inaccessible path in `crdDir`).

**Motivation for the change:**
The `empty kuttl test suite was found` error message is not helpful in case kuttl cannot be started.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
