### PR TITLE
updating ansible plugin to 1.36.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.9.0
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
-	github.com/operator-framework/ansible-operator-plugins v1.36.0
+	github.com/operator-framework/ansible-operator-plugins v1.36.1
 	github.com/operator-framework/api v0.24.0
 	github.com/operator-framework/operator-lib v0.14.0
 	github.com/operator-framework/operator-manifest-tools v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,8 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/operator-framework/ansible-operator-plugins v1.36.0 h1:EdoaRUZ/wKVSEQO5fuLiZXAmU2GkNQBJoyifiUhw93g=
-github.com/operator-framework/ansible-operator-plugins v1.36.0/go.mod h1:fYIrY1/7PSLGTH2wWOBEb6Lu9/qUu23yYv+iKJo82GI=
+github.com/operator-framework/ansible-operator-plugins v1.36.1 h1:6TNrJ04JWey/7McBzrawe9HQWGjSMtILfahC4nRKDx0=
+github.com/operator-framework/ansible-operator-plugins v1.36.1/go.mod h1:vX76IEGaJ09L83swBQrfCwN5a4KErCpH5S+YMRZKOL0=
 github.com/operator-framework/api v0.24.0 h1:fHynWEzuY/YhUTlsK9hd+QQ0bZcFakxCTdaZbFaVXbc=
 github.com/operator-framework/api v0.24.0/go.mod h1:EXKrka63NyQDDpWZ+DGTDEliNV0xRq6UMZRoUPhilVM=
 github.com/operator-framework/operator-lib v0.14.0 h1:er+BgZymZD1im2wytLJiPLZpGALAX6N0gXaHx3PKbO4=


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**
Updating ansible-operator-plugin to v1.36.1 that has the proper metrics rbac scaffolding inplace

**Motivation for the change:**
To have all operator types have the proper scaffolding, now that `kube-rbac-proxy` scaffolding is removed.

- Relates:#6730

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
