### PR TITLE
Remove CGO_ENABLED=0 references for FIPS compliance 

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,5 @@
 # Global environment variables for builds.
 env:
-  - CGO_ENABLED=0
   - GO111MODULE=on
   - GOPROXY=https://proxy.golang.org|direct
   - REPO=github.com/operator-framework/operator-sdk

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ GO_BUILD_ARGS = \
   " \
 
 export GO111MODULE = on
-export CGO_ENABLED = 0
 export PATH := $(PWD)/$(BUILD_DIR):$(PWD)/$(TOOLS_DIR):$(PATH)
 
 ##@ Development

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.7.0
 	github.com/onsi/gomega v1.24.2
 	github.com/operator-framework/api v0.17.4-0.20230223191600-0131a6301e42
-	github.com/operator-framework/helm-operator-plugins v0.0.12-0.20230413193425-4632388adc61
+	github.com/operator-framework/helm-operator-plugins v0.0.12-0.20230720162659-dcf106e4d558
 	github.com/operator-framework/java-operator-plugins v0.7.1-0.20230306190439-0eed476d2b75
 	github.com/operator-framework/operator-lib v0.11.1-0.20230306195046-28cadc6b6055
 	github.com/operator-framework/operator-manifest-tools v0.2.3-0.20230227155221-caa8b9e1ab12

--- a/go.sum
+++ b/go.sum
@@ -767,6 +767,8 @@ github.com/operator-framework/api v0.17.4-0.20230223191600-0131a6301e42 h1:d/Pnr
 github.com/operator-framework/api v0.17.4-0.20230223191600-0131a6301e42/go.mod h1:l/cuwtPxkVUY7fzYgdust2m9tlmb8I4pOvbsUufRb24=
 github.com/operator-framework/helm-operator-plugins v0.0.12-0.20230413193425-4632388adc61 h1:FPO2hS4HNIU2pzWeX2KusKxqDFeGIURRMkxRtn/i570=
 github.com/operator-framework/helm-operator-plugins v0.0.12-0.20230413193425-4632388adc61/go.mod h1:QpVyiSOKGbWADyNRl7LvMlRuuMGrWXJQdEYyHPQWMUg=
+github.com/operator-framework/helm-operator-plugins v0.0.12-0.20230720162659-dcf106e4d558 h1:syU3CVjVhle1TqsJB/dc8fWfAB5fy/KuVxWbCxQWFPU=
+github.com/operator-framework/helm-operator-plugins v0.0.12-0.20230720162659-dcf106e4d558/go.mod h1:QpVyiSOKGbWADyNRl7LvMlRuuMGrWXJQdEYyHPQWMUg=
 github.com/operator-framework/java-operator-plugins v0.7.1-0.20230306190439-0eed476d2b75 h1:mjMid39qs1lEXpIldVmj7sa1wtuZvYge8oHkT0qOY0Y=
 github.com/operator-framework/java-operator-plugins v0.7.1-0.20230306190439-0eed476d2b75/go.mod h1:oQTt35EEUrDY8ca/kRWYz5omWsVhk9Sj78vKlHFqxjM=
 github.com/operator-framework/operator-lib v0.11.1-0.20230306195046-28cadc6b6055 h1:G9N8wEf9qDZ/4Fj5cbIejKUoFOYta0v72Yg8tPAdvc0=

--- a/go.sum
+++ b/go.sum
@@ -765,8 +765,6 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.m
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/operator-framework/api v0.17.4-0.20230223191600-0131a6301e42 h1:d/Pnr19TnmIq3zQ6ebewC+5jt5zqYbRkvYd37YZENQY=
 github.com/operator-framework/api v0.17.4-0.20230223191600-0131a6301e42/go.mod h1:l/cuwtPxkVUY7fzYgdust2m9tlmb8I4pOvbsUufRb24=
-github.com/operator-framework/helm-operator-plugins v0.0.12-0.20230413193425-4632388adc61 h1:FPO2hS4HNIU2pzWeX2KusKxqDFeGIURRMkxRtn/i570=
-github.com/operator-framework/helm-operator-plugins v0.0.12-0.20230413193425-4632388adc61/go.mod h1:QpVyiSOKGbWADyNRl7LvMlRuuMGrWXJQdEYyHPQWMUg=
 github.com/operator-framework/helm-operator-plugins v0.0.12-0.20230720162659-dcf106e4d558 h1:syU3CVjVhle1TqsJB/dc8fWfAB5fy/KuVxWbCxQWFPU=
 github.com/operator-framework/helm-operator-plugins v0.0.12-0.20230720162659-dcf106e4d558/go.mod h1:QpVyiSOKGbWADyNRl7LvMlRuuMGrWXJQdEYyHPQWMUg=
 github.com/operator-framework/java-operator-plugins v0.7.1-0.20230306190439-0eed476d2b75 h1:mjMid39qs1lEXpIldVmj7sa1wtuZvYge8oHkT0qOY0Y=

--- a/images/ansible-operator/Dockerfile
+++ b/images/ansible-operator/Dockerfile
@@ -14,7 +14,7 @@ RUN go mod download
 COPY . .
 
 # Build
-RUN GOOS=linux GOARCH=$TARGETARCH make build/ansible-operator
+RUN GOOS=linux GOARCH=$TARGETARCH CGO_ENABLED=0 make build/ansible-operator
 
 # Final image.
 FROM quay.io/operator-framework/ansible-operator-base:master-b247ac8390699c2773625b321a55b2240c5ce3c0

--- a/images/custom-scorecard-tests/Dockerfile
+++ b/images/custom-scorecard-tests/Dockerfile
@@ -14,7 +14,7 @@ RUN go mod download
 COPY . .
 
 # Build
-RUN GOOS=linux GOARCH=$TARGETARCH make build/custom-scorecard-tests
+RUN GOOS=linux GOARCH=$TARGETARCH CGO_ENABLED=0 make build/custom-scorecard-tests
 
 # Final image.
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8

--- a/images/helm-operator/Dockerfile
+++ b/images/helm-operator/Dockerfile
@@ -14,7 +14,7 @@ RUN go mod download
 COPY . .
 
 # Build
-RUN GOOS=linux GOARCH=$TARGETARCH make build/helm-operator
+RUN GOOS=linux GOARCH=$TARGETARCH CGO_ENABLED=0 make build/helm-operator
 
 # Final image.
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8

--- a/images/operator-sdk/Dockerfile
+++ b/images/operator-sdk/Dockerfile
@@ -14,7 +14,7 @@ RUN go mod download
 COPY . .
 
 # Build
-RUN GOOS=linux GOARCH=$TARGETARCH make build/operator-sdk
+RUN GOOS=linux GOARCH=$TARGETARCH CGO_ENABLED=0 make build/operator-sdk
 
 # Final image.
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8

--- a/images/scorecard-test-kuttl/Dockerfile
+++ b/images/scorecard-test-kuttl/Dockerfile
@@ -15,7 +15,7 @@ RUN go mod download
 COPY . .
 
 # Build
-RUN GOOS=linux GOARCH=$TARGETARCH make build/scorecard-test-kuttl
+RUN GOOS=linux GOARCH=$TARGETARCH CGO_ENABLED=0 make build/scorecard-test-kuttl
 
 # Final image.
 #FROM kudobuilder/kuttl@sha256:8d4dad161521450db95f88fe0e62487cc6587c5818df2a4e750fb9e54c082170

--- a/images/scorecard-test/Dockerfile
+++ b/images/scorecard-test/Dockerfile
@@ -14,7 +14,7 @@ RUN go mod download
 COPY . .
 
 # Build
-RUN GOOS=linux GOARCH=$TARGETARCH make build/scorecard-test
+RUN GOOS=linux GOARCH=$TARGETARCH CGO_ENABLED=0 make build/scorecard-test
 
 # Final image.
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8

--- a/internal/plugins/manifests/v2/init.go
+++ b/internal/plugins/manifests/v2/init.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
 	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 
 	"github.com/operator-framework/operator-sdk/internal/plugins/manifests/v2/templates/config/manifests"
 	"github.com/operator-framework/operator-sdk/internal/util/projutil"
@@ -74,6 +75,14 @@ func (s *initSubcommand) Scaffold(fs machinery.Filesystem) error {
 	// Append SDK recipes.
 	switch operatorType {
 	case projutil.OperatorTypeGo:
+		//(TODO): This removes `CGO_ENABLED=0` references from the go/v3 and go/v4-alpha scaffolds for FIPS compliance.
+		// This is a temporary workaround to remove CGO_ENABLED=0 references in the Go plugin chain from files scaffolded from upstream plugins.
+		// We would need to remove this when the fix is made in upstream Kubebuilder eventually.
+		err = util.ReplaceInFile("Dockerfile", "CGO_ENABLED=0", "")
+		if err != nil {
+			return err
+		}
+
 		makefileBytes = append(makefileBytes, []byte(makefileSDKFragmentGo)...)
 	default:
 		makefileBytes = append(makefileBytes, []byte(makefileSDKFragmentNonGo)...)

--- a/testdata/ansible/memcached-operator/Makefile
+++ b/testdata/ansible/memcached-operator/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.30.0
+OPERATOR_SDK_VERSION ?= v1.31.0
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest

--- a/testdata/go/v3/memcached-operator/Dockerfile
+++ b/testdata/go/v3/memcached-operator/Dockerfile
@@ -21,7 +21,7 @@ COPY controllers/ controllers/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/go/v3/memcached-operator/Dockerfile
+++ b/testdata/go/v3/memcached-operator/Dockerfile
@@ -21,11 +21,11 @@ COPY controllers/ controllers/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
+RUN  GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base-debian11:nonroot
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/testdata/go/v3/memcached-operator/Dockerfile
+++ b/testdata/go/v3/memcached-operator/Dockerfile
@@ -25,7 +25,7 @@ RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/base-debian11:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/testdata/go/v3/memcached-operator/Makefile
+++ b/testdata/go/v3/memcached-operator/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.30.0
+OPERATOR_SDK_VERSION ?= v1.31.0
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest

--- a/testdata/go/v3/monitoring/memcached-operator/Dockerfile
+++ b/testdata/go/v3/monitoring/memcached-operator/Dockerfile
@@ -26,7 +26,7 @@ RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/base-debian11:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/testdata/go/v3/monitoring/memcached-operator/Dockerfile
+++ b/testdata/go/v3/monitoring/memcached-operator/Dockerfile
@@ -22,7 +22,7 @@ COPY monitoring/ monitoring/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/go/v3/monitoring/memcached-operator/Dockerfile
+++ b/testdata/go/v3/monitoring/memcached-operator/Dockerfile
@@ -22,11 +22,11 @@ COPY monitoring/ monitoring/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
+RUN  GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base-debian11:nonroot
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/testdata/go/v3/monitoring/memcached-operator/Makefile
+++ b/testdata/go/v3/monitoring/memcached-operator/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.30.0
+OPERATOR_SDK_VERSION ?= v1.31.0
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest

--- a/testdata/go/v4-alpha/memcached-operator/Dockerfile
+++ b/testdata/go/v4-alpha/memcached-operator/Dockerfile
@@ -25,7 +25,7 @@ RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/base-debian11:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/testdata/go/v4-alpha/memcached-operator/Dockerfile
+++ b/testdata/go/v4-alpha/memcached-operator/Dockerfile
@@ -21,11 +21,11 @@ COPY internal/controller/ internal/controller/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN  GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base-debian11:nonroot
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/testdata/go/v4-alpha/memcached-operator/Dockerfile
+++ b/testdata/go/v4-alpha/memcached-operator/Dockerfile
@@ -21,7 +21,7 @@ COPY internal/controller/ internal/controller/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/go/v4-alpha/memcached-operator/Makefile
+++ b/testdata/go/v4-alpha/memcached-operator/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.30.0
+OPERATOR_SDK_VERSION ?= v1.31.0
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest

--- a/testdata/go/v4-alpha/monitoring/memcached-operator/Dockerfile
+++ b/testdata/go/v4-alpha/monitoring/memcached-operator/Dockerfile
@@ -22,7 +22,7 @@ COPY monitoring/ monitoring/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/go/v4-alpha/monitoring/memcached-operator/Dockerfile
+++ b/testdata/go/v4-alpha/monitoring/memcached-operator/Dockerfile
@@ -26,7 +26,7 @@ RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/base-debian11:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/testdata/go/v4-alpha/monitoring/memcached-operator/Dockerfile
+++ b/testdata/go/v4-alpha/monitoring/memcached-operator/Dockerfile
@@ -22,11 +22,11 @@ COPY monitoring/ monitoring/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN  GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base-debian11:nonroot
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/testdata/go/v4-alpha/monitoring/memcached-operator/Makefile
+++ b/testdata/go/v4-alpha/monitoring/memcached-operator/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.30.0
+OPERATOR_SDK_VERSION ?= v1.31.0
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest

--- a/testdata/helm/memcached-operator/Makefile
+++ b/testdata/helm/memcached-operator/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.30.0
+OPERATOR_SDK_VERSION ?= v1.31.0
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest

--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -376,7 +376,7 @@ You might need to port some customizations made in your old Dockerfile as well. 
 ```docker
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/base-debian11:nonroot
 ```
 
 With:

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -328,7 +328,7 @@ NOTE: If you receive an error, please run the specified command in the error and
 All that remains is to build and push the operator image to the desired image registry.
 
 Before building the operator image, ensure the generated Dockerfile references
-the base image you want. You can change the default "runner" image `gcr.io/distroless/static:nonroot`
+the base image you want. You can change the default "runner" image `gcr.io/distroless/base-debian11:nonroot`
 by replacing its tag with another, for example `alpine:latest`, and removing
 the `USER 65532:65532` directive.
 

--- a/website/content/en/docs/faqs/_index.md
+++ b/website/content/en/docs/faqs/_index.md
@@ -314,7 +314,7 @@ and push this image, which can be added to your operator's  `FROM`.
 
 ## Running `operator-sdk create api` results in an error with `/usr/local/go/src/net/cgo_linux.go:13:8: no such package located` in the error message
 
-By default Go will set the `CGO_ENABLED` environment variable to `1` which means that [cgo][cgo-docs] is enabled. Depending on the architecture and OS of your system you may run into an issue similar to this one: 
+Depending on the architecture and OS of your system you may run into an issue similar to this one: 
 
 ```sh
 /usr/local/go/src/net/cgo_linux.go:13:8: no such package located
@@ -327,7 +327,6 @@ Error: failed to create API: unable to run post-scaffold tasks of "base.go.kubeb
 Here are a couple workarounds to try to resolve the issue:
 
 - Ensure `gcc` is installed
-- Set the `CGO_ENABLED` environment variable to `0` to disable [cgo][cgo-docs]
 
 If neither of those solutions work for you, please [open an issue][open-issue]
 


### PR DESCRIPTION
Removes all of the CGO_ENABLED=0 references in order to enable FIPS compliance 