### PR TITLE
[v1.25.x] (bugfix): bump operator-framework/api dependency version (#6227)

### DIFF
--- a/changelog/fragments/01-validate-bugfix.yaml
+++ b/changelog/fragments/01-validate-bugfix.yaml
@@ -1,0 +1,20 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      `operator-sdk bundle validate`: Fix a bug in the Kubernetes 1.25 validation logic that would warn that a
+      Kubernetes resource was deprecated without checking the group that contains the resource. 
+      (i.e if apps/deployments was deprecated and you used other/deployments you would recieve a warning)".
+      The validation logic will now verify the group and resource before issuing a warning.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false
+

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2
 	github.com/onsi/ginkgo/v2 v2.2.0
 	github.com/onsi/gomega v1.20.2
-	github.com/operator-framework/api v0.17.2-0.20221028193825-b611f6cef49c
+	github.com/operator-framework/api v0.17.4-0.20221221181915-f1b729684854
 	github.com/operator-framework/helm-operator-plugins v0.0.12-0.20221014213227-6f6106714f0d
 	github.com/operator-framework/java-operator-plugins v0.7.1-0.20221007075838-2e24140314fb
 	github.com/operator-framework/operator-lib v0.11.1-0.20220921174810-791cc547e6c5

--- a/go.sum
+++ b/go.sum
@@ -818,8 +818,8 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
-github.com/operator-framework/api v0.17.2-0.20221028193825-b611f6cef49c h1:aQPFE1Oc7qh02FniuUrAeUemv01wfisfUHGL1aQOxEc=
-github.com/operator-framework/api v0.17.2-0.20221028193825-b611f6cef49c/go.mod h1:34tb98EwTN5SZLkgoxwvRkhMJKLHUWHOrrcv1ZwvEeA=
+github.com/operator-framework/api v0.17.4-0.20221221181915-f1b729684854 h1:/EFqPU6baS6MzfLvIeGlfVV0bDLehlA1jwSxHxL0D9s=
+github.com/operator-framework/api v0.17.4-0.20221221181915-f1b729684854/go.mod h1:34tb98EwTN5SZLkgoxwvRkhMJKLHUWHOrrcv1ZwvEeA=
 github.com/operator-framework/helm-operator-plugins v0.0.12-0.20221014213227-6f6106714f0d h1:xPqV1TH9ZCbo/fNIp1CVMYlKkD28wmIMrwuwibXaXo4=
 github.com/operator-framework/helm-operator-plugins v0.0.12-0.20221014213227-6f6106714f0d/go.mod h1:zaxx1ikQMg/sm/j5WDG2aJHK4phIti5TkeKH8EePt0M=
 github.com/operator-framework/java-operator-plugins v0.7.1-0.20221007075838-2e24140314fb h1:lHKsuPfcDwgFFvwwh4OdA9MUyZ+xY82Q/xztJkotUKI=


### PR DESCRIPTION
 Cherry-pick of https://github.com/operator-framework/operator-sdk/pull/6227