### PR TITLE
Fix missing +/- prefixes in migration diff for v1.39.0.md

### DIFF
--- a/website/content/en/docs/upgrading-sdk-version/v1.39.0.md
+++ b/website/content/en/docs/upgrading-sdk-version/v1.39.0.md
@@ -16,18 +16,18 @@ so this release should be easier to follow.
 
 2) [go/v4] Update your `go.mod` file to upgrade the dependencies and run `go mod tidy` to download them
    ```go
-    github.com/onsi/ginkgo/v2 v2.17.1
-    github.com/onsi/gomega v1.32.0
-    k8s.io/api v0.30.1
-    k8s.io/apimachinery v0.30.1
-    k8s.io/client-go v0.30.1
-    sigs.k8s.io/controller-runtime v0.18.4
-    github.com/onsi/ginkgo/v2 v2.19.0
-    github.com/onsi/gomega v1.33.1
-    k8s.io/api v0.31.0
-    k8s.io/apimachinery v0.31.0
-    k8s.io/client-go v0.31.0
-    sigs.k8s.io/controller-runtime v0.19.0
+   - github.com/onsi/ginkgo/v2 v2.17.1
+   - github.com/onsi/gomega v1.32.0
+   - k8s.io/api v0.30.1
+   - k8s.io/apimachinery v0.30.1
+   - k8s.io/client-go v0.30.1
+   - sigs.k8s.io/controller-runtime v0.18.4
+   + github.com/onsi/ginkgo/v2 v2.19.0
+   + github.com/onsi/gomega v1.33.1
+   + k8s.io/api v0.31.0
+   + k8s.io/apimachinery v0.31.0
+   + k8s.io/client-go v0.31.0
+   + sigs.k8s.io/controller-runtime v0.19.0
    ```
 
 3) [go/v4] Update your `Makefile` with the below changes:


### PR DESCRIPTION
Improves readability when migrating to v1.39.0

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**

In [the v1.39.0 migration guide](https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.39.0/), the section

```
 github.com/onsi/ginkgo/v2 v2.17.1
 github.com/onsi/gomega v1.32.0
 k8s.io/api v0.30.1
 k8s.io/apimachinery v0.30.1
 k8s.io/client-go v0.30.1
 sigs.k8s.io/controller-runtime v0.18.4
 github.com/onsi/ginkgo/v2 v2.19.0
 github.com/onsi/gomega v1.33.1
 k8s.io/api v0.31.0
 k8s.io/apimachinery v0.31.0
 k8s.io/client-go v0.31.0
 sigs.k8s.io/controller-runtime v0.19.0
```

now looks like:

```
- github.com/onsi/ginkgo/v2 v2.17.1
- github.com/onsi/gomega v1.32.0
- k8s.io/api v0.30.1
- k8s.io/apimachinery v0.30.1
- k8s.io/client-go v0.30.1
- sigs.k8s.io/controller-runtime v0.18.4
+ github.com/onsi/ginkgo/v2 v2.19.0
+ github.com/onsi/gomega v1.33.1
+ k8s.io/api v0.31.0
+ k8s.io/apimachinery v0.31.0
+ k8s.io/client-go v0.31.0
+ sigs.k8s.io/controller-runtime v0.19.0
```

as intended.

**Motivation for the change:**

To make the migration steps easier to read.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [x] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

I haven't added a changelog entry. Let me know if I should.