### PR TITLE
use go version from builder image, instead of downloading in Dockerfile

### DIFF
--- a/images/operator-sdk/Dockerfile
+++ b/images/operator-sdk/Dockerfile
@@ -19,17 +19,12 @@ RUN GOOS=linux GOARCH=$TARGETARCH make build/operator-sdk
 # Final image.
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 
-# TODO: Figure out how to take the go binary from the builder image so this doesn't have to be maintained.
-ENV GO_VERSION=1.23.4
-
 ARG TARGETARCH
 RUN microdnf install -y make gcc which tar gzip
-RUN curl -sSLo /tmp/go.tar.gz https://golang.org/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz \
-	&& rm -rf /usr/local/go \
-	&& tar -C /usr/local -xzf /tmp/go.tar.gz \
-	&& ln -sf /usr/local/go/bin/* /usr/local/bin/ \
-	&& rm -f /tmp/go.tar.gz \
-	&& go version
+
+# Copy Go runtime from builder image
+COPY --from=builder /usr/local/go /usr/local/go
+RUN ln -sf /usr/local/go/bin/* /usr/local/bin/ && go version
 
 COPY --from=builder /workspace/build/operator-sdk /usr/local/bin/operator-sdk
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**
- Updating the operator-sdk Dockerfile to copy go from the builder images, instead of downloading.

**Motivation for the change:**
- to speed up build time.
- to lessen burden of remembering to update the `GO_VERSION` for every update.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
