### PR TITLE
[v1.25.x] updated code and made state as pass and throw suggestion instead of error for missing spec in CR

### DIFF
--- a/changelog/fragments/spec-scoreacrd-fix.yaml
+++ b/changelog/fragments/spec-scoreacrd-fix.yaml
@@ -1,0 +1,17 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      (scorecard): Fixes a bug where an error would be thrown if a Custom Resource did not have a `.spec` field, which is a perfectly valid scenario.  Instead of throwing an error scorecard will now issue a suggestion.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false
+

--- a/internal/scorecard/tests/basic.go
+++ b/internal/scorecard/tests/basic.go
@@ -50,8 +50,7 @@ func checkSpec(crSet []unstructured.Unstructured,
 	res scapiv1alpha3.TestResult) scapiv1alpha3.TestResult {
 	for _, cr := range crSet {
 		if cr.Object["spec"] == nil {
-			res.Errors = append(res.Errors, fmt.Sprintf("error spec does not exist for the custom resource %s", cr.GetName()))
-			res.State = scapiv1alpha3.FailState
+			res.State = scapiv1alpha3.PassState
 			res.Suggestions = append(res.Suggestions, fmt.Sprintf("spec missing from [%+v]", cr.GetName()))
 			return res
 		}

--- a/internal/scorecard/tests/bundle_test.go
+++ b/internal/scorecard/tests/bundle_test.go
@@ -283,7 +283,7 @@ var _ = Describe("Basic and OLM tests", func() {
 					},
 				}
 				result = checkSpec(cr, result)
-				Expect(result.State).To(Equal(scapiv1alpha3.FailState))
+				Expect(result.State).To(Equal(scapiv1alpha3.PassState))
 			})
 			It("should pass when CRs do have spec field specified", func() {
 				cr := []unstructured.Unstructured{


### PR DESCRIPTION
Cherry-pick of PR https://github.com/operator-framework/operator-sdk/pull/6245