### PR TITLE
Fix RFE-4185: run bundle-upgrade with long image names

### DIFF
--- a/changelog/fragments/01-hash-cache-directory-name.yaml
+++ b/changelog/fragments/01-hash-cache-directory-name.yaml
@@ -1,0 +1,6 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: In `run bundle-upgrade`, hash the cache directory name to avoid error of too long file name.
+    kind: "bugfix"
+    breaking: false

--- a/internal/olm/fbcutil/util.go
+++ b/internal/olm/fbcutil/util.go
@@ -17,6 +17,7 @@ package fbcutil
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -134,7 +135,8 @@ func NullLogger() *log.Entry {
 // RenderRefs will invoke Operator Registry APIs and return a declarative config object representation
 // of the references that are passed in as a string array.
 func RenderRefs(ctx context.Context, refs []string, skipTLSVerify bool, useHTTP bool) (*declarativeconfig.DeclarativeConfig, error) {
-	cacheDir := strings.ReplaceAll(strings.Join(refs, "_"), "/", "-")
+	cacheDir := dirNameFromRefs(refs)
+
 	if cacheDir == "" {
 		cacheDir = DefaultCacheDir
 	}
@@ -167,6 +169,14 @@ func RenderRefs(ctx context.Context, refs []string, skipTLSVerify bool, useHTTP 
 	}
 
 	return declcfg, nil
+}
+
+func dirNameFromRefs(refs []string) string {
+	dirNameBytes := []byte(strings.ReplaceAll(strings.Join(refs, "_"), "/", "-"))
+	hash := sha256.New()
+	hash.Write(dirNameBytes)
+	hashBytes := hash.Sum(nil)
+	return fmt.Sprintf("%x", hashBytes)
 }
 
 // IsFBC will determine if an index image uses the File-Based Catalog or SQLite index image format.

--- a/internal/olm/fbcutil/util_test.go
+++ b/internal/olm/fbcutil/util_test.go
@@ -1,0 +1,52 @@
+// Copyright 2023 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fbcutil
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("test fbutil", func() {
+
+	emptyListHash := fmt.Sprintf("%x", sha256.New().Sum(nil))
+
+	Context("test dirNameFromRefs", func() {
+		DescribeTable("should name the directory with sha256 of the concatenation of the bundle image names", func(refs []string, expectedHash string) {
+			dirName := dirNameFromRefs(refs)
+
+			Expect(dirName).Should(HaveLen(sha256.Size * 2)) // in hex representation, each byte is two hex digits
+			Expect(dirName).Should(Equal(expectedHash))
+		},
+			Entry("long image names", []string{
+				"BtU5KRr8IWafnGTvckShoj3xBb5duLZp/XKHZRpOqdVxhHQkCL0Dy0lSRw0a0M/y158JRQKk1S@6KAauQHujQ30my9sivVYGZahR7R7UUSoUBUmnuFdqGHiUTT0aV5Di2",
+				"lKM63iKupQcUPKd6AAsmRRABbGYNmwFTmQEX6fpswndQdb/niJPLRG8WhzaH84Q3kfZC/7hc3nK7Oeq@L5KxmVqbAz6jXlv1yKna2cH4zbZ3be0pcYNHyCSVUG/ZVqRAo",
+			}, "cc048355dce06491fd090ce0c3ce5a48db3528250ad13a4fbf4090a3de8c325a"),
+			Entry("multiple refs", []string{"a/b/c", "d/e/f", "g/h/i/j", "k/l/m/n/o"}, "df22ac3ac9e59ed300f70b9c2fdd7128be064652839a813948ee9fd1a2f36581"),
+			Entry("single ref", []string{"a/b/c"}, "cbd2be7b96f770a0326948ebd158cf539fab0627e8adbddc97f7a65c6a8ae59a"),
+			Entry("no refs", []string{}, emptyListHash),
+			Entry("no refs (nil)", nil, emptyListHash),
+		)
+	})
+})
+
+func TestRegistry(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "fbutil Suite")
+}


### PR DESCRIPTION
Fix #6476 

## Description of the change
In `run bundle-upgrade`, hash the cache directory name to avoid error of too long file name.


## Motivation for the change
`run bundle-upgrade` is failing if the bundle image names are long. See #6476 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
