### PR TITLE
Set REST timeout when timeout cli arg is provided

### DIFF
--- a/internal/olm/operator/config.go
+++ b/internal/olm/operator/config.go
@@ -68,6 +68,10 @@ func (c *Configuration) Load() error {
 	if c.overrides == nil {
 		c.overrides = &clientcmd.ConfigOverrides{}
 	}
+	if c.overrides.Timeout == "" && c.Timeout > 0 {
+		c.overrides.Timeout = c.Timeout.String()
+	}
+
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.ExplicitPath = c.KubeconfigPath
 	mergedConfig, err := loadingRules.Load()


### PR DESCRIPTION
**Description of the change:**
The timeout arg sets the overall timeout for the full command to finish, such as `run bundle`, but it doesn't affect the timeout of individual API server requests. This remains the default timeout specified in the API server configuration. This means that even if a user wants `run bundle` to timeout after 5m, the command may return earlier due to an individual request's timeout being hit.

This commit fixes that behavior by setting the Timeout value in the client cfg to the value passed in by the user, this will prevent the individual request from timing out before the desired timeout.

**Motivation for the change:**
operator-sdk bundle run fails on operators that take longer than usual to install