### PR TITLE
fix: migrate apis directory to api per standard

### DIFF
--- a/internal/cmd/operator-sdk/alpha/config3alphato3/convert_config_3-alpha_to_3.go
+++ b/internal/cmd/operator-sdk/alpha/config3alphato3/convert_config_3-alpha_to_3.go
@@ -93,7 +93,7 @@ func convertConfig3AlphaTo3(cfgBytes []byte) (_ []byte, err error) {
 				// Only Go projects use "resources[*].path".
 				var apiPath string
 				if isMultigroup {
-					apiPath = path.Join("apis", resources[i].Group, resources[i].Version)
+					apiPath = path.Join("api", resources[i].Group, resources[i].Version)
 				} else {
 					apiPath = path.Join("api", resources[i].Version)
 				}

--- a/internal/cmd/operator-sdk/generate/kustomize/manifests.go
+++ b/internal/cmd/operator-sdk/generate/kustomize/manifests.go
@@ -156,11 +156,7 @@ func (c *manifestsCmd) setDefaults(cfg config.Config) error {
 	}
 
 	if c.apisDir == "" {
-		if cfg.IsMultiGroup() {
-			c.apisDir = "apis"
-		} else {
-			c.apisDir = "api"
-		}
+		c.apisDir = "api"
 	}
 	return nil
 }

--- a/testdata/go/v3/memcached-operator/Makefile
+++ b/testdata/go/v3/memcached-operator/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.32.0
+OPERATOR_SDK_VERSION ?= v1.33.0
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest

--- a/testdata/go/v3/monitoring/memcached-operator/Makefile
+++ b/testdata/go/v3/monitoring/memcached-operator/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.32.0
+OPERATOR_SDK_VERSION ?= v1.33.0
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest

--- a/testdata/go/v4/memcached-operator/Makefile
+++ b/testdata/go/v4/memcached-operator/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.32.0
+OPERATOR_SDK_VERSION ?= v1.33.0
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest

--- a/testdata/go/v4/monitoring/memcached-operator/Makefile
+++ b/testdata/go/v4/monitoring/memcached-operator/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.32.0
+OPERATOR_SDK_VERSION ?= v1.33.0
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest

--- a/testdata/helm/memcached-operator/Makefile
+++ b/testdata/helm/memcached-operator/Makefile
@@ -48,7 +48,7 @@ endif
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.32.0
+OPERATOR_SDK_VERSION ?= v1.33.0
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest


### PR DESCRIPTION
- When multigroup is true, the api directory (which is considered the project layout standard) is now used instead of apis. See https://kubebuilder.io/migration/manually_migration_guide_gov3_to_gov4

This appears to have been missed in the latest release which uses go/v4.
