### PR TITLE
Add missing "controller-tools" update instructions to the v1.25.0 migration guide

### DIFF
--- a/website/content/en/docs/upgrading-sdk-version/v1.25.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.25.0.md
@@ -33,6 +33,7 @@ weight: 998975000
         - docker buildx rm project-v3-builder
         rm Dockerfile.cross
     ```
+
 3. (go/v3) Bump dependencies in go.mod file
 
     ```go
@@ -46,6 +47,10 @@ weight: 998975000
         k8s.io/client-go v0.25.0
         sigs.k8s.io/controller-runtime v0.13.0
     ```
+
+4. (go/v3) Update `controller-tools` from `0.9.2` to `0.10.0`. 
+
+   In the `Makefile` file, replace `CONTROLLER_TOOLS_VERSION ?= v0.9.2` with `CONTROLLER_TOOLS_VERSION ?= v0.10.0`
 
 _See [#6047](https://github.com/operator-framework/operator-sdk/pull/6047) for more details._
 


### PR DESCRIPTION
Fixes https://github.com/operator-framework/operator-sdk/issues/6525.