### PR TITLE
Make `run bundle` init image choosable

### DIFF
--- a/internal/olm/fbcutil/util.go
+++ b/internal/olm/fbcutil/util.go
@@ -47,6 +47,8 @@ const (
 	// DefaultIndexImage is the index base image used if none is specified. It contains no bundles.
 	// TODO(v2.0.0): pin this image tag to a specific version.
 	DefaultIndexImage = DefaultIndexImageBase + "latest"
+	// DefaultInitImage is the default image to be used in the registry init container
+	DefaultInitImage = "docker.io/library/busybox:1.36.0"
 )
 
 // BundleDeclcfg represents a minimal File-Based Catalog.

--- a/internal/olm/operator/bundle/install.go
+++ b/internal/olm/operator/bundle/install.go
@@ -51,6 +51,9 @@ func NewInstall(cfg *operator.Configuration) Install {
 
 func (i *Install) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&i.IndexImage, "index-image", fbcutil.DefaultIndexImage, "index image in which to inject bundle")
+	fs.StringVar(&i.InitImage, "decompression-image", fbcutil.DefaultInitImage, "image used in an init container in "+
+		"the registry pod to decompress the compressed catalog contents. cat and gzip binaries are expected to exist "+
+		"in the PATH")
 	fs.Var(&i.InstallMode, "install-mode", "install mode")
 
 	// --mode is hidden so only users who know what they're doing can alter add mode.

--- a/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
+++ b/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
@@ -60,6 +60,9 @@ type FBCRegistryPod struct { //nolint:maligned
 	// new version of an operator bundle when published can be added to an index image
 	IndexImage string
 
+	// InitImage is the image to be used in the registry init container
+	InitImage string
+
 	// GRPCPort is the container grpc port
 	GRPCPort int32
 
@@ -349,7 +352,7 @@ func (f *FBCRegistryPod) addGZIPInitContainer(containerVolumeMount []corev1.Volu
 	initContainerVolumeMount := append(containerVolumeMount, gzipVolumeMount...)
 	f.pod.Spec.InitContainers = append(f.pod.Spec.InitContainers, corev1.Container{
 		Name:  defaultInitContainerName,
-		Image: "docker.io/library/busybox:1.36.0",
+		Image: f.InitImage,
 		Command: []string{
 			"sh",
 			"-c",

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -98,6 +98,7 @@ type IndexImageCatalogCreator struct {
 	FBCContent      string
 	PackageName     string
 	IndexImage      string
+	InitImage       string
 	BundleImage     string
 	SecretName      string
 	CASecretName    string
@@ -518,12 +519,16 @@ func (c IndexImageCatalogCreator) createAnnotatedRegistry(ctx context.Context, c
 	if c.IndexImage == "" {
 		c.IndexImage = fbcutil.DefaultIndexImage
 	}
+	if c.InitImage == "" {
+		c.InitImage = fbcutil.DefaultInitImage
+	}
 
 	if c.HasFBCLabel {
 		// Initialize and create the FBC registry pod.
 		fbcRegistryPod := fbcindex.FBCRegistryPod{
 			BundleItems:     items,
 			IndexImage:      c.IndexImage,
+			InitImage:       c.InitImage,
 			FBCContent:      c.FBCContent,
 			SecurityContext: c.SecurityContext.String(),
 		}

--- a/website/content/en/docs/cli/operator-sdk_run_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle.md
@@ -29,6 +29,7 @@ operator-sdk run bundle <bundle-image> [flags]
 
 ```
       --ca-secret-name string                     Name of a generic secret containing a PEM root certificate file required to pull bundle images. This secret *must* be in the namespace that this command is configured to run in, and the file *must* be encoded under the key "cert.pem"
+      --decompression-image string                image used in an init container in the registry pod to decompress the compressed catalog contents. cat and gzip binaries are expected to exist in the PATH (default "docker.io/library/busybox:1.36.0")
   -h, --help                                      help for bundle
       --index-image string                        index image in which to inject bundle (default "quay.io/operator-framework/opm:latest")
       --install-mode InstallModeValue             install mode


### PR DESCRIPTION


<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**
The  `--init-image` argument  has been added to the `run bundle` command. This argument will override the docker.io/library/busybox image, used when creating a registry pod. Not including the argument will cause the same behavior as before this change.

**Motivation for the change:**
The forced use of the image docker.io/library/busybox causes issues for users making use of operator-sdk run bundle. Dockerhub rate limits container image pulls. The rate limiting will cause operator-sdk run bundle to fail once `run bundle` has been used too many times within a time period.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Closes #6578 
