### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   check_docs_only:
     name: check_docs_only

--- a/.github/workflows/freshen-images.yml
+++ b/.github/workflows/freshen-images.yml
@@ -11,6 +11,9 @@ on:
   # Run at 11 am UTC every day.
   - cron: '0 11 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   git_tags:
     runs-on: ubuntu-24.04

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,6 +2,9 @@ name: integration
 on:
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   check_docs_only:
     name: check_docs_only

--- a/.github/workflows/olm-check.yml
+++ b/.github/workflows/olm-check.yml
@@ -5,7 +5,10 @@ on:
    branches:
     - 'release-*'
  workflow_dispatch:
-   
+
+
+permissions:
+  contents: read
 
 jobs:
   check-olm-minor-releases:

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -2,6 +2,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   rerun_tests:
     name: rerun_pr_tests

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -2,6 +2,9 @@ name: go
 on:
   pull_request: {}
 
+permissions:
+  contents: read
+
 env:
   MEMCACHED_IMAGE: "memcached:1.4.36-alpine"
 

--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -2,6 +2,9 @@ name: helm
 on:
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   check_docs_only:
     name: check_docs_only

--- a/.github/workflows/test-sample-go.yml
+++ b/.github/workflows/test-sample-go.yml
@@ -2,6 +2,9 @@ name: memcached-sample
 on:
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   check_docs_only:
     name: check_docs_only

--- a/.github/workflows/test-sanity.yml
+++ b/.github/workflows/test-sanity.yml
@@ -2,6 +2,9 @@ name: sanity
 on:
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   check_docs_only:
     name: check_docs_only


### PR DESCRIPTION
**Description of the change:**

Currently the score for the Token Permissions is 0 because the top level permissions and a few job level permissions are missing in the workflows. With this change, the score will move to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

Fixes #7090

**Motivation for the change:**

Improves the OpenSSF Scorecard Token-Permissions check from 0 to 10 by adding minimal top-level permissions (`contents: read`) to all GitHub Actions workflows, and keeping any `write` permissions scoped to the specific jobs that need them. This hardens the CI supply chain by following the principle of least privilege for `GITHUB_TOKEN`.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] ~Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))~
- [ ] ~Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)~
