### PR TITLE
when deploying a bundle, if the namespace is missing - create it instead of exit with error

### DIFF
--- a/changelog/fragments/create_ns_if_missing.yaml
+++ b/changelog/fragments/create_ns_if_missing.yaml
@@ -1,0 +1,10 @@
+entries:
+  - description: >
+      When running `operator-sdk run bundle` with a specific namespace,
+      if the namespace is missing, the operator-sdk now creates it instead of 
+      exiting with error.
+
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false


### PR DESCRIPTION
## Description of the change
when deploying a bundle, if the namespace is missing - create it instead of exit with error

For example:
```shell
$ operator-sdk run bundle my-bundle-image:latest -n aaa

INFO[0009] Creating a File-Based Catalog of the bundle "my-bundle-image:latest" 
INFO[0010] Generated a valid File-Based Catalog         
INFO[0010] the "aaa" namespace does not exist. creating it... 
INFO[0010] the "aaa" namespace was created successfully 
...
```

## Motivation for the change
As an operator-sdk user, it's annoying to get error when trying to deploy a bundle with a specified namespace, assuming that if the namespace is mentioned explicitly, the user want to use it, and so it make sense to create it if it's missing.

## Checklist

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
