### PR TITLE
docs: Image Digest Pinning

### DIFF
--- a/website/content/en/docs/advanced-topics/digest-pinning.md
+++ b/website/content/en/docs/advanced-topics/digest-pinning.md
@@ -1,0 +1,42 @@
+---
+title: Digest Pinning
+weight: 80
+---
+
+# Image Digest Pinning
+
+Operator authors have the ability to pin container images by their
+[digest](https://github.com/opencontainers/image-spec/blob/main/descriptor.md) when generating
+bundles. The digest simultaneously acts as a unique identifier for the image as well as a checksum
+for the image contents. Referencing images by digest rather than their tag ensures the operator
+bundle deployment is consistent and reproducible.
+
+## Usage
+
+To generate bundles that reference images by digest, pass the `--use-image-digests` flag to operator-sdk:
+
+```sh
+$ operator-sdk generate bundle --use-image-digests
+```
+
+Operator projects using the `go` and `helm` builders can also set the `USE_IMAGE_DIGESTS` Makefile variable to `true`:
+
+```sh
+$ make bundle USE_IMAGE_DIGESTS=true
+```
+
+## Bundle Image Detection and Resolution
+
+`operator-sdk` resolves image references to digests by analyzing the `ClusterServiceVersion` object
+provided as input. The following fields in the CSV are used to find and resolve image references:
+
+- All containers in the CSV deployments (`spec.install.spec.deployments`).
+- All environment variables prefixed with `RELATED_IMAGE_` and have a valid container image reference.
+
+Each resolved image is rendered into the ouput bundle's `ClusterServiceVersion` as follows:
+
+1. Images referenced by tag are updated to be referenced by image digest SHA.
+2. Each resolved image is also referenced in the `spec.relatedImages` field in the bundle CSV.
+
+The `relatedImages` field is intended for external tools to identify all container images needed to
+deploy your operator and operands. It is not required to bundle or deploy your operator.


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**

Add an "advanced" article to describe how `relatedImages` and image digest pinning works. This includes the use of `RELATED_IMAGE_*` environment variables to digest pin operands deployed by the operator, which is not currently documented.

**Motivation for the change:**

I was very confused by the behavior of `relatedImages` and digest pinning. For example - when attempting to set `relatedImages` in the base CSV manifest, I discovered that `operator-sdk generate bundle` would always overwrite the `relatedImages` field in tree. It wasn't until I started iterating on a pull request (#6869) that I discovered there is an undocumented environment variable that lets operator authors define and wire in image digests for their operands.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
