### PR TITLE
(ansible): update kubernetes.core collection default to v2.4.0

### DIFF
--- a/changelog/fragments/02-update-kubernetes-core.yaml
+++ b/changelog/fragments/02-update-kubernetes-core.yaml
@@ -1,0 +1,42 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For ansible operators: fix a JSON parsing bug by updating the kubernetes.core collection to v2.4.0
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: (ansible) - Upgrade kubernetes.core collection to v2.4.0
+      body: |
+        In the requirements.yaml file replace:
+        ```yaml
+          - name: kubernetes.core
+            version: "2.3.1"
+        ```
+        with:
+        ```yaml
+          - name: kubernetes.core
+            version: "2.4.0"
+        ```

--- a/internal/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
+++ b/internal/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
@@ -40,7 +40,7 @@ collections:
   - name: operator_sdk.util
     version: "0.4.0"
   - name: kubernetes.core
-    version: "2.3.1"
+    version: "2.4.0"
   - name: cloud.common
     version: "2.1.1"
   - name: community.docker

--- a/testdata/ansible/memcached-operator/requirements.yml
+++ b/testdata/ansible/memcached-operator/requirements.yml
@@ -5,7 +5,7 @@ collections:
   - name: operator_sdk.util
     version: "0.4.0"
   - name: kubernetes.core
-    version: "2.3.1"
+    version: "2.4.0"
   - name: cloud.common
     version: "2.1.1"
   - name: community.docker


### PR DESCRIPTION
**Description of the change:**
Updates the default kubernetes.core collection version included in the scaffolded `requirements.yaml` file to be v2.4.0.

**Motivation for the change:**
- fixes #6258 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
