### PR TITLE
🌱 (fix) fis GOBIN to allow run make install in Mac Os

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,13 @@ clean: ## Cleanup build artifacts and tool binaries.
 
 ##@ Build
 
+# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
+ifeq (,$(shell go env GOBIN))
+GOBIN=$(shell go env GOPATH)/bin
+else
+GOBIN=$(shell go env GOBIN)
+endif
+
 .PHONY: install
 install: ## Install operator-sdk and helm-operator.
 	@if [ -z "$(GOBIN)" ]; then \


### PR DESCRIPTION
Without this change we are unable to run make install on mac os envs:

```
$ make install
Error: GOBIN is not set
make: *** [install] Error 1
```
