### PR TITLE
Bump java-operator-plugins to v0.11.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/operator-framework/ansible-operator-plugins v1.35.0
 	github.com/operator-framework/api v0.23.0
 	github.com/operator-framework/helm-operator-plugins v0.2.2
-	github.com/operator-framework/java-operator-plugins v0.10.0
+	github.com/operator-framework/java-operator-plugins v0.11.1
 	github.com/operator-framework/operator-lib v0.13.0
 	github.com/operator-framework/operator-manifest-tools v0.6.0
 	github.com/operator-framework/operator-registry v1.39.0

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,8 @@ github.com/operator-framework/api v0.23.0 h1:kHymOwcHBpBVujT49SKOCd4EVG7Odwj4wl3
 github.com/operator-framework/api v0.23.0/go.mod h1:oKcFOz+Xc1UhMi2Pzcp6qsO7wjS4r+yP7EQprQBXrfM=
 github.com/operator-framework/helm-operator-plugins v0.2.2 h1:xbVRXM4VIpixrjA9OwVF+Kky6DpYHpkOnME2HEoQUfg=
 github.com/operator-framework/helm-operator-plugins v0.2.2/go.mod h1:h8HwfHHr29GRpduxy5jCL/sIe4TDarS5XHExBHVDc8k=
-github.com/operator-framework/java-operator-plugins v0.10.0 h1:JkYapsvQv08+KXMWXhIyJ3JKcB6BSSvvK+RsJe2VMz0=
-github.com/operator-framework/java-operator-plugins v0.10.0/go.mod h1:2qkhvf5jY3Myd6Ef+3HtseJyZPAAOWTa8xTOsPidHKY=
+github.com/operator-framework/java-operator-plugins v0.11.1 h1:NdKIEu9HKT5II1RZiU0LeH6QUPRHiDqzFbKDltcrjiM=
+github.com/operator-framework/java-operator-plugins v0.11.1/go.mod h1:2qkhvf5jY3Myd6Ef+3HtseJyZPAAOWTa8xTOsPidHKY=
 github.com/operator-framework/operator-lib v0.13.0 h1:+TWgJhbJqyNix9m1LmHK5gY/lb3CGqZX3Wvl7K0k+6I=
 github.com/operator-framework/operator-lib v0.13.0/go.mod h1:RDs1wGdOKWSMCO+BYSbqmmKGnD5jOP7TVP+KvoX8jMg=
 github.com/operator-framework/operator-manifest-tools v0.6.0 h1:1fUP0ki3plXM6WivlcE6m5cV8fO2ZZVPHJM93vlgWJo=


### PR DESCRIPTION
**Description of the change:**
Update java-operator-plugins to v0.11.1.

**Motivation for the change:**
https://github.com/operator-framework/operator-sdk/issues/6645
Fixed #6645

