### PR TITLE
Add `generate bundle --ignore-if-only-created-at-changed` option

### DIFF
--- a/changelog/fragments/6419.yaml
+++ b/changelog/fragments/6419.yaml
@@ -1,0 +1,38 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Add ability to ignore bundle updates on `generate bundle` command if createdAt timestamp is the only change.
+      The flag to use is `--ignore-if-only-createdAt`.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    # migration:
+    #   header: Header text for the migration section
+    #   body: |
+    #     Body of the migration section. This should be formatted as markdown and can
+    #     span multiple lines.
+
+    #     Using the YAML string '|' operator means that newlines in this string will
+    #     be honored and interpretted as newlines in the rendered markdown.

--- a/internal/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/internal/cmd/operator-sdk/generate/bundle/bundle.go
@@ -201,6 +201,10 @@ func (c bundleCmd) runManifests() (err error) {
 		opts = append(opts, gencsv.WithWriter(stdout))
 	} else {
 		opts = append(opts, gencsv.WithBundleWriter(c.outputDir))
+		if c.ignoreIfOnlyCreatedAt && genutil.IsExist(c.outputDir) {
+			opts = append(opts, gencsv.WithBundleReader(c.outputDir))
+			opts = append(opts, gencsv.WithIgnoreIfOnlyCreatedAt())
+		}
 	}
 
 	csvGen := gencsv.Generator{

--- a/internal/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/internal/cmd/operator-sdk/generate/bundle/bundle.go
@@ -201,9 +201,9 @@ func (c bundleCmd) runManifests() (err error) {
 		opts = append(opts, gencsv.WithWriter(stdout))
 	} else {
 		opts = append(opts, gencsv.WithBundleWriter(c.outputDir))
-		if c.ignoreIfOnlyCreatedAt && genutil.IsExist(c.outputDir) {
+		if c.ignoreIfOnlyCreatedAtChanged && genutil.IsExist(c.outputDir) {
 			opts = append(opts, gencsv.WithBundleReader(c.outputDir))
-			opts = append(opts, gencsv.WithIgnoreIfOnlyCreatedAt())
+			opts = append(opts, gencsv.WithIgnoreIfOnlyCreatedAtChanged())
 		}
 	}
 

--- a/internal/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/generate/bundle/cmd.go
@@ -45,7 +45,7 @@ type bundleCmd struct {
 	channels              string
 	defaultChannel        string
 	overwrite             bool
-	ignoreIfOnlyCreatedAt bool
+	ignoreIfOnlyCreatedAtChanged bool
 
 	// These are set if a PROJECT config is not present.
 	layout      string
@@ -139,7 +139,7 @@ func (c *bundleCmd) addFlagsTo(fs *pflag.FlagSet) {
 		"Names of service accounts, outside of the operator's Deployment account, "+
 			"that have bindings to {Cluster}Roles that should be added to the CSV")
 	fs.BoolVar(&c.overwrite, "overwrite", true, "Overwrite the bundle's metadata and Dockerfile if they exist")
-	fs.BoolVar(&c.ignoreIfOnlyCreatedAt, "ignore-if-only-createdAt", false, "Ignore if only createdAt is changed")
+	fs.BoolVar(&c.ignoreIfOnlyCreatedAtChanged, "ignore-if-only-created-at-changed", false, "Ignore if only createdAt is changed")
 	fs.BoolVarP(&c.quiet, "quiet", "q", false, "Run in quiet mode")
 	fs.BoolVar(&c.stdout, "stdout", false, "Write bundle manifest to stdout")
 

--- a/internal/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/generate/bundle/cmd.go
@@ -42,9 +42,10 @@ type bundleCmd struct {
 	extraServiceAccounts []string
 
 	// Metadata options.
-	channels       string
-	defaultChannel string
-	overwrite      bool
+	channels              string
+	defaultChannel        string
+	overwrite             bool
+	ignoreIfOnlyCreatedAt bool
 
 	// These are set if a PROJECT config is not present.
 	layout      string
@@ -138,6 +139,7 @@ func (c *bundleCmd) addFlagsTo(fs *pflag.FlagSet) {
 		"Names of service accounts, outside of the operator's Deployment account, "+
 			"that have bindings to {Cluster}Roles that should be added to the CSV")
 	fs.BoolVar(&c.overwrite, "overwrite", true, "Overwrite the bundle's metadata and Dockerfile if they exist")
+	fs.BoolVar(&c.ignoreIfOnlyCreatedAt, "ignore-if-only-createdAt", false, "Ignore if only createdAt is changed")
 	fs.BoolVarP(&c.quiet, "quiet", "q", false, "Run in quiet mode")
 	fs.BoolVar(&c.stdout, "stdout", false, "Write bundle manifest to stdout")
 

--- a/internal/generate/clusterserviceversion/clusterserviceversion_test.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/onsi/gomega/format"
 	operatorversion "github.com/operator-framework/api/pkg/lib/version"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/yaml"
@@ -154,7 +153,7 @@ var _ = Describe("Testing CRDs with single version", func() {
 					outputFile := filepath.Join(tmp, bundle.ManifestsDir, makeCSVFileName(operatorName))
 					Expect(outputFile).To(BeAnExistingFile())
 					Expect(readFileHelper(outputFile)).To(MatchYAML(newCSVUIMetaStr))
-					var initiallyWrittenCSV operatorsv1alpha1.ClusterServiceVersion
+					var initiallyWrittenCSV v1alpha1.ClusterServiceVersion
 					r, err := bundleReader(tmp, makeCSVFileName(operatorName))
 					Expect(err).ToNot(HaveOccurred())
 					err = genutil.ReadObject(r, &initiallyWrittenCSV)
@@ -169,7 +168,7 @@ var _ = Describe("Testing CRDs with single version", func() {
 					opts = []Option{
 						WithBundleWriter(tmp),
 						WithBundleReader(tmp),
-						WithIgnoreIfOnlyCreatedAt(),
+						WithIgnoreIfOnlyCreatedAtChanged(),
 					}
 					time.Sleep(1*time.Second + 1*time.Millisecond) // sleep to ensure createdAt is different if not for ignore option
 					Expect(g.Generate(opts...)).ToNot(HaveOccurred())

--- a/internal/generate/internal/genutil.go
+++ b/internal/generate/internal/genutil.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	"github.com/operator-framework/operator-sdk/internal/util/k8sutil"
@@ -110,4 +111,12 @@ func IsNotExist(path string) bool {
 	}
 	_, err := os.Stat(path)
 	return err != nil && errors.Is(err, os.ErrNotExist)
+}
+
+func ReadObject(r io.Reader, obj client.Object) error {
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		return err
+	}
+	return k8sutil.GetObjectFromBytes(buf.Bytes(), obj)
 }

--- a/internal/util/k8sutil/object.go
+++ b/internal/util/k8sutil/object.go
@@ -16,6 +16,7 @@ package k8sutil
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
 )
 
 type MarshalFunc func(interface{}) ([]byte, error)
@@ -52,4 +53,12 @@ func deleteKeyFromUnstructured(u map[string]interface{}, key string) {
 			}
 		}
 	}
+}
+
+func GetObjectFromBytes(b []byte, obj interface{}) error {
+	var u map[string]interface{}
+	if err := yaml.Unmarshal(b, &u); err != nil {
+		return err
+	}
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(u, obj)
 }


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Add ability to ignore bundle updates on `generate bundle` command if createdAt timestamp is the only change.

The flag to use is `--ignore-if-only-created-at-changed`.

**Motivation for the change:**
> > 2\. We can define a constant. As part of the testdata generation process we replace the `createdAt` value in the generated CSV with this constant. This should prevent the `git diff` check from failing solely because of the `createdAt` value.
> 
> Number 2 probably makes more sense then. I assume the constant and code changes for the testdata generation should be under the `hack/` directory?

from [PR](https://github.com/operator-framework/operator-sdk/pull/6136#issuecomment-1310710519)
This is indeed a hack. A constant only works for test data. For a real operators repo, we would want the createdAt updated when there are changes in `config/`. It should be possible to simply in CI check if `config/` has become **out of sync** with `bundle/` by running `make bundle` in CI and diffing the bundle without hacky workarounds noted in #6285.

The only other explanation that would make sense for not honoring this issue is if the suggestion is to add `bundle/` to `.gitignore` which further hides the resulting bundle CSV from version control and makes it harder to track down issues.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Fix #6285 