### PR TITLE
`generate bundle`: Support overwriting of annotations.yaml

### DIFF
--- a/changelog/fragments/feat-overwrite-annotations.yaml
+++ b/changelog/fragments/feat-overwrite-annotations.yaml
@@ -1,0 +1,6 @@
+entries:
+  - description: >
+      Add `--overwrite-annotations` option to the `operator-sdk generate bundle` command.
+      This allows developers to overwrite `annotations.yaml` without modifying `bundle.Dockerfile`.
+    kind: "addition"
+    breaking: false

--- a/internal/cmd/operator-sdk/generate/bundle/bundle.go
+++ b/internal/cmd/operator-sdk/generate/bundle/bundle.go
@@ -286,7 +286,7 @@ func (c bundleCmd) runMetadata() error {
 			if !errors.As(err, &merr) {
 				return err
 			}
-		} else if !c.overwrite {
+		} else if !c.overwrite && !c.overwriteAnnotations {
 			return nil
 		}
 	}
@@ -302,6 +302,11 @@ func (c bundleCmd) runMetadata() error {
 		IsScoreConfigPresent: genutil.IsExist(scorecardConfigPath),
 	}
 
+	if c.overwriteAnnotations {
+		return bundleMetadata.GenerateAnnotations() // Overwrite only annotations.yaml
+	}
+
+	// If overwrite or metadata is generated for the first time, all files will be overwritten.
 	return bundleMetadata.GenerateMetadata()
 }
 

--- a/internal/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/generate/bundle/cmd.go
@@ -42,9 +42,10 @@ type bundleCmd struct {
 	extraServiceAccounts []string
 
 	// Metadata options.
-	channels       string
-	defaultChannel string
-	overwrite      bool
+	channels             string
+	defaultChannel       string
+	overwrite            bool
+	overwriteAnnotations bool
 
 	// These are set if a PROJECT config is not present.
 	layout      string
@@ -63,6 +64,11 @@ func NewCmd() *cobra.Command {
 		Long:    longHelp,
 		Example: examples,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if c.overwriteAnnotations {
+				// Priority control, when checking --overwrite-annotations, set --overwrite to false
+				c.overwrite = false
+			}
+
 			if len(args) != 0 {
 				return fmt.Errorf("command %s doesn't accept any arguments", cmd.CommandPath())
 			}
@@ -138,6 +144,7 @@ func (c *bundleCmd) addFlagsTo(fs *pflag.FlagSet) {
 		"Names of service accounts, outside of the operator's Deployment account, "+
 			"that have bindings to {Cluster}Roles that should be added to the CSV")
 	fs.BoolVar(&c.overwrite, "overwrite", true, "Overwrite the bundle's metadata and Dockerfile if they exist")
+	fs.BoolVar(&c.overwriteAnnotations, "overwrite-annotations", false, "Only overwrite annotations.yaml without modifying bundle.Dockerfile")
 	fs.BoolVarP(&c.quiet, "quiet", "q", false, "Run in quiet mode")
 	fs.BoolVar(&c.stdout, "stdout", false, "Write bundle manifest to stdout")
 

--- a/internal/generate/internal/genutil.go
+++ b/internal/generate/internal/genutil.go
@@ -70,7 +70,7 @@ func WriteObject(w io.Writer, obj interface{}) error {
 	return write(w, b)
 }
 
-// WriteObject writes any object to w.
+// WriteYAML writes any object to w.
 func WriteYAML(w io.Writer, obj interface{}) error {
 	b, err := yaml.Marshal(obj)
 	if err != nil {

--- a/website/content/en/docs/cli/operator-sdk_generate_bundle.md
+++ b/website/content/en/docs/cli/operator-sdk_generate_bundle.md
@@ -100,6 +100,7 @@ operator-sdk generate bundle [flags]
       --metadata                         Generate bundle metadata and Dockerfile
       --output-dir string                Directory to write the bundle to
       --overwrite                        Overwrite the bundle's metadata and Dockerfile if they exist (default true)
+      --overwrite-annotations            Only overwrite annotations.yaml without modifying bundle.Dockerfile
       --package string                   Bundle's package name
   -q, --quiet                            Run in quiet mode
       --stdout                           Write bundle manifest to stdout


### PR DESCRIPTION
**Description of the change:**

```diff

jitli@RedHat:~/work/src/github/sdk/operator-sdk$ ./build/operator-sdk generate bundle -h

Flags:
      --channels string                  A comma-separated list of channels the bundle belongs to (default "alpha")
      --crds-dir string                  Directory to read cluster-ready CustomResoureDefinition manifests from. This option can only be used if --deploy-dir is set
      --default-channel string           The default channel for the bundle
      --deploy-dir string                Directory to read cluster-ready operator manifests from. If --crds-dir is not set, CRDs are ready from this directory. This option is mutually exclusive with --input-dir and piping to stdin
      --extra-service-accounts strings   Names of service accounts, outside of the operator's Deployment account, that have bindings to {Cluster}Roles that should be added to the CSV
  -h, --help                             help for bundle
      --input-dir string                 Directory to read cluster-ready operator manifests from. This option is mutually exclusive with --deploy-dir/--crds-dir and piping to stdin. This option should not be passed an existing bundle directory, as this bundle will not contain the correct set of manifests required to generate a CSV. Use --kustomize-dir to pass a base CSV
      --kustomize-dir string             Directory containing kustomize bases in a "bases" dir and a kustomization.yaml for operator-framework manifests (default "config/manifests")
      --manifests                        Generate bundle manifests
      --metadata                         Generate bundle metadata and Dockerfile
      --output-dir string                Directory to write the bundle to
      --overwrite                        Overwrite the bundle's metadata and Dockerfile if they exist (default true)
+     --overwrite-annotations            Only overwrite annotations.yaml without modifying bundle.Dockerfile
      --package string                   Bundle's package name
  -q, --quiet                            Run in quiet mode
      --stdout                           Write bundle manifest to stdout
      --use-image-digests                Use SHA Digest for images
  -v, --version string                   Semantic version of the operator in the generated bundle. Only set if creating a new bundle or upgrading your operator

Global Flags:
      --plugins strings   plugin keys to be used for this subcommand execution
      --verbose           Enable verbose logging

```

**Motivation for the change:**
--overwrite wipes out any additional labels on the bundle.Dockerfile.
Provide a new --overwrite-annotations option to support overwriting annotations only.

Closes https://github.com/operator-framework/operator-sdk/issues/6787

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
