### PR TITLE
Manage recording OverrideValues

### DIFF
--- a/changelog/fragments/01-suppress-overrides.yaml
+++ b/changelog/fragments/01-suppress-overrides.yaml
@@ -1,0 +1,42 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Currently, when setting `overrideValues` in your `watches.yaml`, every entry is logged with its key and its value.
+      When working with confidential information such as credentials, logging those information would not be optimal nor
+      desirable. Therefore, there should be a way to silence/suppress these values.
+      
+      This feature introduces the `--suppress-override-values` boolean-flag for the `helm-operator`. When set to true,
+      the value of the overrideValues entry is sanitized with this value "****".
+      
+      This is a simple example of `overrideValues` of the `watches.yaml`
+      ```yaml
+      overrideValues:
+        x: y
+      ```
+      
+      The default-value of `--suppress-override-values` is `false` so therefore we would get this warning logged:
+      `Chart value x overridden to y by operator's watches.yaml`
+
+      When setting `--suppress-override-values` `true` the warning will be logged in the following manner:
+      `Chart value x overridden to **** by operator's watches.yaml`
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/internal/cmd/helm-operator/run/cmd.go
+++ b/internal/cmd/helm-operator/run/cmd.go
@@ -213,6 +213,7 @@ func run(cmd *cobra.Command, f *flags.Flags) {
 			ReconcilePeriod:         reconcilePeriod,
 			WatchDependentResources: *w.WatchDependentResources,
 			OverrideValues:          w.OverrideValues,
+			SuppressOverrideValues:  f.SuppressOverrideValues,
 			MaxConcurrentReconciles: f.MaxConcurrentReconciles,
 			Selector:                w.Selector,
 		})

--- a/internal/helm/controller/controller.go
+++ b/internal/helm/controller/controller.go
@@ -52,6 +52,7 @@ type WatchOptions struct {
 	ReconcilePeriod         time.Duration
 	WatchDependentResources bool
 	OverrideValues          map[string]string
+	SuppressOverrideValues  bool
 	MaxConcurrentReconciles int
 	Selector                metav1.LabelSelector
 }
@@ -61,12 +62,13 @@ func Add(mgr manager.Manager, options WatchOptions) error {
 	controllerName := fmt.Sprintf("%v-controller", strings.ToLower(options.GVK.Kind))
 
 	r := &HelmOperatorReconciler{
-		Client:          mgr.GetClient(),
-		EventRecorder:   mgr.GetEventRecorderFor(controllerName),
-		GVK:             options.GVK,
-		ManagerFactory:  options.ManagerFactory,
-		ReconcilePeriod: options.ReconcilePeriod,
-		OverrideValues:  options.OverrideValues,
+		Client:                 mgr.GetClient(),
+		EventRecorder:          mgr.GetEventRecorderFor(controllerName),
+		GVK:                    options.GVK,
+		ManagerFactory:         options.ManagerFactory,
+		ReconcilePeriod:        options.ReconcilePeriod,
+		OverrideValues:         options.OverrideValues,
+		SuppressOverrideValues: options.SuppressOverrideValues,
 	}
 
 	// Register the GVK with the schema

--- a/internal/helm/controller/reconcile.go
+++ b/internal/helm/controller/reconcile.go
@@ -46,13 +46,14 @@ type ReleaseHookFunc func(*rpb.Release) error
 
 // HelmOperatorReconciler reconciles custom resources as Helm releases.
 type HelmOperatorReconciler struct {
-	Client          client.Client
-	EventRecorder   record.EventRecorder
-	GVK             schema.GroupVersionKind
-	ManagerFactory  release.ManagerFactory
-	ReconcilePeriod time.Duration
-	OverrideValues  map[string]string
-	releaseHook     ReleaseHookFunc
+	Client                 client.Client
+	EventRecorder          record.EventRecorder
+	GVK                    schema.GroupVersionKind
+	ManagerFactory         release.ManagerFactory
+	ReconcilePeriod        time.Duration
+	OverrideValues         map[string]string
+	SuppressOverrideValues bool
+	releaseHook            ReleaseHookFunc
 }
 
 const (
@@ -231,6 +232,9 @@ func (r HelmOperatorReconciler) Reconcile(ctx context.Context, request reconcile
 
 	if !manager.IsInstalled() {
 		for k, v := range r.OverrideValues {
+			if r.SuppressOverrideValues {
+				v = "****"
+			}
 			r.EventRecorder.Eventf(o, "Warning", "OverrideValuesInUse",
 				"Chart value %q overridden to %q by operator's watches.yaml", k, v)
 		}
@@ -300,6 +304,9 @@ func (r HelmOperatorReconciler) Reconcile(ctx context.Context, request reconcile
 
 	if manager.IsUpgradeRequired() {
 		for k, v := range r.OverrideValues {
+			if r.SuppressOverrideValues {
+				v = "****"
+			}
 			r.EventRecorder.Eventf(o, "Warning", "OverrideValuesInUse",
 				"Chart value %q overridden to %q by operator's watches.yaml", k, v)
 		}

--- a/internal/helm/flags/flag.go
+++ b/internal/helm/flags/flag.go
@@ -33,6 +33,7 @@ type Flags struct {
 	LeaderElectionNamespace string
 	MaxConcurrentReconciles int
 	ProbeAddr               string
+	SuppressOverrideValues  bool
 
 	// Path to a controller-runtime componentconfig file.
 	// If this is empty, use default values.
@@ -118,6 +119,11 @@ func (f *Flags) AddTo(flagSet *pflag.FlagSet) {
 		"Namespace in which to create the leader election configmap for"+
 			" holding the leader lock (required if running locally with leader"+
 			" election enabled).",
+	)
+	flagSet.BoolVar(&f.SuppressOverrideValues,
+		"suppress-override-values",
+		false,
+		"Silences the override-value for OverrideValuesInUse events",
 	)
 }
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->
**Description of the change:**
***Changes***
I made enhancements to the Operator-SDK to include an additional flag to the Helm-Operator. By adding this feature the Event-Recorder will not print/log the Override-Values.

I introduced the `--suppress-override-values`-flag to manage whether or not the OverrideValues are printed/logged. By introducing this flag users that use the helm-operator can be sure that their confidental information in the OverrideValues are not exposed.

**Motivation for the change:**
At Mercedes-Benz, our team is running a Container-as-a-Service (CaaS) platform based on Kubernetes.
We use the helm-operator with confidental OverrideValues which we do not want to be exposed

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

*Ugur Gündüz [ugur.guenduez@mercedes-benz.com](mailto:ugur.guenduez@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH, [Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)*