### PR TITLE
Using singular for Operator Creation Tutorial to work

### DIFF
--- a/testdata/go/v3/memcached-operator/controller/memcached_controller.go
+++ b/testdata/go/v3/memcached-operator/controller/memcached_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"context"

--- a/testdata/go/v3/memcached-operator/controller/memcached_controller_test.go
+++ b/testdata/go/v3/memcached-operator/controller/memcached_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"context"

--- a/testdata/go/v3/memcached-operator/controller/suite_test.go
+++ b/testdata/go/v3/memcached-operator/controller/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"path/filepath"


### PR DESCRIPTION
**Description of the change:**

Please read at for details: https://github.com/operator-framework/operator-sdk/issues/6506

Having singular is helping the Operator Creation Tutorial to work.

**Motivation for the change:**

To make tutorial to work.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
