### PR TITLE
Remove java-operator-plugins

### DIFF
--- a/changelog/fragments/01-template.yaml
+++ b/changelog/fragments/01-template.yaml
@@ -1,0 +1,35 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Remove the Quarkus plugin (java-operator-plugins integration).
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "removal"
+
+    # Is this a breaking change?
+    breaking: true
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: Migrate to the Quarkus extension provided bootstrap
+      body: |
+        From now on, you can bootstrap your Quarkus-based operator
+        with the provided Quarkus tools as described in the bootstrapping
+        instructions - https://github.com/quarkiverse/quarkus-operator-sdk?tab=readme-ov-file#bootstrapping-a-project. 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/operator-framework/ansible-operator-plugins v1.35.0
 	github.com/operator-framework/api v0.23.0
 	github.com/operator-framework/helm-operator-plugins v0.2.2
-	github.com/operator-framework/java-operator-plugins v0.11.1
 	github.com/operator-framework/operator-lib v0.13.0
 	github.com/operator-framework/operator-manifest-tools v0.6.0
 	github.com/operator-framework/operator-registry v1.39.0

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,6 @@ github.com/operator-framework/api v0.23.0 h1:kHymOwcHBpBVujT49SKOCd4EVG7Odwj4wl3
 github.com/operator-framework/api v0.23.0/go.mod h1:oKcFOz+Xc1UhMi2Pzcp6qsO7wjS4r+yP7EQprQBXrfM=
 github.com/operator-framework/helm-operator-plugins v0.2.2 h1:xbVRXM4VIpixrjA9OwVF+Kky6DpYHpkOnME2HEoQUfg=
 github.com/operator-framework/helm-operator-plugins v0.2.2/go.mod h1:h8HwfHHr29GRpduxy5jCL/sIe4TDarS5XHExBHVDc8k=
-github.com/operator-framework/java-operator-plugins v0.11.1 h1:NdKIEu9HKT5II1RZiU0LeH6QUPRHiDqzFbKDltcrjiM=
-github.com/operator-framework/java-operator-plugins v0.11.1/go.mod h1:2qkhvf5jY3Myd6Ef+3HtseJyZPAAOWTa8xTOsPidHKY=
 github.com/operator-framework/operator-lib v0.13.0 h1:+TWgJhbJqyNix9m1LmHK5gY/lb3CGqZX3Wvl7K0k+6I=
 github.com/operator-framework/operator-lib v0.13.0/go.mod h1:RDs1wGdOKWSMCO+BYSbqmmKGnD5jOP7TVP+KvoX8jMg=
 github.com/operator-framework/operator-manifest-tools v0.6.0 h1:1fUP0ki3plXM6WivlcE6m5cV8fO2ZZVPHJM93vlgWJo=

--- a/internal/cmd/operator-sdk/cli/cli.go
+++ b/internal/cmd/operator-sdk/cli/cli.go
@@ -16,7 +16,6 @@ package cli
 
 import (
 	hybrid "github.com/operator-framework/helm-operator-plugins/pkg/plugins/hybrid/v1alpha"
-	quarkusv1 "github.com/operator-framework/java-operator-plugins/pkg/quarkus/v1beta"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -171,7 +170,6 @@ func GetPluginsCLIAndRoot() (*cli.CLI, *cobra.Command) {
 			grafanav1alpha.Plugin{},
 			deployImageBundle,
 			declarativev1.Plugin{},
-			&quarkusv1.Plugin{},
 		),
 		cli.WithDefaultPlugins(cfgv2.Version, gov2Bundle),
 		cli.WithDefaultPlugins(cfgv3.Version, gov4Bundle),

--- a/website/content/en/docs/cli/operator-sdk.md
+++ b/website/content/en/docs/cli/operator-sdk.md
@@ -34,7 +34,6 @@ and <PROJECT VERSION> a supported project version for these plugins.
                grafana.kubebuilder.io/v1-alpha |                          3
               helm.sdk.operatorframework.io/v1 |                          3
  hybrid.helm.sdk.operatorframework.io/v1-alpha |                          3
-            quarkus.javaoperatorsdk.io/v1-beta |                          3
 
 For more specific help for the init command of a certain plugins and project version
 configuration please run:


### PR DESCRIPTION
Fixes #6819 

**Description of the change:**
Removing java-operator-plugins and the plugin quarkus so the command `operator-sdk init --plugins quarkus` will no longer work. This is a breaking change.


**Motivation for the change:**
The team behind the Quarkus plugin no longer want to support this integration and users should instead use the Quarkus provided API to generate projects (https://github.com/quarkiverse/quarkus-operator-sdk?tab=readme-ov-file#bootstrapping-a-project)


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
