### PR TITLE
fix small typo in filename referenced in documentation

### DIFF
--- a/website/content/en/docs/upgrading-sdk-version/v1.38.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.38.0.md
@@ -214,7 +214,7 @@ if these migrations become difficult to follow, it might be beneficial to scaffo
     + - --health-probe-bind-address=:8081
     ```
 
-13) [go/v4, helm/v1, ansible/v1] Update your `/config/prometheus/monitor/yaml` file with the below changes:
+13) [go/v4, helm/v1, ansible/v1] Update your `/config/prometheus/monitor.yaml` file with the below changes:
     ```diff
          - path: /metrics
     -      port: https


### PR DESCRIPTION

**Description of the change:**

Fix very small typo in 1.38.0 migration documentation on line 196 of file`operator-sdk/website/content/en/docs/upgrading-sdk-version/v1.38.0.md`.

Changed `monitor/yaml` to `monitor.yaml`

Full original line: '13) [go/v4, helm/v1, ansible/v1] Update your `/config/prometheus/monitor/yaml` file with the below changes:'
Full new line: '13) [go/v4, helm/v1, ansible/v1] Update your `/config/prometheus/monitor.yaml` file with the below changes:'

**Motivation for the change:**
Simply fixing a small typo that would prevent a user from doing a direct copy and paste of this file name without causing an error.

