### PR TITLE
Added label to enable cluster-monitoring in Openshift

### DIFF
--- a/testdata/go/v4/monitoring/memcached-operator/config/manager/manager.yaml
+++ b/testdata/go/v4/monitoring/memcached-operator/config/manager/manager.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    openshift.io/cluster-monitoring: "true"
     control-plane: controller-manager
     app.kubernetes.io/name: memcached-operator
     app.kubernetes.io/managed-by: kustomize


### PR DESCRIPTION
Closes #6825
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**
Added label to enable cluster-monitoring in Openshift

**Motivation for the change:**
This label is required in order to enable OpenShift cluster monitoring for that namespace.
Mentioned in OKD Docs related to [enabling metrics for Custom operators](https://docs.okd.io/4.16/operators/operator_sdk/osdk-monitoring-prometheus.html#osdk-monitoring-custom-metrics_osdk-monitoring-prometheus)
