### PR TITLE
[Do Not Merge] Update ansible operator conditions

### DIFF
--- a/changelog/fragments/ansible-operator-conditions.yaml
+++ b/changelog/fragments/ansible-operator-conditions.yaml
@@ -1,0 +1,21 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      For ansible-based-operators, we will no longer set the status of
+      the failure condition to `False` when a subsequent reconcile commences.
+
+      The failure condition will however been removed when reconcile is complete
+      and the custom resource was successfully deployed.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false
+

--- a/internal/ansible/controller/reconcile.go
+++ b/internal/ansible/controller/reconcile.go
@@ -302,11 +302,6 @@ func (r *AnsibleOperatorReconciler) markRunning(ctx context.Context, nn types.Na
 	crStatus := getStatus(u)
 
 	// If there is no current status add that we are working on this resource.
-	errCond := ansiblestatus.GetCondition(crStatus, ansiblestatus.FailureConditionType)
-	if errCond != nil {
-		errCond.Status = v1.ConditionFalse
-		ansiblestatus.SetCondition(&crStatus, *errCond)
-	}
 	successCond := ansiblestatus.GetCondition(crStatus, ansiblestatus.SuccessfulConditionType)
 	if successCond != nil {
 		successCond.Status = v1.ConditionFalse

--- a/internal/ansible/controller/status/utils_test.go
+++ b/internal/ansible/controller/status/utils_test.go
@@ -96,7 +96,7 @@ func TestGetCondition(t *testing.T) {
 			condType: RunningConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: RunningConditionType,
 					},
 				},
@@ -110,7 +110,7 @@ func TestGetCondition(t *testing.T) {
 			condType: RunningConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: FailureConditionType,
 					},
 				},
@@ -122,7 +122,7 @@ func TestGetCondition(t *testing.T) {
 			condType: FailureConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: FailureConditionType,
 					},
 				},
@@ -136,7 +136,7 @@ func TestGetCondition(t *testing.T) {
 			condType: FailureConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: RunningConditionType,
 					},
 				},
@@ -167,7 +167,7 @@ func TestRemoveCondition(t *testing.T) {
 			condType: RunningConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: RunningConditionType,
 					},
 				},
@@ -179,7 +179,7 @@ func TestRemoveCondition(t *testing.T) {
 			condType: RunningConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: FailureConditionType,
 					},
 				},
@@ -191,7 +191,7 @@ func TestRemoveCondition(t *testing.T) {
 			condType: FailureConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: FailureConditionType,
 					},
 				},
@@ -203,7 +203,7 @@ func TestRemoveCondition(t *testing.T) {
 			condType: FailureConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: RunningConditionType,
 					},
 				},
@@ -247,7 +247,7 @@ func TestSetCondition(t *testing.T) {
 			name: "update running condition",
 			status: &Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type:               RunningConditionType,
 						Status:             v1.ConditionTrue,
 						Reason:             SuccessfulReason,
@@ -264,7 +264,7 @@ func TestSetCondition(t *testing.T) {
 			name: "do not update running condition",
 			status: &Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type:               RunningConditionType,
 						Status:             v1.ConditionTrue,
 						Reason:             RunningReason,


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

Given it is possible for a custom resource to be in error / failed state while a new reconcile process is ongoing, it is unnecessary to mark the status of previous Failure conditions to `False` while the reconcile loop is still running.

The failure condition will be removed when the custom resource is successfully deployed as it works today.

**Motivation for the change:**

The failure conditions have timestamps and are accurate as at the time of reporting. Therefore, it would be unnecessary and misleading to set the failure condition status to `False` before the custom resource is successfully deployed.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Closes #6560