### PR TITLE
Update kuttl to v0.15.0 in the scorecard-test-kuttl image

### DIFF
--- a/changelog/fragments/01-update-kuttl.yaml
+++ b/changelog/fragments/01-update-kuttl.yaml
@@ -1,0 +1,16 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Update kuttl to v0.15.0 in the scorecard-test-kuttl image
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false

--- a/images/scorecard-test-kuttl/Dockerfile
+++ b/images/scorecard-test-kuttl/Dockerfile
@@ -18,8 +18,8 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/scorecard-test-kuttl
 
 # Final image.
-#FROM kudobuilder/kuttl@sha256:924a709a1d2c6bede8815415ea5d5be640b506ec5aeaddc68acb443ae8ee7926
-FROM kudobuilder/kuttl:v0.12.1
+#FROM kudobuilder/kuttl@sha256:8d4dad161521450db95f88fe0e62487cc6587c5818df2a4e750fb9e54c082170
+FROM kudobuilder/kuttl:v0.15.0
 
 ENV HOME=/opt/scorecard-test-kuttl \
     USER_NAME=scorecard-test-kuttl \
@@ -29,6 +29,8 @@ ENV HOME=/opt/scorecard-test-kuttl \
 RUN echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
 
 WORKDIR ${HOME}
+# kuttl writes a kubeconfig file in the current working directory
+RUN chmod g+w "${HOME}"
 
 COPY --from=builder /workspace/build/scorecard-test-kuttl /usr/local/bin/scorecard-test-kuttl
 COPY --from=builder /workspace/images/scorecard-test-kuttl/entrypoint /usr/local/bin/entrypoint

--- a/images/scorecard-test-kuttl/main.go
+++ b/images/scorecard-test-kuttl/main.go
@@ -31,10 +31,10 @@ import (
 // scorecard v1alpha3.TestStatus json format.
 //
 // The kuttl output is expected to be produced by kubectl-kuttl
-// at /tmp/kuttl-test.json.
+// at /tmp/kuttl-report.json.
 func main() {
 
-	jsonFile, err := os.Open("/tmp/kuttl-test.json")
+	jsonFile, err := os.Open("/tmp/kuttl-report.json")
 	if err != nil {
 		printErrorStatus(fmt.Errorf("could not open kuttl report %v", err))
 		return


### PR DESCRIPTION
**Description of the change:**
Update kuttl to v0.15.0 in the scorecard-test-kuttl image

**Motivation for the change:**
Fixes cleanup of created resources in kuttl (created resources of a kuttl test will be deleted after the test is run).
This change is especially relevant when using a single namespace for testing (default with this image).
See https://github.com/kudobuilder/kuttl/releases/tag/v0.14.0

**Checklist**
If the pull request includes user-facing changes, extra documentation is required:
- [X] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
