### PR TITLE
docs: cleanup aftert test should remove namespace, Closes #6791

### DIFF
--- a/testdata/go/v4/memcached-operator/test/e2e/e2e_test.go
+++ b/testdata/go/v4/memcached-operator/test/e2e/e2e_test.go
@@ -84,7 +84,7 @@ var _ = Describe("memcached", Ordered, func() {
 		utils.UninstallCertManager()
 
 		By("removing manager namespace")
-		cmd := exec.Command("kubectl", "create", "ns", namespace)
+		cmd := exec.Command("kubectl", "delete", "ns", namespace)
 		_, _ = utils.Run(cmd)
 	})
 

--- a/testdata/go/v4/monitoring/memcached-operator/test/e2e/e2e_test.go
+++ b/testdata/go/v4/monitoring/memcached-operator/test/e2e/e2e_test.go
@@ -100,7 +100,7 @@ var _ = Describe("memcached", Ordered, func() {
 		utils.UninstallCertManager()
 
 		By("removing manager namespace")
-		cmd := exec.Command("kubectl", "create", "ns", namespace)
+		cmd := exec.Command("kubectl", "delete", "ns", namespace)
 		_, _ = utils.Run(cmd)
 	})
 


### PR DESCRIPTION
Two examples have the same issue. 
Should be: `namespace should be removed at the end of the test`
It is: `namespace is created again`

 * https://github.com/operator-framework/operator-sdk/blob/e95abdbd5ccb7ca0fd586e0c6f578e491b0a025b/testdata/go/v4/memcached-operator/test/e2e/e2e_test.go#L87
 * https://github.com/operator-framework/operator-sdk/blob/e95abdbd5ccb7ca0fd586e0c6f578e491b0a025b/testdata/go/v4/monitoring/memcached-operator/test/e2e/e2e_test.go#L103
