### PR TITLE
fix: align example code to comments

### DIFF
--- a/website/content/en/docs/building-operators/golang/advanced-topics.md
+++ b/website/content/en/docs/building-operators/golang/advanced-topics.md
@@ -164,7 +164,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
         }
         // Error reading the object - requeue the request.
         reqLogger.Error(err, "Failed to get Memcached.")
-        return ctrl.Result{}, err
+        return ctrl.Result{Requeue: true}, err
     }
 
     ...


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

Aligns the code example to what the proceeding comment above it says. When I was reading through, it seems to imply with this example that a blank `ctrl.Result{}` will perform the retry, later code populates the struct with a `bool` for this behaviour.

```go
...
		// Error reading the object - requeue the request. <-- this comment
		log.Error(err, "Failed to get memcached")
		return ctrl.Result{}, err // <-- there is no {Requeue: true}
```

However, later on it demonstrates that the code for this would include the `Requeue: true` field, such as below.

```go
...
			log.Error(err, "Failed to add finalizer into the custom resource")
			return ctrl.Result{Requeue: true}, nil
```

I understand that this is `testdata`, which may be similar to this comment https://github.com/operator-framework/operator-sdk/pull/6211#issuecomment-1341373531, but I could not find where this would be generated from - any pointers are welcome.

If this is a legitimate fix, then a similar issue is present in multiple places where this comment resides, which I can also remedy. I'm raising this in a single place to point out what I believe to be an issue.

```bash
rg "requeue the request"
website/content/en/docs/upgrading-sdk-version/v0.1.0-migration-guide.md
172:        // Error reading the object - requeue the request.

website/content/en/docs/building-operators/golang/advanced-topics.md
165:        // Error reading the object - requeue the request.

website/content/en/docs/building-operators/golang/references/logging.md
219:            // Error reading the object - requeue the request.

testdata/go/v3/memcached-operator/controllers/memcached_controller.go
97:             // Error reading the object - requeue the request.

testdata/go/v4-alpha/memcached-operator/controllers/memcached_controller.go
97:             // Error reading the object - requeue the request.

testdata/go/v4-alpha/monitoring/memcached-operator/controllers/memcached_controller.go
128:            // Error reading the object - requeue the request.

testdata/go/v3/monitoring/memcached-operator/controllers/memcached_controller.go
128:            // Error reading the object - requeue the request.
```


**Motivation for the change:**

When reading the code for the first time it may be somewhat misleading that a blank `ctrl.Result` struct performs a requeuing of the request.

If this is not a problem, feel free to close this pull request.


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
