### PR TITLE
Manage printing OverrideValues

### DIFF
--- a/internal/cmd/helm-operator/run/cmd.go
+++ b/internal/cmd/helm-operator/run/cmd.go
@@ -213,6 +213,7 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 			ReconcilePeriod:         reconcilePeriod,
 			WatchDependentResources: *w.WatchDependentResources,
 			OverrideValues:          w.OverrideValues,
+			VerboseOverride:         f.VerboseOverride,
 			MaxConcurrentReconciles: f.MaxConcurrentReconciles,
 			Selector:                w.Selector,
 		})

--- a/internal/helm/controller/controller.go
+++ b/internal/helm/controller/controller.go
@@ -52,6 +52,7 @@ type WatchOptions struct {
 	ReconcilePeriod         time.Duration
 	WatchDependentResources bool
 	OverrideValues          map[string]string
+	VerboseOverride         bool
 	MaxConcurrentReconciles int
 	Selector                metav1.LabelSelector
 }
@@ -67,6 +68,7 @@ func Add(mgr manager.Manager, options WatchOptions) error {
 		ManagerFactory:  options.ManagerFactory,
 		ReconcilePeriod: options.ReconcilePeriod,
 		OverrideValues:  options.OverrideValues,
+		VerboseOverride: options.VerboseOverride,
 	}
 
 	// Register the GVK with the schema

--- a/internal/helm/controller/reconcile.go
+++ b/internal/helm/controller/reconcile.go
@@ -52,6 +52,7 @@ type HelmOperatorReconciler struct {
 	ManagerFactory  release.ManagerFactory
 	ReconcilePeriod time.Duration
 	OverrideValues  map[string]string
+	VerboseOverride bool
 	releaseHook     ReleaseHookFunc
 }
 
@@ -230,9 +231,11 @@ func (r HelmOperatorReconciler) Reconcile(ctx context.Context, request reconcile
 	status.RemoveCondition(types.ConditionIrreconcilable)
 
 	if !manager.IsInstalled() {
-		for k, v := range r.OverrideValues {
-			r.EventRecorder.Eventf(o, "Warning", "OverrideValuesInUse",
-				"Chart value %q overridden to %q by operator's watches.yaml", k, v)
+		if r.VerboseOverride {
+			for k, v := range r.OverrideValues {
+				r.EventRecorder.Eventf(o, "Warning", "OverrideValuesInUse",
+					"Chart value %q overridden to %q by operator's watches.yaml", k, v)
+			}
 		}
 		installedRelease, err := manager.InstallRelease(ctx)
 		if err != nil {
@@ -299,9 +302,11 @@ func (r HelmOperatorReconciler) Reconcile(ctx context.Context, request reconcile
 	}
 
 	if manager.IsUpgradeRequired() {
-		for k, v := range r.OverrideValues {
-			r.EventRecorder.Eventf(o, "Warning", "OverrideValuesInUse",
-				"Chart value %q overridden to %q by operator's watches.yaml", k, v)
+		if r.VerboseOverride {
+			for k, v := range r.OverrideValues {
+				r.EventRecorder.Eventf(o, "Warning", "OverrideValuesInUse",
+					"Chart value %q overridden to %q by operator's watches.yaml", k, v)
+			}
 		}
 		force := hasAnnotation(helmUpgradeForceAnnotation, o)
 		previousRelease, upgradedRelease, err := manager.UpgradeRelease(ctx, release.ForceUpgrade(force))

--- a/internal/helm/flags/flag.go
+++ b/internal/helm/flags/flag.go
@@ -33,7 +33,7 @@ type Flags struct {
 	LeaderElectionNamespace string
 	MaxConcurrentReconciles int
 	ProbeAddr               string
-
+	VerboseOverride         bool
 	// Path to a controller-runtime componentconfig file.
 	// If this is empty, use default values.
 	ManagerConfigPath string
@@ -118,6 +118,12 @@ func (f *Flags) AddTo(flagSet *pflag.FlagSet) {
 		"Namespace in which to create the leader election configmap for"+
 			" holding the leader lock (required if running locally with leader"+
 			" election enabled).",
+	)
+	flagSet.BoolVar(&f.VerboseOverride,
+		"verbose-override",
+		true,
+		"Enable log events about overriding template values"+
+			" including the actual old and new values.",
 	)
 }
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->
(Hint: If you are not satisfied with the variable name, flag-name or the description of the flag feel free to suggest - it's my first open-source PR :) )
**Description of the change:**
***Changes***
I made enhancements to the Operator-SDK to include an additional flag to the Helm-Operator. By adding this feature the Event-Recorder will not print/log the Override-Values.

I introduced the `--verbose-override`-flag to manage whether or not the OverrideValues are printed/logged. By introducing this flag users that use the helm-operator can be sure that their confidental information in the OverrideValues are not exposed.

**Motivation for the change:**
In my own projects I use some Certificate/Credential/Confidental Information in the OverrideValues which I do not want to be printed/logged.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
