### PR TITLE
Upgrade Five GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -31,7 +31,7 @@ jobs:
         registry: quay.io
 
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
 

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -24,7 +24,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: quay.io login
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -21,7 +21,7 @@ jobs:
       uses: docker/setup-qemu-action@v2
 
     - name: set up buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: quay.io login
       uses: docker/login-action@v1

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
     - name: set up qemu
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: set up buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - id: check_docs_only
@@ -38,7 +38,7 @@ jobs:
     environment: deploy
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -91,7 +91,7 @@ jobs:
 
     # Check out repo before tag step for script.
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -137,7 +137,7 @@ jobs:
 
     # Check out repo before tag step for script.
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
 
     - name: set up qemu
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: set up buildx
       uses: docker/setup-buildx-action@v1
@@ -122,7 +122,7 @@ jobs:
     steps:
 
     - name: set up qemu
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: set up buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,7 @@ jobs:
       uses: docker/setup-qemu-action@v2
 
     - name: set up buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: quay.io login
       if: github.event_name != 'pull_request'
@@ -125,7 +125,7 @@ jobs:
       uses: docker/setup-qemu-action@v2
 
     - name: set up buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: quay.io login
       if: github.event_name != 'pull_request'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
         fetch-depth: 0
 
     - name: install
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.19
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
 
     - name: quay.io login
       if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
@@ -129,7 +129,7 @@ jobs:
 
     - name: quay.io login
       if: github.event_name != 'pull_request'
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/freshen-images.yml
+++ b/.github/workflows/freshen-images.yml
@@ -18,7 +18,7 @@ jobs:
       git_tags: ${{ steps.tags.outputs.git_tags }}
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - id: tags
@@ -45,7 +45,7 @@ jobs:
         password: ${{ secrets.QUAY_PASSWORD }}
         registry: quay.io
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
     - name: build and push

--- a/.github/workflows/freshen-images.yml
+++ b/.github/workflows/freshen-images.yml
@@ -37,7 +37,7 @@ jobs:
     - name: set up qemu
       uses: docker/setup-qemu-action@v2
     - name: set up buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
     - name: quay.io login
       uses: docker/login-action@v1
       with:

--- a/.github/workflows/freshen-images.yml
+++ b/.github/workflows/freshen-images.yml
@@ -35,7 +35,7 @@ jobs:
         id: ["operator-sdk", "ansible-operator", "helm-operator", "scorecard-test"]
     steps:
     - name: set up qemu
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
     - name: set up buildx
       uses: docker/setup-buildx-action@v1
     - name: quay.io login

--- a/.github/workflows/freshen-images.yml
+++ b/.github/workflows/freshen-images.yml
@@ -39,7 +39,7 @@ jobs:
     - name: set up buildx
       uses: docker/setup-buildx-action@v2
     - name: quay.io login
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - id: check_docs_only
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.19
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - run: make test-e2e-integration

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - uses: actions/checkout@v3

--- a/.github/workflows/test-ansible.yml
+++ b/.github/workflows/test-ansible.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - id: check_docs_only
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.19
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - run: sudo rm -rf /usr/local/bin/kustomize
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.19
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - run: sudo rm -rf /usr/local/bin/kustomize

--- a/.github/workflows/test-ansible.yml
+++ b/.github/workflows/test-ansible.yml
@@ -26,7 +26,7 @@ jobs:
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - uses: actions/checkout@v3
@@ -41,7 +41,7 @@ jobs:
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - uses: actions/checkout@v3

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - id: check_docs_only
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.19
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - run: sudo rm -rf /usr/local/bin/kustomize
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.19
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - run: make test-unit

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -29,7 +29,7 @@ jobs:
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - uses: actions/checkout@v3

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - id: check_docs_only
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.19
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - run: sudo rm -rf /usr/local/bin/kustomize

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -26,7 +26,7 @@ jobs:
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - uses: actions/checkout@v3

--- a/.github/workflows/test-sample-go.yml
+++ b/.github/workflows/test-sample-go.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - id: check_docs_only
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.19
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - run: sudo rm -rf /usr/local/bin/kustomize

--- a/.github/workflows/test-sample-go.yml
+++ b/.github/workflows/test-sample-go.yml
@@ -26,7 +26,7 @@ jobs:
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - uses: actions/checkout@v3

--- a/.github/workflows/test-sanity.yml
+++ b/.github/workflows/test-sanity.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       skip: ${{ steps.check_docs_only.outputs.skip }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - id: check_docs_only
@@ -30,7 +30,7 @@ jobs:
       with:
         go-version: 1.19
       id: go
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - run: sudo rm -rf /usr/local/bin/kustomize
@@ -40,7 +40,7 @@ jobs:
     name: docs
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
         submodules: recursive

--- a/.github/workflows/test-sanity.yml
+++ b/.github/workflows/test-sanity.yml
@@ -26,7 +26,7 @@ jobs:
     needs: check_docs_only
     if: needs.check_docs_only.outputs.skip != 'true'
     steps:
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: 1.19
       id: go


### PR DESCRIPTION
**Description of the change:**
Upgrade Five GitHub Action Versions

**Motivation for the change:**
There are newer versions for five GitHub Actions : 

- [actions/checkout](https://github.com/actions/checkout/releases)
- [actions/setup-go](https://github.com/actions/setup-go/releases)
- [docker/setup-qemu-action](https://github.com/docker/setup-qemu-action/releases)
- [docker/setup-buildx-action](https://github.com/docker/setup-buildx-action/releases)
- [docker/login-action](https://github.com/docker/login-action/releases)

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
