### PR TITLE
fix typo in filename `kustomization.yaml`

### DIFF
--- a/website/content/en/docs/upgrading-sdk-version/v1.40.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.40.0.md
@@ -278,7 +278,7 @@ _See [#6928](https://github.com/operator-framework/operator-sdk/pull/6928) for m
 
 **Changes required under the hood `config/prometheus/`**
 
-- 1. Update the `config/prometheus/kutomization.yaml` add at the bottom:
+- 1. Update the `config/prometheus/kustomization.yaml` add at the bottom:
 
 ```yaml
       # [PROMETHEUS-WITH-CERTS] The following patch configures the ServiceMonitor in ../prometheus


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**

Thank you team for your work and attention to this.

I simply fixed a single character typo.  Documentation referred to the file `kutomization.yaml`. I corrected it by adding an `s` so that it now reads `kustomization.yaml`.

**Motivation for the change:**

Although this is a very trivial typo, I noticed it when my command failed as I had copy/pasted the incorrect file name. Fixing this will hopefully benefit others who copy/paste command names like this.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
