### PR TITLE
refactor: follow go fix advice about `any`

### DIFF
--- a/internal/bindata/olm/manifests.go
+++ b/internal/bindata/olm/manifests.go
@@ -78,7 +78,7 @@ func (fi bindataFileInfo) IsDir() bool {
 }
 
 // Sys return file is sys mode
-func (fi bindataFileInfo) Sys() interface{} {
+func (fi bindataFileInfo) Sys() any {
 	return nil
 }
 

--- a/internal/cmd/operator-sdk/alpha/config3alphato3/convert_config_3-alpha_to_3.go
+++ b/internal/cmd/operator-sdk/alpha/config3alphato3/convert_config_3-alpha_to_3.go
@@ -42,7 +42,7 @@ type templObj struct {
 // convertConfig3AlphaTo3 returns cfgBytes converted to 3 iff cfgBytes is version 3-alpha.
 func convertConfig3AlphaTo3(cfgBytes []byte) (_ []byte, err error) {
 	tObj := templObj{}
-	cfgObj := make(map[string]interface{}, 5)
+	cfgObj := make(map[string]any, 5)
 	if err := yaml.Unmarshal(cfgBytes, &cfgObj); err != nil {
 		return nil, err
 	}
@@ -72,13 +72,13 @@ func convertConfig3AlphaTo3(cfgBytes []byte) (_ []byte, err error) {
 			domain = domainObj.(string)
 		}
 
-		resObjs := obj.([]interface{})
+		resObjs := obj.([]any)
 		resources := make([]resource.Resource, len(resObjs))
 
 		for i, resObj := range resObjs {
 			resources[i].Domain = domain
 
-			res := resObj.(map[string]interface{})
+			res := resObj.(map[string]any)
 			if groupObj, ok := res["group"]; ok {
 				resources[i].Group = groupObj.(string)
 			}

--- a/internal/cmd/operator-sdk/generate/bundle/cmd.go
+++ b/internal/cmd/operator-sdk/generate/bundle/cmd.go
@@ -146,7 +146,7 @@ func (c *bundleCmd) addFlagsTo(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.useImageDigests, "use-image-digests", false, "Use SHA Digest for images")
 }
 
-func (c bundleCmd) println(a ...interface{}) {
+func (c bundleCmd) println(a ...any) {
 	if !c.quiet && !c.stdout {
 		fmt.Println(a...)
 	}

--- a/internal/cmd/operator-sdk/generate/internal/genutil.go
+++ b/internal/cmd/operator-sdk/generate/internal/genutil.go
@@ -118,7 +118,7 @@ func makeObjectFileName(obj client.Object) string {
 }
 
 // writeObjectToFile marshals crd to bytes and writes them to dir in file.
-func writeObjectToFile(dir string, obj interface{}, fileName string) error {
+func writeObjectToFile(dir string, obj any, fileName string) error {
 	f, err := os.Create(filepath.Join(dir, fileName))
 	if err != nil {
 		return err
@@ -128,7 +128,7 @@ func writeObjectToFile(dir string, obj interface{}, fileName string) error {
 }
 
 // writeObject marshals crd to bytes and writes them to w.
-func writeObject(w io.Writer, obj interface{}) error {
+func writeObject(w io.Writer, obj any) error {
 	b, err := yaml.Marshal(obj)
 	if err != nil {
 		return err

--- a/internal/cmd/operator-sdk/generate/packagemanifests/cmd.go
+++ b/internal/cmd/operator-sdk/generate/packagemanifests/cmd.go
@@ -111,7 +111,7 @@ func (c *packagemanifestsCmd) addFlagsTo(fs *pflag.FlagSet) {
 	fs.StringVar(&c.packageName, "package", "", "Package name")
 }
 
-func (c packagemanifestsCmd) println(a ...interface{}) {
+func (c packagemanifestsCmd) println(a ...any) {
 	if !c.quiet && !c.stdout {
 		fmt.Println(a...)
 	}

--- a/internal/cmd/operator-sdk/scorecard/xunit/xunit.go
+++ b/internal/cmd/operator-sdk/scorecard/xunit/xunit.go
@@ -36,8 +36,8 @@ type TestSuites struct {
 
 // Preperty is a named property that will be formatted as an XML tag.
 type Property struct {
-	Name  string      `xml:"name,attr"`
-	Value interface{} `xml:"value,attr"`
+	Name  string `xml:"name,attr"`
+	Value any    `xml:"value,attr"`
 }
 
 // TestSuite contains for details about a test beyond the final status

--- a/internal/generate/clusterserviceversion/bases/definitions/crd.go
+++ b/internal/generate/clusterserviceversion/bases/definitions/crd.go
@@ -117,7 +117,7 @@ func (g generator) buildCRDDescriptionFromType(gvk schema.GroupVersionKind, type
 	return description, descriptionOrder, nil
 }
 
-func (g generator) getTypedDescriptors(pkg *loader.Package, kindType *markers.TypeInfo, t reflect.Type, descType string) ([]interface{}, error) {
+func (g generator) getTypedDescriptors(pkg *loader.Package, kindType *markers.TypeInfo, t reflect.Type, descType string) ([]any, error) {
 	// Find child in the kind type.
 	child, err := findChildForDescType(kindType, descType)
 	if err != nil {
@@ -133,7 +133,7 @@ func (g generator) getTypedDescriptors(pkg *loader.Package, kindType *markers.Ty
 	return getTypedDescriptors(markedFields, t, descType), nil
 }
 
-func getTypedDescriptors(markedFields map[crd.TypeIdent][]*fieldInfo, t reflect.Type, descType string) (descriptors []interface{}) {
+func getTypedDescriptors(markedFields map[crd.TypeIdent][]*fieldInfo, t reflect.Type, descType string) (descriptors []any) {
 	descriptorBuckets := make(map[int][]reflect.Value)
 	orders := make([]int, 0)
 	for _, fields := range markedFields {

--- a/internal/generate/clusterserviceversion/bases/definitions/crd_test.go
+++ b/internal/generate/clusterserviceversion/bases/definitions/crd_test.go
@@ -34,7 +34,7 @@ import (
 var _ = Describe("getTypedDescriptors", func() {
 	var (
 		markedFields map[crd.TypeIdent][]*fieldInfo
-		out          []interface{}
+		out          []any
 	)
 
 	BeforeEach(func() {
@@ -50,7 +50,7 @@ var _ = Describe("getTypedDescriptors", func() {
 			{
 				FieldInfo: markers.FieldInfo{
 					Markers: markers.MarkerValues{
-						"": []interface{}{
+						"": []any{
 							Descriptor{"spec", "Foo", []string{"urn:alm:descriptor:com.tectonic.ui:text"}, nil},
 						},
 					},
@@ -59,7 +59,7 @@ var _ = Describe("getTypedDescriptors", func() {
 		}
 		out = getTypedDescriptors(markedFields, reflect.TypeOf(v1alpha1.SpecDescriptor{}), spec)
 		Expect(out).To(HaveLen(1))
-		Expect(out).To(BeEquivalentTo([]interface{}{
+		Expect(out).To(BeEquivalentTo([]any{
 			v1alpha1.SpecDescriptor{
 				DisplayName:  "Foo",
 				XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:text"},
@@ -71,7 +71,7 @@ var _ = Describe("getTypedDescriptors", func() {
 			{
 				FieldInfo: markers.FieldInfo{
 					Markers: markers.MarkerValues{
-						"": []interface{}{
+						"": []any{
 							Descriptor{"status", "Foo", []string{"urn:alm:descriptor:com.tectonic.ui:text"}, nil},
 						},
 					},
@@ -86,7 +86,7 @@ var _ = Describe("getTypedDescriptors", func() {
 			{
 				FieldInfo: markers.FieldInfo{
 					Markers: markers.MarkerValues{
-						"": []interface{}{
+						"": []any{
 							Descriptor{"status", "Foo", []string{"urn:alm:descriptor:com.tectonic.ui:text"}, nil},
 						},
 					},
@@ -95,7 +95,7 @@ var _ = Describe("getTypedDescriptors", func() {
 		}
 		out = getTypedDescriptors(markedFields, reflect.TypeOf(v1alpha1.StatusDescriptor{}), status)
 		Expect(out).To(HaveLen(1))
-		Expect(out).To(BeEquivalentTo([]interface{}{
+		Expect(out).To(BeEquivalentTo([]any{
 			v1alpha1.StatusDescriptor{
 				DisplayName:  "Foo",
 				XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:text"},
@@ -107,7 +107,7 @@ var _ = Describe("getTypedDescriptors", func() {
 			{
 				FieldInfo: markers.FieldInfo{
 					Markers: markers.MarkerValues{
-						"": []interface{}{
+						"": []any{
 							Descriptor{"spec", "Foo", nil, nil},
 							Descriptor{"spec", "", nil, intPtr(2)},
 							Descriptor{"spec", "", []string{"urn:alm:descriptor:com.tectonic.ui:text"}, nil},
@@ -120,7 +120,7 @@ var _ = Describe("getTypedDescriptors", func() {
 		}
 		out = getTypedDescriptors(markedFields, reflect.TypeOf(v1alpha1.SpecDescriptor{}), spec)
 		Expect(out).To(HaveLen(1))
-		Expect(out).To(BeEquivalentTo([]interface{}{
+		Expect(out).To(BeEquivalentTo([]any{
 			v1alpha1.SpecDescriptor{
 				DisplayName:  "Foo",
 				XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:text"},
@@ -133,7 +133,7 @@ var _ = Describe("getTypedDescriptors", func() {
 			{
 				FieldInfo: markers.FieldInfo{
 					Markers: markers.MarkerValues{
-						"": []interface{}{Descriptor{"spec", "Foo", nil, intPtr(1)}},
+						"": []any{Descriptor{"spec", "Foo", nil, intPtr(1)}},
 					},
 				},
 				pathSegments: []string{"foo"},
@@ -141,7 +141,7 @@ var _ = Describe("getTypedDescriptors", func() {
 			{
 				FieldInfo: markers.FieldInfo{
 					Markers: markers.MarkerValues{
-						"": []interface{}{Descriptor{"spec", "Bar", nil, intPtr(0)}},
+						"": []any{Descriptor{"spec", "Bar", nil, intPtr(0)}},
 					},
 				},
 				pathSegments: []string{"bar"},
@@ -149,7 +149,7 @@ var _ = Describe("getTypedDescriptors", func() {
 		}
 		out = getTypedDescriptors(markedFields, reflect.TypeOf(v1alpha1.SpecDescriptor{}), spec)
 		Expect(out).To(HaveLen(2))
-		Expect(out).To(BeEquivalentTo([]interface{}{
+		Expect(out).To(BeEquivalentTo([]any{
 			v1alpha1.SpecDescriptor{DisplayName: "Bar", Path: "bar"},
 			v1alpha1.SpecDescriptor{DisplayName: "Foo", Path: "foo"},
 		}))
@@ -166,7 +166,7 @@ func intPtr(i int) *int { return &i }
 
 // makeMockMarkedFields returns a randomly generated mock marked field set,
 // and the expected sorted set of descriptors.
-func makeMockMarkedFields() (markedFields map[crd.TypeIdent][]*fieldInfo, expected []interface{}) {
+func makeMockMarkedFields() (markedFields map[crd.TypeIdent][]*fieldInfo, expected []any) {
 	descBuckets := make(map[int][]v1alpha1.SpecDescriptor, 100)
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	markedFields = make(map[crd.TypeIdent][]*fieldInfo, 100)
@@ -186,7 +186,7 @@ func makeMockMarkedFields() (markedFields map[crd.TypeIdent][]*fieldInfo, expect
 			{
 				FieldInfo: markers.FieldInfo{
 					Markers: markers.MarkerValues{
-						"": []interface{}{Descriptor{"spec", name, nil, intPtr(order)}},
+						"": []any{Descriptor{"spec", name, nil, intPtr(order)}},
 					},
 				},
 				pathSegments: []string{s},

--- a/internal/generate/internal/genutil.go
+++ b/internal/generate/internal/genutil.go
@@ -57,7 +57,7 @@ func Open(dir, fileName string) (*File, error) {
 }
 
 // WriteObject writes a k8s object to w.
-func WriteObject(w io.Writer, obj interface{}) error {
+func WriteObject(w io.Writer, obj any) error {
 	b, err := k8sutil.GetObjectBytes(obj, yaml.Marshal)
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func WriteObject(w io.Writer, obj interface{}) error {
 }
 
 // WriteObject writes any object to w.
-func WriteYAML(w io.Writer, obj interface{}) error {
+func WriteYAML(w io.Writer, obj any) error {
 	b, err := yaml.Marshal(obj)
 	if err != nil {
 		return err

--- a/internal/helm/client/actionconfig.go
+++ b/internal/helm/client/actionconfig.go
@@ -43,7 +43,7 @@ type ActionConfigGetter interface {
 func NewActionConfigGetter(cfg *rest.Config, rm meta.RESTMapper, log logr.Logger) (ActionConfigGetter, error) {
 	rcg := newRESTClientGetter(cfg, rm, "")
 	// Setup the debug log function that Helm will use
-	debugLog := func(format string, v ...interface{}) {
+	debugLog := func(format string, v ...any) {
 		if log.Enabled() {
 			log.V(1).Info(fmt.Sprintf(format, v...))
 		}
@@ -72,7 +72,7 @@ var _ ActionConfigGetter = &actionConfigGetter{}
 type actionConfigGetter struct {
 	kubeClient          *kube.Client
 	kubeClientSet       kubernetes.Interface
-	debugLog            func(string, ...interface{})
+	debugLog            func(string, ...any)
 	restClientGetter    *restClientGetter
 	watchedSecrets      map[string]*WatchedSecrets
 	watchedSecretsMutex *sync.Mutex

--- a/internal/helm/controller/reconcile.go
+++ b/internal/helm/controller/reconcile.go
@@ -433,8 +433,8 @@ func (r HelmOperatorReconciler) Reconcile(ctx context.Context, request reconcile
 // will be returned. An error will be thrown if the custom resource time period is not in proper format.
 func determineReconcilePeriod(currentPeriod time.Duration, o *unstructured.Unstructured) (time.Duration, error) {
 	// If custom resource annotations are present, they will take precedence over the command-line flag
-	if annot, exists := o.UnstructuredContent()["metadata"].(map[string]interface{})["annotations"]; exists {
-		if timeDuration, present := annot.(map[string]interface{})[helmReconcilePeriodAnnotation]; present {
+	if annot, exists := o.UnstructuredContent()["metadata"].(map[string]any)["annotations"]; exists {
+		if timeDuration, present := annot.(map[string]any)[helmReconcilePeriodAnnotation]; present {
 			annotationsPeriod, err := time.ParseDuration(timeDuration.(string))
 			if err != nil {
 				return currentPeriod, err // First return value does not matter, since err != nil

--- a/internal/helm/controller/reconcile_test.go
+++ b/internal/helm/controller/reconcile_test.go
@@ -25,9 +25,9 @@ import (
 func TestDetermineReconcilePeriod(t *testing.T) {
 	testPeriod1, _ := time.ParseDuration("10s")
 	obj1 := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"annotations": map[string]interface{}{
+		Object: map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
 					"name":                        "test-obj-1",
 					helmReconcilePeriodAnnotation: "3s",
 				},
@@ -41,9 +41,9 @@ func TestDetermineReconcilePeriod(t *testing.T) {
 
 	testPeriod2, _ := time.ParseDuration("1h3m4s")
 	obj2 := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"annotations": map[string]interface{}{
+		Object: map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
 					"name": "test-obj-2",
 				},
 			},
@@ -56,9 +56,9 @@ func TestDetermineReconcilePeriod(t *testing.T) {
 
 	testPeriod3, _ := time.ParseDuration("5m15s")
 	obj3 := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"annotations": map[string]interface{}{
+		Object: map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
 					"name":                        "test-obj-3",
 					helmReconcilePeriodAnnotation: "4x",
 				},
@@ -73,48 +73,48 @@ func TestDetermineReconcilePeriod(t *testing.T) {
 
 func TestHasAnnotation(t *testing.T) {
 	upgradeForceTests := []struct {
-		input       map[string]interface{}
+		input       map[string]any
 		expectedVal bool
 		expectedOut string
 		name        string
 	}{
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"helm.sdk.operatorframework.io/upgrade-force": "True",
 			},
 			expectedVal: true,
 			name:        "upgrade force base case true",
 		},
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"helm.sdk.operatorframework.io/upgrade-force": "False",
 			},
 			expectedVal: false,
 			name:        "upgrade force base case false",
 		},
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"helm.sdk.operatorframework.io/upgrade-force": "1",
 			},
 			expectedVal: true,
 			name:        "upgrade force true as int",
 		},
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"helm.sdk.operatorframework.io/upgrade-force": "0",
 			},
 			expectedVal: false,
 			name:        "upgrade force false as int",
 		},
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"helm.sdk.operatorframework.io/wrong-annotation": "true",
 			},
 			expectedVal: false,
 			name:        "upgrade force annotation not set",
 		},
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"helm.sdk.operatorframework.io/upgrade-force": "invalid",
 			},
 			expectedVal: false,
@@ -127,48 +127,48 @@ func TestHasAnnotation(t *testing.T) {
 	}
 
 	uninstallWaitTests := []struct {
-		input       map[string]interface{}
+		input       map[string]any
 		expectedVal bool
 		expectedOut string
 		name        string
 	}{
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"helm.sdk.operatorframework.io/uninstall-wait": "True",
 			},
 			expectedVal: true,
 			name:        "uninstall wait base case true",
 		},
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"helm.sdk.operatorframework.io/uninstall-wait": "False",
 			},
 			expectedVal: false,
 			name:        "uninstall wait base case false",
 		},
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"helm.sdk.operatorframework.io/uninstall-wait": "1",
 			},
 			expectedVal: true,
 			name:        "uninstall wait true as int",
 		},
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"helm.sdk.operatorframework.io/uninstall-wait": "0",
 			},
 			expectedVal: false,
 			name:        "uninstall wait false as int",
 		},
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"helm.sdk.operatorframework.io/wrong-annotation": "true",
 			},
 			expectedVal: false,
 			name:        "uninstall wait annotation not set",
 		},
 		{
-			input: map[string]interface{}{
+			input: map[string]any{
 				"helm.sdk.operatorframework.io/uninstall-wait": "invalid",
 			},
 			expectedVal: false,
@@ -181,10 +181,10 @@ func TestHasAnnotation(t *testing.T) {
 	}
 }
 
-func annotations(m map[string]interface{}) *unstructured.Unstructured {
+func annotations(m map[string]any) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
+		Object: map[string]any{
+			"metadata": map[string]any{
 				"annotations": m,
 			},
 		},

--- a/internal/helm/internal/types/types.go
+++ b/internal/helm/internal/types/types.go
@@ -35,7 +35,7 @@ type HelmApp struct {
 	Status            HelmAppStatus `json:"status,omitempty"`
 }
 
-type HelmAppSpec map[string]interface{}
+type HelmAppSpec map[string]any
 
 type HelmAppConditionType string
 type ConditionStatus string
@@ -79,8 +79,8 @@ type HelmAppStatus struct {
 	DeployedRelease *HelmAppRelease    `json:"deployedRelease,omitempty"`
 }
 
-func (s *HelmAppStatus) ToMap() (map[string]interface{}, error) {
-	var out map[string]interface{}
+func (s *HelmAppStatus) ToMap() (map[string]any, error) {
+	var out map[string]any
 	jsonObj, err := json.Marshal(&s)
 	if err != nil {
 		return nil, err
@@ -134,7 +134,7 @@ func StatusFor(cr *unstructured.Unstructured) *HelmAppStatus {
 	switch s := cr.Object["status"].(type) {
 	case *HelmAppStatus:
 		return s
-	case map[string]interface{}:
+	case map[string]any:
 		var status *HelmAppStatus
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(s, &status); err != nil {
 			return &HelmAppStatus{}

--- a/internal/helm/internal/types/types_test.go
+++ b/internal/helm/internal/types/types_test.go
@@ -88,14 +88,14 @@ func TestStatusForFilledRaw(t *testing.T) {
 
 func newTestResource() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "Character",
 			"apiVersion": "stable.nicolerenee.io",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "dory",
 				"namespace": testNamespaceName,
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"Name": "Dory",
 				"From": "Finding Nemo",
 				"By":   "Disney",
@@ -119,9 +119,9 @@ func newTestStatus() *HelmAppStatus {
 	}
 }
 
-func newTestStatusRaw() map[string]interface{} {
-	return map[string]interface{}{
-		"conditions": []map[string]interface{}{
+func newTestStatusRaw() map[string]any {
+	return map[string]any{
+		"conditions": []map[string]any{
 			{
 				"type":               "Deployed",
 				"status":             "True",
@@ -130,6 +130,6 @@ func newTestStatusRaw() map[string]interface{} {
 				"lastTransitionTime": now.UTC(),
 			},
 		},
-		"deployedRelease": map[string]interface{}{"name": "SomeRelease"},
+		"deployedRelease": map[string]any{"name": "SomeRelease"},
 	}
 }

--- a/internal/helm/release/manager.go
+++ b/internal/helm/release/manager.go
@@ -68,7 +68,7 @@ type manager struct {
 	releaseName string
 	namespace   string
 
-	values map[string]interface{}
+	values map[string]any
 	status *types.HelmAppStatus
 
 	isInstalled       bool
@@ -157,7 +157,7 @@ func (m manager) getDeployedRelease() (*rpb.Release, error) {
 }
 
 func (m manager) getCandidateRelease(namespace, name string, chart *cpb.Chart,
-	values map[string]interface{}) (*rpb.Release, error) {
+	values map[string]any) (*rpb.Release, error) {
 	upgrade := action.NewUpgrade(m.actionConfig)
 	upgrade.Namespace = namespace
 	upgrade.DryRun = true

--- a/internal/helm/release/manager_factory.go
+++ b/internal/helm/release/manager_factory.go
@@ -67,7 +67,7 @@ func (f managerFactory) NewManager(cr *unstructured.Unstructured, overrideValues
 		return nil, fmt.Errorf("failed to get helm release name: %w", err)
 	}
 
-	crValues, ok := cr.Object["spec"].(map[string]interface{})
+	crValues, ok := cr.Object["spec"].(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("failed to get spec: expected map[string]interface{}")
 	}
@@ -148,8 +148,8 @@ func releaseHistory(storageBackend *storage.Storage, releaseName string) ([]*hel
 	return releaseHistory, len(releaseHistory) > 0, nil
 }
 
-func parseOverrides(in map[string]string) (map[string]interface{}, error) {
-	out := make(map[string]interface{})
+func parseOverrides(in map[string]string) (map[string]any, error) {
+	out := make(map[string]any)
 	for k, v := range in {
 		val := fmt.Sprintf("%s=%s", k, v)
 		if err := strvals.ParseIntoString(val, out); err != nil {
@@ -159,15 +159,15 @@ func parseOverrides(in map[string]string) (map[string]interface{}, error) {
 	return out, nil
 }
 
-func mergeMaps(a, b map[string]interface{}) map[string]interface{} {
-	out := make(map[string]interface{}, len(a))
+func mergeMaps(a, b map[string]any) map[string]any {
+	out := make(map[string]any, len(a))
 	for k, v := range a {
 		out[k] = v
 	}
 	for k, v := range b {
-		if v, ok := v.(map[string]interface{}); ok {
+		if v, ok := v.(map[string]any); ok {
 			if bv, ok := out[k]; ok {
-				if bv, ok := bv.(map[string]interface{}); ok {
+				if bv, ok := bv.(map[string]any); ok {
 					out[k] = mergeMaps(bv, v)
 					continue
 				}

--- a/internal/helm/release/manager_test.go
+++ b/internal/helm/release/manager_test.go
@@ -29,18 +29,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func newTestUnstructured(containers []interface{}) *unstructured.Unstructured {
+func newTestUnstructured(containers []any) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"kind":       "MyResource",
 			"apiVersion": "myApi",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "test",
 				"namespace": "ns",
 			},
-			"spec": map[string]interface{}{
-				"template": map[string]interface{}{
-					"spec": map[string]interface{}{
+			"spec": map[string]any{
+				"template": map[string]any{
+					"spec": map[string]any{
 						"containers": containers,
 					},
 				},
@@ -72,16 +72,16 @@ func TestManagerGenerateStrategicMergePatch(t *testing.T) {
 		patchType apitypes.PatchType
 	}{
 		{
-			o1: newTestUnstructured([]interface{}{
-				map[string]interface{}{
+			o1: newTestUnstructured([]any{
+				map[string]any{
 					"name": "test1",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name": "test2",
 				},
 			}),
-			o2: newTestUnstructured([]interface{}{
-				map[string]interface{}{
+			o2: newTestUnstructured([]any{
+				map[string]any{
 					"name": "test1",
 				},
 			}),
@@ -89,16 +89,16 @@ func TestManagerGenerateStrategicMergePatch(t *testing.T) {
 			patchType: apitypes.JSONPatchType,
 		},
 		{
-			o1: newTestUnstructured([]interface{}{
-				map[string]interface{}{
+			o1: newTestUnstructured([]any{
+				map[string]any{
 					"name": "test1",
 				},
 			}),
-			o2: newTestUnstructured([]interface{}{
-				map[string]interface{}{
+			o2: newTestUnstructured([]any{
+				map[string]any{
 					"name": "test1",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"name": "test2",
 				},
 			}),
@@ -106,13 +106,13 @@ func TestManagerGenerateStrategicMergePatch(t *testing.T) {
 			patchType: apitypes.JSONPatchType,
 		},
 		{
-			o1: newTestUnstructured([]interface{}{
-				map[string]interface{}{
+			o1: newTestUnstructured([]any{
+				map[string]any{
 					"name": "test1",
 				},
 			}),
-			o2: newTestUnstructured([]interface{}{
-				map[string]interface{}{
+			o2: newTestUnstructured([]any{
+				map[string]any{
 					"name": "test1",
 					"test": nil,
 				},
@@ -121,13 +121,13 @@ func TestManagerGenerateStrategicMergePatch(t *testing.T) {
 			patchType: apitypes.JSONPatchType,
 		},
 		{
-			o1: newTestUnstructured([]interface{}{
-				map[string]interface{}{
+			o1: newTestUnstructured([]any{
+				map[string]any{
 					"name": "test1",
 				},
 			}),
-			o2: newTestUnstructured([]interface{}{
-				map[string]interface{}{
+			o2: newTestUnstructured([]any{
+				map[string]any{
 					"name": "test2",
 				},
 			}),

--- a/internal/helm/watches/watches.go
+++ b/internal/helm/watches/watches.go
@@ -50,7 +50,7 @@ type Watch struct {
 // watches.yaml data. To ensure the correct defaults are applied when loading
 // watches.yaml, use Load() or LoadReader() instead of this function and/or
 // yaml.Unmarshal().
-func (w *Watch) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (w *Watch) UnmarshalYAML(unmarshal func(any) error) error {
 	// by default, the operator will watch dependent resources
 	trueVal := true
 	w.WatchDependentResources = &trueVal

--- a/internal/olm/operator/registry/configmap/configmap.go
+++ b/internal/olm/operator/registry/configmap/configmap.go
@@ -79,7 +79,7 @@ func makeConfigMapsForPackageManifests(pkg *apimanifests.PackageManifest,
 
 // makeObjectBinaryData creates a ConfigMap's binary data, indexed by a file
 // name key containing names.
-func makeObjectBinaryData(obj interface{}, names ...string) (map[string][]byte, error) {
+func makeObjectBinaryData(obj any, names ...string) (map[string][]byte, error) {
 	binaryData := make(map[string][]byte)
 	err := addObjectToBinaryData(binaryData, obj, names...)
 	return binaryData, err
@@ -100,7 +100,7 @@ func makeBundleBinaryData(bundle *apimanifests.Bundle) (map[string][]byte, error
 
 // addObjectToBinaryData adds an object's bytes to binaryData indexed by a
 // file name key containing names.
-func addObjectToBinaryData(binaryData map[string][]byte, obj interface{}, names ...string) error {
+func addObjectToBinaryData(binaryData map[string][]byte, obj any, names ...string) error {
 	b, err := yaml.Marshal(obj)
 	if err != nil {
 		return fmt.Errorf("error creating %s binary data: %w", names, err)

--- a/internal/olm/operator/registry/configmap/configmap_test.go
+++ b/internal/olm/operator/registry/configmap/configmap_test.go
@@ -136,10 +136,10 @@ var _ = Describe("ConfigMap", func() {
 				Name: "testbundle",
 				Objects: []*unstructured.Unstructured{
 					{
-						Object: map[string]interface{}{"val1": "val1"},
+						Object: map[string]any{"val1": "val1"},
 					},
 					{
-						Object: map[string]interface{}{"val2": "va2"},
+						Object: map[string]any{"val2": "va2"},
 					},
 				},
 			}
@@ -167,10 +167,10 @@ var _ = Describe("ConfigMap", func() {
 					Name: "testbundle",
 					Objects: []*unstructured.Unstructured{
 						{
-							Object: map[string]interface{}{"val1": "val1"},
+							Object: map[string]any{"val1": "val1"},
 						},
 						{
-							Object: map[string]interface{}{"val2": "va2"},
+							Object: map[string]any{"val2": "va2"},
 						},
 					},
 					CSV: &v1alpha1.ClusterServiceVersion{
@@ -185,10 +185,10 @@ var _ = Describe("ConfigMap", func() {
 					Name: "testbundle_2",
 					Objects: []*unstructured.Unstructured{
 						{
-							Object: map[string]interface{}{"val1": "val1"},
+							Object: map[string]any{"val1": "val1"},
 						},
 						{
-							Object: map[string]interface{}{"val2": "va2"},
+							Object: map[string]any{"val2": "va2"},
 						},
 					},
 					CSV: &v1alpha1.ClusterServiceVersion{

--- a/internal/olm/operator/registry/configmap/registry_test.go
+++ b/internal/olm/operator/registry/configmap/registry_test.go
@@ -84,10 +84,10 @@ var _ = Describe("Registry", func() {
 						Name: "testbundle",
 						Objects: []*unstructured.Unstructured{
 							{
-								Object: map[string]interface{}{"val1": "val1"},
+								Object: map[string]any{"val1": "val1"},
 							},
 							{
-								Object: map[string]interface{}{"val2": "va2"},
+								Object: map[string]any{"val2": "va2"},
 							},
 						},
 						CSV: &v1alpha1.ClusterServiceVersion{
@@ -145,10 +145,10 @@ var _ = Describe("Registry", func() {
 						Name: "testbundle",
 						Objects: []*unstructured.Unstructured{
 							{
-								Object: map[string]interface{}{"val1": "val1"},
+								Object: map[string]any{"val1": "val1"},
 							},
 							{
-								Object: map[string]interface{}{"val2": "va2"},
+								Object: map[string]any{"val2": "va2"},
 							},
 						},
 						CSV: &v1alpha1.ClusterServiceVersion{
@@ -226,10 +226,10 @@ var _ = Describe("Registry", func() {
 						Name:    "testbundle",
 						Objects: []*unstructured.Unstructured{
 							{
-								Object: map[string]interface{}{"val1": "val1"},
+								Object: map[string]any{"val1": "val1"},
 							},
 							{
-								Object: map[string]interface{}{"val2": "va2"},
+								Object: map[string]any{"val2": "va2"},
 							},
 						},
 						CSV: &v1alpha1.ClusterServiceVersion{

--- a/internal/olm/operator/registry/index_image.go
+++ b/internal/olm/operator/registry/index_image.go
@@ -402,7 +402,7 @@ func (c IndexImageCatalogCreator) UpdateCatalog(ctx context.Context, cs *v1alpha
 
 		// search for the list of the previous injected bundles using the catalog source's annotations
 		if value, hasAnnotation := annotations[injectedBundlesAnnotation]; hasAnnotation && value != "" {
-			var injectedBundles []map[string]interface{}
+			var injectedBundles []map[string]any
 			if err := json.Unmarshal([]byte(annotations[injectedBundlesAnnotation]), &injectedBundles); err != nil {
 				return fmt.Errorf("unable to unmarshal injected bundles json: %v", err)
 			}

--- a/internal/olm/operator/uninstall.go
+++ b/internal/olm/operator/uninstall.go
@@ -46,7 +46,7 @@ type Uninstall struct {
 	DeleteOperatorGroups     bool
 	DeleteOperatorGroupNames []string
 
-	Logf func(string, ...interface{})
+	Logf func(string, ...any)
 }
 
 func NewUninstall(cfg *Configuration) *Uninstall {

--- a/internal/registry/validate.go
+++ b/internal/registry/validate.go
@@ -84,7 +84,7 @@ func ValidateBundleContent(logger *log.Entry, bundle *apimanifests.Bundle, media
 	}
 
 	// Validate all CRD versions in the bundle together.
-	var crds []interface{}
+	var crds []any
 	for _, crd := range bundle.V1beta1CRDs {
 		crds = append(crds, crd)
 	}

--- a/internal/scorecard/tests/bundle_test.go
+++ b/internal/scorecard/tests/bundle_test.go
@@ -182,11 +182,11 @@ var _ = Describe("Basic and OLM tests", func() {
 
 			It("should pass when status descriptor field is present in CR", func() {
 				cr := unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"status": map[string]interface{}{
+					Object: map[string]any{
+						"status": map[string]any{
 							"status": "val",
 						},
-						"spec": map[string]interface{}{
+						"spec": map[string]any{
 							"spec": "val",
 						},
 					},
@@ -203,11 +203,11 @@ var _ = Describe("Basic and OLM tests", func() {
 
 			It("should pass when required spec descriptor field is present in CR", func() {
 				cr := unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"status": map[string]interface{}{
+					Object: map[string]any{
+						"status": map[string]any{
 							"status": "val",
 						},
-						"spec": map[string]interface{}{
+						"spec": map[string]any{
 							"spec": "val",
 						},
 					},
@@ -224,8 +224,8 @@ var _ = Describe("Basic and OLM tests", func() {
 
 			It("should pass with warning when no status descriptor field is present in CR", func() {
 				cr := unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"spec": map[string]interface{}{
+					Object: map[string]any{
+						"spec": map[string]any{
 							"spec": "val",
 						},
 					},
@@ -243,11 +243,11 @@ var _ = Describe("Basic and OLM tests", func() {
 
 			It("should fail CRD with given GVK cannot be found", func() {
 				cr := unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"status": map[string]interface{}{
+					Object: map[string]any{
+						"status": map[string]any{
 							"status": "val",
 						},
-						"spec": map[string]interface{}{
+						"spec": map[string]any{
 							"spec": "val",
 						},
 					},
@@ -264,8 +264,8 @@ var _ = Describe("Basic and OLM tests", func() {
 
 			It("should fail when CR does not have GVK set", func() {
 				cr := unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"status": map[string]interface{}{
+					Object: map[string]any{
+						"status": map[string]any{
 							"status": "val",
 						},
 					},
@@ -277,8 +277,8 @@ var _ = Describe("Basic and OLM tests", func() {
 
 			It("should fail when required spec descriptor field is not present in CR", func() {
 				cr := unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"spec": map[string]interface{}{
+					Object: map[string]any{
+						"spec": map[string]any{
 							"node": "val",
 						},
 					},
@@ -296,8 +296,8 @@ var _ = Describe("Basic and OLM tests", func() {
 			It("should pass when CRs have spec field specified", func() {
 				cr := []unstructured.Unstructured{
 					{
-						Object: map[string]interface{}{
-							"spec": map[string]interface{}{
+						Object: map[string]any{
+							"spec": map[string]any{
 								"spec": "val",
 							},
 						},
@@ -310,7 +310,7 @@ var _ = Describe("Basic and OLM tests", func() {
 			It("should pass with warning when CRs do not have spec field specified", func() {
 				cr := []unstructured.Unstructured{
 					{
-						Object: map[string]interface{}{},
+						Object: map[string]any{},
 					},
 				}
 				result = checkSpec(cr, result)
@@ -361,8 +361,8 @@ var _ = Describe("Basic and OLM tests", func() {
 
 		It("should pass when CR has Spec field", func() {
 			cr = unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"spec": map[string]interface{}{
+				Object: map[string]any{
+					"spec": map[string]any{
 						"node": "val",
 					},
 				},
@@ -380,8 +380,8 @@ var _ = Describe("Basic and OLM tests", func() {
 
 		It("should fail when cr does not have required fields in Spec", func() {
 			cr = unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"spec": map[string]interface{}{
+				Object: map[string]any{
+					"spec": map[string]any{
 						"items": "val",
 					},
 				},
@@ -399,8 +399,8 @@ var _ = Describe("Basic and OLM tests", func() {
 
 		It("should skip and pass when version/kind does not match for CR with CRD", func() {
 			cr = unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"spec": map[string]interface{}{
+				Object: map[string]any{
+					"spec": map[string]any{
 						"node": "val",
 					},
 				},

--- a/internal/scorecard/tests/olm.go
+++ b/internal/scorecard/tests/olm.go
@@ -98,7 +98,7 @@ func BundleValidationTest(bundleRoot string, metadata registryutil.LabelsMap) sc
 		return wrapResult(r)
 	}
 
-	objs := []interface{}{bundle, bundle.CSV}
+	objs := []any{bundle, bundle.CSV}
 	for _, crd := range bundle.V1CRDs {
 		objs = append(objs, crd)
 	}
@@ -253,7 +253,7 @@ func checkOwnedCSVStatusDescriptor(cr unstructured.Unstructured, csv *operatorsv
 	hasStatusDefinition := false
 	if cr.Object["status"] != nil {
 		// Ensure that has no empty keys
-		hasStatusDefinition = len(cr.Object["status"].(map[string]interface{})) > 0
+		hasStatusDefinition = len(cr.Object["status"].(map[string]any)) > 0
 	}
 
 	if !hasStatusDefinition {
@@ -284,7 +284,7 @@ func checkOwnedCSVSpecDescriptors(cr unstructured.Unstructured, csv *operatorsv1
 		return r
 	}
 
-	block := cr.Object[specDescriptor].(map[string]interface{})
+	block := cr.Object[specDescriptor].(map[string]any)
 
 	var crd *operatorsv1alpha1.CRDDescription
 	for _, owned := range csv.Spec.CustomResourceDefinitions.Owned {
@@ -359,7 +359,7 @@ func isCRFromCRDApi(cr unstructured.Unstructured, crds []*apiextv1.CustomResourc
 			}
 			failed := false
 			if cr.Object["spec"] != nil {
-				spec := cr.Object["spec"].(map[string]interface{})
+				spec := cr.Object["spec"].(map[string]any)
 				for key := range spec {
 					if _, ok := version.Schema.OpenAPIV3Schema.Properties["spec"].Properties[key]; !ok {
 						failed = true
@@ -370,7 +370,7 @@ func isCRFromCRDApi(cr unstructured.Unstructured, crds []*apiextv1.CustomResourc
 				}
 			}
 			if cr.Object["status"] != nil {
-				status := cr.Object["status"].(map[string]interface{})
+				status := cr.Object["status"].(map[string]any)
 				for key := range status {
 					if _, ok := version.Schema.OpenAPIV3Schema.Properties["status"].Properties[key]; !ok {
 						failed = true

--- a/internal/util/k8sutil/k8sutil_test.go
+++ b/internal/util/k8sutil/k8sutil_test.go
@@ -83,20 +83,20 @@ func TestSupportsOwnerReference(t *testing.T) {
 			name:       "Returns false when owner is Namespaced and dependent resource is Clusterscoped.",
 			restMapper: restMapper,
 			owner: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "MyNamespaceKind",
 					"apiVersion": "apps/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "example-nginx-controller",
 						"namespace": "ns",
 					},
 				},
 			},
 			dependent: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "MyClusterKind",
 					"apiVersion": "rbac/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "example-nginx-role",
 						"namespace": "ns",
 					},
@@ -108,20 +108,20 @@ func TestSupportsOwnerReference(t *testing.T) {
 			name:       "Returns true for owner and dependant are both ClusterScoped.",
 			restMapper: restMapper,
 			owner: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "MyClusterKind",
 					"apiVersion": "rbac/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "example-nginx-controller",
 						"namespace": "ns",
 					},
 				},
 			},
 			dependent: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "MyClusterKind",
 					"apiVersion": "rbac/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "example-nginx-role",
 						"namespace": "ns",
 					},
@@ -133,20 +133,20 @@ func TestSupportsOwnerReference(t *testing.T) {
 			name:       "Returns true when owner and dependant are Namespaced with in same namespace.",
 			restMapper: restMapper,
 			owner: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "MyNamespaceKind",
 					"apiVersion": "apps/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "example-nginx-controller",
 						"namespace": "ns",
 					},
 				},
 			},
 			dependent: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "MyNamespaceKind",
 					"apiVersion": "apps/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "example-nginx-role",
 						"namespace": "ns",
 					},
@@ -158,20 +158,20 @@ func TestSupportsOwnerReference(t *testing.T) {
 			name:       "Returns false when owner,and dependant are Namespaced, with different namespaces.",
 			restMapper: restMapper,
 			owner: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "MyNamespaceKind",
 					"apiVersion": "apps/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "example-nginx-controller",
 						"namespace": "ns1",
 					},
 				},
 			},
 			dependent: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "MyNamespaceKind",
 					"apiVersion": "apps/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "example-nginx-role",
 						"namespace": "ns",
 					},
@@ -183,20 +183,20 @@ func TestSupportsOwnerReference(t *testing.T) {
 			name:       "Returns false for invalid Owner Kind.",
 			restMapper: restMapper,
 			owner: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "Dummy",
 					"apiVersion": "apps/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "example-nginx-controller",
 						"namespace": "ns1",
 					},
 				},
 			},
 			dependent: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "MyNamespaceKind",
 					"apiVersion": "apps/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "example-nginx-role",
 						"namespace": "ns",
 					},
@@ -208,20 +208,20 @@ func TestSupportsOwnerReference(t *testing.T) {
 			name:       "Returns false for invalid dependant Kind.",
 			restMapper: restMapper,
 			owner: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "MyNamespaceKind",
 					"apiVersion": "apps/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "example-nginx-controller",
 						"namespace": "ns1",
 					},
 				},
 			},
 			dependent: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "Dummy",
 					"apiVersion": "apps/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "example-nginx-role",
 						"namespace": "ns",
 					},
@@ -234,20 +234,20 @@ func TestSupportsOwnerReference(t *testing.T) {
 			restMapper:   restMapper,
 			depNamespace: "ns",
 			owner: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "MyNamespaceKind",
 					"apiVersion": "apps/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "example-nginx-controller",
 						"namespace": "ns",
 					},
 				},
 			},
 			dependent: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "MyNamespaceKind",
 					"apiVersion": "apps/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name": "example-nginx-role",
 					},
 				},
@@ -259,20 +259,20 @@ func TestSupportsOwnerReference(t *testing.T) {
 			restMapper:   restMapper,
 			depNamespace: "ns1",
 			owner: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "MyNamespaceKind",
 					"apiVersion": "apps/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "example-nginx-controller",
 						"namespace": "ns",
 					},
 				},
 			},
 			dependent: &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"kind":       "MyNamespaceKind",
 					"apiVersion": "apps/v1alpha1",
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name": "example-nginx-role",
 					},
 				},

--- a/internal/util/k8sutil/object.go
+++ b/internal/util/k8sutil/object.go
@@ -18,11 +18,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-type MarshalFunc func(interface{}) ([]byte, error)
+type MarshalFunc func(any) ([]byte, error)
 
 // GetObjectBytes marshalls an object with m and removes runtime-managed fields:
 // 'status', 'creationTimestamp'
-func GetObjectBytes(obj interface{}, m MarshalFunc) ([]byte, error) {
+func GetObjectBytes(obj any, m MarshalFunc) ([]byte, error) {
 	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func GetObjectBytes(obj interface{}, m MarshalFunc) ([]byte, error) {
 	return m(u)
 }
 
-func deleteKeyFromUnstructured(u map[string]interface{}, key string) {
+func deleteKeyFromUnstructured(u map[string]any, key string) {
 	if _, ok := u[key]; ok {
 		delete(u, key)
 		return
@@ -42,11 +42,11 @@ func deleteKeyFromUnstructured(u map[string]interface{}, key string) {
 
 	for _, v := range u {
 		switch t := v.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			deleteKeyFromUnstructured(t, key)
-		case []interface{}:
+		case []any:
 			for _, ti := range t {
-				if m, ok := ti.(map[string]interface{}); ok {
+				if m, ok := ti.(map[string]any); ok {
 					deleteKeyFromUnstructured(m, key)
 				}
 			}


### PR DESCRIPTION
I only launch the following command:
```
go fix -any ./...
```

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

Note, the location for ansible operator related logic has changed. For ansible operator related changes, please create the Pull Request in https://github.com/operator-framework/ansible-operator-plugins 

-->

**Description of the change:**

use `any` keyword rather than `interface`

**Motivation for the change:**

use the new go syntax

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)
