### PR TITLE
Bumped the Golang version to 1.19 in pre-requisite documentation

### DIFF
--- a/changelog/fragments/docs-bump-go-version.yaml
+++ b/changelog/fragments/docs-bump-go-version.yaml
@@ -1,0 +1,12 @@
+entries:
+  - description: >
+      (docs) Update the go version in the developer guide.  The documentation wasn't updated when the go version was bumped to v1.19.
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+    # Is this a breaking change?
+    breaking: false

--- a/website/content/en/docs/contribution-guidelines/developer-guide.md
+++ b/website/content/en/docs/contribution-guidelines/developer-guide.md
@@ -9,7 +9,7 @@ weight: 1
 ### Prerequisites
 
 - [git][git-tool]
-- [go][go-tool] version 1.18
+- [go][go-tool] version 1.19
 
 ### Download Operator SDK
 


### PR DESCRIPTION
**Description of the change:**
Go.mod is using golang 1.19 and pre-requisite is using 1.18. So Incrementing the developer guide to meet the golang version.

Bumped the Golang version.


**Motivation for the change:**
#6385 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)


Closes #6385 