### PR TITLE
updating both webhook links to reference main docs url

### DIFF
--- a/website/content/en/docs/building-operators/ansible/reference/webhooks.md
+++ b/website/content/en/docs/building-operators/ansible/reference/webhooks.md
@@ -165,5 +165,5 @@ Ansible-based Operator, you must
 
 
 [admission-controllers]:https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
-[validating-webhook]:https://v1-26.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#validatingwebhookconfiguration-v1-admissionregistration-k8s-io
-[mutating-webhook]:https://v1-26.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#mutatingwebhookconfiguration-v1-admissionregistration-k8s-io
+[validating-webhook]:https://kubernetes.io/docs/reference/kubernetes-api/extend-resources/validating-webhook-configuration-v1/
+[mutating-webhook]:https://kubernetes.io/docs/reference/kubernetes-api/extend-resources/mutating-webhook-configuration-v1/


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**
Pointing to main doc site, instead of version specific site.

**Motivation for the change:**
The site no longer exists at the version URL.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
