### PR TITLE
Bump Golang version in ansible-operator images to 1.19

### DIFF
--- a/changelog/fragments/image-ansible-operator-go-version.yaml
+++ b/changelog/fragments/image-ansible-operator-go-version.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Bump the golang base image version in the ansible-operator Dockerfiles from 1.18 to 1.19
+    kind: "change"
+    breaking: false

--- a/images/ansible-operator-2.11-preview/Dockerfile
+++ b/images/ansible-operator-2.11-preview/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.18 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 ARG TARGETARCH
 
 WORKDIR /workspace

--- a/images/ansible-operator/Dockerfile
+++ b/images/ansible-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.18 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 ARG TARGETARCH
 
 WORKDIR /workspace


### PR DESCRIPTION
Project uses 1.19 when building locally but still use 1.18 for images pushed to Quay

Resolves https://github.com/operator-framework/operator-sdk/issues/6397

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Bumps the golang base image from 1.18 to 1.19 to align with local builds


**Motivation for the change:**
https://github.com/operator-framework/operator-sdk/issues/6397

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
