### PR TITLE
docs: Replace memcached-operator in v1.39.0 update instructions

### DIFF
--- a/website/content/en/docs/upgrading-sdk-version/v1.39.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.39.0.md
@@ -72,7 +72,7 @@ so this release should be easier to follow.
     + kind: NetworkPolicy
     + metadata:
     +   labels:
-    +     app.kubernetes.io/name: memcached-operator
+    +     app.kubernetes.io/name: <operator-name>
     +     app.kubernetes.io/managed-by: kustomize
     +   name: allow-metrics-traffic
     +   namespace: system
@@ -107,7 +107,7 @@ so this release should be easier to follow.
     + kind: NetworkPolicy
     + metadata:
     +   labels:
-    +     app.kubernetes.io/name: memcached-operator
+    +     app.kubernetes.io/name: <operator-name>
     +     app.kubernetes.io/managed-by: kustomize
     +   name: allow-webhook-traffic
     +   namespace: system


### PR DESCRIPTION
**Description of the change:**

The update instructions for v1.39.0 have a template that contains the "memcached-operator" name but I do believe that this should be replaced by the user with their operator name. I replaced it with "<operator-name>" as in the other update instructions.

**Motivation for the change:**

Make the upgrade path better.

