### PR TITLE
Parametrized go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ export K8S_VERSION = 1.26.0
 # Build settings
 export TOOLS_DIR = tools/bin
 export SCRIPTS_DIR = tools/scripts
-REPO = $(shell go list -m)
+GO := $(shell type -P go)
+REPO = $(shell $(GO) list -m)
 BUILD_DIR = build
 GO_ASMFLAGS = -asmflags "all=-trimpath=$(shell dirname $(PWD))"
 GO_GCFLAGS = -gcflags "all=-trimpath=$(shell dirname $(PWD))"
@@ -37,10 +38,10 @@ export PATH := $(PWD)/$(BUILD_DIR):$(PWD)/$(TOOLS_DIR):$(PATH)
 .PHONY: generate
 generate: build # Generate CLI docs and samples
 	rm -rf testdata
-	go run ./hack/generate/cncf-maintainers/main.go
-	go run ./hack/generate/cli-doc/gen-cli-doc.go
-	go run ./hack/generate/samples/generate_testdata.go
-	go generate ./...
+	$(GO) run ./hack/generate/cncf-maintainers/main.go
+	$(GO) run ./hack/generate/cli-doc/gen-cli-doc.go
+	$(GO) run ./hack/generate/samples/generate_testdata.go
+	$(GO) generate ./...
 
 .PHONY: bindata
 OLM_VERSIONS = 0.23.1 0.24.0 0.25.0
@@ -50,8 +51,8 @@ bindata: ## Update project bindata
 
 .PHONY: fix
 fix: ## Fixup files in the repo.
-	go mod tidy
-	go fmt ./...
+	$(GO) mod tidy
+	$(GO) fmt ./...
 	make setup-lint
 	$(TOOLS_DIR)/golangci-lint run --fix
 
@@ -72,21 +73,21 @@ clean: ## Cleanup build artifacts and tool binaries.
 
 .PHONY: install
 install: ## Install operator-sdk and helm-operator.
-	go install $(GO_BUILD_ARGS) ./cmd/{operator-sdk,helm-operator}
+	$(GO) install $(GO_BUILD_ARGS) ./cmd/{operator-sdk,helm-operator}
 
 .PHONY: build
 build: ## Build operator-sdk and helm-operator.
 	@mkdir -p $(BUILD_DIR)
-	go build $(GO_BUILD_ARGS) -o $(BUILD_DIR) ./cmd/{operator-sdk,helm-operator}
+	$(GO) build $(GO_BUILD_ARGS) -o $(BUILD_DIR) ./cmd/{operator-sdk,helm-operator}
 
 .PHONY: build/operator-sdk build/helm-operator
 build/operator-sdk build/helm-operator:
-	go build $(GO_BUILD_ARGS) -o $(BUILD_DIR)/$(@F) ./cmd/$(@F)
+	$(GO) build $(GO_BUILD_ARGS) -o $(BUILD_DIR)/$(@F) ./cmd/$(@F)
 
 # Build scorecard binaries.
 .PHONY: build/scorecard-test build/scorecard-test-kuttl build/custom-scorecard-tests
 build/scorecard-test build/scorecard-test-kuttl build/custom-scorecard-tests:
-	go build $(GO_GCFLAGS) $(GO_ASMFLAGS) -o $(BUILD_DIR)/$(@F) ./images/$(@F)
+	$(GO) build $(GO_GCFLAGS) $(GO_ASMFLAGS) -o $(BUILD_DIR)/$(@F) ./images/$(@F)
 
 ##@ Dev image build
 
@@ -139,21 +140,21 @@ test-sanity: generate fix ## Test repo formatting, linting, etc.
 	git diff --exit-code # fast-fail if generate or fix produced changes
 	./hack/check-license.sh
 	./hack/check-error-log-msg-format.sh
-	go vet ./...
+	$(GO) vet ./...
 	make setup-lint
 	make lint
 	git diff --exit-code # diff again to ensure other checks don't change repo
 
 .PHONY: test-docs
 test-docs: ## Test doc links
-	go run ./release/changelog/gen-changelog.go -validate-only
+	$(GO) run ./release/changelog/gen-changelog.go -validate-only
 	git submodule update --init --recursive website/
 	./hack/check-links.sh
 
 .PHONY: test-unit
-TEST_PKGS = $(shell go list ./... | grep -v -E 'github.com/operator-framework/operator-sdk/test/')
+TEST_PKGS = $(shell $(GO) list ./... | grep -v -E 'github.com/operator-framework/operator-sdk/test/')
 test-unit: ## Run unit tests
-	go test -coverprofile=coverage.out -covermode=count -short $(TEST_PKGS)
+	$(GO) test -coverprofile=coverage.out -covermode=count -short $(TEST_PKGS)
 
 e2e_tests := test-e2e-go test-e2e-helm test-e2e-integration
 e2e_targets := test-e2e $(e2e_tests)
@@ -162,7 +163,7 @@ e2e_targets := test-e2e $(e2e_tests)
 .PHONY: test-e2e-setup
 export KIND_CLUSTER := osdk-test
 
-KUBEBUILDER_ASSETS = $(PWD)/$(shell go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest && $(shell go env GOPATH)/bin/setup-envtest use $(K8S_VERSION) --bin-dir tools/bin/ -p path)
+KUBEBUILDER_ASSETS = $(PWD)/$(shell $(GO) install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest && $(shell $(GO) env GOPATH)/bin/setup-envtest use $(K8S_VERSION) --bin-dir tools/bin/ -p path)
 test-e2e-setup:: build dev-install cluster-create
 
 .PHONY: cluster-create
@@ -188,11 +189,11 @@ test-e2e:: $(e2e_tests) ## Run e2e tests
 test-e2e-sample-go:: dev-install cluster-create ## Run Memcached Operator Sample e2e tests
 	make test-e2e -C ./testdata/go/v3/memcached-operator/
 test-e2e-go:: image/custom-scorecard-tests ## Run Go e2e tests
-	go test ./test/e2e/go -v -ginkgo.v
+	$(GO) test ./test/e2e/go -v -ginkgo.v
 test-e2e-helm:: image/helm-operator ## Run Helm e2e tests
-	go test ./test/e2e/helm -v -ginkgo.v
+	$(GO) test ./test/e2e/helm -v -ginkgo.v
 test-e2e-integration:: ## Run integration tests
-	go test ./test/integration -v -ginkgo.v
+	$(GO) test ./test/integration -v -ginkgo.v
 	./hack/tests/subcommand-olm-install.sh
 
 .DEFAULT_GOAL := help


### PR DESCRIPTION
**Description of the change:**

The *go* executable in the *Makefile* is parametrized. This allows to select an explicit instance / version among a set of local go installations. The default remains »go« as found on the PATH.

**Motivation for the change:**

The *go* ecosystem has a nice [facility](https://go.dev/doc/manage-install) to maintain different versions of go on a local system. To enable a developer to choose the appropriate go version without manipulating the local system or the *Makefile*, this simple parametrization is helpful.

A typical application workflow could look like
```sh
GOBIN="${HOME}/.local/bin" go install golang.org/dl/go1.19@latest
go1.19 download
make GO=go1.19
```
