### PR TITLE
(bugfix): `operator-sdk bundle validate` returns exit code 0 despite test failures

### DIFF
--- a/changelog/fragments/6247-bundle-validate-exit-code.yaml
+++ b/changelog/fragments/6247-bundle-validate-exit-code.yaml
@@ -1,0 +1,8 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For `operator-sdk bundle validate`: Fix a bug that would make the command exit with a 0 exit code even if there
+      were validation failures.
+    kind: "bugfix"
+    breaking: false

--- a/internal/cmd/operator-sdk/bundle/validate/cmd.go
+++ b/internal/cmd/operator-sdk/bundle/validate/cmd.go
@@ -159,10 +159,11 @@ func NewCmd() *cobra.Command {
 			}
 
 			// if a test failed don't print that it was successful
-			if !failed {
-				logger.Info("All validation tests have completed successfully")
+			if failed {
+				os.Exit(1)
 			}
 
+			logger.Info("All validation tests have completed successfully")
 			return nil
 		},
 	}


### PR DESCRIPTION
**Description of the change:**
Updates the `operator-sdk bundle validate` command to properly issue a non-zero exit code if there are validation test failures.

**Motivation for the change:**
- fixes #6247 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
