### PR TITLE
Fix `go.sum` Mismatch for kubebuilder 4.1.1

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -788,7 +788,7 @@ sigs.k8s.io/controller-tools v0.14.0 h1:rnNoCC5wSXlrNoBKKzL70LNJKIQKEzT6lloG6/LF
 sigs.k8s.io/controller-tools v0.14.0/go.mod h1:TV7uOtNNnnR72SpzhStvPkoS/U5ir0nMudrkrC4M9Sc=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/kubebuilder/v4 v4.1.1 h1:aUdzTq3FjpuNIqzlJRTtRJMKZBNQnTwd05PCu7xVeAY=
+sigs.k8s.io/kubebuilder/v4 v4.1.1 h1:cYSgEfjS5qzTdc1RgPHWZgCrgd1USbz2iO+mFr7BPls=
 sigs.k8s.io/kubebuilder/v4 v4.1.1/go.mod h1:h5VTUGFardXU5BCjEgGuOkSzb86/Nhd3ojmcMZseiVU=
 sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 h1:XX3Ajgzov2RKUdc5jW3t5jwY7Bo7dcRm+tFxT+NfgY0=
 sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3/go.mod h1:9n16EZKMhXBNSiUC5kSdFQJkdH3zbxS/JoO619G1VAY=


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**

Golang reports that the current checksum for kubebuilder/v4 is invalid. This fixes the checksum in `go.sum` to the current version, which unblocks builds. That said, this change should be held until the proper checksum for the `v4.1.1` tag can be verified.

**Motivation for the change:**

Golang 1.22.5 is reporting compile errors due to checksum mismatch.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
