### PR TITLE
enable ginkgolinter and fix findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
     - nakedret
     - misspell
     - ineffassign
+    - ginkgolinter
     - goconst
     - goimports
     - errcheck

--- a/internal/ansible/handler/logging_enqueue_annotation_test.go
+++ b/internal/ansible/handler/logging_enqueue_annotation_test.go
@@ -95,8 +95,7 @@ var _ = Describe("LoggingEnqueueRequestForAnnotation", func() {
 			}
 			repl.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"})
 
-			err := handler.SetOwnerAnnotations(podOwner, repl)
-			Expect(err).To(BeNil())
+			Expect(handler.SetOwnerAnnotations(podOwner, repl)).To(Succeed())
 
 			evt := event.CreateEvent{
 				Object: repl,
@@ -280,8 +279,7 @@ var _ = Describe("LoggingEnqueueRequestForAnnotation", func() {
 			newPod.Name = pod.Name + "2"
 			newPod.Namespace = pod.Namespace + "2"
 
-			err := handler.SetOwnerAnnotations(podOwner, pod)
-			Expect(err).To(BeNil())
+			Expect(handler.SetOwnerAnnotations(podOwner, pod)).To(Succeed())
 
 			evt := event.UpdateEvent{
 				ObjectOld: pod,
@@ -395,8 +393,7 @@ var _ = Describe("LoggingEnqueueRequestForAnnotation", func() {
 			newPod.Name = pod.Name + "2"
 			newPod.Namespace = pod.Namespace + "2"
 
-			err := handler.SetOwnerAnnotations(podOwner, pod)
-			Expect(err).To(BeNil())
+			Expect(handler.SetOwnerAnnotations(podOwner, pod)).To(Succeed())
 
 			var podOwner2 = &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -406,8 +403,7 @@ var _ = Describe("LoggingEnqueueRequestForAnnotation", func() {
 			}
 			podOwner2.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Kind: "Pod"})
 
-			err = handler.SetOwnerAnnotations(podOwner2, newPod)
-			Expect(err).To(BeNil())
+			Expect(handler.SetOwnerAnnotations(podOwner2, newPod)).To(Succeed())
 
 			evt := event.UpdateEvent{
 				ObjectOld: pod,

--- a/internal/ansible/proxy/inject_owner_test.go
+++ b/internal/ansible/proxy/inject_owner_test.go
@@ -112,7 +112,7 @@ var _ = Describe("injectOwnerReferenceHandler", func() {
 			}
 			ownerRefs := modifiedCM.ObjectMeta.OwnerReferences
 
-			Expect(len(ownerRefs)).To(Equal(1))
+			Expect(ownerRefs).To(HaveLen(1))
 
 			ownerRef := ownerRefs[0]
 

--- a/internal/cmd/ansible-operator/version/cmd_test.go
+++ b/internal/cmd/ansible-operator/version/cmd_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Running a version command", func() {
 				w.Close()
 			}()
 			stdout, err := io.ReadAll(r)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			stdoutString := string(stdout)
 			version := ver.GitVersion
 			if version == "unknown" {

--- a/internal/cmd/helm-operator/version/cmd_test.go
+++ b/internal/cmd/helm-operator/version/cmd_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Running a version command", func() {
 				w.Close()
 			}()
 			stdout, err := io.ReadAll(r)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			stdoutString := string(stdout)
 			version := ver.GitVersion
 			if version == "unknown" {

--- a/internal/cmd/operator-sdk/bundle/cmd_test.go
+++ b/internal/cmd/operator-sdk/bundle/cmd_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Running a bundle command", func() {
 			Expect(cmd).NotTo(BeNil())
 
 			subcommands := cmd.Commands()
-			Expect(len(subcommands)).To(Equal(1))
+			Expect(subcommands).To(HaveLen(1))
 			Expect(subcommands[0].Use).To(Equal("validate"))
 		})
 	})

--- a/internal/cmd/operator-sdk/bundle/validate/optional_test.go
+++ b/internal/cmd/operator-sdk/bundle/validate/optional_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Running optional validators", func() {
 		It("runs no validators for an empty selector", func() {
 			bundle = &apimanifests.Bundle{}
 			sel = labels.SelectorFromSet(map[string]string{})
-			Expect(vals.run(bundle, sel, nil)).To(HaveLen(0))
+			Expect(vals.run(bundle, sel, nil)).To(BeEmpty())
 		})
 		It("runs a validator for one selector on an empty bundle", func() {
 			bundle = &apimanifests.Bundle{}
@@ -80,14 +80,14 @@ var _ = Describe("Running optional validators", func() {
 		It("returns an error for an empty selector with no validators", func() {
 			sel = labels.SelectorFromSet(map[string]string{})
 			err = vals.checkMatches(sel)
-			Expect(err).NotTo(BeNil())
+			Expect(err).To(HaveOccurred())
 		})
 		It("returns an error for an unmatched selector with no validators", func() {
 			sel = labels.SelectorFromSet(map[string]string{
 				nameKey: "operatorhub",
 			})
 			err = vals.checkMatches(sel)
-			Expect(err).NotTo(BeNil())
+			Expect(err).To(HaveOccurred())
 		})
 		It("returns no error for an unmatched selector with all optional validators", func() {
 			sel = labels.SelectorFromSet(map[string]string{
@@ -95,7 +95,7 @@ var _ = Describe("Running optional validators", func() {
 			})
 			vals = optionalValidators
 			err = vals.checkMatches(sel)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 

--- a/internal/cmd/operator-sdk/olm/cmd_test.go
+++ b/internal/cmd/operator-sdk/olm/cmd_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Running an olm command", func() {
 			Expect(cmd.Short).NotTo(BeNil())
 
 			subcommands := cmd.Commands()
-			Expect(len(subcommands)).To(Equal(3))
+			Expect(subcommands).To(HaveLen(3))
 			Expect(subcommands[0].Use).To(Equal("install"))
 			Expect(subcommands[1].Use).To(Equal("status"))
 			Expect(subcommands[2].Use).To(Equal("uninstall"))

--- a/internal/cmd/operator-sdk/run/cmd_test.go
+++ b/internal/cmd/operator-sdk/run/cmd_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Running a run command", func() {
 			Expect(cmd.Long).NotTo(BeNil())
 
 			subcommands := cmd.Commands()
-			Expect(len(subcommands)).To(Equal(3))
+			Expect(subcommands).To(HaveLen(3))
 			Expect(subcommands[0].Use).To(Equal("bundle <bundle-image>"))
 			Expect(subcommands[1].Use).To(Equal("bundle-upgrade <bundle-image>"))
 			Expect(subcommands[2].Use).To(Equal("packagemanifests [packagemanifests-root-dir]"))

--- a/internal/cmd/operator-sdk/run/packagemanifests/packagemanifests_test.go
+++ b/internal/cmd/operator-sdk/run/packagemanifests/packagemanifests_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Running a run packagemanifests command", func() {
 			Expect(cmd.Short).NotTo(BeNil())
 			Expect(cmd.Long).NotTo(BeNil())
 			aliases := cmd.Aliases
-			Expect(len(aliases)).To(Equal(1))
+			Expect(aliases).To(HaveLen(1))
 			Expect(aliases[0]).To(Equal("pm"))
 		})
 	})

--- a/internal/generate/clusterserviceversion/bases/definitions/crd_test.go
+++ b/internal/generate/clusterserviceversion/bases/definitions/crd_test.go
@@ -43,7 +43,7 @@ var _ = Describe("getTypedDescriptors", func() {
 
 	It("handles an empty set of marked fields", func() {
 		out = getTypedDescriptors(markedFields, reflect.TypeOf(v1alpha1.SpecDescriptor{}), spec)
-		Expect(out).To(HaveLen(0))
+		Expect(out).To(BeEmpty())
 	})
 	It("returns one spec descriptor for one spec marker on a field", func() {
 		markedFields[crd.TypeIdent{}] = []*fieldInfo{
@@ -79,7 +79,7 @@ var _ = Describe("getTypedDescriptors", func() {
 			},
 		}
 		out = getTypedDescriptors(markedFields, reflect.TypeOf(v1alpha1.SpecDescriptor{}), spec)
-		Expect(out).To(HaveLen(0))
+		Expect(out).To(BeEmpty())
 	})
 	It("returns one status descriptor for one status marker on a field", func() {
 		markedFields[crd.TypeIdent{}] = []*fieldInfo{

--- a/internal/generate/clusterserviceversion/clusterserviceversion_test.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_test.go
@@ -259,7 +259,7 @@ var _ = Describe("Testing CRDs with single version", func() {
 					}
 					// Update the input's and expected CSV's Deployment image.
 					collectManifestsFromFileHelper(g.Collector, goBasicOperatorPath)
-					Expect(len(g.Collector.Deployments)).To(BeNumerically(">=", 1))
+					Expect(g.Collector.Deployments).ToNot(BeEmpty())
 					imageTag := "controller:v" + g.Version
 					modifyDepImageHelper(&g.Collector.Deployments[0].Spec, imageTag)
 					updatedCSV := updateCSV(newCSVUIMeta, modifyCSVDepImageHelper(imageTag))
@@ -269,7 +269,7 @@ var _ = Describe("Testing CRDs with single version", func() {
 					Expect(csv).To(Equal(updatedCSV))
 
 					// verify if conversion webhooks are added
-					Expect(len(csv.Spec.WebhookDefinitions)).NotTo(Equal(0))
+					Expect(csv.Spec.WebhookDefinitions).NotTo(BeEmpty())
 					Expect(containsConversionWebhookDefinition(csv.Spec.WebhookDefinitions)).To(BeTrue())
 				})
 			})
@@ -424,14 +424,14 @@ func readFileHelper(path string) string {
 func modifyCSVDepImageHelper(tag string) func(csv *v1alpha1.ClusterServiceVersion) {
 	return func(csv *v1alpha1.ClusterServiceVersion) {
 		depSpecs := csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs
-		ExpectWithOffset(2, len(depSpecs)).To(BeNumerically(">=", 1))
+		ExpectWithOffset(2, depSpecs).ToNot(BeEmpty())
 		modifyDepImageHelper(&depSpecs[0].Spec, tag)
 	}
 }
 
 func modifyDepImageHelper(depSpec *appsv1.DeploymentSpec, tag string) {
 	containers := depSpec.Template.Spec.Containers
-	ExpectWithOffset(1, len(containers)).To(BeNumerically(">=", 1))
+	ExpectWithOffset(1, containers).ToNot(BeEmpty())
 	containers[0].Image = tag
 }
 

--- a/internal/generate/clusterserviceversion/clusterserviceversion_updaters_test.go
+++ b/internal/generate/clusterserviceversion/clusterserviceversion_updaters_test.go
@@ -53,7 +53,7 @@ var _ = Describe("apply functions", func() {
 
 				c.Deployments = []appsv1.Deployment{newDeploymentWithLabels(depName, labels)}
 				applyDeployments(c, strategy)
-				Expect(len(strategy.DeploymentSpecs)).To(Equal(1))
+				Expect(strategy.DeploymentSpecs).To(HaveLen(1))
 				Expect(strategy.DeploymentSpecs[0].Label).To(Equal(labels))
 			})
 		})

--- a/internal/generate/collector/clusterserviceversion_test.go
+++ b/internal/generate/collector/clusterserviceversion_test.go
@@ -37,16 +37,16 @@ var _ = Describe("SplitCSVPermissionsObjects", func() {
 	It("returns empty lists for an empty Manifests", func() {
 		c.Roles = []rbacv1.Role{}
 		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
-		Expect(inPerm).To(HaveLen(0))
-		Expect(inCPerm).To(HaveLen(0))
-		Expect(out).To(HaveLen(0))
+		Expect(inPerm).To(BeEmpty())
+		Expect(inCPerm).To(BeEmpty())
+		Expect(out).To(BeEmpty())
 	})
 
 	It("splitting 1 Role no RoleBinding", func() {
 		c.Roles = []rbacv1.Role{newRole("my-role")}
 		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
-		Expect(inPerm).To(HaveLen(0))
-		Expect(inCPerm).To(HaveLen(0))
+		Expect(inPerm).To(BeEmpty())
+		Expect(inCPerm).To(BeEmpty())
 		Expect(out).To(HaveLen(1))
 		Expect(getRoleNames(out)).To(Equal([]string{"my-role"}))
 	})
@@ -58,8 +58,8 @@ var _ = Describe("SplitCSVPermissionsObjects", func() {
 			newRoleBinding("my-role-binding", newRoleRef("my-role"), newServiceAccountSubject("my-other-account")),
 		}
 		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
-		Expect(inPerm).To(HaveLen(0))
-		Expect(inCPerm).To(HaveLen(0))
+		Expect(inPerm).To(BeEmpty())
+		Expect(inCPerm).To(BeEmpty())
 		Expect(out).To(HaveLen(2))
 		Expect(getRoleNames(out)).To(Equal([]string{"my-role"}))
 		Expect(getRoleBindingNames(out)).To(Equal([]string{"my-role-binding"}))
@@ -72,8 +72,8 @@ var _ = Describe("SplitCSVPermissionsObjects", func() {
 			newRoleBinding("my-role-binding", newClusterRoleRef("my-role"), newServiceAccountSubject("my-other-account")),
 		}
 		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
-		Expect(inPerm).To(HaveLen(0))
-		Expect(inCPerm).To(HaveLen(0))
+		Expect(inPerm).To(BeEmpty())
+		Expect(inCPerm).To(BeEmpty())
 		Expect(out).To(HaveLen(2))
 		Expect(getClusterRoleNames(out)).To(Equal([]string{"my-role"}))
 		Expect(getRoleBindingNames(out)).To(Equal([]string{"my-role-binding"}))
@@ -88,8 +88,8 @@ var _ = Describe("SplitCSVPermissionsObjects", func() {
 			newRoleBinding("my-role-binding-2", newClusterRoleRef("my-role"), newServiceAccountSubject("my-other-account")),
 		}
 		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
-		Expect(inPerm).To(HaveLen(0))
-		Expect(inCPerm).To(HaveLen(0))
+		Expect(inPerm).To(BeEmpty())
+		Expect(inCPerm).To(BeEmpty())
 		Expect(out).To(HaveLen(4))
 		Expect(getRoleNames(out)).To(Equal([]string{"my-role"}))
 		Expect(getClusterRoleNames(out)).To(Equal([]string{"my-role"}))
@@ -105,8 +105,8 @@ var _ = Describe("SplitCSVPermissionsObjects", func() {
 		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
 		Expect(inPerm).To(HaveLen(1))
 		Expect(getRoleNames(inPerm)).To(Equal([]string{"my-role"}))
-		Expect(inCPerm).To(HaveLen(0))
-		Expect(out).To(HaveLen(0))
+		Expect(inCPerm).To(BeEmpty())
+		Expect(out).To(BeEmpty())
 	})
 
 	It("splitting 1 ClusterRole 1 RoleBinding with 1 Subject containing a Deployment serviceAccountName", func() {
@@ -118,8 +118,8 @@ var _ = Describe("SplitCSVPermissionsObjects", func() {
 		inPerm, inCPerm, out = c.SplitCSVPermissionsObjects(nil)
 		Expect(inPerm).To(HaveLen(1))
 		Expect(getClusterRoleNames(inPerm)).To(Equal([]string{"my-role"}))
-		Expect(inCPerm).To(HaveLen(0))
-		Expect(out).To(HaveLen(0))
+		Expect(inCPerm).To(BeEmpty())
+		Expect(out).To(BeEmpty())
 	})
 
 	It("splitting 1 Role 1 ClusterRole 1 RoleBinding with 1 Subject containing a Deployment serviceAccountName", func() {
@@ -134,8 +134,8 @@ var _ = Describe("SplitCSVPermissionsObjects", func() {
 		Expect(inPerm).To(HaveLen(2))
 		Expect(getRoleNames(inPerm)).To(Equal([]string{"my-role"}))
 		Expect(getClusterRoleNames(inPerm)).To(Equal([]string{"my-role"}))
-		Expect(inCPerm).To(HaveLen(0))
-		Expect(out).To(HaveLen(0))
+		Expect(inCPerm).To(BeEmpty())
+		Expect(out).To(BeEmpty())
 	})
 
 	It("splitting 1 Role 1 ClusterRole 1 RoleBinding with 2 Subjects containing a Deployment serviceAccountName", func() {
@@ -219,7 +219,7 @@ var _ = Describe("SplitCSVPermissionsObjects", func() {
 			Expect(getClusterRoleNames(inPerm)).To(Equal([]string{roleName1}))
 			Expect(inCPerm).To(HaveLen(2))
 			Expect(getClusterRoleNames(inCPerm)).To(Equal([]string{roleName1, roleName2}))
-			Expect(out).To(HaveLen(0))
+			Expect(out).To(BeEmpty())
 		})
 	})
 })

--- a/internal/generate/packagemanifest/packagemanifest_test.go
+++ b/internal/generate/packagemanifest/packagemanifest_test.go
@@ -195,7 +195,7 @@ packageName: memcached-operator
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pm).NotTo(BeNil())
 			Expect(pm.PackageName).To(Equal("memcached-operator"))
-			Expect(len(pm.Channels)).To(Equal(1))
+			Expect(pm.Channels).To(HaveLen(1))
 			Expect(pm.Channels[0].Name).To(Equal("alpha"))
 			Expect(pm.Channels[0].CurrentCSVName).To(Equal("memcached-operator.v0.0.1"))
 			Expect(pm.DefaultChannelName).To(Equal("alpha"))

--- a/internal/olm/operator/registry/configmap/configmap_test.go
+++ b/internal/olm/operator/registry/configmap/configmap_test.go
@@ -100,10 +100,10 @@ var _ = Describe("ConfigMap", func() {
 
 			binaryData := make(map[string][]byte)
 			expected, err := yaml.Marshal(obj)
-			Expect(err).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
 			binaryData[makeObjectFileName(expected, userInput...)] = expected
 			// Test and verify function
-			Expect(addObjectToBinaryData(b, obj, userInput...)).Should(BeNil())
+			Expect(addObjectToBinaryData(b, obj, userInput...)).Should(Succeed())
 			Expect(b).Should(Equal(binaryData))
 		})
 
@@ -122,10 +122,9 @@ var _ = Describe("ConfigMap", func() {
 
 			userInput := []string{"userInput", "userInput2"}
 			b, e := makeObjectBinaryData(obj, userInput...)
-			Expect(e).Should(BeNil())
+			Expect(e).ShouldNot(HaveOccurred())
 			// Test and verify function
-			e = addObjectToBinaryData(binaryData, obj, userInput...)
-			Expect(e).Should(BeNil())
+			Expect(addObjectToBinaryData(binaryData, obj, userInput...)).Should(Succeed())
 			Expect(b).Should(Equal(binaryData))
 
 		})
@@ -133,7 +132,6 @@ var _ = Describe("ConfigMap", func() {
 
 	Describe("makeBundleBinaryData", func() {
 		It("should serialize bundle to binary data", func() {
-			var e error
 			b := apimanifests.Bundle{
 				Name: "testbundle",
 				Objects: []*unstructured.Unstructured{
@@ -147,11 +145,10 @@ var _ = Describe("ConfigMap", func() {
 			}
 
 			binaryData, err := makeBundleBinaryData(&b)
-			Expect(err).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
 			val := make(map[string][]byte)
 			for _, obj := range b.Objects {
-				e = addObjectToBinaryData(val, obj, obj.GetName(), obj.GetKind())
-				Expect(e).Should(BeNil())
+				Expect(addObjectToBinaryData(val, obj, obj.GetName(), obj.GetKind())).Should(Succeed())
 			}
 
 			Expect(binaryData).Should(Equal(val))
@@ -218,17 +215,17 @@ var _ = Describe("ConfigMap", func() {
 		})
 		It("should serialize packagemanifest to binary data", func() {
 			binaryDataByConfigMap, err := makeConfigMapsForPackageManifests(&p, b)
-			Expect(err).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
 
 			val := make(map[string]map[string][]byte)
 			cmName := getRegistryConfigMapName(p.PackageName) + "-package"
 			val[cmName], err = makeObjectBinaryData(p)
-			Expect(err).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
 			for _, bundle := range b {
 				version := bundle.CSV.Spec.Version.String()
 				cmName := getRegistryConfigMapName(p.PackageName) + "-" + k8sutil.FormatOperatorNameDNS1123(version)
 				val[cmName], e = makeBundleBinaryData(bundle)
-				Expect(e).Should(BeNil())
+				Expect(e).ShouldNot(HaveOccurred())
 			}
 
 			Expect(binaryDataByConfigMap).Should(Equal(val))
@@ -240,7 +237,6 @@ var _ = Describe("ConfigMap", func() {
 		var (
 			rr   RegistryResources
 			list corev1.ConfigMapList
-			e    error
 		)
 		BeforeEach(func() {
 			fakeclient := fake.NewClientBuilder().WithObjects(
@@ -274,10 +270,9 @@ var _ = Describe("ConfigMap", func() {
 				client_cr.MatchingLabels(makeRegistryLabels(rr.Pkg.PackageName)),
 				client_cr.InNamespace("testns"),
 			}
-			e = rr.Client.KubeClient.List(context.TODO(), &list, opts...)
-			Expect(e).Should(BeNil())
+			Expect(rr.Client.KubeClient.List(context.TODO(), &list, opts...)).Should(Succeed())
 			configmaps, err := rr.getRegistryConfigMaps(context.TODO(), "testns")
-			Expect(err).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(configmaps).Should(Equal(list.Items))
 		})

--- a/internal/olm/operator/registry/configmap/registry_test.go
+++ b/internal/olm/operator/registry/configmap/registry_test.go
@@ -105,13 +105,12 @@ var _ = Describe("Registry", func() {
 				},
 			}
 			dep := appsv1.Deployment{}
-			err := rr.Client.KubeClient.Get(context.TODO(), types.NamespacedName{Name: getRegistryServerName("pkgName"), Namespace: "testns"}, &dep)
-			Expect(err).Should(BeNil())
+			Expect(
+				rr.Client.KubeClient.Get(context.TODO(), types.NamespacedName{Name: getRegistryServerName("pkgName"), Namespace: "testns"}, &dep),
+			).Should(Succeed())
+			Expect(rr.DeletePackageManifestsRegistry(context.TODO(), "testns")).Should(Succeed())
 
-			err = rr.DeletePackageManifestsRegistry(context.TODO(), "testns")
-			Expect(err).Should(BeNil())
-
-			err = rr.Client.KubeClient.Get(context.TODO(), types.NamespacedName{Name: "pkgName-registry-server", Namespace: "testns"}, &dep)
+			err := rr.Client.KubeClient.Get(context.TODO(), types.NamespacedName{Name: "pkgName-registry-server", Namespace: "testns"}, &dep)
 			Expect(apierrors.IsNotFound(err)).Should(BeTrue())
 		})
 	})
@@ -170,7 +169,7 @@ var _ = Describe("Registry", func() {
 
 		It("should return true if a deployment exitsts in the registry", func() {
 			temp, err := rr.IsRegistryExist(context.TODO(), testns)
-			Expect(err).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(temp).Should(BeTrue())
 		})
 
@@ -180,11 +179,10 @@ var _ = Describe("Registry", func() {
 				temp bool
 			)
 
-			err = rr.DeletePackageManifestsRegistry(context.TODO(), testns)
-			Expect(err).Should(BeNil())
+			Expect(rr.DeletePackageManifestsRegistry(context.TODO(), testns)).Should(Succeed())
 
 			temp, err = rr.IsRegistryExist(context.TODO(), testns)
-			Expect(err).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(temp).Should(BeFalse())
 		})
 	})
@@ -254,14 +252,14 @@ var _ = Describe("Registry", func() {
 			rr.Client.KubeClient = fake.NewClientBuilder().Build()
 			temp, err := rr.IsRegistryDataStale(context.TODO(), testns)
 
-			Expect(err).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(temp).Should(BeTrue())
 		})
 
 		It("should return true if the configmap does not exist", func() {
 			temp, err := rr.IsRegistryDataStale(context.TODO(), testns)
 
-			Expect(err).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(temp).Should(BeTrue())
 		})
 
@@ -286,7 +284,7 @@ var _ = Describe("Registry", func() {
 			).Build()
 			temp, err := rr.IsRegistryDataStale(context.TODO(), testns)
 
-			Expect(err).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(temp).Should(BeTrue())
 		})
 
@@ -319,7 +317,7 @@ var _ = Describe("Registry", func() {
 			).Build()
 			temp, err := rr.IsRegistryDataStale(context.TODO(), testns)
 
-			Expect(err).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(temp).Should(BeTrue())
 		})
 
@@ -353,7 +351,7 @@ var _ = Describe("Registry", func() {
 			).Build()
 			temp, err := rr.IsRegistryDataStale(context.TODO(), testns)
 
-			Expect(err).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(temp).Should(BeTrue())
 		})
 	})

--- a/internal/olm/operator/registry/configmap_test.go
+++ b/internal/olm/operator/registry/configmap_test.go
@@ -70,9 +70,7 @@ var _ = Describe("Configmap", func() {
 				},
 			}
 			expected := cs.DeepCopy()
-			err := ctlog.updateCatalogSource(context.TODO(), cs)
-
-			Expect(err).Should(BeNil())
+			Expect(ctlog.updateCatalogSource(context.TODO(), cs)).Should(Succeed())
 			Expect(expected.Spec.Address).ShouldNot(Equal(cs.Spec.Address))
 			Expect(expected.Spec.SourceType).ShouldNot(Equal(cs.Spec.SourceType))
 		})

--- a/internal/olm/operator/registry/fbcindex/fbc_registry_pod_test.go
+++ b/internal/olm/operator/registry/fbcindex/fbc_registry_pod_test.go
@@ -104,7 +104,7 @@ var _ = Describe("FBCRegistryPod", func() {
 
 			It("should return a valid container command for one image", func() {
 				output, err := rp.getContainerCmd()
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(output).Should(Equal(containerCommandFor(rp.FBCIndexRootDir, rp.GRPCPort)))
 			})
 
@@ -128,7 +128,7 @@ var _ = Describe("FBCRegistryPod", func() {
 					BundleItems: bundleItems,
 				}
 				output, err := rp2.getContainerCmd()
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(output).Should(Equal(containerCommandFor(rp2.FBCIndexRootDir, rp2.GRPCPort)))
 			})
 		})
@@ -138,7 +138,7 @@ var _ = Describe("FBCRegistryPod", func() {
 				expectedErr := "bundle image set cannot be empty"
 				rp := &FBCRegistryPod{}
 				err := rp.init(cfg, cs)
-				Expect(err).NotTo(BeNil())
+				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring(expectedErr))
 			})
 
@@ -159,7 +159,7 @@ var _ = Describe("FBCRegistryPod", func() {
 				cancel()
 
 				err := rp.checkPodStatus(ctx, mockBadPodCheck)
-				Expect(err).NotTo(BeNil())
+				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring(expectedErr))
 			})
 		})
@@ -170,7 +170,7 @@ var _ = Describe("FBCRegistryPod", func() {
 				Expect(cm.GetObjectKind().GroupVersionKind()).Should(Equal(corev1.SchemeGroupVersion.WithKind("ConfigMap")))
 				Expect(cm.GetNamespace()).Should(Equal(cfg.Namespace))
 				Expect(cm.Data).ShouldNot(BeNil())
-				Expect(len(cm.Data)).Should(Equal(0))
+				Expect(cm.Data).Should(BeEmpty())
 			})
 
 			It("partitionedConfigMaps() should return a single ConfigMap", func() {
@@ -184,7 +184,7 @@ var _ = Describe("FBCRegistryPod", func() {
 					expectedYaml += yaml
 				}
 				cms := rp.partitionedConfigMaps()
-				Expect(len(cms)).Should(Equal(1))
+				Expect(cms).Should(HaveLen(1))
 				Expect(cms[0].Data).Should(HaveKey("extraFBC"))
 				Expect(cms[0].Data["extraFBC"]).Should(Equal(expectedYaml))
 			})
@@ -200,7 +200,7 @@ var _ = Describe("FBCRegistryPod", func() {
 				rp.FBCContent = largeYaml
 
 				cms := rp.partitionedConfigMaps()
-				Expect(len(cms)).Should(Equal(2))
+				Expect(cms).Should(HaveLen(2))
 				Expect(cms[0].Data).Should(HaveKey("extraFBC"))
 				Expect(cms[0].Data["extraFBC"]).ShouldNot(BeEmpty())
 				Expect(cms[1].Data).Should(HaveKey("extraFBC"))
@@ -249,7 +249,7 @@ var _ = Describe("FBCRegistryPod", func() {
 
 				cms, err := rp.createConfigMaps(cs)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(len(cms)).Should(Equal(1))
+				Expect(cms).Should(HaveLen(1))
 				Expect(cms[0].GetNamespace()).Should(Equal(rp.cfg.Namespace))
 				Expect(cms[0].GetName()).Should(Equal(expectedName))
 				Expect(cms[0].Data).Should(HaveKey("extraFBC"))
@@ -259,7 +259,7 @@ var _ = Describe("FBCRegistryPod", func() {
 				Expect(rp.cfg.Client.Get(context.TODO(), types.NamespacedName{Namespace: rp.cfg.Namespace, Name: expectedName}, testCm)).Should(Succeed())
 				Expect(testCm.Data).Should(HaveKey("extraFBC"))
 				Expect(testCm.Data["extraFBC"]).Should(Equal(expectedYaml))
-				Expect(len(testCm.OwnerReferences)).Should(Equal(1))
+				Expect(testCm.OwnerReferences).Should(HaveLen(1))
 			})
 
 			It("createConfigMaps() should create multiple ConfigMaps", func() {
@@ -272,7 +272,7 @@ var _ = Describe("FBCRegistryPod", func() {
 
 				cms, err := rp.createConfigMaps(cs)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(len(cms)).Should(Equal(2))
+				Expect(cms).Should(HaveLen(2))
 
 				for i, cm := range cms {
 					expectedName := fmt.Sprintf("%s-configmap-partition-%d", cs.GetName(), i+1)
@@ -285,7 +285,7 @@ var _ = Describe("FBCRegistryPod", func() {
 					Expect(rp.cfg.Client.Get(context.TODO(), types.NamespacedName{Namespace: rp.cfg.Namespace, Name: expectedName}, testCm)).Should(Succeed())
 					Expect(testCm.Data).Should(HaveKey("extraFBC"))
 					Expect(testCm.Data["extraFBC"]).Should(Equal(cm.Data["extraFBC"]))
-					Expect(len(testCm.OwnerReferences)).Should(Equal(1))
+					Expect(testCm.OwnerReferences).Should(HaveLen(1))
 				}
 			})
 		})

--- a/internal/olm/operator/registry/index/registry_pod_test.go
+++ b/internal/olm/operator/registry/index/registry_pod_test.go
@@ -93,14 +93,14 @@ var _ = Describe("SQLiteRegistryPod", func() {
 
 			It("should return a valid container command for one image", func() {
 				output, err := rp.getContainerCmd()
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(output).Should(Equal(containerCommandFor(defaultDBPath, defaultBundleItems, false, rp.SkipTLSVerify, false)))
 			})
 
 			It("should return a container command with --ca-file", func() {
 				rp.CASecretName = caSecretName
 				output, err := rp.getContainerCmd()
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(output).Should(Equal(containerCommandFor(defaultDBPath, defaultBundleItems, true, rp.SkipTLSVerify, false)))
 			})
 
@@ -110,7 +110,7 @@ var _ = Describe("SQLiteRegistryPod", func() {
 					rp.BundleItems = bundles
 					rp.SkipTLSVerify = true
 					output, err := rp.getContainerCmd()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(output).Should(Equal(containerCommandFor(defaultDBPath, bundles, false, rp.SkipTLSVerify, false)))
 				}
 			})
@@ -137,20 +137,20 @@ var _ = Describe("SQLiteRegistryPod", func() {
 					SkipTLSVerify: true,
 				}
 				output, err := rp2.getContainerCmd()
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(output).Should(Equal(containerCommandFor(defaultDBPath, bundleItems, false, rp2.SkipTLSVerify, false)))
 			})
 
 			It("should return a valid container command for one image", func() {
 				output, err := rp.getContainerCmd()
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(output).Should(Equal(containerCommandFor(defaultDBPath, defaultBundleItems, false, false, rp.UseHTTP)))
 			})
 
 			It("should return a container command with --ca-file", func() {
 				rp.CASecretName = caSecretName
 				output, err := rp.getContainerCmd()
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(output).Should(Equal(containerCommandFor(defaultDBPath, defaultBundleItems, true, false, rp.UseHTTP)))
 			})
 
@@ -160,7 +160,7 @@ var _ = Describe("SQLiteRegistryPod", func() {
 					rp.BundleItems = bundles
 					rp.UseHTTP = true
 					output, err := rp.getContainerCmd()
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(output).Should(Equal(containerCommandFor(defaultDBPath, bundles, false, false, rp.UseHTTP)))
 				}
 			})
@@ -187,7 +187,7 @@ var _ = Describe("SQLiteRegistryPod", func() {
 					UseHTTP:     true,
 				}
 				output, err := rp2.getContainerCmd()
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(output).Should(Equal(containerCommandFor(defaultDBPath, bundleItems, false, false, rp2.UseHTTP)))
 			})
 
@@ -196,9 +196,7 @@ var _ = Describe("SQLiteRegistryPod", func() {
 					return true, nil
 				})
 
-				err := rp.checkPodStatus(context.Background(), mockGoodPodCheck)
-
-				Expect(err).To(BeNil())
+				Expect(rp.checkPodStatus(context.Background(), mockGoodPodCheck)).To(Succeed())
 			})
 
 			It("adds secrets and a service account to the pod", func() {
@@ -244,7 +242,7 @@ var _ = Describe("SQLiteRegistryPod", func() {
 				expectedErr := "bundle image set cannot be empty"
 				rp := &SQLiteRegistryPod{}
 				err := rp.init(cfg)
-				Expect(err).NotTo(BeNil())
+				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring(expectedErr))
 			})
 
@@ -254,7 +252,7 @@ var _ = Describe("SQLiteRegistryPod", func() {
 					BundleItems: []BundleItem{{ImageTag: "quay.io/example/example-operator-bundle:0.2.0", AddMode: "invalid"}},
 				}
 				err := rp.init(cfg)
-				Expect(err).NotTo(BeNil())
+				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring(expectedErr))
 			})
 
@@ -275,7 +273,7 @@ var _ = Describe("SQLiteRegistryPod", func() {
 				cancel()
 
 				err := rp.checkPodStatus(ctx, mockBadPodCheck)
-				Expect(err).NotTo(BeNil())
+				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring(expectedErr))
 			})
 		})

--- a/internal/olm/operator/registry/operator_installer_test.go
+++ b/internal/olm/operator/registry/operator_installer_test.go
@@ -196,7 +196,7 @@ var _ = Describe("OperatorInstaller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ip.Name).To(Equal(name))
 			Expect(ip.Namespace).To(Equal(namespace))
-			Expect(ip.Spec.Approved).To(Equal(true))
+			Expect(ip.Spec.Approved).To(BeTrue())
 		})
 		It("should return an error if the install plan does not exist.", func() {
 			oi.cfg.Client = fake.NewClientBuilder().WithScheme(sch).Build()
@@ -356,11 +356,10 @@ var _ = Describe("OperatorInstaller", func() {
 				It("should create one with the given target namespaces", func() {
 					_ = oi.InstallMode.Set(string(v1alpha1.InstallModeTypeSingleNamespace))
 					oi.InstallMode.TargetNamespaces = []string{"anotherns"}
-					err := oi.ensureOperatorGroup(context.TODO())
-					Expect(err).To(BeNil())
+					Expect(oi.ensureOperatorGroup(context.TODO())).To(Succeed())
 
 					og, found, err := oi.getOperatorGroup(context.TODO())
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(og).ToNot(BeNil())
 					Expect(og.Name).To(Equal("operator-sdk-og"))
@@ -371,34 +370,32 @@ var _ = Describe("OperatorInstaller", func() {
 					_ = oi.InstallMode.Set(string(v1alpha1.InstallModeTypeSingleNamespace))
 					oi.InstallMode.TargetNamespaces = []string{"testns"}
 					err := oi.ensureOperatorGroup(context.TODO())
-					Expect(err).ToNot(BeNil())
+					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).Should(ContainSubstring("use install mode \"OwnNamespace\""))
 				})
 			})
 			Context("given OwnNamespace", func() {
 				It("should create one with the given target namespaces", func() {
 					_ = oi.InstallMode.Set(string(v1alpha1.InstallModeTypeOwnNamespace))
-					err := oi.ensureOperatorGroup(context.TODO())
-					Expect(err).To(BeNil())
+					Expect(oi.ensureOperatorGroup(context.TODO())).To(Succeed())
 
 					og, found, err := oi.getOperatorGroup(context.TODO())
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(og).ToNot(BeNil())
 					Expect(og.Name).To(Equal("operator-sdk-og"))
 					Expect(og.Namespace).To(Equal("testns"))
-					Expect(len(og.Spec.TargetNamespaces)).To(Equal(1))
+					Expect(og.Spec.TargetNamespaces).To(HaveLen(1))
 				})
 			})
 			Context("given MultiNamespaces", func() {
 				It("should create one with the given target namespaces", func() {
 					_ = oi.InstallMode.Set(string(v1alpha1.InstallModeTypeMultiNamespace))
 					oi.InstallMode.TargetNamespaces = []string{"anotherns1", "anotherns2"}
-					err := oi.ensureOperatorGroup(context.TODO())
-					Expect(err).To(BeNil())
+					Expect(oi.ensureOperatorGroup(context.TODO())).To(Succeed())
 
 					og, found, err := oi.getOperatorGroup(context.TODO())
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(og).ToNot(BeNil())
 					Expect(og.Name).To(Equal("operator-sdk-og"))
@@ -409,16 +406,15 @@ var _ = Describe("OperatorInstaller", func() {
 			Context("given AllNamespaces", func() {
 				It("should create one with the given target namespaces", func() {
 					_ = oi.InstallMode.Set(string(v1alpha1.InstallModeTypeAllNamespaces))
-					err := oi.ensureOperatorGroup(context.TODO())
-					Expect(err).To(BeNil())
+					Expect(oi.ensureOperatorGroup(context.TODO())).To(Succeed())
 
 					og, found, err := oi.getOperatorGroup(context.TODO())
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(og).ToNot(BeNil())
 					Expect(og.Name).To(Equal("operator-sdk-og"))
 					Expect(og.Namespace).To(Equal("testns"))
-					Expect(len(og.Spec.TargetNamespaces)).To(Equal(0))
+					Expect(og.Spec.TargetNamespaces).To(BeEmpty())
 				})
 			})
 		})
@@ -430,11 +426,10 @@ var _ = Describe("OperatorInstaller", func() {
 				It("should return nil for AllNamespaces with empty targets", func() {
 					// context, client, name, ns, targets
 					oog := createOperatorGroupHelper(context.TODO(), client, "existing-og", "testns")
-					err := oi.ensureOperatorGroup(context.TODO())
-					Expect(err).To(BeNil())
+					Expect(oi.ensureOperatorGroup(context.TODO())).To(Succeed())
 
 					og, found, err := oi.getOperatorGroup(context.TODO())
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(og.Name).To(Equal(oog.Name))
 					Expect(og.Namespace).To(Equal(oog.Namespace))
@@ -444,7 +439,7 @@ var _ = Describe("OperatorInstaller", func() {
 					_ = createOperatorGroupHelper(context.TODO(), client, "existing-og",
 						"testns", "incompatiblens")
 					err := oi.ensureOperatorGroup(context.TODO())
-					Expect(err).ShouldNot(BeNil())
+					Expect(err).Should(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("is not compatible"))
 				})
 			})
@@ -456,10 +451,10 @@ var _ = Describe("OperatorInstaller", func() {
 					oog := createOperatorGroupHelper(context.TODO(), client, "existing-og",
 						"testns", "testns")
 					err := oi.ensureOperatorGroup(context.TODO())
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 
 					og, found, err := oi.getOperatorGroup(context.TODO())
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(og.Name).To(Equal(oog.Name))
 					Expect(og.Namespace).To(Equal(oog.Namespace))
@@ -468,7 +463,7 @@ var _ = Describe("OperatorInstaller", func() {
 					_ = createOperatorGroupHelper(context.TODO(), client, "existing-og",
 						"testns", "incompatiblens")
 					err := oi.ensureOperatorGroup(context.TODO())
-					Expect(err).ShouldNot(BeNil())
+					Expect(err).Should(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("is not compatible"))
 				})
 			})
@@ -480,11 +475,10 @@ var _ = Describe("OperatorInstaller", func() {
 					oi.InstallMode.TargetNamespaces = []string{"anotherns"}
 					oog := createOperatorGroupHelper(context.TODO(), client, "existing-og",
 						"testns", "anotherns")
-					err := oi.ensureOperatorGroup(context.TODO())
-					Expect(err).To(BeNil())
+					Expect(oi.ensureOperatorGroup(context.TODO())).To(Succeed())
 
 					og, found, err := oi.getOperatorGroup(context.TODO())
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(og.Name).To(Equal(oog.Name))
 					Expect(og.Namespace).To(Equal(oog.Namespace))
@@ -494,7 +488,7 @@ var _ = Describe("OperatorInstaller", func() {
 					_ = createOperatorGroupHelper(context.TODO(), client, "existing-og",
 						"testns", "testns")
 					err := oi.ensureOperatorGroup(context.TODO())
-					Expect(err).ShouldNot(BeNil())
+					Expect(err).Should(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("use install mode \"OwnNamespace\""))
 				})
 			})
@@ -530,7 +524,7 @@ var _ = Describe("OperatorInstaller", func() {
 			Expect(og).ShouldNot(BeNil())
 			Expect(og.Name).To(Equal(operator.SDKOperatorGroupName))
 			Expect(og.Namespace).To(Equal("testnamespace"))
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
@@ -550,15 +544,14 @@ var _ = Describe("OperatorInstaller", func() {
 			}
 
 			err := oi.isOperatorGroupCompatible(og, oi.InstallMode.TargetNamespaces)
-			Expect(err).ShouldNot(BeNil())
+			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("is not compatible"))
 		})
 		It("should return nil if no installmode is empty", func() {
 			// empty install mode
 			oi.InstallMode = operator.InstallMode{}
 			Expect(oi.InstallMode.IsEmpty()).To(BeTrue())
-			err := oi.isOperatorGroupCompatible(og, oi.InstallMode.TargetNamespaces)
-			Expect(err).Should(BeNil())
+			Expect(oi.isOperatorGroupCompatible(og, oi.InstallMode.TargetNamespaces)).Should(Succeed())
 		})
 		It("should return nil if namespaces match", func() {
 			oi.InstallMode = operator.InstallMode{
@@ -566,8 +559,7 @@ var _ = Describe("OperatorInstaller", func() {
 				TargetNamespaces: []string{"matchingns"},
 			}
 			aog := createOperatorGroupHelper(context.TODO(), nil, "existing-og", "testns", "matchingns")
-			err := oi.isOperatorGroupCompatible(aog, oi.InstallMode.TargetNamespaces)
-			Expect(err).Should(BeNil())
+			Expect(oi.isOperatorGroupCompatible(aog, oi.InstallMode.TargetNamespaces)).Should(Succeed())
 		})
 	})
 
@@ -601,7 +593,7 @@ var _ = Describe("OperatorInstaller", func() {
 			grp, found, err := oi.getOperatorGroup(context.TODO())
 			Expect(grp).To(BeNil())
 			Expect(found).To(BeFalse())
-			Expect(err).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("should return an error when more than OperatorGroup found", func() {
 			_ = createOperatorGroupHelper(context.TODO(), client, "og1", "atestns")
@@ -618,7 +610,7 @@ var _ = Describe("OperatorInstaller", func() {
 			Expect(grp.Name).To(Equal(og.Name))
 			Expect(grp.Namespace).To(Equal(og.Namespace))
 			Expect(found).To(BeTrue())
-			Expect(err).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 
@@ -643,15 +635,15 @@ var _ = Describe("OperatorInstaller", func() {
 			supported.Insert(string(v1alpha1.InstallModeTypeAllNamespaces))
 			target, err := oi.getTargetNamespaces(supported)
 			Expect(target).To(BeNil())
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		It("should return operator's namespace when OwnNamespace is supported", func() {
 			oi.cfg.Namespace = "test-ns"
 			supported.Insert(string(v1alpha1.InstallModeTypeOwnNamespace))
 			target, err := oi.getTargetNamespaces(supported)
-			Expect(len(target)).To(Equal(1))
+			Expect(target).To(HaveLen(1))
 			Expect(target[0]).To(Equal("test-ns"))
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		It("should return configured namespace when SingleNamespace is passed in", func() {
 
@@ -662,9 +654,9 @@ var _ = Describe("OperatorInstaller", func() {
 
 			supported.Insert(string(v1alpha1.InstallModeTypeSingleNamespace))
 			target, err := oi.getTargetNamespaces(supported)
-			Expect(len(target)).To(Equal(1))
+			Expect(target).To(HaveLen(1))
 			Expect(target[0]).To(Equal("test-ns"))
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		It("should return configured namespace when MultiNamespace is passed in", func() {
 
@@ -675,9 +667,9 @@ var _ = Describe("OperatorInstaller", func() {
 
 			supported.Insert(string(v1alpha1.InstallModeTypeMultiNamespace))
 			target, err := oi.getTargetNamespaces(supported)
-			Expect(len(target)).To(Equal(2))
+			Expect(target).To(HaveLen(2))
 			Expect(target).To(Equal([]string{"test-ns1", "test-ns2"}))
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/internal/registry/labels_test.go
+++ b/internal/registry/labels_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Labels", func() {
 				expPath = defaultPath
 				writeMetadataHelper(fs, expPath, annotationsStringValidV1)
 				metadata, path, err = findBundleMetadata(fs, "/bundle")
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(path).To(Equal(expPath))
 				Expect(metadata).To(BeEquivalentTo(annotationsValidV1))
 			})
@@ -53,7 +53,7 @@ var _ = Describe("Labels", func() {
 				expPath = "/bundle/metadata/my-metadata.yaml"
 				writeMetadataHelper(fs, expPath, annotationsStringValidV1)
 				metadata, path, err = findBundleMetadata(fs, "/bundle")
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(path).To(Equal(expPath))
 				Expect(metadata).To(BeEquivalentTo(annotationsValidV1))
 			})
@@ -61,7 +61,7 @@ var _ = Describe("Labels", func() {
 				expPath = "/bundle/my-dir/my-metadata.yaml"
 				writeMetadataHelper(fs, expPath, annotationsStringValidV1)
 				metadata, path, err = findBundleMetadata(fs, "/bundle")
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(path).To(Equal(expPath))
 				Expect(metadata).To(BeEquivalentTo(annotationsValidV1))
 			})
@@ -69,7 +69,7 @@ var _ = Describe("Labels", func() {
 				expPath = "/bundle/my-parent-dir/my-dir/annotations.yaml"
 				writeMetadataHelper(fs, expPath, annotationsStringValidV1)
 				metadata, path, err = findBundleMetadata(fs, "/bundle")
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(path).To(Equal(expPath))
 				Expect(metadata).To(BeEquivalentTo(annotationsValidV1))
 			})
@@ -78,7 +78,7 @@ var _ = Describe("Labels", func() {
 				writeMetadataHelper(fs, expPath, annotationsStringValidV1)
 				writeMetadataHelper(fs, "/bundle/other-metadata/annotations.yaml", annotationsStringValidNoRegLabels)
 				metadata, path, err = findBundleMetadata(fs, "/bundle")
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(path).To(Equal(expPath))
 				Expect(metadata).To(BeEquivalentTo(annotationsValidV1))
 			})
@@ -87,7 +87,7 @@ var _ = Describe("Labels", func() {
 				writeMetadataHelper(fs, expPath, annotationsStringValidV1)
 				writeMetadataHelper(fs, "/bundle/custom2/annotations.yaml", annotationsStringValidNoRegLabels)
 				metadata, path, err = findBundleMetadata(fs, "/bundle")
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(path).To(Equal(expPath))
 				Expect(metadata).To(BeEquivalentTo(annotationsValidV1))
 			})
@@ -97,7 +97,7 @@ var _ = Describe("Labels", func() {
 				expPath = defaultPath
 				writeMetadataHelper(fs, defaultPath, annotationsStringValidNoRegLabels)
 				metadata, path, err = findBundleMetadata(fs, "/bundle")
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Expect(path).To(Equal(expPath))
 				Expect(metadata).To(BeEquivalentTo(annotationsValidNoRegLabels))
 			})

--- a/internal/scorecard/bundle_test.go
+++ b/internal/scorecard/bundle_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Tarring a bundle", func() {
 		BeforeEach(func() {
 			r = PodTestRunner{}
 			expTarball, err = os.ReadFile(expTarPath)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("with a valid on-disk bundle", func() {
@@ -54,9 +54,9 @@ var _ = Describe("Tarring a bundle", func() {
 			It("creates a tarball successfully", func() {
 				r.BundlePath = validBundlePath
 				r.BundleMetadata, _, err = registry.FindBundleMetadata(validBundlePath)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				tarredBundleData, err := r.getBundleData()
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				cmpTarFilesHelper(expTarball, tarredBundleData)
 			})
 		})
@@ -64,7 +64,7 @@ var _ = Describe("Tarring a bundle", func() {
 		Context("with an invalid on-disk bundle", func() {
 			It("returns an error", func() {
 				_, err = r.getBundleData()
-				Expect(err).NotTo(BeNil())
+				Expect(err).To(HaveOccurred())
 			})
 		})
 	})
@@ -76,9 +76,9 @@ var _ = Describe("Tarring a bundle", func() {
 func cmpTarFilesHelper(c1, c2 []byte) {
 	r1, r2 := bytes.NewBuffer(c1), bytes.NewBuffer(c2)
 	set1, err := untarToFileSet(r1)
-	ExpectWithOffset(1, err).To(BeNil())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	set2, err := untarToFileSet(r2)
-	ExpectWithOffset(1, err).To(BeNil())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 	for fileName, contents1 := range set1 {
 		contents2, hasFileName := set2[fileName]
@@ -87,7 +87,7 @@ func cmpTarFilesHelper(c1, c2 []byte) {
 			"contents of file %s differ in first and second tarballs", fileName)
 		delete(set2, fileName)
 	}
-	ExpectWithOffset(1, set2).To(HaveLen(0), "second tarball has files not in the first")
+	ExpectWithOffset(1, set2).To(BeEmpty(), "second tarball has files not in the first")
 }
 
 // untarToFileSet reads a gizpped tarball from r and writes each object's bytes to a set, keyed by header name.

--- a/internal/scorecard/tests/bundle_test.go
+++ b/internal/scorecard/tests/bundle_test.go
@@ -190,7 +190,7 @@ var _ = Describe("Basic and OLM tests", func() {
 				})
 
 				result = checkOwnedCSVStatusDescriptor(cr, &csv, result)
-				Expect(len(result.Suggestions)).To(Equal(1))
+				Expect(result.Suggestions).To(HaveLen(1))
 				Expect(result.State).To(Equal(scapiv1alpha3.PassState))
 			})
 

--- a/internal/validate/external_test.go
+++ b/internal/validate/external_test.go
@@ -46,7 +46,7 @@ var _ = Describe("External", func() {
 		It("should return false", func() {
 			entrypoints, hasExternal := GetExternalValidatorEntrypoints("")
 			Expect(hasExternal).To(BeFalse())
-			Expect(entrypoints).To(HaveLen(0))
+			Expect(entrypoints).To(BeEmpty())
 		})
 	})
 
@@ -58,7 +58,7 @@ var _ = Describe("External", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(results).To(HaveLen(1))
 			Expect(results[0].Name).To(Equal("passes-bundle"))
-			Expect(results[0].Errors).To(HaveLen(0))
+			Expect(results[0].Errors).To(BeEmpty())
 		})
 	})
 
@@ -85,7 +85,7 @@ var _ = Describe("External", func() {
 			results, err := RunExternalValidators(ctx, entrypoints, "foo/bar")
 			Expect(err).To(HaveOccurred())
 			Expect(stderrBuf.String()).To(Equal("validator runtime error"))
-			Expect(results).To(HaveLen(0))
+			Expect(results).To(BeEmpty())
 		})
 	})
 

--- a/test/e2e/ansible/cluster_test.go
+++ b/test/e2e/ansible/cluster_test.go
@@ -280,7 +280,7 @@ var _ = Describe("Running ansible projects", func() {
 			Expect(err).NotTo(HaveOccurred())
 			token, err := base64.StdEncoding.DecodeString(strings.TrimSpace(b64Token))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(token)).To(BeNumerically(">", 0))
+			Expect(token).ToNot(BeEmpty())
 
 			By("creating a curl pod")
 			cmdOpts := []string{
@@ -322,7 +322,7 @@ var _ = Describe("Running ansible projects", func() {
 				fmt.Sprintf("%s-sample", strings.ToLower(tc.Kind)),
 				"-o=jsonpath={..metadata.namespace}")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(crNamespace).NotTo(HaveLen(0))
+			Expect(crNamespace).NotTo(BeEmpty())
 
 			By("ensuring the operator metrics contains a `resource_created_at` metric for the Memcached CR")
 			metricExportedMemcachedCR := fmt.Sprintf("resource_created_at_seconds{group=\"%s\","+

--- a/test/e2e/go/cluster_test.go
+++ b/test/e2e/go/cluster_test.go
@@ -137,7 +137,7 @@ var _ = Describe("operator-sdk", func() {
 			Expect(err).NotTo(HaveOccurred())
 			token, err := base64.StdEncoding.DecodeString(strings.TrimSpace(b64Token))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(token)).To(BeNumerically(">", 0))
+			Expect(token).ToNot(BeEmpty())
 
 			By("creating a curl pod")
 			cmdOpts := []string{

--- a/test/e2e/helm/cluster_test.go
+++ b/test/e2e/helm/cluster_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Running Helm projects", func() {
 			Expect(err).NotTo(HaveOccurred())
 			token, err := base64.StdEncoding.DecodeString(strings.TrimSpace(b64Token))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(token)).To(BeNumerically(">", 0))
+			Expect(token).ToNot(BeEmpty())
 
 			By("creating a curl pod")
 			cmdOpts := []string{
@@ -266,7 +266,7 @@ var _ = Describe("Running Helm projects", func() {
 				fmt.Sprintf("%s-sample", strings.ToLower(tc.Kind)),
 				"-o=jsonpath={..metadata.namespace}")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(crNamespace).NotTo(HaveLen(0))
+			Expect(crNamespace).NotTo(BeEmpty())
 
 			By("ensuring the operator metrics contains a `resource_created_at` metric for the CR")
 			metricExportedCR := fmt.Sprintf("resource_created_at_seconds{group=\"%s\","+


### PR DESCRIPTION
## Description of the change
enable [ginkgolinter](https://github.com/nunnatsa/ginkgolinter) and fix findings.

## Motivation for the change
Improve test code quality and prevent some bug, when using ginkgo and gomega.

## Checklist

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
