### PR TITLE
🌱 Upgrade golangci from 1.63.4 to 1.64.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ fix: ## Fixup files in the repo.
 
 .PHONY: setup-lint
 setup-lint: ## Setup the lint
-	$(SCRIPTS_DIR)/fetch golangci-lint 1.62.2
+	$(SCRIPTS_DIR)/fetch golangci-lint 1.64.8
 
 .PHONY: lint
 lint: setup-lint ## Run the lint check

--- a/internal/helm/release/manager.go
+++ b/internal/helm/release/manager.go
@@ -430,7 +430,7 @@ func (m manager) CleanupRelease(manifest string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to build resources from manifests: %w", err)
 	}
-	if resources == nil || len(resources) <= 0 {
+	if len(resources) <= 0 {
 		return true, nil
 	}
 	for _, resource := range resources {


### PR DESCRIPTION
Upgrade golangci from 1.63.4 to 1.64.8
Otherwise, with golang 1.24 installed locally is not possible to run ` make test-sanity`