### PR TITLE
(testing): Bump K8S_VERSION for testing to 1.26.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,19 +3,14 @@ run:
 linters:
   enable:
     - nakedret
-    - interfacer
-    - varcheck
-    - deadcode
-    - structcheck
     - misspell
-    - maligned
     - ineffassign
     - goconst
     - goimports
     - errcheck
     - dupl
     - unparam
-    - golint
+    - revive
     - staticcheck
     - unused
     - gosimple
@@ -27,7 +22,7 @@ issues:
     # Allow dot imports for ginkgo and gomega
     - source: ginkgo|gomega
       linters:
-      - golint
+      - revive
       text: "should not use dot imports"
 
     - linters:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export IMAGE_VERSION = v1.27.0
 export SIMPLE_VERSION = $(shell (test "$(shell git describe --tags)" = "$(shell git describe --tags --abbrev=0)" && echo $(shell git describe --tags)) || echo $(shell git describe --tags --abbrev=0)+git)
 export GIT_VERSION = $(shell git describe --dirty --tags --always)
 export GIT_COMMIT = $(shell git rev-parse HEAD)
-export K8S_VERSION = 1.25.0
+export K8S_VERSION = 1.26.0
 
 # Build settings
 export TOOLS_DIR = tools/bin
@@ -175,12 +175,12 @@ cluster-create::
 
 .PHONY: dev-install
 dev-install::
-	$(SCRIPTS_DIR)/fetch kind 0.16.0
+	$(SCRIPTS_DIR)/fetch kind 0.17.0
 	$(SCRIPTS_DIR)/fetch kubectl $(K8S_VERSION) # Install kubectl AFTER envtest because envtest includes its own kubectl binary
 
 .PHONY: test-e2e-teardown
 test-e2e-teardown:
-	$(SCRIPTS_DIR)/fetch kind 0.16.0
+	$(SCRIPTS_DIR)/fetch kind 0.17.0
 	$(TOOLS_DIR)/kind delete cluster --name $(KIND_CLUSTER)
 	rm -f $(KUBECONFIG)
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ fix: ## Fixup files in the repo.
 
 .PHONY: setup-lint
 setup-lint: ## Setup the lint
-	$(SCRIPTS_DIR)/fetch golangci-lint 1.50.0
+	$(SCRIPTS_DIR)/fetch golangci-lint 1.51.2
 
 .PHONY: lint
 lint: setup-lint ## Run the lint check

--- a/internal/ansible/runner/runner_test.go
+++ b/internal/ansible/runner/runner_test.go
@@ -247,7 +247,7 @@ func TestAnsibleVerbosityString(t *testing.T) {
 
 func TestMakeParameters(t *testing.T) {
 	var (
-		inputSpec string = "testKey"
+		inputSpec = "testKey"
 	)
 
 	testCases := []struct {


### PR DESCRIPTION
**Description of the change:**
- Bumps `K8S_VERSION` in Makefile to 1.26.0 so that our testing environment uses k8s 1.26
- Bumps `kind` version in Makefile to `0.17.0` so that it is up to date with the latest release
- Bumps `golangci-lint` version in Makefile to `1.51.2` to fix a problem I had locally where running `make lint` resulted in my terminal or editor crashing.

**Motivation for the change:**
- K8s 1.26 bump

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
