### PR TITLE
fix broken links to molecule docs

### DIFF
--- a/website/content/en/docs/building-operators/ansible/testing-guide.md
+++ b/website/content/en/docs/building-operators/ansible/testing-guide.md
@@ -48,7 +48,7 @@ Our molecule scenarios have the following basic structure:
 └── verify.yml
 ```
 
-- `molecule.yml` is a configuration file for molecule. It defines what driver to use to stand up an environment and the associated configuration, linting rules, and a variety of other configuration options. For full documentation on the options available here, see the [molecule configuration documentation](https://molecule.readthedocs.io/en/latest/configuration.html)
+- `molecule.yml` is a configuration file for molecule. It defines what driver to use to stand up an environment and the associated configuration, linting rules, and a variety of other configuration options. For full documentation on the options available here, see the [molecule configuration documentation](https://molecule.readthedocs.io/en/latest/configuration)
 
 - `prepare.yml` is an Ansible playbook that is run once during the set up of a scenario. You can put any arbitrary Ansible in this playbook. It is used for one-time configuration of your test environment, for example, creating the cluster-wide `CustomResourceDefinition` that your Operator will watch.
 

--- a/website/content/en/docs/upgrading-sdk-version/version-upgrade-guide.md
+++ b/website/content/en/docs/upgrading-sdk-version/version-upgrade-guide.md
@@ -1288,7 +1288,7 @@ which ./bin/openapi-gen > /dev/null || go build -o ./bin/openapi-gen k8s.io/kube
 The Molecule version for Ansible based-operators was upgraded from `2.22` to `3.0.2`. The following changes are required in the default scaffold files.
 
 - Remove the `scenario.name` from `molecule.yaml` and then, ensure that any condition with will look for the folder name which determines the scenario name from now on
-- Replace the lint with newer syntax from [documentation](https://molecule.readthedocs.io/en/latest/configuration.html#lint). See:
+- Replace the lint with newer syntax from [documentation](https://molecule.readthedocs.io/en/latest/contributing/#linting). See:
 
 Replace:
 


### PR DESCRIPTION
Looks like these are failing in CI? not sure what's the deal with the original links, but I fixed them to where I think they're supposed to go.