### PR TITLE
Prefer strings.SplitSeq over strings.Split where possible

### DIFF
--- a/internal/bindata/olm/manifests.go
+++ b/internal/bindata/olm/manifests.go
@@ -281,8 +281,8 @@ func AssetDir(name string) ([]string, error) {
 	node := _bintree
 	if len(name) != 0 {
 		cannonicalName := strings.Replace(name, "\\", "/", -1)
-		pathList := strings.Split(cannonicalName, "/")
-		for _, p := range pathList {
+		pathList := strings.SplitSeq(cannonicalName, "/")
+		for p := range pathList {
 			node = node.Children[p]
 			if node == nil {
 				return nil, fmt.Errorf("Asset %s not found", name)

--- a/internal/olm/operator/install_mode.go
+++ b/internal/olm/operator/install_mode.go
@@ -38,8 +38,8 @@ func (i *InstallMode) Set(str string) error {
 	split := strings.SplitN(str, "=", 2)
 	i.InstallModeType = v1alpha1.InstallModeType(split[0])
 	if len(split) == 2 {
-		namespaces := strings.Split(split[1], ",")
-		for _, ns := range namespaces {
+		namespaces := strings.SplitSeq(split[1], ",")
+		for ns := range namespaces {
 			i.TargetNamespaces = append(i.TargetNamespaces, strings.TrimSpace(ns))
 		}
 		sort.Strings(i.TargetNamespaces)

--- a/internal/util/projutil/interactive_promt_util.go
+++ b/internal/util/projutil/interactive_promt_util.go
@@ -106,7 +106,7 @@ func readArray(reader *bufio.Reader) []string {
 	arr := make([]string, 0)
 	text := readLine(reader)
 
-	for _, words := range strings.Split(text, ",") {
+	for words := range strings.SplitSeq(text, ",") {
 		arr = append(arr, strings.TrimSpace(words))
 	}
 	return arr


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**
Replace usages of `strings.Split` with `strings.SplitSeq` in cases where we are iterating through the results; this returns an iterator over the original string, saving a slice allocation and is generally more efficient when `range`ing over it. There is no expected user-facing change in behavior. 

**Motivation for the change:**
Some slight performance improvements.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
