### PR TITLE
removing helm hybrid operator plugin

### DIFF
--- a/changelog/fragments/02-remove-helm-hybrid-plugin.yaml
+++ b/changelog/fragments/02-remove-helm-hybrid-plugin.yaml
@@ -1,0 +1,23 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      (hybrid.helm/v1-alpha) Remove hybrid-helm v1-alpha support, due to low adoption, in favor of maintenance simplicity. 
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "removal"
+
+    # Is this a breaking change?
+    breaking: true
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+    migration:
+      header: Remove hybrid-helm v1-alpha support
+      body: |
+        As an operator author you can switch to a go-based operator. 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/onsi/gomega v1.33.0
 	github.com/operator-framework/ansible-operator-plugins v1.35.0
 	github.com/operator-framework/api v0.23.0
-	github.com/operator-framework/helm-operator-plugins v0.2.2
 	github.com/operator-framework/operator-lib v0.13.0
 	github.com/operator-framework/operator-manifest-tools v0.6.0
 	github.com/operator-framework/operator-registry v1.39.0

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,6 @@ github.com/operator-framework/ansible-operator-plugins v1.35.0 h1:ranI6NhcnAl2so
 github.com/operator-framework/ansible-operator-plugins v1.35.0/go.mod h1:ehsR1S7COaxHD54t7/1CXuvnTkSiMxUqgJhTGVcH6Fs=
 github.com/operator-framework/api v0.23.0 h1:kHymOwcHBpBVujT49SKOCd4EVG7Odwj4wl3NbOR2LLA=
 github.com/operator-framework/api v0.23.0/go.mod h1:oKcFOz+Xc1UhMi2Pzcp6qsO7wjS4r+yP7EQprQBXrfM=
-github.com/operator-framework/helm-operator-plugins v0.2.2 h1:xbVRXM4VIpixrjA9OwVF+Kky6DpYHpkOnME2HEoQUfg=
-github.com/operator-framework/helm-operator-plugins v0.2.2/go.mod h1:h8HwfHHr29GRpduxy5jCL/sIe4TDarS5XHExBHVDc8k=
 github.com/operator-framework/operator-lib v0.13.0 h1:+TWgJhbJqyNix9m1LmHK5gY/lb3CGqZX3Wvl7K0k+6I=
 github.com/operator-framework/operator-lib v0.13.0/go.mod h1:RDs1wGdOKWSMCO+BYSbqmmKGnD5jOP7TVP+KvoX8jMg=
 github.com/operator-framework/operator-manifest-tools v0.6.0 h1:1fUP0ki3plXM6WivlcE6m5cV8fO2ZZVPHJM93vlgWJo=

--- a/internal/cmd/operator-sdk/cli/cli.go
+++ b/internal/cmd/operator-sdk/cli/cli.go
@@ -15,7 +15,6 @@
 package cli
 
 import (
-	hybrid "github.com/operator-framework/helm-operator-plugins/pkg/plugins/hybrid/v1alpha"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -138,17 +137,6 @@ func GetPluginsCLIAndRoot() (*cli.CLI, *cobra.Command) {
 		),
 	)
 
-	hybridBundle, _ := plugin.NewBundleWithOptions(
-		plugin.WithName("hybrid.helm"+plugins.DefaultNameQualifier),
-		plugin.WithVersion(plugin.Version{Number: 1, Stage: stage.Alpha}),
-		plugin.WithPlugins(
-			kustomizev2.Plugin{},
-			hybrid.Plugin{},
-			manifestsv2.Plugin{},
-			scorecardv2.Plugin{},
-		),
-	)
-
 	deployImageBundle, _ := plugin.NewBundleWithOptions(
 		plugin.WithName("deploy-image."+golang.DefaultNameQualifier),
 		plugin.WithVersion(plugin.Version{Number: 1, Stage: stage.Alpha}),
@@ -166,7 +154,6 @@ func GetPluginsCLIAndRoot() (*cli.CLI, *cobra.Command) {
 			gov3Bundle, // Deprecated
 			gov4Bundle,
 			helmBundle,
-			hybridBundle,
 			grafanav1alpha.Plugin{},
 			deployImageBundle,
 			declarativev1.Plugin{},

--- a/internal/util/projutil/project_util.go
+++ b/internal/util/projutil/project_util.go
@@ -54,8 +54,6 @@ const (
 	OperatorTypeAnsible OperatorType = "ansible"
 	// OperatorTypeHelm - helm type of operator.
 	OperatorTypeHelm OperatorType = "helm"
-	// OperatorTypeHybrid - hybrid type of operator.
-	operatorTypeHybridHelm OperatorType = "hybridHelm"
 	// OperatorTypeUnknown - unknown type of operator.
 	OperatorTypeUnknown OperatorType = "unknown"
 )
@@ -106,8 +104,6 @@ func PluginChainToOperatorType(pluginKeys []string) OperatorType {
 			return OperatorTypeHelm
 		case strings.HasPrefix(pluginKey, "ansible"):
 			return OperatorTypeAnsible
-		case strings.HasPrefix(pluginKey, "hybrid"):
-			return operatorTypeHybridHelm
 		}
 	}
 	return OperatorTypeUnknown

--- a/website/content/en/docs/cli/operator-sdk.md
+++ b/website/content/en/docs/cli/operator-sdk.md
@@ -23,17 +23,16 @@ The first step is to initialize your project:
 <PLUGIN KEYS> is a comma-separated list of plugin keys from the following table
 and <PROJECT VERSION> a supported project version for these plugins.
 
-                                   Plugin keys | Supported project versions
------------------------------------------------+----------------------------
-           ansible.sdk.operatorframework.io/v1 |                          3
-              declarative.go.kubebuilder.io/v1 |                       2, 3
-       deploy-image.go.kubebuilder.io/v1-alpha |                          3
-                          go.kubebuilder.io/v2 |                       2, 3
-                          go.kubebuilder.io/v3 |                          3
-                          go.kubebuilder.io/v4 |                          3
-               grafana.kubebuilder.io/v1-alpha |                          3
-              helm.sdk.operatorframework.io/v1 |                          3
- hybrid.helm.sdk.operatorframework.io/v1-alpha |                          3
+                             Plugin keys | Supported project versions
+-----------------------------------------+----------------------------
+     ansible.sdk.operatorframework.io/v1 |                          3
+        declarative.go.kubebuilder.io/v1 |                       2, 3
+ deploy-image.go.kubebuilder.io/v1-alpha |                          3
+                    go.kubebuilder.io/v2 |                       2, 3
+                    go.kubebuilder.io/v3 |                          3
+                    go.kubebuilder.io/v4 |                          3
+         grafana.kubebuilder.io/v1-alpha |                          3
+        helm.sdk.operatorframework.io/v1 |                          3
 
 For more specific help for the init command of a certain plugins and project version
 configuration please run:


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**
Removing the `helm-operators-plugin` dependency, so that we no longer support the `hybrid.helm` type.

**Motivation for the change:**
This plugin saw low adoption, so to make development/maintenance/support easier for `operator-sdk` it makes sense to remove this plugin.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
