### PR TITLE
point kuttl docs to github repo, instead of defunct kuttl website

### DIFF
--- a/website/content/en/docs/building-operators/golang/testing.md
+++ b/website/content/en/docs/building-operators/golang/testing.md
@@ -53,7 +53,7 @@ To implement application-specific tests, the SDK's test harness, [scorecard][sco
 [writing-custom-scorecard-tests]: /docs/testing-operators/scorecard/custom-tests
 [scorecard]: /docs/testing-operators/scorecard/
 [gomega]: https://onsi.github.io/gomega/
-[kuttl]: https://kuttl.dev/
+[kuttl]: https://github.com/kudobuilder/kuttl/
 [sample]: https://github.com/operator-framework/operator-sdk/tree/master/testdata/go/v4/memcached-operator
 [molecule]: https://molecule.readthedocs.io/
 [molecule-tests]: /docs/building-operators/ansible/testing-guide

--- a/website/content/en/docs/testing-operators/scorecard/kuttl-tests.md
+++ b/website/content/en/docs/testing-operators/scorecard/kuttl-tests.md
@@ -159,7 +159,7 @@ have to provide RBAC access for reading kubernetes events to the
 service account used to run kuttl tests.
 
 [client_go]: https://github.com/kubernetes/client-go
-[kuttl]: https://kuttl.dev
-[kuttl_yaml]: https://kuttl.dev/docs/cli.html#examples
-[kuttl_tests]: https://kuttl.dev/docs/kuttl-test-harness.html#writing-your-first-test
-[kuttl_configuration]:https://kuttl.dev/docs/testing/reference.html#testsuite
+[kuttl]: https://github.com/kudobuilder/kuttl/
+[kuttl_yaml]: https://github.com/kudobuilder/kuttl/blob/main/docs/cli.md#examples
+[kuttl_tests]: https://github.com/kudobuilder/kuttl/blob/main/docs/kuttl-test-harness.md#writing-your-first-test
+[kuttl_configuration]:https://github.com/kudobuilder/kuttl/blob/main/docs/testing/reference.md#testsuite


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**
- Pointing kuttl docs to their github docs, and not the website.

**Motivation for the change:**
- To have docs sanity checks pass.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
