### PR TITLE
Upgrade Ubuntu runner image in github actions

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   # Build the ansible-operator-base image.
   ansible-operator-base:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: deploy
     steps:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   check_docs_only:
     name: check_docs_only
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
@@ -34,7 +34,7 @@ jobs:
     needs: check_docs_only
     # Run this job on a tag like 'vX.Y.Z' or on a branch or pull request with code changes.
     if: startsWith(github.ref, 'refs/tags/v') || ( needs.check_docs_only.outputs.skip != 'true' && !startsWith(github.ref, 'refs/tags/') )
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: deploy
     steps:
     - name: checkout
@@ -68,7 +68,7 @@ jobs:
     needs: check_docs_only
     # Run this job on a tag like 'vX.Y.Z' or on a branch or pull request with code changes.
     if: startsWith(github.ref, 'refs/tags/v') || ( needs.check_docs_only.outputs.skip != 'true' && !startsWith(github.ref, 'refs/tags/') )
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: deploy
     strategy:
       matrix:
@@ -117,7 +117,7 @@ jobs:
     needs: check_docs_only
     # Run this job on a tag like 'scorecard-kuttl/vX.Y.Z' or on a branch or pull request with code changes.
     if: startsWith(github.ref, 'refs/tags/scorecard-kuttl/v') || ( needs.check_docs_only.outputs.skip != 'true' && !startsWith(github.ref, 'refs/tags/') )
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: deploy
     steps:
 

--- a/.github/workflows/freshen-images.yml
+++ b/.github/workflows/freshen-images.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   git_tags:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       git_tags: ${{ steps.tags.outputs.git_tags }}
     steps:
@@ -27,7 +27,7 @@ jobs:
   build:
     name: build
     needs: git_tags
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: deploy
     strategy:
       matrix:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   check_docs_only:
     name: check_docs_only
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
@@ -22,7 +22,7 @@ jobs:
 
   integration:
     name: integration
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -6,7 +6,7 @@ jobs:
   rerun_tests:
     name: rerun_pr_tests
     if: ${{ github.event.issue.pull_request }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: operator-framework/rerun-actions@v0.4.0
       with:

--- a/.github/workflows/test-ansible.yml
+++ b/.github/workflows/test-ansible.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   check_docs_only:
     name: check_docs_only
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
@@ -22,7 +22,7 @@ jobs:
 
   e2e:
     name: e2e
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:
@@ -37,7 +37,7 @@ jobs:
 
   e2e-molecule:
     name: e2e-molecule
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   check_docs_only:
     name: check_docs_only
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
@@ -25,7 +25,7 @@ jobs:
 
   e2e:
     name: e2e
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:
@@ -40,7 +40,7 @@ jobs:
 
   unit:
     name: unit
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   check_docs_only:
     name: check_docs_only
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
@@ -22,7 +22,7 @@ jobs:
 
   e2e:
     name: e2e
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:

--- a/.github/workflows/test-sample-go.yml
+++ b/.github/workflows/test-sample-go.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   check_docs_only:
     name: check_docs_only
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
@@ -22,7 +22,7 @@ jobs:
 
   e2e:
     name: e2e
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:

--- a/.github/workflows/test-sanity.yml
+++ b/.github/workflows/test-sanity.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   check_docs_only:
     name: check_docs_only
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
@@ -22,7 +22,7 @@ jobs:
 
   sanity:
     name: sanity
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:
@@ -38,7 +38,7 @@ jobs:
 
   docs:
     name: docs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
New Ubuntu 22.04 runner image has been released


**Description of the change:**
Upgrade[ Ubuntu runner image](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners) in Github Actions- `ubuntu-20.04`->`ubuntu-22.04`

**Motivation for the change:**
Use the latest Ubuntu runner image for CI.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
