### PR TITLE
removing kube-rbac-proxy from website docs

### DIFF
--- a/website/content/en/docs/building-operators/ansible/development-tips.md
+++ b/website/content/en/docs/building-operators/ansible/development-tips.md
@@ -337,7 +337,7 @@ check the full Ansible result in the logs in order to be able to debug it.
 
 **Example**
 
-In `config/manager/manager.yaml` and `config/default/manager_auth_proxy_patch.yaml`:
+In `config/manager/manager.yaml` and `config/default/manager_metrics_patch.yaml`:
 
 ```yaml
 ...

--- a/website/content/en/docs/building-operators/golang/operator-scope.md
+++ b/website/content/en/docs/building-operators/golang/operator-scope.md
@@ -315,7 +315,6 @@ If the operator can watch multiple namespaces, set the following in your `spec.i
 [ctrl-manager]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#Manager
 [ctrl-options]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#Options
 [k8s-rbac]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
-[kube-rbac-proxy]: https://github.com/brancz/kube-rbac-proxy
 [rbac-clusterrole]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole
 [crd-scope-doc]: /docs/building-operators/golang/crds-scope/
 [rbac-markers]: https://book.kubebuilder.io/reference/markers/rbac.html

--- a/website/content/en/docs/building-operators/golang/references/logging.md
+++ b/website/content/en/docs/building-operators/golang/references/logging.md
@@ -151,34 +151,15 @@ run: manifests generate fmt vet
 
 ### Setting flags when deploying to a cluster
 
-When deploying your operator to a cluster you can set additional flags using an `args` array in your operator's `container` spec in the file `config/default/manager_auth_proxy_patch.yaml` For example:
+When deploying your operator to a cluster you can set additional flags using an `args` array in your operator's `container` spec in the file `config/default/manager_metrics_patch.yaml` For example:
 
 ```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller-manager
-  namespace: system
-spec:
-  template:
-    spec:
-      containers:
-      - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
-        args:
-        - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
-        - "--v=10"
-        ports:
-        - containerPort: 8443
-          name: https
-      - name: manager
-        args:
-        - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"
-        - "--zap-encoder=console"
-        - "--zap-log-level=debug"
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --zap-log-level=debug 
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --zap-encoder=console
 ```
 
 ## Creating a structured log statement

--- a/website/content/en/docs/building-operators/helm/reference/advanced_features/max_concurrent_reconciles.md
+++ b/website/content/en/docs/building-operators/helm/reference/advanced_features/max_concurrent_reconciles.md
@@ -23,6 +23,6 @@ While running locally, this flag can also be added to the helm binary. For examp
 helm-operator --max-concurrent-reconciles=10
 ```
 
-**NOTE**: If you're using the default scaffolding, it is necessary to also apply this change to the `config/default/manager_auth_proxy_patch.yaml` file. This file is a `kustomize` patch to the operator deployment that configures [kube-rbac-proxy][kube-rbac-proxy] to require authorization for accessing your operator metrics. When `kustomize` applies this patch, it overrides the args defined in `config/manager/manager.yaml`
-
-[kube-rbac-proxy]: https://github.com/brancz/kube-rbac-proxy
+**NOTE**: If you're using the default scaffolding, it is necessary to also apply this change to the `config/default/manager_metrics_patch.yaml` file. 
+This file is a `kustomize` patch to the operator deployment that configures metrics to require authorization for accessing 
+your operator metrics. When `kustomize` applies this patch, it overrides the args defined in `config/manager/manager.yaml`


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**
Remove references to `kube-rbac-proxy` from the main parts of the website. References in the migration docs can remain.

**Motivation for the change:**
To accuratly reflect the the state of scaffolding.

- Relates: #6730 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
