### PR TITLE
Add support for ClusterRole AggregationRule during bundle generation

### DIFF
--- a/changelog/fragments/01-support-aggregated-rules-of-clusterroles.yaml
+++ b/changelog/fragments/01-support-aggregated-rules-of-clusterroles.yaml
@@ -1,0 +1,41 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      The bundle generator now includes policy rules from ClusterRoles originating through AggregationRule.
+      Previously, only policy rules of ClusterRoles explicitly bound to ServiceAccounts via ClusterRoleBindings were included.
+      With this update, the generator also aggregates and applies rules from matching ClusterRoles, 
+      ensuring proper RBAC coverage.
+    
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: addition
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0
+
+
+    # Migration can be defined to automatically add a section to
+    # the migration guide. This is required for breaking changes.
+#    migration:
+#      header: Header text for the migration section
+#      body: |
+#        Body of the migration section. This should be formatted as markdown and can
+#        span multiple lines.
+#
+#        Using the YAML string '|' operator means that newlines in this string will
+#        be honored and interpretted as newlines in the rendered markdown.

--- a/hack/generate/samples/internal/go/memcached-with-customization/manifests/aggregation-subrole.clusterole.yaml
+++ b/hack/generate/samples/internal/go/memcached-with-customization/manifests/aggregation-subrole.clusterole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregation-memcached-subrole
+  labels:
+    rbac.example.memcached.com/aggregate-to-aggregation-memcached: "true"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - update

--- a/hack/generate/samples/internal/go/memcached-with-customization/manifests/aggregation.clusterolebinding.yaml
+++ b/hack/generate/samples/internal/go/memcached-with-customization/manifests/aggregation.clusterolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aggregation-memcached
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aggregation-memcached
+subjects:
+  - kind: ServiceAccount
+    name: controller-manager
+    namespace: system

--- a/hack/generate/samples/internal/go/memcached-with-customization/manifests/aggregation.clusterrole.yaml
+++ b/hack/generate/samples/internal/go/memcached-with-customization/manifests/aggregation.clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregation-memcached
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.example.memcached.com/aggregate-to-aggregation-memcached: "true"

--- a/hack/generate/samples/internal/go/memcached-with-customization/manifests/aggregation.kustomization.patch.yaml
+++ b/hack/generate/samples/internal/go/memcached-with-customization/manifests/aggregation.kustomization.patch.yaml
@@ -1,0 +1,4 @@
+
+- aggregation.clusterrolebinding.yaml
+- aggregation-subrole.clusterrole.yaml
+- aggregation.clusterrole.yaml

--- a/hack/generate/samples/internal/go/memcached-with-customization/manifests/registry.go
+++ b/hack/generate/samples/internal/go/memcached-with-customization/manifests/registry.go
@@ -1,0 +1,19 @@
+package manifests
+
+import (
+	_ "embed"
+)
+
+var (
+	//go:embed "aggregation.clusterrole.yaml"
+	AggregationClusterRoleString string
+
+	//go:embed "aggregation-subrole.clusterole.yaml"
+	AggregationSubroleClusterRoleString string
+
+	//go:embed "aggregation.clusterolebinding.yaml"
+	AggregationClusterRoleBindingString string
+
+	//go:embed "aggregation.kustomization.patch.yaml"
+	AggregationKustomizationPatchString string
+)

--- a/testdata/go/v4/memcached-operator/bundle/manifests/memcached-operator-aggregation-memcached-subrole_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/testdata/go/v4/memcached-operator/bundle/manifests/memcached-operator-aggregation-memcached-subrole_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    rbac.example.memcached.com/aggregate-to-aggregation-memcached: "true"
+  name: memcached-operator-aggregation-memcached-subrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - update

--- a/testdata/go/v4/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v4/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -61,6 +61,12 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - pods
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
           - events
           verbs:
           - create

--- a/testdata/go/v4/memcached-operator/config/rbac/aggregation-subrole.clusterrole.yaml
+++ b/testdata/go/v4/memcached-operator/config/rbac/aggregation-subrole.clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregation-memcached-subrole
+  labels:
+    rbac.example.memcached.com/aggregate-to-aggregation-memcached: "true"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - update

--- a/testdata/go/v4/memcached-operator/config/rbac/aggregation.clusterrole.yaml
+++ b/testdata/go/v4/memcached-operator/config/rbac/aggregation.clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregation-memcached
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.example.memcached.com/aggregate-to-aggregation-memcached: "true"

--- a/testdata/go/v4/memcached-operator/config/rbac/aggregation.clusterrolebinding.yaml
+++ b/testdata/go/v4/memcached-operator/config/rbac/aggregation.clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aggregation-memcached
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aggregation-memcached
+subjects:
+  - kind: ServiceAccount
+    name: controller-manager
+    namespace: system

--- a/testdata/go/v4/memcached-operator/config/rbac/kustomization.yaml
+++ b/testdata/go/v4/memcached-operator/config/rbac/kustomization.yaml
@@ -25,4 +25,8 @@ resources:
 - memcached_admin_role.yaml
 - memcached_editor_role.yaml
 - memcached_viewer_role.yaml
+- aggregation.clusterrolebinding.yaml
+- aggregation-subrole.clusterrole.yaml
+- aggregation.clusterrole.yaml
+
 

--- a/testdata/go/v4/monitoring/memcached-operator/bundle/manifests/memcached-operator-aggregation-memcached-subrole_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/testdata/go/v4/monitoring/memcached-operator/bundle/manifests/memcached-operator-aggregation-memcached-subrole_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    rbac.example.memcached.com/aggregate-to-aggregation-memcached: "true"
+  name: memcached-operator-aggregation-memcached-subrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - update

--- a/testdata/go/v4/monitoring/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
+++ b/testdata/go/v4/monitoring/memcached-operator/bundle/manifests/memcached-operator.clusterserviceversion.yaml
@@ -61,6 +61,12 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - pods
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
           - events
           verbs:
           - create

--- a/testdata/go/v4/monitoring/memcached-operator/config/rbac/aggregation-subrole.clusterrole.yaml
+++ b/testdata/go/v4/monitoring/memcached-operator/config/rbac/aggregation-subrole.clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregation-memcached-subrole
+  labels:
+    rbac.example.memcached.com/aggregate-to-aggregation-memcached: "true"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - update

--- a/testdata/go/v4/monitoring/memcached-operator/config/rbac/aggregation.clusterrole.yaml
+++ b/testdata/go/v4/monitoring/memcached-operator/config/rbac/aggregation.clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregation-memcached
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.example.memcached.com/aggregate-to-aggregation-memcached: "true"

--- a/testdata/go/v4/monitoring/memcached-operator/config/rbac/aggregation.clusterrolebinding.yaml
+++ b/testdata/go/v4/monitoring/memcached-operator/config/rbac/aggregation.clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aggregation-memcached
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aggregation-memcached
+subjects:
+  - kind: ServiceAccount
+    name: controller-manager
+    namespace: system

--- a/testdata/go/v4/monitoring/memcached-operator/config/rbac/kustomization.yaml
+++ b/testdata/go/v4/monitoring/memcached-operator/config/rbac/kustomization.yaml
@@ -27,4 +27,8 @@ resources:
 - memcached_admin_role.yaml
 - memcached_editor_role.yaml
 - memcached_viewer_role.yaml
+- aggregation.clusterrolebinding.yaml
+- aggregation-subrole.clusterrole.yaml
+- aggregation.clusterrole.yaml
+
 


### PR DESCRIPTION
**Description of the change:**

ClusterRoles that use an AggregationRule often do not have any rules defined directly. Instead, their rules are aggregated from other ClusterRoles that match the AggregationRule’s label selector.

The existing generator logic only included rules from ClusterRoles that were explicitly bound via ClusterRoleBindings to the ServiceAccounts used by Deployments. Since ClusterRoles with an AggregationRule typically lack direct rule definitions, the resulting permission bundle ended up being empty.

**Motivation for the change:**

Improve user experience of bundle generator for users using ClusterRole AggregationRule.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)

Fixes #6977 