### PR TITLE
Fix Ansible CI

### DIFF
--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -27,11 +27,12 @@ set +u; source "${ENVDIR}/bin/activate"; set -u
 TMPDIR="$(mktemp -d)"
 trap_add "rm -rf $TMPDIR" EXIT
 pip3 install pyasn1==0.4.7 pyasn1-modules==0.2.6 idna==2.8 ipaddress==1.0.23
-pip3 install cryptography==3.3.2 molecule==3.0.2
+pip3 install cryptography==3.3.2 molecule==3.6.0
 pip3 install ansible-lint yamllint
-pip3 install docker==4.2.2 openshift==0.12.1 jmespath
+pip3 install docker openshift==0.12.1 jmespath
 ansible-galaxy collection install 'kubernetes.core:==2.2.0'
 ansible-galaxy collection install 'operator_sdk.util:==0.4.0'
+ansible-galaxy collection install 'community.docker:==3.4.0'
 
 header_text "Copying molecule testdata scenarios"
 ROOTDIR="$(pwd)"

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
@@ -43,4 +43,6 @@ collections:
     version: "2.3.1"
   - name: cloud.common
     version: "2.1.1"
+  - name: community.docker
+    version: "3.4.0"
 `

--- a/testdata/ansible/memcached-operator/requirements.yml
+++ b/testdata/ansible/memcached-operator/requirements.yml
@@ -8,3 +8,5 @@ collections:
     version: "2.3.1"
   - name: cloud.common
     version: "2.1.1"
+  - name: community.docker
+    version: "3.4.0"


### PR DESCRIPTION
**Description of the change:**
- Update molecule version in CI and the default ansible scaffolds to support a newer molecule version.

**Motivation for the change:**
- Fix the ansible CI failures

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
