### PR TITLE
(ansible): update ansible base images to use multi-stage builds

### DIFF
--- a/changelog/fragments/01-ansible-image-fixes.yaml
+++ b/changelog/fragments/01-ansible-image-fixes.yaml
@@ -1,0 +1,17 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+     For ansible operators: fix a bug where the quay.io/operator-framework/ansible-operator image did not
+     include the cryptography package on ppc64le & s390x architectures.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false

--- a/images/ansible-operator-2.11-preview/base.Dockerfile
+++ b/images/ansible-operator-2.11-preview/base.Dockerfile
@@ -1,20 +1,12 @@
 # This Dockerfile defines the base image for the ansible-operator image.
 # It is built with dependencies that take a while to download, thus speeding
 # up ansible deploy jobs.
+FROM registry.access.redhat.com/ubi8/ubi:8.7 AS builder
 
-FROM registry.access.redhat.com/ubi8/ubi:8.7
-ARG TARGETARCH
-
-# Label this image with the repo and commit that built it, for freshmaking purposes.
-ARG GIT_COMMIT=devel
-LABEL git_commit=$GIT_COMMIT
-
-RUN mkdir -p /etc/ansible \
-  && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
-  && echo '[defaults]' > /etc/ansible/ansible.cfg \
-  && echo 'roles_path = /opt/ansible/roles' >> /etc/ansible/ansible.cfg \
-  && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg
-
+# Install Rust so that we can ensure backwards compatibility with installing/building the cryptography wheel across all platforms
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustc --version
 
 # Copy python dependencies (including ansible) to be installed using Pipenv
 COPY Pipfile* ./
@@ -30,13 +22,36 @@ ENV PIP_NO_CACHE_DIR=1 \
 RUN set -e && yum clean all && rm -rf /var/cache/yum/* \
   && yum update -y \
   && yum install -y libffi-devel openssl-devel python38-devel gcc python38-pip python38-setuptools \
-  && pip3 install --upgrade pip~=21.1.0 \
+  && pip3 install --upgrade pip~=23.0.1 \
   && pip3 install pipenv==2022.1.8 \
   && pipenv install --deploy \
-  && pipenv check -i 45114 \
+  && pipenv check  -i 42926 -i 42923 -i 45114 \
   && yum remove -y gcc libffi-devel openssl-devel python38-devel \
   && yum clean all \
   && rm -rf /var/cache/yum
+
+FROM registry.access.redhat.com/ubi8/ubi:8.7
+ARG TARGETARCH
+
+# Label this image with the repo and commit that built it, for freshmaking purposes.
+ARG GIT_COMMIT=devel
+LABEL git_commit=$GIT_COMMIT
+
+RUN mkdir -p /etc/ansible \
+  && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
+  && echo '[defaults]' > /etc/ansible/ansible.cfg \
+  && echo 'roles_path = /opt/ansible/roles' >> /etc/ansible/ansible.cfg \
+  && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg
+
+RUN set -e && yum clean all && rm -rf /var/cache/yum/* \
+  && yum update -y \
+  && yum install -y python38-pip python38-setuptools \
+  && pip3 install --upgrade pip~=23.0.1 \
+  && yum clean all \
+  && rm -rf /var/cache/yum
+
+COPY --from=builder /usr/local/lib64/python3.8/site-packages /usr/local/lib64/python3.8/site-packages
+COPY --from=builder /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
 
 ENV TINI_VERSION=v0.19.0
 RUN curl -L -o /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} \

--- a/images/ansible-operator-2.11-preview/base.Dockerfile
+++ b/images/ansible-operator-2.11-preview/base.Dockerfile
@@ -1,6 +1,7 @@
 # This Dockerfile defines the base image for the ansible-operator image.
 # It is built with dependencies that take a while to download, thus speeding
 # up ansible deploy jobs.
+
 FROM registry.access.redhat.com/ubi8/ubi:8.7 AS builder
 
 # Install Rust so that we can ensure backwards compatibility with installing/building the cryptography wheel across all platforms
@@ -23,7 +24,7 @@ RUN set -e && yum clean all && rm -rf /var/cache/yum/* \
   && yum update -y \
   && yum install -y libffi-devel openssl-devel python38-devel gcc python38-pip python38-setuptools \
   && pip3 install --upgrade pip~=23.0.1 \
-  && pip3 install pipenv==2022.1.8 \
+  && pip3 install pipenv==2023.2.18 \
   && pipenv install --deploy \
   && pipenv check  -i 42926 -i 42923 -i 45114 \
   && yum remove -y gcc libffi-devel openssl-devel python38-devel \
@@ -47,6 +48,7 @@ RUN set -e && yum clean all && rm -rf /var/cache/yum/* \
   && yum update -y \
   && yum install -y python38-pip python38-setuptools \
   && pip3 install --upgrade pip~=23.0.1 \
+  && pip3 install pipenv==2023.2.18 \
   && yum clean all \
   && rm -rf /var/cache/yum
 

--- a/images/ansible-operator/base.Dockerfile
+++ b/images/ansible-operator/base.Dockerfile
@@ -2,19 +2,12 @@
 # It is built with dependencies that take a while to download, thus speeding
 # up ansible deploy jobs.
 
-FROM registry.access.redhat.com/ubi8/ubi:8.7
-ARG TARGETARCH
+FROM registry.access.redhat.com/ubi8/ubi:8.7 AS builder
 
-# Label this image with the repo and commit that built it, for freshmaking purposes.
-ARG GIT_COMMIT=devel
-LABEL git_commit=$GIT_COMMIT
-
-RUN mkdir -p /etc/ansible \
-  && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
-  && echo '[defaults]' > /etc/ansible/ansible.cfg \
-  && echo 'roles_path = /opt/ansible/roles' >> /etc/ansible/ansible.cfg \
-  && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg
-
+# Install Rust so that we can ensure backwards compatibility with installing/building the cryptography wheel across all platforms
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustc --version
 
 # Copy python dependencies (including ansible) to be installed using Pipenv
 COPY Pipfile* ./
@@ -30,13 +23,37 @@ ENV PIP_NO_CACHE_DIR=1 \
 RUN set -e && yum clean all && rm -rf /var/cache/yum/* \
   && yum update -y \
   && yum install -y libffi-devel openssl-devel python38-devel gcc python38-pip python38-setuptools \
-  && pip3 install --upgrade pip~=21.1.0 \
-  && pip3 install pipenv==2022.1.8 \
+  && pip3 install --upgrade pip~=23.0.1 \
+  && pip3 install pipenv==2023.2.18 \
   && pipenv install --deploy \
   && pipenv check  -i 42926 -i 42923 -i 45114 \
   && yum remove -y gcc libffi-devel openssl-devel python38-devel \
   && yum clean all \
   && rm -rf /var/cache/yum
+
+FROM registry.access.redhat.com/ubi8/ubi:8.7
+ARG TARGETARCH
+
+# Label this image with the repo and commit that built it, for freshmaking purposes.
+ARG GIT_COMMIT=devel
+LABEL git_commit=$GIT_COMMIT
+
+RUN mkdir -p /etc/ansible \
+  && echo "localhost ansible_connection=local" > /etc/ansible/hosts \
+  && echo '[defaults]' > /etc/ansible/ansible.cfg \
+  && echo 'roles_path = /opt/ansible/roles' >> /etc/ansible/ansible.cfg \
+  && echo 'library = /usr/share/ansible/openshift' >> /etc/ansible/ansible.cfg
+
+RUN set -e && yum clean all && rm -rf /var/cache/yum/* \
+  && yum update -y \
+  && yum install -y python38-pip python38-setuptools \
+  && pip3 install --upgrade pip~=23.0.1 \
+  && pip3 install pipenv==2023.2.18 \
+  && yum clean all \
+  && rm -rf /var/cache/yum
+
+COPY --from=builder /usr/local/lib64/python3.8/site-packages /usr/local/lib64/python3.8/site-packages
+COPY --from=builder /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
 
 ENV TINI_VERSION=v0.19.0
 RUN curl -L -o /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} \


### PR DESCRIPTION
**Description of the change:**
Updates the ansible operator images base.Dockerfile to multi-stage builds so that we can ensure all packages are always included in the images we deliver by installing/building all packages in a build stage and copying them over to the final build stage.

**Motivation for the change:**
fixes #6302

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
