### PR TITLE
Use k8s.io/utils set instead of apimachinery sets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	k8s.io/cli-runtime v0.26.2
 	k8s.io/client-go v0.26.2
 	k8s.io/kubectl v0.26.2
-	k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5
+	k8s.io/utils v0.0.0-20230711102312-30195339c3c7
 	sigs.k8s.io/controller-runtime v0.14.5
 	sigs.k8s.io/controller-tools v0.11.3
 	sigs.k8s.io/kubebuilder/v3 v3.9.1

--- a/go.sum
+++ b/go.sum
@@ -1649,8 +1649,8 @@ k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 h1:+70TFaan3hfJzs+7VK2o+O
 k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280/go.mod h1:+Axhij7bCpeqhklhUTe3xmOn6bWxolyZEeyaFpjGtl4=
 k8s.io/kubectl v0.26.2 h1:SMPB4j48eVFxsYluBq3VLyqXtE6b72YnszkbTAtFye4=
 k8s.io/kubectl v0.26.2/go.mod h1:KYWOXSwp2BrDn3kPeoU/uKzKtdqvhK1dgZGd0+no4cM=
-k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5 h1:kmDqav+P+/5e1i9tFfHq1qcF3sOrDp+YEkVDAHu7Jwk=
-k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20230711102312-30195339c3c7 h1:ZgnF1KZsYxWIifwSNZFZgNtWE89WI5yiP5WwlfDoIyc=
+k8s.io/utils v0.0.0-20230711102312-30195339c3c7/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 oras.land/oras-go v1.2.2 h1:0E9tOHUfrNH7TCDk5KU0jVBEzCqbfdyuVfGmJ7ZeRPE=
 oras.land/oras-go v1.2.2/go.mod h1:Apa81sKoZPpP7CDciE006tSZ0x3Q3+dOoBcMZ/aNxvw=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/hack/generate/cncf-maintainers/main.go
+++ b/hack/generate/cncf-maintainers/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/set"
 	"sigs.k8s.io/yaml"
 )
 
@@ -33,9 +33,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	expandedOwners := make(map[string]sets.Set[string])
+	expandedOwners := make(map[string]set.Set[string])
 	for group, ownersAliases := range owners {
-		expandedOwners[group] = sets.New[string]()
+		expandedOwners[group] = set.New[string]()
 		for _, alias := range ownersAliases {
 			if members, ok := aliases.Aliases[alias]; ok {
 				expandedOwners[group].Insert(members...)
@@ -47,7 +47,7 @@ func main() {
 
 	outOwners := make(map[string][]string)
 	for g, m := range expandedOwners {
-		outOwners[g] = sets.List(m)
+		outOwners[g] = m.SortedList()
 	}
 
 	out, err := yaml.Marshal(outOwners)

--- a/internal/ansible/proxy/cache_response.go
+++ b/internal/ansible/proxy/cache_response.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/set"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -58,8 +58,8 @@ func (c *cacheResponseHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 	switch req.Method {
 	case http.MethodGet:
 		// GET request means we need to check the cache
-		rf := k8sRequest.RequestInfoFactory{APIPrefixes: sets.Set[string]{"api": {}, "apis": {}},
-			GrouplessAPIPrefixes: sets.Set[string]{"api": {}}}
+		rf := k8sRequest.RequestInfoFactory{APIPrefixes: set.New("api", "apis"),
+			GrouplessAPIPrefixes: set.New("api")}
 		r, err := rf.NewRequestInfo(req)
 		if err != nil {
 			log.Error(err, "Failed to convert request")

--- a/internal/ansible/proxy/inject_owner.go
+++ b/internal/ansible/proxy/inject_owner.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/set"
 
 	"github.com/operator-framework/operator-sdk/internal/ansible/proxy/controllermap"
 	k8sRequest "github.com/operator-framework/operator-sdk/internal/ansible/proxy/requestfactory"
@@ -50,8 +50,8 @@ func (i *injectOwnerReferenceHandler) ServeHTTP(w http.ResponseWriter, req *http
 	case http.MethodPost:
 		dump, _ := httputil.DumpRequest(req, false)
 		log.V(2).Info("Dumping request", "RequestDump", string(dump))
-		rf := k8sRequest.RequestInfoFactory{APIPrefixes: sets.Set[string]{"api": {}, "apis": {}},
-			GrouplessAPIPrefixes: sets.Set[string]{"api": {}}}
+		rf := k8sRequest.RequestInfoFactory{APIPrefixes: set.New("api", "apis"),
+			GrouplessAPIPrefixes: set.New("api")}
 		r, err := rf.NewRequestInfo(req)
 		if err != nil {
 			m := "Could not convert request"

--- a/internal/ansible/proxy/requestfactory/requestinfo.go
+++ b/internal/ansible/proxy/requestfactory/requestinfo.go
@@ -29,7 +29,7 @@ import (
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metainternalscheme "k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/set"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -75,24 +75,24 @@ type RequestInfo struct {
 // actions that don't fall under the normal CRUDdy GET/POST/PUT/DELETE actions
 // on REST objects.  TODO: find a way to keep this up to date automatically.
 // Maybe dynamically populate list as handlers added to master's Mux.
-var specialVerbs = sets.NewString("proxy", "watch")
+var specialVerbs = set.New("proxy", "watch")
 
 // specialVerbsNoSubresources contains root verbs which do not allow
 // subresources
-var specialVerbsNoSubresources = sets.NewString("proxy")
+var specialVerbsNoSubresources = set.New("proxy")
 
 // namespaceSubresources contains subresources of namespace this list allows
 // the parser to distinguish between a namespace subresource, and a namespaced
 // resource
-var namespaceSubresources = sets.NewString("status", "finalize")
+var namespaceSubresources = set.New("status", "finalize")
 
 // NamespaceSubResourcesForTest exports namespaceSubresources for testing in
 // pkg/master/master_test.go, so we never drift
-var NamespaceSubResourcesForTest = sets.NewString(namespaceSubresources.List()...)
+var NamespaceSubResourcesForTest = set.New(namespaceSubresources.SortedList()...)
 
 type RequestInfoFactory struct {
-	APIPrefixes          sets.Set[string] // without leading and trailing slashes
-	GrouplessAPIPrefixes sets.Set[string] // without leading and trailing slashes
+	APIPrefixes          set.Set[string] // without leading and trailing slashes
+	GrouplessAPIPrefixes set.Set[string] // without leading and trailing slashes
 }
 
 // TODO write an integration test against the swagger doc to test the

--- a/internal/cmd/operator-sdk/generate/internal/relatedimages.go
+++ b/internal/cmd/operator-sdk/generate/internal/relatedimages.go
@@ -22,7 +22,7 @@ import (
 	"github.com/operator-framework/operator-sdk/internal/generate/collector"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/set"
 )
 
 // FindRelatedImages looks in the controller manager's environment for images used by the operator.
@@ -31,7 +31,7 @@ func FindRelatedImages(manifestCol *collector.Manifests) ([]operatorsv1alpha1.Re
 		relatedImages:           []*relatedImage{},
 		relatedImagesByName:     make(map[string][]*relatedImage),
 		relatedImagesByImageRef: make(map[string][]*relatedImage),
-		seenRelatedImages:       sets.Set[string]{},
+		seenRelatedImages:       set.Set[string]{},
 	}
 
 	for _, deployment := range manifestCol.Deployments {
@@ -65,7 +65,7 @@ type relatedImageCollector struct {
 	relatedImages           []*relatedImage
 	relatedImagesByName     map[string][]*relatedImage
 	relatedImagesByImageRef map[string][]*relatedImage
-	seenRelatedImages       sets.Set[string]
+	seenRelatedImages       set.Set[string]
 }
 
 func (c *relatedImageCollector) collectFromEnvironment(containerRef string, env []corev1.EnvVar) error {

--- a/internal/olm/client/status.go
+++ b/internal/olm/client/status.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	apiutilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/set"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -111,8 +111,8 @@ func (s Status) HasInstalledResources() (bool, error) {
 }
 
 // getCRDKindSet returns the set of all kinds specified by all CRDs in s.
-func (s Status) getCRDKindSet() (sets.Set[string], error) {
-	crdKindSet := sets.New[string]()
+func (s Status) getCRDKindSet() (set.Set[string], error) {
+	crdKindSet := set.New[string]()
 	for _, r := range s.Resources {
 		if r.GVK.Kind == "CustomResourceDefinition" {
 			u := &unstructured.Unstructured{}

--- a/internal/olm/operator/install_mode.go
+++ b/internal/olm/operator/install_mode.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/utils/set"
 )
 
 type InstallMode struct {
@@ -131,8 +131,8 @@ func (i InstallMode) CheckCompatibility(csv *v1alpha1.ClusterServiceVersion, ope
 
 // GetSupportedInstallModes returns the given slice of InstallModes as a
 // String set.
-func GetSupportedInstallModes(csvInstallModes []v1alpha1.InstallMode) sets.Set[string] {
-	supported := sets.New[string]()
+func GetSupportedInstallModes(csvInstallModes []v1alpha1.InstallMode) set.Set[string] {
+	supported := set.New[string]()
 	for _, im := range csvInstallModes {
 		if im.Supported {
 			supported.Insert(string(im.Type))

--- a/internal/olm/operator/registry/operator_installer_test.go
+++ b/internal/olm/operator/registry/operator_installer_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/set"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -617,13 +617,13 @@ var _ = Describe("OperatorInstaller", func() {
 	Describe("getTargetNamespaces", func() {
 		var (
 			oi        OperatorInstaller
-			supported sets.Set[string]
+			supported set.Set[string]
 		)
 		BeforeEach(func() {
 			oi = OperatorInstaller{
 				cfg: &operator.Configuration{},
 			}
-			supported = sets.New[string]()
+			supported = set.New[string]()
 		})
 		It("should return an error when nothing is supported", func() {
 			target, err := oi.getTargetNamespaces(supported)


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

Use the `k8s.io/utils` implemention of `set` rather than the `apimachinery` `sets`.

**Motivation for the change:**

Following https://github.com/kubernetes/utils/pull/243 it's likely that the k8s.io/utils version will end up being the canonical one.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
