### PR TITLE
Ci/disable dependabot push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - '**'
+    - '!dependabot/**'
     tags:
     - 'v*'
     - 'scorecard-kuttl/v*'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
         go-version: 1.19
 
     - name: gpg init
-      if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
+      if: ${{ github.event_name != 'pull_request' }}
       run: .ci/gpg/create-keyring.sh
       env:
         GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
@@ -83,7 +83,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: quay.io login
-      if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
+      if: ${{ github.event_name != 'pull_request' }}
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.QUAY_USERNAME }}
@@ -129,7 +129,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: quay.io login
-      if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
+      if: ${{ github.event_name != 'pull_request' }}
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
**Description of the change:**
- Disables running the `deploy` action on pushes to `dependabot/*` branches 

**Motivation for the change:**
- Save CI cycles on dependabot PRs
- Reduce if condition complexity

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
