### PR TITLE
(repo): update issue+PR templates to point to new ansible repo

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,4 +2,6 @@
 Thanks for filing an issue! Before you submit, please read the following:
 
 Check the other issue templates if you are trying to submit a bug report, feature request, or question. Search open/closed issues before submitting since someone might have asked the same thing before!
+
+For ansible operator related requests, please create the issue in https://github.com/operator-framework/ansible-operator-plugins 
 -->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -35,7 +35,7 @@ Note: Make sure to first check the prerequisites that can be found in the main R
 <!-- Uncomment one or more of the following lines corresponding to the language of the operator type -->
 
 <!-- /language go -->
-<!-- /language ansible -->
+<!-- /language ansible - For ansible operator related bugs, please create the issue in https://github.com/operator-framework/ansible-operator-plugins -->
 <!-- /language helm -->
 
 **Kubernetes cluster type:**

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -24,5 +24,5 @@ I have an issue when ...
 <!-- If your request relates to a particular operator type, uncomment one or more of the following lines corresponding to the language of that type -->
 
 <!-- /language go -->
-<!-- /language ansible -->
+<!-- /language ansible For ansible operator related feature requests, please create the issue in https://github.com/operator-framework/ansible-operator-plugins -->
 <!-- /language helm -->

--- a/.github/ISSUE_TEMPLATE/support-question.md
+++ b/.github/ISSUE_TEMPLATE/support-question.md
@@ -45,7 +45,7 @@ We will try our best to answer the question, but we also have a mailing list and
 <!-- Uncomment one or more of the following lines corresponding to the language of the operator type -->
 
 <!-- /language go -->
-<!-- /language ansible -->
+<!-- /language ansible - For ansible operator related questions, please create the issue in https://github.com/operator-framework/ansible-operator-plugins -->
 <!-- /language helm -->
 
 **Kubernetes cluster type:**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,8 @@ Welcome to the Operator SDK! Before contributing, make sure to:
     - Sign your commit https://github.com/apps/dco
 - Follow the below checklist if making a user-facing change 
 
+Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 
+
 -->
 
 **Description of the change:**


### PR DESCRIPTION
**Description of the change:**
- Updates the issue and PR templates to point towards the new ansible repo at https://github.com/operator-framework/ansible-operator-plugins for filing issues and creating PRs

**Motivation for the change:**
- Drive ansible related requests towards the new https://github.com/operator-framework/ansible-operator-plugins repository

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
