### PR TITLE
generate bundle: Add Image Digest Resolver Option

### DIFF
--- a/changelog/fragments/feat-image-digest-resolver.yaml
+++ b/changelog/fragments/feat-image-digest-resolver.yaml
@@ -1,0 +1,10 @@
+entries:
+  - description: >
+      Add `--image-digest-resolver` option to the operator-sdk
+      `generate bundle` command. When using image digests in operator bundles,
+      this lets developers choose `crane`, `skopeo` or a custom script to
+      resolve image SHAs.
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false

--- a/internal/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/generate/bundle/cmd.go
@@ -52,6 +52,8 @@ type bundleCmd struct {
 
 	// Use Image Digests flag to toggle using traditional Image tags vs SHA Digests
 	useImageDigests bool
+	// Tool to use when resolving image digests. Defaults to crane.
+	imageDigestResolver string
 }
 
 // NewCmd returns the 'bundle' command configured for the new project layout.
@@ -144,6 +146,7 @@ func (c *bundleCmd) addFlagsTo(fs *pflag.FlagSet) {
 	fs.StringVar(&c.packageName, "package", "", "Bundle's package name")
 
 	fs.BoolVar(&c.useImageDigests, "use-image-digests", false, "Use SHA Digest for images")
+	fs.StringVar(&c.imageDigestResolver, "image-digest-resolver", "crane", "Resolver for image digests. Options are crane, skopeo, or script")
 }
 
 func (c bundleCmd) println(a ...interface{}) {


### PR DESCRIPTION
**Description of the change:**

Add option to select the image digest resolver when rendering bundles with image digests pinned. The set of supported tools is defined in the `operator-manifest-tools` library (currently `crane`, `skopeo`, and `script`).

**Motivation for the change:**

Fixes #6868

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
