### PR TITLE
fix: update test-docs to fail less randomly

### DIFF
--- a/hack/check-links.sh
+++ b/hack/check-links.sh
@@ -11,9 +11,10 @@ docker run --rm -v "$(pwd):/src" -v sdk-html:/src/website/public klakegg/hugo:0.
 
 header_text "Checking links"
 # For config explanation: https://github.com/gjtorikian/html-proofer#special-cases-for-the-command-line
-docker run --rm -v sdk-html:/target klakegg/html-proofer:3.18.8 /target \
+docker run --rm -v sdk-html:/target klakegg/html-proofer:3.19.2 /target \
   --empty-alt-ignore \
   --http-status-ignore 429 \
   --allow_hash_href \
-  --typhoeus '{"followlocation":true,"connecttimeout":600,"timeout":600}' \
+  --typhoeus-config='{"ssl_verifypeer":false,"followlocation":true,"connecttimeout":600,"timeout":600}' \
+  --hydra-config='{"max_concurrency":5}' \
   --url-ignore "/github.com\/operator-framework\/operator-sdk\/edit\/master\//,https://docs.github.com/en/get-started/quickstart/fork-a-repo,https://github.com/operator-framework/operator-sdk/settings/access"


### PR DESCRIPTION
**Description of the change:**
- Seems that the `make test-docs` is failing randomly. This updates the config and container version to reduce random failures.

**Motivation for the change:**
Have passing CI for link url checking.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
