### PR TITLE
fix: consider version when getting CRDs for validating descriptors

### DIFF
--- a/changelog/fragments/01-olm-scorecard-fix.yaml
+++ b/changelog/fragments/01-olm-scorecard-fix.yaml
@@ -1,0 +1,28 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      An additional condition is included for matching `apiVersion` of example CRs with CRD `version` when searching for the CRD in the CSV. 
+      Previously, The `olm-spec-descriptors` scorecard test failed when multiple versions of CRD is included in the CSV. 
+      The CR specified in `alm-examples` annotations are validated only against the first matched CRD (by name), which is incorrect. 
+      This ensures the correct CRD version is selected for validations.
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/internal/scorecard/tests/bundle_test.go
+++ b/internal/scorecard/tests/bundle_test.go
@@ -127,15 +127,25 @@ var _ = Describe("Basic and OLM tests", func() {
 	Describe("OLM Tests", func() {
 
 		Describe("Test Status and Spec Descriptors", func() {
-			var (
-				cr  unstructured.Unstructured
-				csv operatorsv1alpha1.ClusterServiceVersion
-			)
-
-			csv = operatorsv1alpha1.ClusterServiceVersion{
+			csv := operatorsv1alpha1.ClusterServiceVersion{
 				Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
 					CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
 						Owned: []operatorsv1alpha1.CRDDescription{
+							operatorsv1alpha1.CRDDescription{
+								Name:    "Test",
+								Version: "v2",
+								Kind:    "TestKind",
+								StatusDescriptors: []operatorsv1alpha1.StatusDescriptor{
+									operatorsv1alpha1.StatusDescriptor{
+										Path: "newStatus",
+									},
+								},
+								SpecDescriptors: []operatorsv1alpha1.SpecDescriptor{
+									operatorsv1alpha1.SpecDescriptor{
+										Path: "newSpec",
+									},
+								},
+							},
 							operatorsv1alpha1.CRDDescription{
 								Name:    "Test",
 								Version: "v1",
@@ -156,8 +166,22 @@ var _ = Describe("Basic and OLM tests", func() {
 				},
 			}
 
-			It("should pass when csv with owned cr and required fields is present", func() {
-				cr = unstructured.Unstructured{
+			It("should pass when CR Object Descriptor is nil", func() {
+				cr := unstructured.Unstructured{
+					Object: nil,
+				}
+				cr.SetGroupVersionKind(schema.GroupVersionKind{
+					Kind:    "TestKind",
+					Group:   "test.example.com",
+					Version: "v1",
+				})
+
+				result = checkOwnedCSVStatusDescriptor(cr, &csv, result)
+				Expect(result.State).To(Equal(scapiv1alpha3.PassState))
+			})
+
+			It("should pass when status descriptor field is present in CR", func() {
+				cr := unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"status": map[string]interface{}{
 							"status": "val",
@@ -168,16 +192,38 @@ var _ = Describe("Basic and OLM tests", func() {
 					},
 				}
 				cr.SetGroupVersionKind(schema.GroupVersionKind{
-					Kind:  "TestKind",
-					Group: "test.example.com",
+					Kind:    "TestKind",
+					Group:   "test.example.com",
+					Version: "v1",
 				})
 
 				result = checkOwnedCSVStatusDescriptor(cr, &csv, result)
 				Expect(result.State).To(Equal(scapiv1alpha3.PassState))
 			})
 
-			It("should return warning when no spec status are defined for CRD", func() {
-				cr = unstructured.Unstructured{
+			It("should pass when required spec descriptor field is present in CR", func() {
+				cr := unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"status": map[string]interface{}{
+							"status": "val",
+						},
+						"spec": map[string]interface{}{
+							"spec": "val",
+						},
+					},
+				}
+				cr.SetGroupVersionKind(schema.GroupVersionKind{
+					Kind:    "TestKind",
+					Group:   "test.example.com",
+					Version: "v1",
+				})
+
+				result = checkOwnedCSVSpecDescriptors(cr, &csv, result)
+				Expect(result.State).To(Equal(scapiv1alpha3.PassState))
+			})
+
+			It("should return warning when no status descriptor field is present in CR", func() {
+				cr := unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"spec": map[string]interface{}{
 							"spec": "val",
@@ -185,8 +231,9 @@ var _ = Describe("Basic and OLM tests", func() {
 					},
 				}
 				cr.SetGroupVersionKind(schema.GroupVersionKind{
-					Kind:  "TestKind",
-					Group: "test.example.com",
+					Kind:    "TestKind",
+					Group:   "test.example.com",
+					Version: "v1",
 				})
 
 				result = checkOwnedCSVStatusDescriptor(cr, &csv, result)
@@ -194,58 +241,7 @@ var _ = Describe("Basic and OLM tests", func() {
 				Expect(result.State).To(Equal(scapiv1alpha3.PassState))
 			})
 
-			It("should pass when CR Object Descriptor is nil", func() {
-				cr := unstructured.Unstructured{
-					Object: nil,
-				}
-				cr.SetGroupVersionKind(schema.GroupVersionKind{
-					Kind:  "TestKind",
-					Group: "test.example.com",
-				})
-
-				result = checkOwnedCSVStatusDescriptor(cr, &csv, result)
-				Expect(result.State).To(Equal(scapiv1alpha3.PassState))
-			})
-
-			It("should fail when CR Object Descriptor is nil and CRD with given GVK cannot be found", func() {
-				cr := unstructured.Unstructured{
-					Object: nil,
-				}
-				cr.SetGroupVersionKind(schema.GroupVersionKind{
-					Kind:  "TestKindNotPresent",
-					Group: "testnotpresent.example.com",
-				})
-
-				result = checkOwnedCSVStatusDescriptor(cr, &csv, result)
-				Expect(result.State).To(Equal(scapiv1alpha3.FailState))
-			})
-
-			It("should fail when owned CRD for CR does not have GVK set", func() {
-				cr := unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"status": map[string]interface{}{
-							"status": "val",
-						},
-					},
-				}
-
-				result = checkOwnedCSVStatusDescriptor(cr, &csv, result)
-				Expect(result.State).To(Equal(scapiv1alpha3.FailState))
-			})
-
-			It("should fail when required descriptor field is not present in CR", func() {
-				cr := unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"node": map[string]interface{}{
-							"node": "val",
-						},
-					},
-				}
-
-				result = checkOwnedCSVStatusDescriptor(cr, &csv, result)
-				Expect(result.State).To(Equal(scapiv1alpha3.FailState))
-			})
-			It("should pass when required descriptor field is present in CR", func() {
+			It("should fail CRD with given GVK cannot be found", func() {
 				cr := unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"status": map[string]interface{}{
@@ -257,14 +253,16 @@ var _ = Describe("Basic and OLM tests", func() {
 					},
 				}
 				cr.SetGroupVersionKind(schema.GroupVersionKind{
-					Kind:  "TestKind",
-					Group: "test.example.com",
+					Kind:    "TestKindNotPresent",
+					Group:   "testnotpresent.example.com",
+					Version: "unknown",
 				})
 
-				result = checkOwnedCSVSpecDescriptors(cr, &csv, result)
-				Expect(result.State).To(Equal(scapiv1alpha3.PassState))
+				result = checkOwnedCSVStatusDescriptor(cr, &csv, result)
+				Expect(result.State).To(Equal(scapiv1alpha3.FailState))
 			})
-			It("should fail when required spec descriptor field is not present in CR", func() {
+
+			It("should fail when CR does not have GVK set", func() {
 				cr := unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"status": map[string]interface{}{
@@ -273,26 +271,46 @@ var _ = Describe("Basic and OLM tests", func() {
 					},
 				}
 
+				result = checkOwnedCSVStatusDescriptor(cr, &csv, result)
+				Expect(result.State).To(Equal(scapiv1alpha3.FailState))
+			})
+
+			It("should fail when required spec descriptor field is not present in CR", func() {
+				cr := unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"spec": map[string]interface{}{
+							"node": "val",
+						},
+					},
+				}
+				cr.SetGroupVersionKind(schema.GroupVersionKind{
+					Kind:    "TestKind",
+					Group:   "test.example.com",
+					Version: "v1",
+				})
+
 				result = checkOwnedCSVSpecDescriptors(cr, &csv, result)
 				Expect(result.State).To(Equal(scapiv1alpha3.FailState))
 			})
-			It("should fail when CRs do not have spec field specified", func() {
-				cr := []unstructured.Unstructured{
-					unstructured.Unstructured{
-						Object: map[string]interface{}{},
-					},
-				}
-				result = checkSpec(cr, result)
-				Expect(result.State).To(Equal(scapiv1alpha3.PassState))
-			})
+
 			It("should pass when CRs do have spec field specified", func() {
 				cr := []unstructured.Unstructured{
-					unstructured.Unstructured{
+					{
 						Object: map[string]interface{}{
 							"spec": map[string]interface{}{
 								"spec": "val",
 							},
 						},
+					},
+				}
+				result = checkSpec(cr, result)
+				Expect(result.State).To(Equal(scapiv1alpha3.PassState))
+			})
+
+			It("should fail when CRs do not have spec field specified", func() {
+				cr := []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{},
 					},
 				}
 				result = checkSpec(cr, result)

--- a/internal/scorecard/tests/olm.go
+++ b/internal/scorecard/tests/olm.go
@@ -237,7 +237,7 @@ func checkOwnedCSVStatusDescriptor(cr unstructured.Unstructured, csv *operatorsv
 	var crdDescription *operatorsv1alpha1.CRDDescription
 
 	for _, owned := range csv.Spec.CustomResourceDefinitions.Owned {
-		if owned.Kind == cr.GetKind() {
+		if owned.Kind == cr.GetKind() && owned.Version == getVersionFromGV(cr) {
 			crdDescription = &owned
 			break
 		}
@@ -288,7 +288,7 @@ func checkOwnedCSVSpecDescriptors(cr unstructured.Unstructured, csv *operatorsv1
 
 	var crd *operatorsv1alpha1.CRDDescription
 	for _, owned := range csv.Spec.CustomResourceDefinitions.Owned {
-		if owned.Kind == cr.GetKind() {
+		if owned.Kind == cr.GetKind() && owned.Version == getVersionFromGV(cr) {
 			crd = &owned
 			break
 		}
@@ -386,6 +386,17 @@ func isCRFromCRDApi(cr unstructured.Unstructured, crds []*apiextv1.CustomResourc
 		}
 	}
 	return r
+}
+
+func getVersionFromGV(cr unstructured.Unstructured) string {
+	gv := strings.Split(cr.GetAPIVersion(), "/")
+	if len(gv) > 2 {
+		return "" // invalid apiVersion
+	}
+	if len(gv) == 2 {
+		return gv[1]
+	}
+	return cr.GetAPIVersion()
 }
 
 func wrapResult(r scapiv1alpha3.TestResult) scapiv1alpha3.TestStatus {


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**

An additional condition is included for matching `apiVersion` of example CRs with CRD `version` when searching for the CRD in the CSV. 

**Motivation for the change:**

Previously, the `olm-spec-descriptors` scorecard test failed when multiple versions of CRD are included in the CSV. The CRs specified in `alm-examples` annotations are validated only against the first matched CRD (by kind), which is incorrect. This ensures the CRD with correct kind and version is selected for descriptor scorecard test.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Fixes #6781 