### PR TITLE
Documentation fix

### DIFF
--- a/website/content/en/docs/building-operators/golang/installation.md
+++ b/website/content/en/docs/building-operators/golang/installation.md
@@ -11,7 +11,7 @@ Follow the steps in the [installation guide][install-guide] to learn how to inst
 ## Additional Prerequisites
 
 - [git][git_tool]
-- [go][go_tool] version 1.18
+- [go][go_tool] version 1.19
 - [docker][docker_tool] version 17.03+.
 - [kubectl][kubectl_tool] and access to a Kubernetes cluster of a [compatible version][k8s-version-compat].
 

--- a/website/layouts/partials/head.html
+++ b/website/layouts/partials/head.html
@@ -12,7 +12,6 @@
 {{ partialCached "favicons.html" . }}
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 {{ if eq (getenv "HUGO_ENV") "production" }}

--- a/website/layouts/partials/navbar.html
+++ b/website/layouts/partials/navbar.html
@@ -7,7 +7,7 @@
         </a>
     <nav class="of-nav-main nav-collapse">
       <ul class="of-nav-main__items menu-items">
-        <li class="of-nav-main__item"><a class="of-link-list__a {{ if eq .URL "/" }} of-m-active {{end}}" href="/">Home</a></li>
+        <li class="of-nav-main__item"><a class="of-link-list__a {{ if eq .Permalink "/" }} of-m-active {{end}}" href="/">Home</a></li>
         {{ $currentPage := . }}
         {{ range .Site.Menus.main }}
         <li class="of-nav-main__item"><a class="of-link-list__a{{if or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }} of-m-active{{end}}" href="{{ .URL }}" title="{{ .Title }}">{{ .Name }}</a></li>


### PR DESCRIPTION
**Description of the change:**
* Delete `_internal/google_news.html` since its deprecated.
* Update '.URL' to '.Permalink' since it can’t evaluate field URL in type *hugolib.pageState.
* Update Go version from '1.18' tp '1.19' in `building-operator` section.

**Checklist**
- [x] I've built and serve your docs to localhost:1313.
- [x] Version of Go has successfully updated.
