### PR TITLE
move v1.21 from netlify to gh like in toml file

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -205,7 +205,7 @@ url_latest_version = "https://sdk.operatorframework.io"
 
 [[params.versions]]
   version = "v1.21"
-  url = "https://v1-21-x.sdk.operatorframework.io"
+  url = "https://github.com/operator-framework/operator-sdk/tree/v1.21.x/website/content/en/docs"
   kube_version = "1.23"
   client_go_version = "v0.23.5"
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**
Updating `config.toml` for v1.21 to point to github, instead of netlify route.

**Motivation for the change:**
We have a limited number of routes in netlify, so need to remove one route before the next release.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
