### PR TITLE
(actions): fix some dependabot actions issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
         go-version: 1.19
 
     - name: gpg init
-      if: github.event_name != 'pull_request'
+      if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
       run: .ci/gpg/create-keyring.sh
       env:
         GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
@@ -82,7 +82,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: quay.io login
-      if: github.event_name != 'pull_request'
+      if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.QUAY_USERNAME }}
@@ -128,7 +128,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: quay.io login
-      if: github.event_name != 'pull_request'
+      if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
**Description of the change:**
- Don't run the gpg and quay login steps for the jobs in https://github.com/operator-framework/operator-sdk/blob/master/.github/workflows/deploy.yml when Dependabot has created the PR. This makes it so CI can run properly on Dependabot PRs without Dependabot having access to secret values.

**Motivation for the change:**
- Make it possible for Dependabot PRs to pass CI so we can truly start taking advantage of the benefits of Dependabot

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
