### PR TITLE
Fix a bug in olm install

### DIFF
--- a/changelog/fragments/02-olm-install-retry.yaml
+++ b/changelog/fragments/02-olm-install-retry.yaml
@@ -1,0 +1,20 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Fix a bug where `olm install` command is failed fo "no-match" error.
+      
+      The output in this case is something like:
+      
+      ```
+      $ operator-sdk olm install --verbose
+      ...
+      FATA[0001] Failed to install OLM version "latest": failed to create CRDs and resources: no matches for kind "OLMConfig" in version "operators.coreos.com/v1" 
+      ```
+        
+      Now, in this case, operator-sdk tries to create the resource again, until it succeed (or until the timeout exceeded).
+
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false


### PR DESCRIPTION
When installing OLM, retry creating resources, if the CRD is not ready yet.

Fixes: #6489

### Description of the change
On olm install command, if the creation of a resource fails with "no-match" error, retry creating it, assuming the CRD is not ready yet, but is going to be ready very soon.

### Motivation for the change
Bug fix. See #6489 

##Checklist

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
