### PR TITLE
add support to scaffold oci helm registry charts

### DIFF
--- a/internal/plugins/helm/v1/api.go
+++ b/internal/plugins/helm/v1/api.go
@@ -108,6 +108,9 @@ func (p *createAPISubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdM
 
   $ %[1]s create api \
       --helm-chart=/path/to/local/chart-archives/app-1.2.3.tgz
+
+  $ %[1]s create api \
+      --helm-chart=oci://charts.mycompany.com/example-namespace/app:1.2.3
 `, cliMeta.CommandName)
 }
 


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**
- Add support for OCI helm registries client to helm's download manager.
- Updating flag arguments for clarification
- Added an example for clarification


**Motivation for the change:**
- Fixes: #610

**Testing**
- Example in the PR now works
-  The follow where `oci://` is passed is also supported `operator-sdk create api --group demo --version v1alpha1 --kind Nginx --helm-chart oci://registry-1.docker.io/bitnamicharts/nginx:21.1.21`

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
