### PR TITLE
fix: create api helm panic

### DIFF
--- a/internal/plugins/helm/v1/chartutil/chart.go
+++ b/internal/plugins/helm/v1/chartutil/chart.go
@@ -27,6 +27,7 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/downloader"
 	"helm.sh/helm/v3/pkg/getter"
+	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/repo"
 )
 
@@ -181,12 +182,16 @@ func ScaffoldChart(chrt *chart.Chart, projectDir string) (*chart.Chart, string, 
 func fetchChartDependencies(chartPath string) error {
 	settings := cli.New()
 	getters := getter.All(settings)
-
+	client, err := registry.NewClient()
+	if err != nil {
+		return err
+	}
 	out := &bytes.Buffer{}
 	man := &downloader.Manager{
 		Out:              out,
 		ChartPath:        chartPath,
 		Getters:          getters,
+		RegistryClient:   client,
 		RepositoryConfig: settings.RepositoryConfig,
 		RepositoryCache:  settings.RepositoryCache,
 	}


### PR DESCRIPTION
**Description of the change:**



helm `downloader.Manager` not initialized correctly. in `operator-sdk/internal/plugins/helm/v1/chartutil/chart.go:186`

**Motivation for the change:**

1. Init project

```
operator-sdk init --plugins=hybrid.helm.sdk.operatorframework.io --project-version="3" --repo=github.com/meimeitou/db-operator 
```

2. Create api

```
operator-sdk create api --plugins helm.sdk.operatorframework.io/v1 --group dns --version v1alpha1 --kind Postgres --helm-chart=postgresql --helm-chart-version=12.12.10 --helm-chart-repo=https://charts.bitnami.com/bitnami
```

than got panic:

```
NFO[0026] Writing kustomize manifests for you to edit... 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x17df48b]

goroutine 1 [running]:
helm.sh/helm/v3/pkg/registry.(*Client).Tags(0x0, {0xc0008f5830?, 0xc002b07210?})
        /home/runner/go/pkg/mod/helm.sh/helm/v3@v3.13.3/pkg/registry/client.go:671 +0x12b
helm.sh/helm/v3/internal/resolver.(*Resolver).Resolve(0xc002b07458, {0xc001e8ed10, 0x1, 0x1}, 0x1?)
        /home/runner/go/pkg/mod/helm.sh/helm/v3@v3.13.3/internal/resolver/resolver.go:153 +0x588
helm.sh/helm/v3/pkg/downloader.(*Manager).resolve(0xc003eb9dd0?, {0xc001e8ed10?, 0xc001e8ed10?, 0x1?}, 0x0?)
        /home/runner/go/pkg/mod/helm.sh/helm/v3@v3.13.3/pkg/downloader/manager.go:235 +0x5f
helm.sh/helm/v3/pkg/downloader.(*Manager).Update(0xc003eb9dd0)
        /home/runner/go/pkg/mod/helm.sh/helm/v3@v3.13.3/pkg/downloader/manager.go:194 +0xdc
helm.sh/helm/v3/pkg/downloader.(*Manager).Build(0xc003eb9dd0)
        /home/runner/go/pkg/mod/helm.sh/helm/v3@v3.13.3/pkg/downloader/manager.go:95 +0x3d2
github.com/operator-framework/operator-sdk/internal/plugins/helm/v1/chartutil.fetchChartDependencies({0xc003eccdc0, 0x3b})
        internal/plugins/helm/v1/chartutil/chart.go:193 +0x273
github.com/operator-framework/operator-sdk/internal/plugins/helm/v1/chartutil.ScaffoldChart(0xc003c8a140, {0xc000058004?, 0xc0007ec6b0?})
        internal/plugins/helm/v1/chartutil/chart.go:168 +0x127
github.com/operator-framework/operator-sdk/internal/plugins/helm/v1/scaffolds.(*apiScaffolder).Scaffold(0xc003c8b4a0)
        internal/plugins/helm/v1/scaffolds/api.go:77 +0xd4
github.com/operator-framework/operator-sdk/internal/plugins/helm/v1.(*createAPISubcommand).Scaffold(0xc0007ee410, {{0x2d03700?, 0x4353920?}})
        internal/plugins/helm/v1/api.go:228 +0x1de
sigs.k8s.io/kubebuilder/v3/pkg/cli.(*CLI).applySubcommandHooks.(*executionHooksFactory).runEFunc.func2.1({0x7fe14a077728?, 0xc0007ee410?})
        /home/runner/go/pkg/mod/sigs.k8s.io/kubebuilder/v3@v3.13.1-0.20240119130530-7fba82c768f8/pkg/cli/cmd_helpers.go:308 +0x2f
sigs.k8s.io/kubebuilder/v3/pkg/cli.(*executionHooksFactory).forEach(0xc0004c2b60, 0xc002b07b70, {0x28796c4, 0x17})
        /home/runner/go/pkg/mod/sigs.k8s.io/kubebuilder/v3@v3.13.1-0.20240119130530-7fba82c768f8/pkg/cli/cmd_helpers.go:198 +0xad
sigs.k8s.io/kubebuilder/v3/pkg/cli.(*CLI).applySubcommandHooks.(*executionHooksFactory).runEFunc.func2(0xc000505600, {0xc0007b8420, 0x0, 0xb})
        /home/runner/go/pkg/mod/sigs.k8s.io/kubebuilder/v3@v3.13.1-0.20240119130530-7fba82c768f8/pkg/cli/cmd_helpers.go:307 +0x3f
github.com/spf13/cobra.(*Command).execute(0xc000902000, {0xc0007b8370, 0xb, 0xb})
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0xabc
github.com/spf13/cobra.(*Command).ExecuteC(0xc0007d1b00)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
sigs.k8s.io/kubebuilder/v3/pkg/cli.CLI.Run(...)
        /home/runner/go/pkg/mod/sigs.k8s.io/kubebuilder/v3@v3.13.1-0.20240119130530-7fba82c768f8/pkg/cli/cli.go:463
github.com/operator-framework/operator-sdk/internal/cmd/operator-sdk/cli.Run()
        internal/cmd/operator-sdk/cli/cli.go:76 +0x45
main.main()
        cmd/operator-sdk/main.go:28 +0x13
```

3. more info

operator-sdk version:
```
operator-sdk version: "v1.34.1", commit: "edaed1e5057db0349568e0b02df3743051b54e68", kubernetes version: "1.28.0", go version: "go1.21.7", GOOS: "linux", GOARCH: "amd64"
```


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
