### PR TITLE
scorecard: add missing space to suggestion

### DIFF
--- a/internal/scorecard/tests/olm.go
+++ b/internal/scorecard/tests/olm.go
@@ -257,8 +257,8 @@ func checkOwnedCSVStatusDescriptor(cr unstructured.Unstructured, csv *operatorsv
 	}
 
 	if !hasStatusDefinition {
-		r.Suggestions = append(r.Suggestions, fmt.Sprintf("%s does not have status spec. Note that"+
-			"All objects that represent a physical resource whose state may vary from the user's desired "+
+		r.Suggestions = append(r.Suggestions, fmt.Sprintf("%s does not have status spec. Note that "+
+			"all objects that represent a physical resource whose state may vary from the user's desired "+
 			"intent SHOULD have a spec and a status. "+
 			"More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status", crdDescription.Name))
 	}


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

Resources with no status produce the following warning:

> ... does not have status spec. Note thatAll objects that represent a
> physical resource ...

This adds the missing space between "that" and "All", and lower-cases the "a" in "all".

**Motivation for the change:**

This makes the suggestions easier to read.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
