### PR TITLE
Add restrictive security context to registry pod and init containers

### DIFF
--- a/changelog/fragments/fix-fbc-init-container-security-context.yaml
+++ b/changelog/fragments/fix-fbc-init-container-security-context.yaml
@@ -1,0 +1,10 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Fixed `operator-sdk run bundle` with `--security-context-config=restricted` to apply
+      the restricted security context to init containers (`registry-grpc-init`), not just
+      the main container. This resolves PodSecurity violations on clusters with
+      `restricted` policy enforcement.
+    kind: bugfix
+    breaking: false

--- a/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
+++ b/internal/olm/operator/registry/fbcindex/fbc_registry_pod.go
@@ -148,14 +148,21 @@ func (f *FBCRegistryPod) Create(ctx context.Context, cfg *operator.Configuration
 			},
 		}
 
-		// Update the Registry Pod container security context to be restrictive
-		f.pod.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+		restrictedSecurityContext := &corev1.SecurityContext{
 			Privileged:               pointer.To(false),
 			ReadOnlyRootFilesystem:   pointer.To(false),
 			AllowPrivilegeEscalation: pointer.To(false),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 			},
+		}
+
+		// Update the Registry Pod container security context to be restrictive
+		f.pod.Spec.Containers[0].SecurityContext = restrictedSecurityContext
+
+		// Update all init containers with the same restrictive security context
+		for i := range f.pod.Spec.InitContainers {
+			f.pod.Spec.InitContainers[i].SecurityContext = restrictedSecurityContext
 		}
 	}
 

--- a/internal/olm/operator/registry/fbcindex/fbc_registry_pod_test.go
+++ b/internal/olm/operator/registry/fbcindex/fbc_registry_pod_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 const testIndexImageTag = "some-image:v1.2.3"
@@ -303,6 +304,79 @@ var _ = Describe("FBCRegistryPod", func() {
 				Expect(rp.pod.Spec.Containers[0].Command).Should(ContainElements("sh", "-c", containerCommandFor(rp.FBCIndexRootDir, rp.GRPCPort)))
 				Expect(rp.pod.Spec.InitContainers).Should(HaveLen(1))
 				Expect(rp.pod.Spec.InitContainers[0].VolumeMounts).Should(HaveLen(2))
+			})
+		})
+
+		Context("with SecurityContext set to restricted", func() {
+			It("should apply restrictive security context to pod, containers, and init containers", func() {
+				schm := runtime.NewScheme()
+				Expect(v1alpha1.AddToScheme(schm)).ShouldNot(HaveOccurred())
+				Expect(corev1.AddToScheme(schm)).ShouldNot(HaveOccurred())
+
+				// Use an interceptor to make the pod appear Running on Get calls
+				fakeClient := fakeclient.NewClientBuilder().
+					WithScheme(schm).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+							if err := c.Get(ctx, key, obj, opts...); err != nil {
+								return err
+							}
+							if pod, ok := obj.(*corev1.Pod); ok {
+								pod.Status.Phase = corev1.PodRunning
+							}
+							return nil
+						},
+					}).
+					Build()
+
+				restrictedCfg := &operator.Configuration{
+					Client:    fakeClient,
+					Namespace: "test-default",
+					Scheme:    schm,
+				}
+
+				cs := &v1alpha1.CatalogSource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-catalogsource",
+					},
+				}
+
+				restrictedRp := &FBCRegistryPod{
+					BundleItems:     defaultBundleItems,
+					IndexImage:      testIndexImageTag,
+					SecurityContext: "restricted",
+				}
+
+				pod, err := restrictedRp.Create(context.Background(), restrictedCfg, cs)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod).NotTo(BeNil())
+
+				By("verifying pod-level security context")
+				Expect(pod.Spec.SecurityContext).NotTo(BeNil())
+				Expect(pod.Spec.SecurityContext.SeccompProfile).NotTo(BeNil())
+				Expect(pod.Spec.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+
+				By("verifying main container security context")
+				Expect(pod.Spec.Containers).To(HaveLen(1))
+				sc := pod.Spec.Containers[0].SecurityContext
+				Expect(sc).NotTo(BeNil())
+				Expect(*sc.Privileged).To(BeFalse())
+				Expect(*sc.ReadOnlyRootFilesystem).To(BeFalse())
+				Expect(*sc.AllowPrivilegeEscalation).To(BeFalse())
+				Expect(sc.Capabilities).NotTo(BeNil())
+				Expect(sc.Capabilities.Drop).To(ContainElement(corev1.Capability("ALL")))
+
+				By("verifying init container security contexts")
+				Expect(pod.Spec.InitContainers).NotTo(BeEmpty())
+				for i, initContainer := range pod.Spec.InitContainers {
+					isc := initContainer.SecurityContext
+					Expect(isc).NotTo(BeNil(), "init container %d (%s) should have security context", i, initContainer.Name)
+					Expect(*isc.Privileged).To(BeFalse(), "init container %d should not be privileged", i)
+					Expect(*isc.ReadOnlyRootFilesystem).To(BeFalse(), "init container %d ReadOnlyRootFilesystem", i)
+					Expect(*isc.AllowPrivilegeEscalation).To(BeFalse(), "init container %d should not allow privilege escalation", i)
+					Expect(isc.Capabilities).NotTo(BeNil(), "init container %d should have capabilities", i)
+					Expect(isc.Capabilities.Drop).To(ContainElement(corev1.Capability("ALL")), "init container %d should drop ALL capabilities", i)
+				}
 			})
 		})
 	})


### PR DESCRIPTION
Fixes #7039

Signed-off-by: Tiger Kaovilai <passawit.kaovilai@gmail.com>

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
