### PR TITLE
Fix MarkUnsafe missing Spec in ansible operator

### DIFF
--- a/changelog/fragments/10-mark-unsafe.yaml
+++ b/changelog/fragments/10-mark-unsafe.yaml
@@ -1,0 +1,25 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      markUnsafe now correctly marks as unsafe the spec extra variable.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/internal/ansible/runner/runner.go
+++ b/internal/ansible/runner/runner.go
@@ -394,7 +394,7 @@ func (r *runner) makeParameters(u *unstructured.Unstructured) map[string]interfa
 func markUnsafe(values interface{}) interface{} {
 	switch v := values.(type) {
 	case []interface{}:
-		var p []interface{}
+		p := make([]interface{}, 0)
 		for _, n := range v {
 			p = append(p, markUnsafe(n))
 		}

--- a/internal/ansible/runner/runner.go
+++ b/internal/ansible/runner/runner.go
@@ -366,6 +366,9 @@ func (r *runner) makeParameters(u *unstructured.Unstructured) map[string]interfa
 
 	specKey := fmt.Sprintf("%s_spec", objKey)
 	parameters[specKey] = spec
+	if r.markUnsafe {
+		parameters[specKey] = markUnsafe(spec)
+	}
 
 	for k, v := range r.Vars {
 		parameters[k] = v


### PR DESCRIPTION
**Description of the change:**
Closes https://github.com/operator-framework/operator-sdk/issues/5160

**Motivation for the change:**
MarkUnsafe was missing some properties.