### PR TITLE
(bugfix): Copy ansible binaries from builder stage when building the base image

### DIFF
--- a/images/ansible-operator/base.Dockerfile
+++ b/images/ansible-operator/base.Dockerfile
@@ -60,6 +60,7 @@ RUN set -e && yum clean all && rm -rf /var/cache/yum/* \
 
 COPY --from=builder /usr/local/lib64/python3.9/site-packages /usr/local/lib64/python3.9/site-packages
 COPY --from=builder /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
 
 ENV TINI_VERSION=v0.19.0
 RUN curl -L -o /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} \


### PR DESCRIPTION
**Description of the change:**
- Copies binaries from the builder stage by adding `COPY --from=builder /usr/local/bin /usr/local/bin` to the steps in the final stage

**Motivation for the change:**
- Ansible binaries were missing in the base image as can be seen by https://github.com/operator-framework/operator-sdk/actions/runs/5672628145/job/15372988930?pr=6518#step:5:545

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
