### PR TITLE
fixing formatting in 1.25.0 doc and updating install prereq

### DIFF
--- a/website/content/en/docs/installation/_index.md
+++ b/website/content/en/docs/installation/_index.md
@@ -88,7 +88,7 @@ chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/l
 #### Prerequisites
 
 - [git][git_tool]
-- [go][go_tool] version 1.18
+- [go][go_tool] version 1.19
   - Ensure that your `GOPROXY` is set to `"https://proxy.golang.org|direct"`
 
 ```sh

--- a/website/content/en/docs/upgrading-sdk-version/v1.25.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.25.0.md
@@ -25,17 +25,19 @@ weight: 998975000
     PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
     .PHONY: docker-buildx
     docker-buildx: test ## Build and push docker image for the manager for cross-platform support
-      # copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-      sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
-      - docker buildx create --name project-v3-builder
-      docker buildx use project-v3-builder
-      - docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
-      - docker buildx rm project-v3-builder
-      rm Dockerfile.cross
+        # copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+        sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+        - docker buildx create --name project-v3-builder
+        docker buildx use project-v3-builder
+        - docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+        - docker buildx rm project-v3-builder
+        rm Dockerfile.cross
     ```
 3. (go/v3) Bump dependencies in go.mod file
 
     ```go
+        go 1.19   
+
       	github.com/onsi/ginkgo/v2 v2.1.4
         github.com/onsi/gomega v1.19.0
         github.com/prometheus/client_golang v1.12.2
@@ -52,7 +54,7 @@ _See [#6047](https://github.com/operator-framework/operator-sdk/pull/6047) for m
 In the project `Makefile` below the `docker-push` target add the new `docker-buildx`
 target.
 
-```yaml
+```sh
 # PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
 # - able to use docker buildx . More info: https://docs.docker.com/build/buildx/


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Fixing some formatting issues in the 1.25.0 upgrade code and change the instillation prereq to be go 1.19

**Motivation for the change:**
When following the upgrade from 1.22 to 1.26 I noticed some formating issues in the 1.25.0 doc that caused them to not copy properly, and also missing the need to change from go 1.18 to go 1.19.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)


Signed-off-by: Adam D. Cornett <adc@redhat.com>