### PR TITLE
Bump ubi(-minimal) to 8.8

### DIFF
--- a/changelog/fragments/01-ubi-image-bump.yaml
+++ b/changelog/fragments/01-ubi-image-bump.yaml
@@ -1,0 +1,14 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      (images): Bumps all Operator SDK maintained images to now use ubi(-minimal) tag 8.8
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+    # Is this a breaking change?
+    breaking: false

--- a/images/ansible-operator-2.11-preview/base.Dockerfile
+++ b/images/ansible-operator-2.11-preview/base.Dockerfile
@@ -2,7 +2,7 @@
 # It is built with dependencies that take a while to download, thus speeding
 # up ansible deploy jobs.
 
-FROM registry.access.redhat.com/ubi8/ubi:8.7
+FROM registry.access.redhat.com/ubi8/ubi:8.8
 ARG TARGETARCH
 
 # Label this image with the repo and commit that built it, for freshmaking purposes.

--- a/images/ansible-operator/base.Dockerfile
+++ b/images/ansible-operator/base.Dockerfile
@@ -2,7 +2,7 @@
 # It is built with dependencies that take a while to download, thus speeding
 # up ansible deploy jobs.
 
-FROM registry.access.redhat.com/ubi8/ubi:8.7
+FROM registry.access.redhat.com/ubi8/ubi:8.8
 ARG TARGETARCH
 
 # Label this image with the repo and commit that built it, for freshmaking purposes.

--- a/images/custom-scorecard-tests/Dockerfile
+++ b/images/custom-scorecard-tests/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/custom-scorecard-tests
 
 # Final image.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 
 ENV HOME=/opt/custom-scorecard-tests \
     USER_NAME=custom-scorecard-tests \

--- a/images/helm-operator/Dockerfile
+++ b/images/helm-operator/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/helm-operator
 
 # Final image.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 
 ENV HOME=/opt/helm \
     USER_NAME=helm \

--- a/images/operator-sdk/Dockerfile
+++ b/images/operator-sdk/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/operator-sdk
 
 # Final image.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 
 ENV GO_VERSION 1.19
 

--- a/images/scorecard-test/Dockerfile
+++ b/images/scorecard-test/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN GOOS=linux GOARCH=$TARGETARCH make build/scorecard-test
 
 # Final image.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
 
 ENV HOME=/opt/scorecard-test \
     USER_NAME=scorecard-test \

--- a/website/content/en/docs/building-operators/ansible/reference/proxy-vars.md
+++ b/website/content/en/docs/building-operators/ansible/reference/proxy-vars.md
@@ -24,7 +24,7 @@ Example:
           spec:
             containers:
               - name: curl-example
-                image: registry.access.redhat.com/ubi8/ubi:8.4-209
+                image: registry.access.redhat.com/ubi8/ubi:8.8
                 command: ["curl"]
                 args: ["http://example.com/job-request"]
                 env:


### PR DESCRIPTION
**Description of the change:**

Bump ubi(-minimal) to 8.8.

**Motivation for the change:**

Some Telco partners use helm-operator and ansible-operator as base images for their operators. Since they are interested in RH-certifying their images, they need to be based on the latest ubi(-minimal)8 in order to pass the [OpenSCAP](https://www.redhat.com/sysadmin/container-vulnerabilities-openscap) vulnerability checks. 
Related issue: https://github.com/operator-framework/operator-sdk/issues/6118 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [X] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
