### PR TITLE
(docs): fix v1.30.0 migration guide

### DIFF
--- a/website/content/en/docs/upgrading-sdk-version/v1.30.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.30.0.md
@@ -3,12 +3,4 @@ title: v1.30.0
 weight: 998970000
 ---
 
-## Header text for the migration section
-
-Body of the migration section. This should be formatted as markdown and can
-span multiple lines.
-
-Using the YAML string '|' operator means that newlines in this string will
-be honored and interpretted as newlines in the rendered markdown.
-
-_See [#6426](https://github.com/operator-framework/operator-sdk/pull/6426) for more details._
+There are no migrations for this release! 🎉


### PR DESCRIPTION
**Description of the change:**
- Fixes the v1.30.0 release migration guide. Looks like the migration template accidentally got committed and resulted in an improper migration guide being produced.

**Motivation for the change:**
- fixes #6480

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
