### PR TITLE
updating molecule links #6413

### DIFF
--- a/website/content/en/docs/best-practices/common-recommendation.md
+++ b/website/content/en/docs/best-practices/common-recommendation.md
@@ -97,7 +97,7 @@ spec:
 [operator-best-practices]: /docs/best-practices/best-practices
 [kb-gkv]: https://book.kubebuilder.io/cronjob-tutorial/gvks.html
 [operator-pattern]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
-[molecule]: https://molecule.readthedocs.io/en/latest/
+[molecule]: https://molecule.readthedocs.io/
 [molecule-tests]: /docs/building-operators/ansible/testing-guide
 [helm-chart-tests]: https://helm.sh/docs/topics/chart_tests/
 [envtest]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest

--- a/website/content/en/docs/building-operators/ansible/migration.md
+++ b/website/content/en/docs/building-operators/ansible/migration.md
@@ -301,7 +301,7 @@ For further steps regarding the deployment of the operator, creation of custom r
 [kube-auth-proxy]: https://github.com/brancz/kube-rbac-proxy
 [metrics]: https://book.kubebuilder.io/reference/metrics.html?highlight=metr#metrics
 [marker]: https://book.kubebuilder.io/reference/markers.html?highlight=markers#marker-syntax
-[molecule]: https://molecule.readthedocs.io/en/latest/#
+[molecule]: https://molecule.readthedocs.io/
 [testing-guide]: /docs/building-operators/ansible/testing-guide
 [migration-doc]: /docs/upgrading-sdk-version/
 [tutorial-deploy]: /docs/building-operators/ansible/tutorial/#run-the-operator

--- a/website/content/en/docs/building-operators/ansible/testing-guide.md
+++ b/website/content/en/docs/building-operators/ansible/testing-guide.md
@@ -48,7 +48,7 @@ Our molecule scenarios have the following basic structure:
 └── verify.yml
 ```
 
-- `molecule.yml` is a configuration file for molecule. It defines what driver to use to stand up an environment and the associated configuration, linting rules, and a variety of other configuration options. For full documentation on the options available here, see the [molecule configuration documentation](https://molecule.readthedocs.io/en/latest/configuration)
+- `molecule.yml` is a configuration file for molecule. It defines what driver to use to stand up an environment and the associated configuration, linting rules, and a variety of other configuration options. For full documentation on the options available here, see the [molecule configuration documentation](https://molecule.readthedocs.io/configuration/)
 
 - `prepare.yml` is an Ansible playbook that is run once during the set up of a scenario. You can put any arbitrary Ansible in this playbook. It is used for one-time configuration of your test environment, for example, creating the cluster-wide `CustomResourceDefinition` that your Operator will watch.
 

--- a/website/content/en/docs/building-operators/golang/testing.md
+++ b/website/content/en/docs/building-operators/golang/testing.md
@@ -53,7 +53,7 @@ To implement application-specific tests, the SDK's test harness, [scorecard][sco
 [gomega]: https://onsi.github.io/gomega/
 [kuttl]: https://kuttl.dev/
 [sample]: https://github.com/operator-framework/operator-sdk/tree/master/testdata/go/v3/memcached-operator
-[molecule]: https://molecule.readthedocs.io/en/latest/
+[molecule]: https://molecule.readthedocs.io/
 [molecule-tests]: /docs/building-operators/ansible/testing-guide
 [helm-chart-tests]: https://helm.sh/docs/topics/chart_tests/
 [go-legacy-shell]: https://github.com/operator-framework/operator-sdk/blob/v1.0.0/hack/tests/e2e-go.sh

--- a/website/content/en/docs/overview/project-layout.md
+++ b/website/content/en/docs/overview/project-layout.md
@@ -84,7 +84,7 @@ Now, let's look at the files and directories specific to Helm-based operators.
 [olm-manifests]: https://github.com/operator-framework/operator-registry/tree/v1.5.3#manifest-format  
 [olm-metadata]: https://github.com/operator-framework/operator-registry/blob/v1.16.1/docs/design/operator-bundle.md#bundle-manifest-format
 [bundle]:https://github.com/operator-framework/operator-registry/blob/v1.16.1/docs/design/operator-bundle.md
-[molecule]: https://molecule.readthedocs.io/en/latest/
+[molecule]: https://molecule.readthedocs.io/
 [ansible-watches]: /docs/building-operators/ansible/reference/watches
 [ansible-test-guide]: /docs/building-operators/ansible/testing-guide
 [helm-watches]: /docs/building-operators/helm/reference/watches

--- a/website/content/en/docs/upgrading-sdk-version/version-upgrade-guide.md
+++ b/website/content/en/docs/upgrading-sdk-version/version-upgrade-guide.md
@@ -1288,7 +1288,7 @@ which ./bin/openapi-gen > /dev/null || go build -o ./bin/openapi-gen k8s.io/kube
 The Molecule version for Ansible based-operators was upgraded from `2.22` to `3.0.2`. The following changes are required in the default scaffold files.
 
 - Remove the `scenario.name` from `molecule.yaml` and then, ensure that any condition with will look for the folder name which determines the scenario name from now on
-- Replace the lint with newer syntax from [documentation](https://molecule.readthedocs.io/en/latest/contributing/#linting). See:
+- Replace the lint with newer syntax from [documentation](https://molecule.readthedocs.io/contributing/#linting). See:
 
 Replace:
 


### PR DESCRIPTION
[Issue](https://github.com/operator-framework/operator-sdk/issues/6413)

**Description of the change:**
Currently, molecule document links are deprecated, making the docs link checker fail. This PR addresses that. 

**Motivation for the change:**
Currently, molecule document links are deprecated, making the docs link checker fail. This PR addresses that. 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
