### PR TITLE
Change DefaultIndexImage to UBI

### DIFF
--- a/internal/olm/fbcutil/util.go
+++ b/internal/olm/fbcutil/util.go
@@ -48,7 +48,7 @@ const (
 	// TODO(v2.0.0): pin this image tag to a specific version.
 	DefaultIndexImage = DefaultIndexImageBase + "latest"
 	// DefaultInitImage is the default image to be used in the registry init container
-	DefaultInitImage = "docker.io/library/busybox:1.36.0"
+	DefaultInitImage = "registry.access.redhat.com/ubi8:8.9"
 )
 
 // BundleDeclcfg represents a minimal File-Based Catalog.

--- a/website/content/en/docs/cli/operator-sdk_run_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle.md
@@ -29,7 +29,7 @@ operator-sdk run bundle <bundle-image> [flags]
 
 ```
       --ca-secret-name string                     Name of a generic secret containing a PEM root certificate file required to pull bundle images. This secret *must* be in the namespace that this command is configured to run in, and the file *must* be encoded under the key "cert.pem"
-      --decompression-image string                image used in an init container in the registry pod to decompress the compressed catalog contents. cat and gzip binaries are expected to exist in the PATH (default "docker.io/library/busybox:1.36.0")
+      --decompression-image string                image used in an init container in the registry pod to decompress the compressed catalog contents. cat and gzip binaries are expected to exist in the PATH (default "registry.access.redhat.com/ubi8:8.9")
   -h, --help                                      help for bundle
       --index-image string                        index image in which to inject bundle (default "quay.io/operator-framework/opm:latest")
       --install-mode InstallModeValue             install mode


### PR DESCRIPTION

**Description of the change:**
Change untar image from busybox to UBI image as #5191

**Motivation for the change:**
Remove dependency on dockerhub

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
