### PR TITLE
Fix Allow IfNotPresent policy when `operator-sdk run bundle` #6795

### DIFF
--- a/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
+++ b/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
@@ -60,6 +60,9 @@ type FBCRegistryPod struct { //nolint:maligned
 	// BundleItems contains all bundles to be added to a registry pod.
 	BundleItems []index.BundleItem
 
+	// ImagePullPolicy is the image pull policy for the registry pod, default is PullAlways
+	ImagePullPolicy corev1.PullPolicy
+
 	// Index image contains a database of pointers to operator manifest content that is queriable via an API.
 	// new version of an operator bundle when published can be added to an index image
 	IndexImage string
@@ -155,6 +158,11 @@ func (f *FBCRegistryPod) Create(ctx context.Context, cfg *operator.Configuration
 			},
 		}
 	}
+
+	if f.ImagePullPolicy == "" {
+		f.ImagePullPolicy = corev1.PullAlways
+	}
+	f.pod.Spec.Containers[0].ImagePullPolicy = f.ImagePullPolicy
 
 	if err := f.cfg.Client.Create(ctx, f.pod); err != nil {
 		return nil, fmt.Errorf("error creating pod: %w", err)

--- a/internal/olm/operator/registry/index/registry_pod.go
+++ b/internal/olm/operator/registry/index/registry_pod.go
@@ -58,6 +58,9 @@ type SQLiteRegistryPod struct { //nolint:maligned
 	// BundleItems contains all bundles to be added to a registry pod.
 	BundleItems []BundleItem
 
+	// ImagePullPolicy is the image pull policy for the registry pod, default is PullAlways
+	ImagePullPolicy corev1.PullPolicy
+
 	// Index image contains a database of pointers to operator manifest content that is queriable via an API.
 	// new version of an operator bundle when published can be added to an index image
 	IndexImage string
@@ -150,6 +153,11 @@ func (rp *SQLiteRegistryPod) Create(ctx context.Context, cfg *operator.Configura
 			},
 		}
 	}
+
+	if rp.ImagePullPolicy == "" {
+		rp.ImagePullPolicy = corev1.PullAlways
+	}
+	rp.pod.Spec.Containers[0].ImagePullPolicy = rp.ImagePullPolicy
 
 	if err := rp.cfg.Client.Create(ctx, rp.pod); err != nil {
 		return nil, fmt.Errorf("error creating pod: %w", err)

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -97,6 +97,7 @@ type IndexImageCatalogCreator struct {
 	HasFBCLabel     bool
 	FBCContent      string
 	PackageName     string
+	ImagePullPolicy string
 	IndexImage      string
 	InitImage       string
 	BundleImage     string
@@ -138,6 +139,7 @@ func (c *IndexImageCatalogCreator) BindFlags(fs *pflag.FlagSet) {
 		"while pulling bundles")
 	fs.BoolVar(&c.UseHTTP, "use-http", false, "use plain HTTP for container image registries "+
 		"while pulling bundles")
+	fs.StringVar(&c.ImagePullPolicy, "image-pull-policy", string(corev1.PullAlways), "image pull policy for the registry pod")
 
 	// default to Legacy
 	c.SecurityContext = SecurityContext{ContextType: Legacy}
@@ -531,6 +533,7 @@ func (c IndexImageCatalogCreator) createAnnotatedRegistry(ctx context.Context, c
 			InitImage:       c.InitImage,
 			FBCContent:      c.FBCContent,
 			SecurityContext: c.SecurityContext.String(),
+			ImagePullPolicy: corev1.PullPolicy(c.ImagePullPolicy),
 		}
 
 		pod, err = fbcRegistryPod.Create(ctx, c.cfg, cs)
@@ -548,6 +551,7 @@ func (c IndexImageCatalogCreator) createAnnotatedRegistry(ctx context.Context, c
 			SkipTLSVerify:   c.SkipTLSVerify,
 			UseHTTP:         c.UseHTTP,
 			SecurityContext: c.SecurityContext.String(),
+			ImagePullPolicy: corev1.PullPolicy(c.ImagePullPolicy),
 		}
 
 		if registryPod.DBPath, err = c.getDBPath(ctx); err != nil {

--- a/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle-upgrade.md
@@ -21,6 +21,7 @@ operator-sdk run bundle-upgrade <bundle-image> [flags]
 ```
       --ca-secret-name string                     Name of a generic secret containing a PEM root certificate file required to pull bundle images. This secret *must* be in the namespace that this command is configured to run in, and the file *must* be encoded under the key "cert.pem"
   -h, --help                                      help for bundle-upgrade
+      --image-pull-policy string                  image pull policy for the registry pod (default "Always")
       --kubeconfig string                         Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string                          If present, namespace scope for this CLI request
       --pull-secret-name string                   Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in

--- a/website/content/en/docs/cli/operator-sdk_run_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_run_bundle.md
@@ -31,6 +31,7 @@ operator-sdk run bundle <bundle-image> [flags]
       --ca-secret-name string                     Name of a generic secret containing a PEM root certificate file required to pull bundle images. This secret *must* be in the namespace that this command is configured to run in, and the file *must* be encoded under the key "cert.pem"
       --decompression-image string                image used in an init container in the registry pod to decompress the compressed catalog contents. cat and gzip binaries are expected to exist in the PATH (default "registry.access.redhat.com/ubi8:8.9")
   -h, --help                                      help for bundle
+      --image-pull-policy string                  image pull policy for the registry pod (default "Always")
       --index-image string                        index image in which to inject bundle (default "quay.io/operator-framework/opm:latest")
       --install-mode InstallModeValue             install mode
       --kubeconfig string                         Path to the kubeconfig file to use for CLI requests.


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**
```diff
❯ go run cmd/operator-sdk/main.go run bundle 
Error: accepts 1 arg(s), received 0
Usage:
  operator-sdk run bundle <bundle-image> [flags]

Flags:
      --ca-secret-name string                     Name of a generic secret containing a PEM root certificate file required to pull bundle images. This secret *must* be in the namespace that this command is configured to run in, and the file *must* be encoded under the key "cert.pem"
      --decompression-image string                image used in an init container in the registry pod to decompress the compressed catalog contents. cat and gzip binaries are expected to exist in the PATH (default "registry.access.redhat.com/ubi8:8.9")
  -h, --help                                      help for bundle
+     --image-pull-policy string                  image pull policy for the registry pod (default "Always")
      --index-image string                        index image in which to inject bundle (default "quay.io/operator-framework/opm:latest")
      --install-mode InstallModeValue             install mode
      --kubeconfig string                         Path to the kubeconfig file to use for CLI requests.
  -n, --namespace string                          If present, namespace scope for this CLI request
      --pull-secret-name string                   Name of image pull secret ("type: kubernetes.io/dockerconfigjson") required to pull bundle images. This secret *must* be both in the namespace and an imagePullSecret of the service account that this command is configured to run in
      --security-context-config SecurityContext   specifies the security context to use for the catalog pod. allowed: 'restricted', 'legacy'. (default legacy)
      --service-account string                    Service account name to bind registry objects to. If unset, the default service account is used. This value does not override the operator's service account
      --skip-tls                                  skip authentication of image registry TLS certificate when pulling a bundle image in-cluster
      --skip-tls-verify                           skip TLS certificate verification for container image registries while pulling bundles
      --timeout duration                          Duration to wait for the command to complete before failing (default 2m0s)
      --use-http                                  use plain HTTP for container image registries while pulling bundles

Global Flags:
      --plugins strings   plugin keys to be used for this subcommand execution
      --verbose           Enable verbose logging

FATA[0000] accepts 1 arg(s), received 0                 
exit status 1
```

**Motivation for the change:**
When pushing bundle to temp registry like ttl.sh, images ought to become unavailable eventually. We want pod restarts if any to not result in pull errors. The images will be tagged with a short sha hash so it should be "globally unique" to the user working on a branch.

Fixes #6795 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
