### PR TITLE
(docs): update broken links

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -187,133 +187,133 @@ url_latest_version = "https://sdk.operatorframework.io"
 
 [[params.versions]]
   version = "v1.19"
-  url = "https://v1-19-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.19.x/website/content/en/docs"
   kube_version = "1.23"
   client_go_version = "v0.23.1"
 
 [[params.versions]]
   version = "v1.18"
-  url = "https://v1-18-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.18.x/website/content/en/docs"
   kube_version = "1.21"
   client_go_version = "v0.23.1"
 
 [[params.versions]]
   version = "v1.17"
-  url = "https://v1-17-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.17.x/website/content/en/docs"
   kube_version = "1.21"
   client_go_version = "v0.23.1"
 
 [[params.versions]]
   version = "v1.16"
-  url = "https://v1-16-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.16.x/website/content/en/docs"
   kube_version = "1.21"
   client_go_version = "v0.22.2"
 
 [[params.versions]]
   version = "v1.15"
-  url = "https://v1-15-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.15.x/website/content/en/docs"
   kube_version = "1.21"
   client_go_version = "v0.22.2"
 
 [[params.versions]]
   version = "v1.14"
-  url = "https://v1-14-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.14.x/website/content/en/docs"
   kube_version = "1.21"
   client_go_version = "v0.22.2"
 
 [[params.versions]]
   version = "v1.13"
-  url = "https://v1-13-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.13.x/website/content/en/docs"
   kube_version = "1.21"
   client_go_version = "v0.22.1"
 
 [[params.versions]]
   version = "v1.12"
-  url = "https://v1-12-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.12.x/website/content/en/docs"
   kube_version = "1.21"
   client_go_version = "v0.21.2"
 
 [[params.versions]]
   version = "v1.11"
-  url = "https://v1-11-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.11.x/website/content/en/docs"
   kube_version = "1.20.2"
   client_go_version = "v0.21.2"
 
 [[params.versions]]
   version = "v1.10"
-  url = "https://v1-10-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.10.x/website/content/en/docs"
   kube_version = "1.20.2"
   client_go_version = "v0.21.2"
 
 [[params.versions]]
   version = "v1.9"
-  url = "https://v1-9-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.9.x/website/content/en/docs"
   kube_version = "1.20.2"
   client_go_version = "v0.20.2"
 
 [[params.versions]]
   version = "v1.8"
-  url = "https://v1-8-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.8.x/website/content/en/docs"
   kube_version = "1.20.2"
   client_go_version = "v0.20.2"
 
 [[params.versions]]
   version = "v1.7"
-  url = "https://v1-7-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.7.x/website/content/en/docs"
   kube_version = "1.19.4"
   client_go_version = "v0.20.2"
 
 [[params.versions]]
   version = "v1.6"
-  url = "https://v1-6-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.6.x/website/content/en/docs"
   kube_version = "1.19.4"
   client_go_version = "v0.20.2"
 
 [[params.versions]]
   version = "v1.5"
-  url = "https://v1-5-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.5.x/website/content/en/docs"
   kube_version = "1.19.4"
   client_go_version = "v0.20.2"
 
 [[params.versions]]
   version = "v1.4"
-  url = "https://v1-4-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.4.x/website/content/en/docs"
   kube_version = "1.19.4"
   client_go_version = "v0.20.1"
 
 [[params.versions]]
   version = "v1.3"
-  url = "https://v1-3-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.3.x/website/content/en/docs"
   kube_version = "1.19.4"
   client_go_version = "v0.19.4"
 
 [[params.versions]]
   version = "v1.2"
-  url = "https://v1-2-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.2.x/website/content/en/docs"
   kube_version = "1.18.8"
   client_go_version = "v0.18.8"
 
 [[params.versions]]
   version = "v1.1"
-  url = "https://v1-1-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.1.x/website/content/en/docs"
   kube_version = "1.18.2"
   client_go_version = "v0.18.8"
 
 [[params.versions]]
   version = "v1.0"
-  url = "https://v1-0-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.0.x/website/content/en/docs"
   kube_version = "1.18.2"
   client_go_version = "v0.18.6"
 
 [[params.versions]]
   version = "v0.19"
-  url = "https://v0-19-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v0.19.x/website/content/en/docs"
   kube_version = "1.18.2"
   client_go_version = "v12.0.0+incompatible"
 
 [[params.versions]]
   version = "v0.18"
-  url = "https://v0-18-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v0.18.x/website/content/en/docs"
   kube_version = "1.18.2"
   client_go_version = "v12.0.0+incompatible"
 

--- a/website/content/en/docs/building-operators/ansible/tutorial.md
+++ b/website/content/en/docs/building-operators/ansible/tutorial.md
@@ -368,7 +368,7 @@ OLM will manage creation of most if not all resources required to run your opera
 [image-reg-config]:/docs/olm-integration/cli-overview#private-bundle-and-catalog-image-registries
 [install-guide]:/docs/building-operators/ansible/installation
 [layout-doc]:/docs/building-operators/ansible/reference/scaffolding
-[legacy-quickstart-doc]:https://v0-19-x.sdk.operatorframework.io/docs/ansible/quickstart/
+[legacy-quickstart-doc]:https://github.com/operator-framework/operator-sdk/blob/v0.19.x/website/content/en/docs/ansible/quickstart.md
 [kustomize-docs]:https://kustomize.io/
 [migration-guide]:/docs/building-operators/ansible/migration
 [tutorial-bundle]:/docs/olm-integration/tutorial-bundle

--- a/website/content/en/docs/building-operators/golang/migration.md
+++ b/website/content/en/docs/building-operators/golang/migration.md
@@ -440,7 +440,7 @@ For further steps regarding the deployment of the operator, creation of custom r
 [multigroup-kubebuilder-doc]: https://book.kubebuilder.io/migration/multi-group.html
 [what-are-the-the-differences-between-kubebuilder-and-operator-sdk]: /docs/faqs/#what-are-the-the-differences-between-kubebuilder-and-operator-sdk
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime/releases
-[cert-manager-docs]: https://cert-manager.io/docs/installation/upgrading/
+[cert-manager-docs]: https://cert-manager.io/docs/installation/upgrade/
 [webhook-doc]: https://book.kubebuilder.io/reference/webhook-overview.html
 [healthz-ping]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/healthz#CheckHandler
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime/releases

--- a/website/content/en/docs/building-operators/golang/references/markers.md
+++ b/website/content/en/docs/building-operators/golang/references/markers.md
@@ -151,7 +151,7 @@ These examples assume `Memcached`, `MemcachedSpec`, and `MemcachedStatus` are th
 
 ## Deprecated markers
 
-[Markers][deprecated-markers] supported by `operator-sdk` prior to v1.0.0 are deprecated.
+Markers supported by `operator-sdk` prior to v1.0.0 are deprecated.
 You can migrate to the new marker system by running the following script:
 
 ```console
@@ -166,4 +166,3 @@ $ ./migrate-markers.sh path/to/*_types.go
 [csv-x-desc]:https://github.com/openshift/console/blob/master/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md
 [csv-spec]:https://github.com/operator-framework/operator-lifecycle-manager/blob/e0eea22/doc/design/building-your-csv.md
 [csv-crds]:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#your-custom-resource-definitions
-[deprecated-markers]:https://v0-19-x.sdk.operatorframework.io/docs/golang/references/markers/

--- a/website/content/en/docs/building-operators/golang/tutorial.md
+++ b/website/content/en/docs/building-operators/golang/tutorial.md
@@ -539,8 +539,8 @@ Next, check out the following:
 [kubebuilder_entrypoint_doc]: https://book.kubebuilder.io/cronjob-tutorial/empty-main.html
 [kubebuilder_layout_doc]:https://book.kubebuilder.io/cronjob-tutorial/basic-project.html
 [kubernetes-extend-api]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/
-[legacy-quickstart-doc]:https://v0-19-x.sdk.operatorframework.io/docs/golang/legacy/quickstart/
-[legacy_CLI]:https://v0-19-x.sdk.operatorframework.io/docs/cli
+[legacy-quickstart-doc]:https://github.com/operator-framework/operator-sdk/blob/v0.19.x/website/content/en/docs/golang/legacy/quickstart.md
+[legacy_CLI]:https://github.com/operator-framework/operator-sdk/tree/v0.19.x/website/content/en/docs/cli
 [manager_go_doc]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#Manager
 [markers]: https://book.kubebuilder.io/reference/markers.html
 [memcached_controller]: https://github.com/operator-framework/operator-sdk/blob/latest/testdata/go/v3/memcached-operator/controllers/memcached_controller.go

--- a/website/content/en/docs/building-operators/helm/tutorial.md
+++ b/website/content/en/docs/building-operators/helm/tutorial.md
@@ -357,7 +357,7 @@ Next, check out the following:
 1. The [advanced features][advanced-features] doc for more use cases and under-the-hood details.
 
 
-[legacy-quickstart-doc]:https://v0-19-x.sdk.operatorframework.io/docs/helm/quickstart/
+[legacy-quickstart-doc]:https://github.com/operator-framework/operator-sdk/tree/v0.19.x/website/content/en/docs/helm/quickstart.md
 [migration-guide]:/docs/building-operators/helm/migration
 [install-guide]:/docs/building-operators/helm/installation
 [image-reg-config]:/docs/olm-integration/cli-overview#private-bundle-and-catalog-image-registries

--- a/website/content/en/docs/upgrading-sdk-version/v0.1.0-migration-guide.md
+++ b/website/content/en/docs/upgrading-sdk-version/v0.1.0-migration-guide.md
@@ -308,7 +308,7 @@ At this point you should be able to build and run your operator to verify that i
 [controller-go-doc]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg#hdr-Controller
 [request-go-doc]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Request
 [result-go-doc]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Result
-[client-api-doc]: https://v0-19-x.sdk.operatorframework.io/docs/golang/references/client/
+[client-api-doc]: https://github.com/operator-framework/operator-sdk/blob/v0.19.x/website/content/en/docs/golang/references/client.md
 [manager-go-doc]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager
-[register-3rd-party-resources]: https://v0-19-x.sdk.operatorframework.io/docs/golang/legacy/quickstart/#adding-3rd-party-resources-to-your-operator
-[user-guide-build-run]: https://v0-19-x.sdk.operatorframework.io/docs/golang/legacy/quickstart/#build-and-run-the-operator
+[register-3rd-party-resources]: https://github.com/operator-framework/operator-sdk/blob/v0.19.x/website/content/en/docs/golang/legacy/quickstart.md#adding-3rd-party-resources-to-your-operator
+[user-guide-build-run]: https://github.com/operator-framework/operator-sdk/blob/v0.19.x/website/content/en/docs/golang/legacy/quickstart.md#build-and-run-the-operator

--- a/website/content/en/docs/upgrading-sdk-version/v0.19.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v0.19.0.md
@@ -52,4 +52,4 @@ to use `UpgradeError` instead of `UpdateError`.
 _See [#3269](https://github.com/operator-framework/operator-sdk/pull/3269) for more details._
 
 [migration-guide]: /docs/building-operators/golang/migration/
-[migration-guide-v0.19.0]: https://v0-19-x.sdk.operatorframework.io/docs/golang/project_migration_guide/
+[migration-guide-v0.19.0]: https://github.com/operator-framework/operator-sdk/blob/v0.19.x/website/content/en/docs/golang/project_migration_guide.md

--- a/website/content/en/docs/upgrading-sdk-version/version-upgrade-guide.md
+++ b/website/content/en/docs/upgrading-sdk-version/version-upgrade-guide.md
@@ -1373,12 +1373,12 @@ first `COPY` from `COPY /*.yaml manifests/` to `COPY deploy/olm-catalog/<operato
 [mercurial]: https://www.mercurial-scm.org/downloads
 [migrating-to-modules]: https://github.com/golang/go/wiki/Modules#migrating-to-modules
 [modules-wiki]: https://github.com/golang/go/wiki/Modules#migrating-to-modules
-[print-deps-cli]: https://v0-19-x.sdk.operatorframework.io/docs/cli/operator-sdk_print-deps/
+[print-deps-cli]: https://github.com/operator-framework/operator-sdk/blob/v0.19.x/website/content/en/docs/cli/operator-sdk_print-deps.md
 [changelog]: https://github.com/operator-framework/operator-sdk/blob/v1.3.0/CHANGELOG.md
 [release-notes]: https://github.com/operator-framework/operator-sdk/releases
 [v0.1.0-migration-guide]: ../v0.1.0-migration-guide
 [manifest-format]: https://github.com/operator-framework/operator-registry#manifest-format
-[client-doc]: https://v0-19-x.sdk.operatorframework.io/docs/golang/legacy/references/client/
+[client-doc]: https://github.com/operator-framework/operator-sdk/blob/v0.19.x/website/content/en/docs/golang/references/client.md
 [api-rules]: https://github.com/kubernetes/kubernetes/tree/36981002246682ed7dc4de54ccc2a96c1a0cbbdb/api/api-rules
 [generating-crd]: https://book.kubebuilder.io/reference/generating-crd.html
 [markers]: https://book.kubebuilder.io/reference/markers.html


### PR DESCRIPTION
**Description of the change:**
- Updates broken links due to the Netlify branch changes that were made

**Motivation for the change:**
- Fix the links that are causing the sanity link checker to fail in CI

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
