### PR TITLE
Check GOBIN on make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,10 @@ clean: ## Cleanup build artifacts and tool binaries.
 
 .PHONY: install
 install: ## Install operator-sdk and helm-operator.
+	@if [ -z "$(GOBIN)" ]; then \
+		echo "Error: GOBIN is not set"; \
+		exit 1; \
+	fi
 	$(GO) install $(GO_BUILD_ARGS) ./cmd/{operator-sdk,helm-operator}
 
 .PHONY: build


### PR DESCRIPTION
**Description of the change:**
Add checking for set GOBIN on `make install`

**Motivation for the change:**
With this change we catch situation where GOBIN isn't defined and `make install` silently fails.

```
$ unset GOBIN
$ make install
Error: GOBIN is not set
make: *** [Makefile:75: install] Error 1
$ source ~/.bash_profile
$ echo $GOBIN/
/usr/local/go/bin/
$ make install
go install -gcflags "all=-trimpath=/home/user1" -asmflags "all=-trimpath=/home/user1" -ldflags " -X 'github.com/operator-framework/operator-sdk/internal/version.Version=v1.32.0+git' -X 'github.com/operator-framework/operator-sdk/internal/version.GitVersion=v1.32.0-6-g034aef67-dirty' -X 'github.com/operator-framework/operator-sdk/internal/version.GitCommit=034aef6779729a30ac3d716f93a01824ed8dd3c7' -X 'github.com/operator-framework/operator-sdk/internal/version.KubernetesVersion=v1.26.0' -X 'github.com/operator-framework/operator-sdk/internal/version.ImageVersion=v1.32.0' "  ./cmd/{operator-sdk,helm-operator}
$ which operator-sdk
/usr/local/go/bin/operator-sdk
```
proposed as a fix for https://github.com/operator-framework/operator-sdk/issues/6627

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
