### PR TITLE
Fix 6323: compress the bundle configMap

### DIFF
--- a/changelog/fragments/support_configmap_compression.yaml
+++ b/changelog/fragments/support_configmap_compression.yaml
@@ -1,0 +1,21 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Compress the bundle content, to avoid the configMap exceed max length error.
+      The error will look like this: 
+      
+      `... ConfigMap ... is invalid: []: Too long: must have at most 1048576 bytes`.
+      
+      Fixes issue [#6323](https://github.com/operator-framework/operator-sdk/issues/6323)
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/olm/operator/registry/fbcindex/configMapWriter.go
+++ b/internal/olm/operator/registry/fbcindex/configMapWriter.go
@@ -1,0 +1,173 @@
+// Copyright 2023 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fbcindex
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	yamlSeparator    = "\n---\n"
+	gzipSuffixLength = 13
+	maxGZIPLength    = maxConfigMapSize - gzipSuffixLength
+
+	ConfigMapEncodingAnnotationKey  = "olm.contentEncoding"
+	ConfigMapEncodingAnnotationGzip = "gzip+base64"
+)
+
+/*
+This file implements the actual building of the CM list. It uses the template method design pattern to implement both
+regular string VM, and compressed binary CM.
+
+The method itself is FBCRegistryPod.getConfigMaps. This file contains the actual implementation of the writing actions,
+used by the method.
+*/
+
+type configMapWriter interface {
+	reset()
+	newConfigMap(string) *corev1.ConfigMap
+	getFilePath() string
+	isEmpty() bool
+	exceedMaxLength(cmSize int, data string) (bool, error)
+	closeCM(cm *corev1.ConfigMap) error
+	addData(data string) error
+	continueAddData(data string) error
+	writeLastFragment(cm *corev1.ConfigMap) error
+}
+
+type gzipCMWriter struct {
+	actualBuff   *bytes.Buffer
+	helperBuff   *bytes.Buffer
+	actualWriter *gzip.Writer
+	helperWriter *gzip.Writer
+	cmName       string
+	namespace    string
+}
+
+func newGZIPWriter(name, namespace string) *gzipCMWriter {
+	actualBuff := &bytes.Buffer{}
+	helperBuff := &bytes.Buffer{}
+
+	return &gzipCMWriter{
+		actualBuff:   actualBuff,
+		helperBuff:   helperBuff,
+		actualWriter: gzip.NewWriter(actualBuff),
+		helperWriter: gzip.NewWriter(helperBuff),
+		cmName:       name,
+		namespace:    namespace,
+	}
+}
+
+func (cmw *gzipCMWriter) reset() {
+	cmw.actualBuff.Reset()
+	cmw.actualWriter.Reset(cmw.actualBuff)
+	cmw.helperBuff.Reset()
+	cmw.helperWriter.Reset(cmw.helperBuff)
+}
+
+func (cmw *gzipCMWriter) newConfigMap(name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cmw.namespace,
+			Name:      name,
+			Annotations: map[string]string{
+				ConfigMapEncodingAnnotationKey: ConfigMapEncodingAnnotationGzip,
+			},
+		},
+		BinaryData: map[string][]byte{},
+	}
+}
+
+func (cmw *gzipCMWriter) getFilePath() string {
+	return fmt.Sprintf("%s.yaml.gz", defaultConfigMapKey)
+}
+
+func (cmw *gzipCMWriter) isEmpty() bool {
+	return cmw.actualBuff.Len() > 0
+}
+
+func (cmw *gzipCMWriter) exceedMaxLength(cmSize int, data string) (bool, error) {
+	_, err := cmw.helperWriter.Write([]byte(data))
+	if err != nil {
+		return false, err
+	}
+
+	err = cmw.helperWriter.Flush()
+	if err != nil {
+		return false, err
+	}
+
+	return cmSize+cmw.helperBuff.Len() > maxGZIPLength, nil
+}
+
+func (cmw *gzipCMWriter) closeCM(cm *corev1.ConfigMap) error {
+	err := cmw.actualWriter.Close()
+	if err != nil {
+		return err
+	}
+
+	err = cmw.actualWriter.Flush()
+	if err != nil {
+		return err
+	}
+
+	cm.BinaryData[defaultConfigMapKey] = make([]byte, cmw.actualBuff.Len())
+	copy(cm.BinaryData[defaultConfigMapKey], cmw.actualBuff.Bytes())
+
+	cmw.reset()
+
+	return nil
+}
+
+func (cmw *gzipCMWriter) addData(data string) error {
+	dataBytes := []byte(data)
+	_, err := cmw.helperWriter.Write(dataBytes)
+	if err != nil {
+		return err
+	}
+	_, err = cmw.actualWriter.Write(dataBytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// continueAddData completes adding the data after starting adding it in exceedMaxLength
+func (cmw *gzipCMWriter) continueAddData(data string) error {
+	_, err := cmw.actualWriter.Write([]byte(data))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmw *gzipCMWriter) writeLastFragment(cm *corev1.ConfigMap) error {
+	err := cmw.actualWriter.Close()
+	if err != nil {
+		return err
+	}
+
+	cm.BinaryData[defaultConfigMapKey] = cmw.actualBuff.Bytes()
+	return nil
+}


### PR DESCRIPTION
## Description of the change
Add the `--gzip-configmap=true` CLI parameter in order to compress the configMap, if it exeeds the max length.

## Motivation for the change
Fix #6323 

It is currently not possible to run bundles with files larger than 1MB (the configMap limit). In these cases, the existing partitioning mechanism is not enough, and the action fails.

OLM solved this issue by compressing the configMap content. This PR motivation is to implement compression mechanism in operator-sdk as well.

By adding the `--gzip-configmap=true` parameter, operator-sdk now will compress the content of the config map. The commad of the pod is also modified in this case. It is not possible to extract the files in the configMap itself. The command now extracts the files to `/var/tmp` which is writable, and then run the opm server form this directory.

Successfully manually tested on a local kind cluster, with:
```shell
$ build/operator-sdk run bundle --gzip-configmap=true quay.io/webcenter/elasticsearch-operator-bundle:v0.0.1 -n default

INFO[0009] Creating a File-Based Catalog of the bundle "quay.io/webcenter/elasticsearch-operator-bundle:v0.0.1" 
INFO[0011] Generated a valid File-Based Catalog         
INFO[0014] Created registry pod: quay-io-webcenter-elasticsearch-operator-bundle-v0-0-1 
INFO[0014] Created CatalogSource: elasticsearch-operator-catalog 
INFO[0014] Created Subscription: elasticsearch-operator-v0-0-1-sub 
INFO[0015] Approved InstallPlan install-z8jv8 for the Subscription: elasticsearch-operator-v0-0-1-sub 
INFO[0015] Waiting for ClusterServiceVersion "default/elasticsearch-operator.v0.0.1" to reach 'Succeeded' phase 
INFO[0015]   Waiting for ClusterServiceVersion "default/elasticsearch-operator.v0.0.1" to appear 
INFO[0028]   Found ClusterServiceVersion "default/elasticsearch-operator.v0.0.1" phase: Pending 
INFO[0030]   Found ClusterServiceVersion "default/elasticsearch-operator.v0.0.1" phase: Installing 
INFO[0051]   Found ClusterServiceVersion "default/elasticsearch-operator.v0.0.1" phase: Succeeded 
INFO[0051] OLM has successfully installed "elasticsearch-operator.v0.0.1" 
```

## Checklist

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
