### PR TITLE
fix: merge existing and extra fbc while rendering the index image

### DIFF
--- a/changelog/fragments/03-run-bundle-cmd.yaml
+++ b/changelog/fragments/03-run-bundle-cmd.yaml
@@ -1,0 +1,10 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Fix a bug where `run bundle` command does not copy all FBC manifests into the new catalog image if custom index-image is passed.
+
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
During the creation of a new catalog image using the operator-sdk, a critical bug was identified where existing FBC (File-Based Configuration) files were not being copied to the new location of the catalog image. Consequently, the generated catalog image was missing essential FBC files, leading to incorrect behavior and potential issues for end-users.

This bug fix addresses the root cause of the problem by ensuring that both the old and new FBC files are correctly included in the catalog image creation process. With this fix, the resulting catalog image will contain all the necessary FBC files, thereby resolving the issue of missing configurations and ensuring the operator functions as expected. Users can now rely on the updated catalog image to access and utilize the complete set of FBC files, enhancing the overall stability and reliability of the operator-sdk.


**Motivation for the change:**
Fix: #6505 


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
