### PR TITLE
fix: primary-resouce is created in wrong place.

### DIFF
--- a/internal/helm/client/client.go
+++ b/internal/helm/client/client.go
@@ -81,7 +81,7 @@ func (c *ownerRefInjectingClient) Build(reader io.Reader, validate bool) (kube.R
 			ownerRef := metav1.NewControllerRef(c.owner, c.owner.GetObjectKind().GroupVersionKind())
 			u.SetOwnerReferences([]metav1.OwnerReference{*ownerRef})
 		} else {
-			err := handler.SetOwnerAnnotations(u, c.owner)
+			err := handler.SetOwnerAnnotations(c.owner, u)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**

This PR fixes the issue where the primary custom resource would randomly get assigned "operator-sdk/primary-resource" and "operator-sdk/primary-resource-type" annotations when helm-operator is used.



**Motivation for the change:**

We use helm operator to deploy our software in OpenShift environment.  However, our primary custom resource would get random annotations assigned , e.g.,

```
apiVersion: apm.neuvector.com/v1alpha1
kind: Neuvector
metadata:
  annotations:
    operator-sdk/primary-resource: /neuvector-binding-nvvulnerabilityprofiles
    operator-sdk/primary-resource-type: ClusterRoleBinding.rbac.authorization.k8s.io
```

The resource name and resource type would change randomly after each deployment. 

After some debugging, it looks like `handler.SetOwnerAnnotations()`'s arguments are in reverse.

[The caller](https://github.com/operator-framework/operator-sdk/blob/32b6ceefb9533b04320f788e634d69bc918ed0c2/internal/helm/client/client.go#L84):
```
err := handler.SetOwnerAnnotations(u, c.owner)
```

[The function](https://github.com/operator-framework/operator-lib/blob/6c4a357f560a6f51fbecf0d182614530a4035910/handler/enqueue_annotation.go#L159):
```
func SetOwnerAnnotations(owner, object client.Object)
```

This PR fixes the issue by correcting the order of arguments. 

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
