### PR TITLE
Correct the Docker buildx command in SDK 1.25.0 upgrade doc

### DIFF
--- a/website/content/en/docs/upgrading-sdk-version/v1.25.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.25.0.md
@@ -25,13 +25,13 @@ weight: 998975000
     PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
     .PHONY: docker-buildx
     docker-buildx: test ## Build and push docker image for the manager for cross-platform support
-        # copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-        sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
-        - docker buildx create --name project-v3-builder
-        docker buildx use project-v3-builder
-        - docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
-        - docker buildx rm project-v3-builder
-        rm Dockerfile.cross
+    	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+    	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+    	- docker buildx create --name project-v3-builder
+    	docker buildx use project-v3-builder
+    	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
+    	- docker buildx rm project-v3-builder
+    	rm Dockerfile.cross
     ```
 
 3. (go/v3) Bump dependencies in go.mod file
@@ -39,7 +39,7 @@ weight: 998975000
     ```go
         go 1.19   
 
-      	github.com/onsi/ginkgo/v2 v2.1.4
+        github.com/onsi/ginkgo/v2 v2.1.4
         github.com/onsi/gomega v1.19.0
         github.com/prometheus/client_golang v1.12.2
         k8s.io/api v0.25.0
@@ -48,7 +48,7 @@ weight: 998975000
         sigs.k8s.io/controller-runtime v0.13.0
     ```
 
-4. (go/v3) Update `controller-tools` from `0.9.2` to `0.10.0`. 
+4. (go/v3) Update `controller-tools` from `0.9.2` to `0.10.0`.
 
    In the `Makefile` file, replace `CONTROLLER_TOOLS_VERSION ?= v0.9.2` with `CONTROLLER_TOOLS_VERSION ?= v0.10.0`
 
@@ -73,7 +73,7 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 ```


### PR DESCRIPTION
**Description of the change:**

The arg for the `docker buildx build` command was missing in the documentation, resulting in the following error:
> ERROR: "docker buildx build" requires exactly 1 argument.

I have added the arg as the current directory:
`docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .`

**Motivation for the change:**

I identified this subtle issue while upgrading an operator to version 1.25.0.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
