### PR TITLE
fix: make `run bundle` use proper YAML library to split documents

### DIFF
--- a/changelog/fragments/fix-run-bundle-yaml-split.yaml
+++ b/changelog/fragments/fix-run-bundle-yaml-split.yaml
@@ -1,0 +1,5 @@
+entries:
+  - description: >
+      Fix naive YAML split in `run bundle` command.
+    kind: "bugfix"
+    breaking: false

--- a/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
+++ b/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
@@ -20,10 +20,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/yaml"
 	"path"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	log "github.com/sirupsen/logrus"

--- a/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
+++ b/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
@@ -15,9 +15,12 @@
 package fbcindex
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"path"
 	"strings"
 	"time"
@@ -399,8 +402,22 @@ func (f *FBCRegistryPod) createConfigMaps(cs *v1alpha1.CatalogSource) ([]*corev1
 // properly have all the FBC contents rendered in the registry pod.
 func (f *FBCRegistryPod) partitionedConfigMaps() ([]*corev1.ConfigMap, error) {
 	var err error
-	// Split on the YAML separator `---`
-	yamlDefs := strings.Split(f.FBCContent, "---")
+
+	var yamlDefs []string
+	yamlReader := yaml.NewYAMLReader(bufio.NewReader(strings.NewReader(f.FBCContent)))
+	for {
+		doc, err := yamlReader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if len(doc) == 0 {
+			continue
+		}
+		yamlDefs = append(yamlDefs, string(doc))
+	}
 
 	configMaps, err := f.getConfigMaps(yamlDefs)
 	if err != nil {

--- a/internal/olm/operator/registry/fbcindex/fbc_registry_pod_test.go
+++ b/internal/olm/operator/registry/fbcindex/fbc_registry_pod_test.go
@@ -200,7 +200,7 @@ var _ = Describe("FBCRegistryPod", func() {
 				largeYaml := largeYamlBuilder.String()
 				rp.FBCContent = largeYaml
 
-				expectedYaml := strings.TrimPrefix(strings.TrimSpace(largeYaml), "---\n")
+				expectedYaml := strings.TrimSpace(largeYaml)
 				expectedYaml = regexp.MustCompile(`\n\n+`).ReplaceAllString(expectedYaml, "\n")
 
 				cms, err := rp.partitionedConfigMaps()


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
