### PR TITLE
Consume 0.20.0 version of operator framework api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.12.0
 	github.com/onsi/gomega v1.27.10
 	github.com/operator-framework/ansible-operator-plugins v1.33.0
-	github.com/operator-framework/api v0.17.7
+	github.com/operator-framework/api v0.20.0
 	github.com/operator-framework/helm-operator-plugins v0.0.11
 	github.com/operator-framework/java-operator-plugins v0.8.1
 	github.com/operator-framework/operator-lib v0.11.1-0.20231020142438-152ee1fb7f83

--- a/go.sum
+++ b/go.sum
@@ -638,8 +638,8 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/operator-framework/ansible-operator-plugins v1.33.0 h1:cN5jYyNjVmDu2o0Q/xSRTgOWP5PkcnttE7IotgjHKKg=
 github.com/operator-framework/ansible-operator-plugins v1.33.0/go.mod h1:V1ju4foYRWiuggI8IThIXuT6P273fnUZi29PNOHsr/0=
-github.com/operator-framework/api v0.17.7 h1:NLn+Ieg+HaPrw75KbX4efllN21ofFArQzS3q8TDbQY0=
-github.com/operator-framework/api v0.17.7/go.mod h1:lnurXgadLnoZ7pufKMHkErr2BVOIZSpHtvEkHBcKvdk=
+github.com/operator-framework/api v0.20.0 h1:A2YCRhr+6s0k3pRJacnwjh1Ue8BqjIGuQ2jvPg9XCB4=
+github.com/operator-framework/api v0.20.0/go.mod h1:rXPOhrQ6mMeXqCmpDgt1ALoar9ZlHL+Iy5qut9R99a4=
 github.com/operator-framework/helm-operator-plugins v0.0.11 h1:u2odF2qJ8y1DswCJBt28tvM7PDNIiA8Yc8bjsC1fpKA=
 github.com/operator-framework/helm-operator-plugins v0.0.11/go.mod h1:X5HB7sPe/cyLg7qZ25k1icC5DKh06oTf3BV8j4kWuxY=
 github.com/operator-framework/java-operator-plugins v0.8.1 h1:xdbzWror/SSzWx7y6T+Y/FRpHAReOHMjRBSQoKmsZMY=

--- a/internal/cmd/operator-sdk/bundle/validate/optional.go
+++ b/internal/cmd/operator-sdk/bundle/validate/optional.go
@@ -33,16 +33,42 @@ const (
 	suiteKey = "suite"
 )
 
-// optionalValidators is a list of validators with 0their name, labels for CLI usage, and a light description.
+// optionalValidators is a list of validators with their name, labels for CLI usage, and a light description.
 var optionalValidators = validators{
 	{
-		Validator: apivalidation.OperatorHubValidator,
-		name:      "operatorhub",
+		Validator: apivalidation.OperatorHubV2Validator,
+		name:      "operatorhubv2",
 		labels: map[string]string{
-			nameKey:  "operatorhub",
+			nameKey:  "operatorhubv2",
 			suiteKey: "operatorframework",
 		},
 		desc: "OperatorHub.io metadata validation. ",
+	},
+	{
+		Validator: apivalidation.StandardCapabilitiesValidator,
+		name:      "capabilities",
+		labels: map[string]string{
+			nameKey:  "capabilities",
+			suiteKey: "operatorframework",
+		},
+		desc: "OperatorHub.io capabilities metadata validation. ",
+	},
+	{
+		Validator: apivalidation.StandardCategoriesValidator,
+		name:      "categories",
+		labels: map[string]string{
+			nameKey:  "categories",
+			suiteKey: "operatorframework",
+		},
+		desc: "OperatorHub.io categories metadata validation. ",
+	},
+	{
+		Validator: apivalidation.OperatorHubValidator, // nolint:staticcheck
+		name:      "operatorhub",
+		labels: map[string]string{
+			nameKey: "operatorhub",
+		},
+		desc: "Deprecated OperatorHub.io metadata validation. ",
 	},
 	{
 		Validator: apivalidation.CommunityOperatorValidator,

--- a/internal/cmd/operator-sdk/bundle/validate/optional_test.go
+++ b/internal/cmd/operator-sdk/bundle/validate/optional_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Running optional validators", func() {
 		It("runs a validator for one selector on an empty bundle", func() {
 			bundle = &apimanifests.Bundle{}
 			sel = labels.SelectorFromSet(map[string]string{
-				nameKey: "operatorhub",
+				suiteKey: "operatorframework",
 			})
 			results = vals.run(bundle, sel, map[string]string{"k8s-version": "1.22"})
 			Expect(results).To(HaveLen(1))
@@ -61,7 +61,7 @@ var _ = Describe("Running optional validators", func() {
 			bundle = &apimanifests.Bundle{}
 			bundle.CSV = &v1alpha1.ClusterServiceVersion{}
 			sel = labels.SelectorFromSet(map[string]string{
-				nameKey: "operatorhub",
+				suiteKey: "operatorframework",
 			})
 			results = vals.run(bundle, sel, nil)
 			Expect(results).To(HaveLen(1))
@@ -84,14 +84,14 @@ var _ = Describe("Running optional validators", func() {
 		})
 		It("returns an error for an unmatched selector with no validators", func() {
 			sel = labels.SelectorFromSet(map[string]string{
-				nameKey: "operatorhub",
+				suiteKey: "operatorframework",
 			})
 			err = vals.checkMatches(sel)
 			Expect(err).To(HaveOccurred())
 		})
 		It("returns no error for an unmatched selector with all optional validators", func() {
 			sel = labels.SelectorFromSet(map[string]string{
-				nameKey: "operatorhub",
+				suiteKey: "operatorframework",
 			})
 			vals = optionalValidators
 			err = vals.checkMatches(sel)


### PR DESCRIPTION
This pull request updates the operator-framework api dependency to 0.20.0.

As part of that consumption, this updates the `operator-sdk bundle validate` command to consume the new hierarchy of optional validators, given the deprecation of the optional `operatorhub` validator. See https://github.com/operator-framework/api/pull/304 for more info.