### PR TITLE
[v1.28.x] Use digest instead of tags in scorecard images (#6393)

### DIFF
--- a/internal/cmd/operator-sdk/scorecard/cmd.go
+++ b/internal/cmd/operator-sdk/scorecard/cmd.go
@@ -90,11 +90,15 @@ If the argument holds an image tag, it must be present remotely.`,
 		"Disable resource cleanup after tests are run")
 	scorecardCmd.Flags().DurationVarP(&c.waitTime, "wait-time", "w", 30*time.Second,
 		"seconds to wait for tests to complete. Example: 35s")
+	// Please note that for Operator-sdk + Preflight + DCI integration in disconnected environments,
+	// it is necessary to refer to storage-image and untar-image using their digests instead of tags.
+	// If you need to make changes to these images, please ensure that you always use the digests.
 	scorecardCmd.Flags().StringVarP(&c.storageImage, "storage-image", "b",
-		"quay.io/operator-framework/scorecard-storage:latest",
+		"quay.io/operator-framework/scorecard-storage@sha256:f7bd62664a0b91034acb977a8bb4ebb76bc98a6e8bdb943eb84c8e364828f056",
 		"Storage image to be used by the Scorecard pod")
+	// Use the digest of the latest scorecard-untar image
 	scorecardCmd.Flags().StringVarP(&c.untarImage, "untar-image", "u",
-		"quay.io/operator-framework/scorecard-untar:latest",
+		"quay.io/operator-framework/scorecard-untar@sha256:56c88afd4f20718dcd4d4384b8ff0b790f95aa4737f89f3b105b5dfc1bdb60c3",
 		"Untar image to be used by the Scorecard pod")
 	scorecardCmd.Flags().StringVarP(&c.testOutput, "test-output", "t", "test-output",
 		"Test output directory.")

--- a/internal/cmd/operator-sdk/scorecard/cmd_test.go
+++ b/internal/cmd/operator-sdk/scorecard/cmd_test.go
@@ -69,12 +69,14 @@ var _ = Describe("Running the scorecard command", func() {
 			flag = cmd.Flags().Lookup("storage-image")
 			Expect(flag).NotTo(BeNil())
 			Expect(flag.Shorthand).To(Equal("b"))
-			Expect(flag.DefValue).To(Equal("quay.io/operator-framework/scorecard-storage:latest"))
+			// Use the digest of the latest scorecard-storage image
+			Expect(flag.DefValue).To(Equal("quay.io/operator-framework/scorecard-storage@sha256:f7bd62664a0b91034acb977a8bb4ebb76bc98a6e8bdb943eb84c8e364828f056"))
 
 			flag = cmd.Flags().Lookup("untar-image")
 			Expect(flag).NotTo(BeNil())
 			Expect(flag.Shorthand).To(Equal("u"))
-			Expect(flag.DefValue).To(Equal("quay.io/operator-framework/scorecard-untar:latest"))
+			// Use the digest of the latest scorecard-untar image
+			Expect(flag.DefValue).To(Equal("quay.io/operator-framework/scorecard-untar@sha256:56c88afd4f20718dcd4d4384b8ff0b790f95aa4737f89f3b105b5dfc1bdb60c3"))
 		})
 	})
 

--- a/website/content/en/docs/cli/operator-sdk_scorecard.md
+++ b/website/content/en/docs/cli/operator-sdk_scorecard.md
@@ -28,9 +28,9 @@ operator-sdk scorecard [flags]
   -l, --selector string          label selector to determine which tests are run
   -s, --service-account string   Service account to use for tests (default "default")
   -x, --skip-cleanup             Disable resource cleanup after tests are run
-  -b, --storage-image string     Storage image to be used by the Scorecard pod (default "quay.io/operator-framework/scorecard-storage:latest")
+  -b, --storage-image string     Storage image to be used by the Scorecard pod (default "quay.io/operator-framework/scorecard-storage@sha256:f7bd62664a0b91034acb977a8bb4ebb76bc98a6e8bdb943eb84c8e364828f056")
   -t, --test-output string       Test output directory. (default "test-output")
-  -u, --untar-image string       Untar image to be used by the Scorecard pod (default "quay.io/operator-framework/scorecard-untar:latest")
+  -u, --untar-image string       Untar image to be used by the Scorecard pod (default "quay.io/operator-framework/scorecard-untar@sha256:56c88afd4f20718dcd4d4384b8ff0b790f95aa4737f89f3b105b5dfc1bdb60c3")
   -w, --wait-time duration       seconds to wait for tests to complete. Example: 35s (default 30s)
 ```
 


### PR DESCRIPTION
Cherry-pick of https://github.com/operator-framework/operator-sdk/pull/6393 